### PR TITLE
Add RELAX NG schema

### DIFF
--- a/import/schema.rnc
+++ b/import/schema.rnc
@@ -1,0 +1,66 @@
+# default namespace = ""
+
+b = element b { text }
+i = element i { text }
+first = element first { text }
+last = element last { text }
+von = element von { text }
+jr = element jr { text }
+Person = (text | first | jr | last | von)+
+Paper = element paper {
+  attribute id { xsd:integer },
+  attribute href { xsd:anyURI }?,
+  (element abstract { (text | b | i)+ }
+   | element address { text }
+   | element attachment {
+       attribute type { xsd:NCName }?,
+       xsd:NCName
+     }
+   | element author { Person }
+   | element bibkey { text }
+   | element bibtype { xsd:NCName }
+   | element booktitle { text }
+   | element dataset { xsd:NCName }
+   | element doi { xsd:anyURI }
+   | element editor { (text | first | jr | last | von)+ }
+   | element erratum {
+       attribute id { xsd:integer },
+       xsd:NCName
+     }
+   | element href { xsd:anyURI }
+   | element ISBN { xsd:NMTOKEN }
+   | element isbn { xsd:NMTOKEN }
+   | element issue { xsd:integer }
+   | element journal { text }
+   | element month { text }
+   | element mrf {
+       attribute src { xsd:NCName },
+       xsd:NCName
+     }
+   | element pages { text }
+   | element presentation { xsd:NCName }
+   | element publisher { text }
+   | element revision {
+       attribute id { xsd:integer },
+       xsd:NCName
+     }
+   | element software { xsd:NCName }
+   | element title {
+       (text
+        | b
+        | i
+        | element SUP { xsd:NCName })+
+     }
+   | element url { xsd:anyURI }
+   | element video {
+       attribute href { xsd:anyURI },
+       attribute tag { text }
+     }
+   | element volume { xsd:integer }
+   | element year { xsd:integer })+
+}
+Volume = element volume {
+  attribute id { xsd:NCName },
+  Paper+
+}
+start = Volume

--- a/import/schema.rng
+++ b/import/schema.rng
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <!-- default namespace = "" -->
+  <define name="b">
+    <element name="b">
+      <text/>
+    </element>
+  </define>
+  <define name="i">
+    <element name="i">
+      <text/>
+    </element>
+  </define>
+  <define name="first">
+    <element name="first">
+      <text/>
+    </element>
+  </define>
+  <define name="last">
+    <element name="last">
+      <text/>
+    </element>
+  </define>
+  <define name="von">
+    <element name="von">
+      <text/>
+    </element>
+  </define>
+  <define name="jr">
+    <element name="jr">
+      <text/>
+    </element>
+  </define>
+  <define name="Person">
+    <oneOrMore>
+      <choice>
+        <text/>
+        <ref name="first"/>
+        <ref name="jr"/>
+        <ref name="last"/>
+        <ref name="von"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <define name="Paper">
+    <element name="paper">
+      <attribute name="id">
+        <data type="integer"/>
+      </attribute>
+      <optional>
+        <attribute name="href">
+          <data type="anyURI"/>
+        </attribute>
+      </optional>
+      <oneOrMore>
+        <choice>
+          <element name="abstract">
+            <oneOrMore>
+              <choice>
+                <text/>
+                <ref name="b"/>
+                <ref name="i"/>
+              </choice>
+            </oneOrMore>
+          </element>
+          <element name="address">
+            <text/>
+          </element>
+          <element name="attachment">
+            <optional>
+              <attribute name="type">
+                <data type="NCName"/>
+              </attribute>
+            </optional>
+            <data type="NCName"/>
+          </element>
+          <element name="author">
+            <ref name="Person"/>
+          </element>
+          <element name="bibkey">
+            <text/>
+          </element>
+          <element name="bibtype">
+            <data type="NCName"/>
+          </element>
+          <element name="booktitle">
+            <text/>
+          </element>
+          <element name="dataset">
+            <data type="NCName"/>
+          </element>
+          <element name="doi">
+            <data type="anyURI"/>
+          </element>
+          <element name="editor">
+            <oneOrMore>
+              <choice>
+                <text/>
+                <ref name="first"/>
+                <ref name="jr"/>
+                <ref name="last"/>
+                <ref name="von"/>
+              </choice>
+            </oneOrMore>
+          </element>
+          <element name="erratum">
+            <attribute name="id">
+              <data type="integer"/>
+            </attribute>
+            <data type="NCName"/>
+          </element>
+          <element name="href">
+            <data type="anyURI"/>
+          </element>
+          <element name="ISBN">
+            <data type="NMTOKEN"/>
+          </element>
+          <element name="isbn">
+            <data type="NMTOKEN"/>
+          </element>
+          <element name="issue">
+            <data type="integer"/>
+          </element>
+          <element name="journal">
+            <text/>
+          </element>
+          <element name="month">
+            <text/>
+          </element>
+          <element name="mrf">
+            <attribute name="src">
+              <data type="NCName"/>
+            </attribute>
+            <data type="NCName"/>
+          </element>
+          <element name="pages">
+            <text/>
+          </element>
+          <element name="presentation">
+            <data type="NCName"/>
+          </element>
+          <element name="publisher">
+            <text/>
+          </element>
+          <element name="revision">
+            <attribute name="id">
+              <data type="integer"/>
+            </attribute>
+            <data type="NCName"/>
+          </element>
+          <element name="software">
+            <data type="NCName"/>
+          </element>
+          <element name="title">
+            <oneOrMore>
+              <choice>
+                <text/>
+                <ref name="b"/>
+                <ref name="i"/>
+                <element name="SUP">
+                  <data type="NCName"/>
+                </element>
+              </choice>
+            </oneOrMore>
+          </element>
+          <element name="url">
+            <data type="anyURI"/>
+          </element>
+          <element name="video">
+            <attribute name="href">
+              <data type="anyURI"/>
+            </attribute>
+            <attribute name="tag"/>
+          </element>
+          <element name="volume">
+            <data type="integer"/>
+          </element>
+          <element name="year">
+            <data type="integer"/>
+          </element>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <define name="Volume">
+    <element name="volume">
+      <attribute name="id">
+        <data type="NCName"/>
+      </attribute>
+      <oneOrMore>
+        <ref name="Paper"/>
+      </oneOrMore>
+    </element>
+  </define>
+  <start>
+    <ref name="Volume"/>
+  </start>
+</grammar>


### PR DESCRIPTION
This PR provides a schema to check the integrity of the data in `import/*.xml`.

It will benefit from further changes, e.g., to reflect structural changes in #75, but the basic advantage is that it picks up on obviously unintended artifacts, as well as your run-of-the-mill XML syntax violations (e.g., the entity issues fixed by `escapeXML.pl` and #61).

_Most_ of the `import/*.xml` files validate just fine. Supposing #61 gets merged and re-run, the remaining errors picked out by this schema should be trivial to fix manually. These can be listed by running this command from the `import/` directory:
```shell
xmllint --relaxng schema.rng --noout *.xml
```
What follows are some snippets resulting from running that command:
```console
C02.xml validates
C04.xml:263: element paper: Relax-NG validity error: Did not expect text in element paper content
C04.xml fails to validate
C08.xml validates
```
Which is referring to the stray `8` on line 268 in `C04.xml`:
```xml
   263	<paper id="1042">
   264	<title>Condition of Projectivity in the Underlying Dependency Structures</title>
   265	<author><first>Katerina</first><last>Vesel&#225;</last></author>
   266	<author><first>Havelka</first><last>Jiri</last></author>
   267	<author><first>Eva</first><last>Hajicov&#225;</last></author>
   268	8	</paper>
```
...after a few more files:
```console
D17.xml:14425: parser error : xmlParseEntityRef: no name
      human supervision! In this paper, using a Task & Talk reference game
                                                      ^
```
Which is a plain old XML syntax violation (fixed by #61).

This be most useful in the context of some automatic CI scaffolding, but in any case, should be handy to catch some of those typos / oddities even after the fact (i.e. already committed).

Files:
- **`schema.rnc`**: hand-tuned schema using [RELAX NG Compact](http://www.relaxng.org/compact-tutorial-20030326.html) syntax.
  After resolving all the XML syntax violations with #61, I auto-generated a first draft with [trang](http://www.thaiopensource.com/relaxng/trang.html) (`trang -O rnc import/*.xml import/schema.rnc`), then manually simplified the resulting schema to rule out many of the inconsistencies (mostly unexpected text content)
- **`schema.rng`**: standard [RELAX NG](http://www.relaxng.org/tutorial-20011203.html) syntax, which is usable by Libxml (`xmllint` does not recognize/read the Compact variant).
  This is directly equivalent to / derived from `schema.rnc`, via trang (`trang schema.rnc schema.rng`).