### PR TITLE
Remove text appearing outside expected elements

### DIFF
--- a/import/C04.xml
+++ b/import/C04.xml
@@ -265,7 +265,7 @@
 		<author><first>Katerina</first><last>Vesel&#225;</last></author>
 		<author><first>Havelka</first><last>Jiri</last></author>
 		<author><first>Eva</first><last>Hajicov&#225;</last></author>
-8	</paper>
+	</paper>
 
 	<paper id="1043">
 		<title>Unificational Combinatory Categorial Grammar. Combining Information Structure and Discourse Representations</title>

--- a/import/E06.xml
+++ b/import/E06.xml
@@ -475,7 +475,7 @@
 <author>Ian P Davy</author>
 </paper>
 					
-<paper id="2021">E06-2021.pdf
+<paper id="2021">
 <title>Automatic Acronym Recognition</title>
 <author>Dana Dann&#x00E9;lls</author>
 </paper>

--- a/import/H93.xml
+++ b/import/H93.xml
@@ -748,7 +748,7 @@
 		<title>NATURAL LANGUAGE PLANNING DIALOGUE FOR INTELLIGENT APPLICATIONS</title>
 		<author>James F. Allen</author>
 		<author>Len Schubert</author>
-.	</paper>
+	</paper>
 
 	<paper id="1115">
 		<title>THE PENMAN PROJECT ON KNOWLEDGE-BASED MACHINE TRANSLATION</title>

--- a/import/J02.xml
+++ b/import/J02.xml
@@ -4,39 +4,39 @@
  <title>Computational Linguistics, Volume 28, Number 1, March 2002</title>
 </paper>
 
-<paper id="1001">1-18.pdf
+<paper id="1001">
  <title>Binding Machines</title>
  <author>Ant&#243;nio Branco</author>
 </paper>
 
-<paper id="1002">19-36.pdf
+<paper id="1002">
  <title>A Critique and Improvement of an Evaluation Metric for Text Segmentation</title>
  <author>Lev Pevzner</author>
  <author>Marti A. Hearst</author>
 </paper>
 
-<paper id="1003">37-52.pdf
+<paper id="1003">
  <title>Generating Referring Expressions: Boolean Extensions of the Incremental Algorithm</title>
  <author>Kees van Deemter</author>
 </paper>
 
-<paper id="1004">53-70.pdf
+<paper id="1004">
  <title>Syllable-Pattern-Based Unknown-Morpheme Segmentation and Estimation for Hybrid Part-of-Speech Tagging of Korean</title>
  <author>Gary Geunbae Lee</author>
  <author>Jeongwon Cha</author>
  <author>Jong-Hyeok Lee</author>
 </paper>
 
-<paper id="1005">71-76.pdf
+<paper id="1005">
  <title>Squibs and Discussions: The DOP Estimation Method is Biased and Inconsistent</title>
  <author>Mark Johnson</author>
 </paper>
 
-<paper id="1006">77-101.pdf
+<paper id="1006">
  <title>Book Reviews: Tree Adjoining Grammars: Formalisms, Linguistic Analysis and Processing edited by Anne Abeille and Owen Rambow, Reviewed by Geoffrey K. Pullum; The Theory and Practice of Discourse Parsing and Summarization by Daniel Marcu, Reviewed by Udo Hahn; Natural Language Semantics by Keith Allan, Reviewed by Rodger Kibble; Intonation: Analysis, Modelling and Technology edited by Antonis Botinis, Reviewed by Martine Grice; Polysemy: Theoretical and Computational Approaches edited by Yael Ravin and Claudia Leacock, Reviewed by Jean V&#233;ronis; Abduction, Belief and Context in Dialogue: Studies in Computational Pragmatics edited by Harry Bunt and William Black, Reviewed by Matthew Stone; Relationships in the Organization of Knowledge edited by Carol A. Bean and Rebecca Green, Reviewed by Gregory Grefenstette</title>
 </paper>
 
-<paper id="1007">102-104.pdf
+<paper id="1007">
  <title>Briefly Noted</title>
 </paper>
 

--- a/import/J16.xml
+++ b/import/J16.xml
@@ -221,7 +221,7 @@
     <author><first>Dong</first><last>Nguyen</last></author>
     <author><first>A. Seza</first><last>Doğruöz</last></author>
     <author><first>Carolyn P.</first><last>Rosé</last></author>
-Franciska de Jong
+    <author><first>Franciska</first><last>de Jong</last></author>
     <month>September</month>
     <year>2016</year>
     <pages>537–593</pages>

--- a/import/J17.xml
+++ b/import/J17.xml
@@ -72,8 +72,8 @@
   <paper id='1006'>
     <title>Evaluative Language Beyond Bags of Words: Linguistic Insights and Computational Applications   </title>
     <author><first>Farah</first><last>Benamara</last></author>
-Maite Taboada
-Yannick Mathieu
+    <author><first>Maite</first><last>Taboada</last></author>
+    <author><first>Yannick</first><last>Mathieu</last></author>
     <month>April</month>
     <year>2017</year>
     <abstract>The study of evaluation, affect, and subjectivity is a multidisciplinary enterprise, including sociology, psychology, economics, linguistics, and computer science. A number of excellent computational linguistics and linguistic surveys of the field exist. Most surveys, however, do not bring the two disciplines together to show how methods from linguistics can benefit computational sentiment analysis systems. In this survey, we show how incorporating linguistic insights, discourse information, and other contextual phenomena, in combination with the statistical exploitation of data, can result in an improvement over approaches that take advantage of only one of these perspectives. We first provide a comprehensive introduction to evaluative language from both a linguistic and computational perspective. We then argue that the standard computational definition of the concept of evaluative language neglects the dynamic nature of evaluation, in which the interpretation of a given evaluation depends on linguistic and extra-linguistic contextual factors. We thus propose a dynamic definition that incorporates update functions. The update functions allow for different contextual aspects to be incorporated into the calculation of sentiment for evaluative words or expressions, and can be applied at all levels of discourse. We explore each level and highlight which linguistic aspects contribute to accurate extraction of sentiment. We end the review by outlining what we believe the future directions of sentiment analysis are, and the role that discourse and contextual information need to play.</abstract>

--- a/import/Q15.xml
+++ b/import/Q15.xml
@@ -179,7 +179,7 @@
     <href>https://tacl2013.cs.columbia.edu/ojs/index.php/tacl/article/download/150/124</href>
     <pages>211--225</pages>
     <url>http://www.aclweb.org/anthology/Q15-1016</url>
-    <video href="http://techtalks.tv/talks/improving-distributional-similarity-with-lessons-learned-from-word-embeddings/61709/" tag="video"/>w
+    <video href="http://techtalks.tv/talks/improving-distributional-similarity-with-lessons-learned-from-word-embeddings/61709/" tag="video"/>
   </paper>
 
   <paper id='1017'>

--- a/import/W98.xml
+++ b/import/W98.xml
@@ -1070,7 +1070,7 @@
 
 <paper id="0703">
  <title>Word Sense Disambiguation based on Semantic Density</title>
- <author>Rada Mihalcea</author>Dan I. Moldovan 
+ <author>Rada Mihalcea</author>
  <author>Dan I. Moldovan</author>
 </paper>
 


### PR DESCRIPTION
These changes bring all the data in `import/*.xml` into compliance with `schema.rng` from #76.