### PR TITLE
use "conference publication" as mods xml genre for workshops

### DIFF
--- a/lib/tasks/bib_export.rake
+++ b/lib/tasks/bib_export.rake
@@ -1,3 +1,4 @@
+# coding: utf-8
 require "rexml/document"
 
 # check whether xml2bib executable has been compiled
@@ -129,9 +130,7 @@ def export_volume_mods volume
 			end
 
 			paper_genre_type = paper_mods.add_element 'genre'
-			if (paper.anthology_id[0] == "W")
-				paper_genre_type.text = "workshop publication"
-			elsif (paper.anthology_id[0] == "Q" || paper.anthology_id[0] == "J") 
+                        if (paper.anthology_id[0] == "Q" || paper.anthology_id[0] == "J")
 				paper_genre_type.text = "article"
 			else
 				paper_genre_type.text = "conference publication"
@@ -228,9 +227,7 @@ def export_paper_mods paper
 	volume_info = related_item.add_element 'titleInfo'
 	volume_name = volume_info.add_element 'title'
         volume_name.text = volume_title # as default
-	if( paper.anthology_id[0] == "W")
-		genre_type.text = "workshop publication"
-	elsif (paper.anthology_id[0] == "Q" || paper.anthology_id[0] == "J") 
+	if (paper.anthology_id[0] == "Q" || paper.anthology_id[0] == "J")
 		genre_type.text = "academic journal"
                 if (paper.volume.journal_volume)
                   if (!part)

--- a/lib/tasks/bib_export.rake
+++ b/lib/tasks/bib_export.rake
@@ -93,7 +93,7 @@ def export_volume_mods volume
 			}
 
 			if (paper.doi) 
-			   	identifier = mods.add_element 'identifier'
+			   	identifier = paper_mods.add_element 'identifier'
 				identifier.attributes["type"] = "DOI"
 				identifier.text = paper.doi
 			end
@@ -129,14 +129,14 @@ def export_volume_mods volume
 				end
 			end
 
-			paper_genre_type = paper_mods.add_element 'genre'
+			paper_related_item = paper_mods.add_element 'relatedItem'
+
+			paper_genre_type = paper_related_item.add_element 'genre'
                         if (paper.anthology_id[0] == "Q" || paper.anthology_id[0] == "J")
-				paper_genre_type.text = "article"
+				paper_genre_type.text = "academic journal"
 			else
 				paper_genre_type.text = "conference publication"
 			end
-
-			paper_related_item = paper_mods.add_element 'relatedItem'
 
 			paper_related_item.attributes["type"]="host"
 			volume_info = paper_related_item.add_element 'titleInfo'


### PR DESCRIPTION
Fixes #46

"workshop publication" does not seem to be a recognized mods genre:
 http://www.loc.gov/standards/valuelist/marcgt.html
and results in bibutils making a @Misc entry
instead of an @InProceedings entry.