### PR TITLE
fixed mis-parsed author and title info

### DIFF
--- a/import/H86.xml
+++ b/import/H86.xml
@@ -55,7 +55,10 @@
 		<author>Ralph M. Weischedel</author>
 		<author>Edward Walker</author>
 		<author>Damaris Ayuso</author>
-		<author>Jos de BruinKimberle Koile, Lance Ramshaw, Varda Shaked</author>
+		<author>Jos de Bruin</author>
+		<author>Kimberle Koile</author>
+		<author>Lance Ramshaw</author>
+		<author>Varda Shaked</author>
 	</paper>
 
 	<paper id="1008">

--- a/import/W08.xml
+++ b/import/W08.xml
@@ -3123,7 +3123,7 @@
 </paper>
 
 <paper id="1132">
-  <title>The Fingerprint of Human Referring Expressions and their Surface Realization with Graph Transducers (IS-FP, IS-GT, IS-FP-GT)}</title>
+  <title>The Fingerprint of Human Referring Expressions and their Surface Realization with Graph Transducers</title>
     <author><first>Bernd</first><last>Bohnet</last></author>
   <booktitle>Proceedings of the Fifth International Natural Language Generation Conference</booktitle>
   <month>June</month>


### PR DESCRIPTION
Fixing mis-parsed entries, on the assumption that this XML data is the master source for everything and therefore the right place to fix it.