### PR TITLE
Patch for problems with the '&' sign

### DIFF
--- a/lib/tasks/xml_import.rake
+++ b/lib/tasks/xml_import.rake
@@ -20,6 +20,7 @@ def load_volume_xml(xml_data)
   xml_data.gsub!(/&amp;/, '&amp;amp;')	# three chars that need to stay
   xml_data.gsub!(/&gt;/, '&amp;gt;')	#  escaped in xml
   xml_data.gsub!(/&lt;/, '&amp;lt;')	# will go back to &amp; &gt; &lt;
+  xml_data.gsub!(/&(?!(?:amp|lt|gt|quot|apos);)/, '&amp;')
 
   xml_data = HTMLEntities.new.decode xml_data # Change all escape characters to Unicode
   # handles html entities such as &eacute; that are not known in xml


### PR DESCRIPTION
The code still has problems with the '&' sign. This patch seems to solve them.

Here's an example: when running `rake import:xml[true,C96]`, the following error appears:

> Seeding individual volume: C96.
> Seeding: import/C96.xml
> rake aborted!
> REXML::ParseException: #<RuntimeError: Illegal character '&' in raw string "A Portable & Quick Japanese Parser: QJP">

The guilty entry, however, reads:

> <paper id="2104">
> <title>A Portable &#38; Quick Japanese Parser: QJP</title>
> <author>Masayuki Kameda</author>
> </paper>

This is a valid XML file (as verified with the schema proposed in #76), but still has the problem that  #63 had in which an entity is de-escaped first and read later.