### PR TITLE
Improvements to the authoritative XML

### DIFF
--- a/import/D18.xml
+++ b/import/D18.xml
@@ -9667,8 +9667,8 @@
 
   <paper id="2000">
     <title>Proceedings of the 2018 Conference on Empirical Methods in Natural Language Processing: System Demonstrations</title>
-    <editor>Eduardo Blanco</editor>
-    <editor>Wei Lu</editor>
+    <editor><first>Eduardo</first><last>Blanco</last></editor>
+    <editor><first>Wei</first><last>Lu</last></editor>
     <month>November</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>

--- a/import/J92.xml
+++ b/import/J92.xml
@@ -209,7 +209,6 @@
 
  <paper id="4000">
  <title>Computational Linguistics, Volume 18, Number 4, December 1992</title>
- <author> </author>
 </paper>
 
  <paper id="4001">

--- a/import/K18.xml
+++ b/import/K18.xml
@@ -2,8 +2,8 @@
 <volume id="K18">
   <paper id="1000">
     <title>Proceedings of the 22nd Conference on Computational Natural Language Learning</title>
-    <editor>Anna Korhonen</editor>
-    <editor>Ivan Titov</editor>
+    <editor><first>Anna</first><last>Korhonen</last></editor>
+    <editor><first>Ivan</first><last>Titov</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -991,8 +991,8 @@
 
   <paper id="2000">
     <title>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</title>
-    <editor>Daniel Zeman</editor>
-    <editor>Jan Haji{&#x10D;}</editor>
+    <editor><first>Daniel</first><last>Zeman</last></editor>
+    <editor><first>Jan</first><last>Haji{&#x10D;}</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1467,8 +1467,8 @@
 
   <paper id="3000">
     <title>Proceedings of the CoNLL SIGMORPHON 2018 Shared Task: Universal Morphological Reinflection</title>
-    <editor>Mans Hulden</editor>
-    <editor>Ryan Cotterell</editor>
+    <editor><first>Mans</first><last>Hulden</last></editor>
+    <editor><first>Ryan</first><last>Cotterell</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels</address>

--- a/import/W17.xml
+++ b/import/W17.xml
@@ -42126,10 +42126,6 @@
     <address>Montpellier, France</address>
     <publisher>Association for Computational Linguistics</publisher>
     <url>http://www.aclweb.org/anthology/W17-7001</url>
-    <title>
-       Proceedings of Language, Ontology, Terminology and Knowledge Structures
-      Workshop (LOTKS 2017) 
-    </title>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id='7002'>

--- a/import/W18.xml
+++ b/import/W18.xml
@@ -17709,12 +17709,12 @@
 
    <paper id="5100">
      <title>Proceedings of the 2nd Workshop on Abusive Language Online (ALW2)</title>
-     <editor>Darja Fišer</editor>
-     <editor>Ruihong Huang</editor>
-     <editor>Vinodkumar Prabhakaran</editor>
-     <editor>Rob Voigt</editor>
-     <editor>Zeerak Waseem</editor>
-     <editor>Jacqueline Wernimont</editor>
+     <editor><first>Darja</first><last>Fišer</last></editor>
+     <editor><first>Ruihong</first><last>Huang</last></editor>
+     <editor><first>Vinodkumar</first><last>Prabhakaran</last></editor>
+     <editor><first>Rob</first><last>Voigt</last></editor>
+     <editor><first>Zeerak</first><last>Waseem</last></editor>
+     <editor><first>Jacqueline</first><last>Wernimont</last></editor>
      <month>October</month>
      <year>2018</year>
      <address>Brussels, Belgium</address>
@@ -18069,8 +18069,8 @@
 
    <paper id="5200">
      <title>Proceedings of the 5th Workshop on Argument Mining</title>
-     <editor>Noam Slonim</editor>
-     <editor>Ranit Aharonov</editor>
+     <editor><first>Noam</first><last>Slonim</last></editor>
+     <editor><first>Ranit</first><last>Aharonov</last></editor>
      <month>November</month>
      <year>2018</year>
      <address>Brussels, Belgium</address>
@@ -18389,9 +18389,9 @@
 
    <paper id="5300">
      <title>Proceedings of the 6th BioASQ Workshop A challenge on large-scale biomedical semantic indexing and question answering</title>
-     <editor>Ioannis A. Kakadiaris</editor>
-     <editor>George Paliouras</editor>
-     <editor>Anastasia Krithara</editor>
+     <editor><first>Ioannis A.</first><last>Kakadiaris</last></editor>
+     <editor><first>George</first><last>Paliouras</last></editor>
+     <editor><first>Anastasia</first><last>Krithara</last></editor>
      <month>November</month>
      <year>2018</year>
      <address>Brussels, Belgium</address>
@@ -19560,11 +19560,11 @@
 
    <paper id="5500">
      <title>Proceedings of the First Workshop on Fact Extraction and VERification (FEVER)</title>
-     <editor>James Thorne</editor>
-     <editor>Andreas Vlachos</editor>
-     <editor>Oana Cocarascu</editor>
-     <editor>Christos Christodoulopoulos</editor>
-     <editor>Arpit Mittal</editor>
+     <editor><first>James</first><last>Thorne</last></editor>
+     <editor><first>Andreas</first><last>Vlachos</last></editor>
+     <editor><first>Oana</first><last>Cocarascu</last></editor>
+     <editor><first>Christos</first><last>Christodoulopoulos</last></editor>
+     <editor><first>Arpit</first><last>Mittal</last></editor>
      <month>November</month>
      <year>2018</year>
      <address>Brussels, Belgium</address>
@@ -20059,9 +20059,9 @@
 
   <paper id="5600">
     <title>Proceedings of the Ninth International Workshop on Health Text Mining and Information Analysis</title>
-    <editor>Alberto Lavelli</editor>
-    <editor>Anne-Lyse Minard</editor>
-    <editor>Fabio Rinaldi</editor>
+    <editor><first>Alberto</first><last>Lavelli</last></editor>
+    <editor><first>Anne-Lyse</first><last>Minard</last></editor>
+    <editor><first>Fabio</first><last>Rinaldi</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -20506,11 +20506,11 @@
 
   <paper id="5700">
     <title>Proceedings of the 2018 EMNLP Workshop SCAI: The 2nd International Workshop on Search-Oriented Conversational AI</title>
-    <editor>Aleksandr Chuklin</editor>
-    <editor>Jeff Dalton</editor>
-    <editor>Julia Kiseleva</editor>
-    <editor>Alexey Borisov</editor>
-    <editor>Mikhail Burtsev</editor>
+    <editor><first>Aleksandr</first><last>Chuklin</last></editor>
+    <editor><first>Jeff</first><last>Dalton</last></editor>
+    <editor><first>Julia</first><last>Kiseleva</last></editor>
+    <editor><first>Alexey</first><last>Borisov</last></editor>
+    <editor><first>Mikhail</first><last>Burtsev</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -20742,8 +20742,8 @@
 
   <paper id="5800">
     <title>Proceedings of the Fifteenth Workshop on Computational Research in Phonetics, Phonology, and Morphology</title>
-    <editor>Sandra Kuebler</editor>
-    <editor>Garrett Nicolai</editor>
+    <editor><first>Sandra</first><last>Kuebler</last></editor>
+    <editor><first>Garrett</first><last>Nicolai</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -21069,10 +21069,10 @@
 
   <paper id="5900">
     <title>Proceedings of the 2018 EMNLP Workshop SMM4H: The 3rd Social Media Mining for Health Applications Workshop and Shared Task</title>
-    <editor>Graciela Gonzalez-Hernandez</editor>
-    <editor>Davy Weissenbacher</editor>
-    <editor>Abeed Sarker</editor>
-    <editor>Michael Paul</editor>
+    <editor><first>Graciela</first><last>Gonzalez-Hernandez</last></editor>
+    <editor><first>Davy</first><last>Weissenbacher</last></editor>
+    <editor><first>Abeed</first><last>Sarker</last></editor>
+    <editor><first>Michael</first><last>Paul</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -21432,9 +21432,9 @@
 
   <paper id="6000">
     <title>Proceedings of the Second Workshop on Universal Dependencies (UDW 2018)</title>
-    <editor>Marie-Catherine de Marneffe</editor>
-    <editor>Teresa Lynn</editor>
-    <editor>Sebastian Schuster</editor>
+    <editor><first>Marie-Catherine</first><last>de Marneffe</last></editor>
+    <editor><first>Teresa</first><last>Lynn</last></editor>
+    <editor><first>Sebastian</first><last>Schuster</last></editor>
     <month>November</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -21846,10 +21846,10 @@
 
   <paper id="6100">
     <title>Proceedings of the 2018 EMNLP Workshop W-NUT: The 4th Workshop on Noisy User-generated Text</title>
-    <editor>Wei Xu</editor>
-    <editor>Alan Ritter</editor>
-    <editor>Tim Baldwin</editor>
-    <editor>Afshin Rahimi</editor>
+    <editor><first>Wei</first><last>Xu</last></editor>
+    <editor><first>Alan</first><last>Ritter</last></editor>
+    <editor><first>Tim</first><last>Baldwin</last></editor>
+    <editor><first>Afshin</first><last>Rahimi</last></editor>
     <month>November</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -22353,10 +22353,10 @@
 
   <paper id="6200">
     <title>Proceedings of the 9th Workshop on Computational Approaches to Subjectivity, Sentiment and Social Media Analysis</title>
-    <editor>Alexandra Balahur</editor>
-    <editor>Saif M. Mohammad</editor>
-    <editor>Veronique Hoste</editor>
-    <editor>Roman Klinger</editor>
+    <editor><first>Alexandra</first><last>Balahur</last></editor>
+    <editor><first>Saif M.</first><last>Mohammad</last></editor>
+    <editor><first>Veronique</first><last>Hoste</last></editor>
+    <editor><first>Roman</first><last>Klinger</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -23225,23 +23225,23 @@
 
   <paper id="6300">
     <title>Proceedings of the Third Conference on Machine Translation: Research Papers</title>
-    <editor>Ondřej Bojar</editor>
-    <editor>Rajen Chatterjee</editor>
-    <editor>Christian Federmann</editor>
-    <editor>Mark Fishel</editor>
-    <editor>Yvette Graham</editor>
-    <editor>Barry Haddow</editor>
-    <editor>Matthias Huck</editor>
-    <editor>Antonio Jimeno Yepes</editor>
-    <editor>Philipp Koehn</editor>
-    <editor>Christof Monz</editor>
-    <editor>Matteo Negri</editor>
-    <editor>Aur&#233;lie N&#233;v&#233;ol</editor>
-    <editor>Mariana Neves</editor>
-    <editor>Matt Post</editor>
-    <editor>Lucia Specia</editor>
-    <editor>Marco Turchi</editor>
-    <editor>Karin Verspoor</editor>
+    <editor><first>Ondřej</first><last>Bojar</last></editor>
+    <editor><first>Rajen</first><last>Chatterjee</last></editor>
+    <editor><first>Christian</first><last>Federmann</last></editor>
+    <editor><first>Mark</first><last>Fishel</last></editor>
+    <editor><first>Yvette</first><last>Graham</last></editor>
+    <editor><first>Barry</first><last>Haddow</last></editor>
+    <editor><first>Matthias</first><last>Huck</last></editor>
+    <editor><first>Antonio Jimeno</first><last>Yepes</last></editor>
+    <editor><first>Philipp</first><last>Koehn</last></editor>
+    <editor><first>Christof</first><last>Monz</last></editor>
+    <editor><first>Matteo</first><last>Negri</last></editor>
+    <editor><first>Aur&#233;lie</first><last>N&#233;v&#233;ol</last></editor>
+    <editor><first>Mariana</first><last>Neves</last></editor>
+    <editor><first>Matt</first><last>Post</last></editor>
+    <editor><first>Lucia</first><last>Specia</last></editor>
+    <editor><first>Marco</first><last>Turchi</last></editor>
+    <editor><first>Karin</first><last>Verspoor</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Belgium, Brussels</address>
@@ -23704,23 +23704,23 @@
 
   <paper id="6400">
     <title>Proceedings of the Third Conference on Machine Translation: Shared Task Papers</title>
-    <editor>Ondřej Bojar</editor>
-    <editor>Rajen Chatterjee</editor>
-    <editor>Christian Federmann</editor>
-    <editor>Mark Fishel</editor>
-    <editor>Yvette Graham</editor>
-    <editor>Barry Haddow</editor>
-    <editor>Matthias Huck</editor>
-    <editor>Antonio Jimeno Yepes</editor>
-    <editor>Philipp Koehn</editor>
-    <editor>Christof Monz</editor>
-    <editor>Matteo Negri</editor>
-    <editor>Aur&#233;lie N&#233;v&#233;ol</editor>
-    <editor>Mariana Neves</editor>
-    <editor>Matt Post</editor>
-    <editor>Lucia Specia</editor>
-    <editor>Marco Turchi</editor>
-    <editor>Karin Verspoor</editor>
+    <editor><first>Ondřej</first><last>Bojar</last></editor>
+    <editor><first>Rajen</first><last>Chatterjee</last></editor>
+    <editor><first>Christian</first><last>Federmann</last></editor>
+    <editor><first>Mark</first><last>Fishel</last></editor>
+    <editor><first>Yvette</first><last>Graham</last></editor>
+    <editor><first>Barry</first><last>Haddow</last></editor>
+    <editor><first>Matthias</first><last>Huck</last></editor>
+    <editor><first>Antonio Jimeno</first><last>Yepes</last></editor>
+    <editor><first>Philipp</first><last>Koehn</last></editor>
+    <editor><first>Christof</first><last>Monz</last></editor>
+    <editor><first>Matteo</first><last>Negri</last></editor>
+    <editor><first>Aur&#233;lie</first><last>N&#233;v&#233;ol</last></editor>
+    <editor><first>Mariana</first><last>Neves</last></editor>
+    <editor><first>Matt</first><last>Post</last></editor>
+    <editor><first>Lucia</first><last>Specia</last></editor>
+    <editor><first>Marco</first><last>Turchi</last></editor>
+    <editor><first>Karin</first><last>Verspoor</last></editor>
     <month>October</month>
     <year>2018</year>
     <address>Belgium, Brussels</address>
@@ -25229,9 +25229,9 @@
 
   <paper id="6500">
     <title>Proceedings of the 11th International Conference on Natural Language Generation</title>
-    <editor>Emiel Krahmer</editor>
-    <editor>Albert Gatt</editor>
-    <editor>Martijn Goudbeek</editor>
+    <editor><first>Emiel</first><last>Krahmer</last></editor>
+    <editor><first>Albert</first><last>Gatt</last></editor>
+    <editor><first>Martijn</first><last>Goudbeek</last></editor>
     <month>November</month>
     <year>2018</year>
     <address>Tilburg University, The Netherlands</address>
@@ -26446,9 +26446,9 @@
     </paper>
 
    <paper id="6700">
-	      <editor>Jose M. Alonso</editor>
-        <editor>Alejandro Catala</editor>
-        <editor>Mariët Theune</editor>
+	      <editor><first>Jose M.</first><last>Alonso</last></editor>
+        <editor><first>Alejandro</first><last>Catala</last></editor>
+        <editor><first>Mariët</first><last>Theune</last></editor>
         <title>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </title>
         <year>2018</year>
         <month>November</month>
@@ -26460,7 +26460,7 @@
 
    <paper id="6701">
         <title>Applications of NLG in practical conversational AI settings</title>
-        <author>Sander Wubben</author> 
+        <author><first>Sander</first><last>Wubben</last></author> 
 				<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>1-2</pages>
         <year>2018</year>
@@ -26473,11 +26473,11 @@
 
    <paper id="6702">	   
         <title>Generating Description for Sequential Images with Local-Object Attention Conditioned on Global Semantic Context</title>
-        <author>Jing Su</author>
-        <author>Chenghua Lin</author>
-        <author>Mian Zhou</author>
-        <author>Qingyun Dai</author>
-	<author>Haoyu Lv</author>
+        <author><first>Jing</first><last>Su</last></author>
+        <author><first>Chenghua</first><last>Lin</last></author>
+        <author><first>Mian</first><last>Zhou</last></author>
+        <author><first>Qingyun</first><last>Dai</last></author>
+	<author><first>Haoyu</first><last>Lv</last></author>
 					<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>3-8</pages>
         <year>2018</year>
@@ -26490,10 +26490,10 @@
 
    <paper id="6703">	   
         <title>Automation and Optimisation of Humor Trait Generation in a Vocal Dialogue System</title>
-        <author>Matthieu Riou</author>
-        <author>Stéphane Huet</author>
-	    <author>Bassam Jabaian</author>
-	    <author>Fabrice Lefèvre</author>
+        <author><first>Matthieu</first><last>Riou</last></author>
+        <author><first>Stéphane</first><last>Huet</last></author>
+	    <author><first>Bassam</first><last>Jabaian</last></author>
+	    <author><first>Fabrice</first><last>Lefèvre</last></author>
 			<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>9-14</pages>
         <year>2018</year>
@@ -26506,10 +26506,10 @@
 
    <paper id="6704">
         <title>Textual Entailment based Question Generation</title>
-        <author>Takaaki Matsumoto</author>
-        <author>Kimihiro Hasegawa</author>
-        <author>Yukari Yamakawa</author>
-	    <author>Teruko Mitamura</author>
+        <author><first>Takaaki</first><last>Matsumoto</last></author>
+        <author><first>Kimihiro</first><last>Hasegawa</last></author>
+        <author><first>Yukari</first><last>Yamakawa</last></author>
+	    <author><first>Teruko</first><last>Mitamura</last></author>
 				<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>15-19</pages>
         <year>2018</year>
@@ -26522,9 +26522,9 @@
 
    <paper id="6705">
         <title>Trouble on the Road: Finding Reasons for Commuter Stress from Tweets</title>
-        <author>Reshmi Gopalakrishna Pillai</author>
-        <author>Mike Thelwall</author>
-        <author>Constantin Orasan</author>
+        <author><first>Reshmi Gopalakrishna</first><last>Pillai</last></author>
+        <author><first>Mike</first><last>Thelwall</last></author>
+        <author><first>Constantin</first><last>Orasan</last></author>
 				<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>20-25</pages>
         <year>2018</year>
@@ -26537,10 +26537,10 @@
 
    <paper id="6706">
         <title>Assisted Nominalization for Academic English Writing</title>
-        <author>John Lee</author>
-        <author>Dariush Saberi</author>
-        <author>Marvin Lam</author>
-	    <author>Jonathan Webster</author>
+        <author><first>John</first><last>Lee</last></author>
+        <author><first>Dariush</first><last>Saberi</last></author>
+        <author><first>Marvin</first><last>Lam</last></author>
+	    <author><first>Jonathan</first><last>Webster</last></author>
 				<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>26-30</pages>
         <year>2018</year>
@@ -26553,11 +26553,11 @@
 
    <paper id="6707">
         <title>Two-Step Training and Mixed Encoding-Decoding for Implementing a Generative Chatbot with a Small Dialogue Corpus</title>
-        <author>Jintae Kim</author>
-        <author>Hyeon-Gu Lee</author>
-        <author>Harksoo Kim</author>
-	    <author>Yeonsoo Lee</author>
-	    <author>Young-Gil Kim</author>	
+        <author><first>Jintae</first><last>Kim</last></author>
+        <author><first>Hyeon-Gu</first><last>Lee</last></author>
+        <author><first>Harksoo</first><last>Kim</last></author>
+	    <author><first>Yeonsoo</first><last>Lee</last></author>
+	    <author><first>Young-Gil</first><last>Kim</last></author>	
 			<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>31-35</pages>
         <year>2018</year>
@@ -26570,9 +26570,9 @@
 
    <paper id="6708">
         <title>Supporting Content Design with an Eye Tracker: The Case of Weather-based Recommendations</title>
-        <author>Alejandro Catala</author>
-        <author>Jose M. Alonso</author>
-        <author>Alberto Bugarin</author>
+        <author><first>Alejandro</first><last>Catala</last></author>
+        <author><first>Jose M.</first><last>Alonso</last></author>
+        <author><first>Alberto</first><last>Bugarin</last></author>
 				<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>36-41</pages>
         <year>2018</year>
@@ -26585,12 +26585,12 @@
 
    <paper id="6709">
         <title>ChatEval: A Tool for the Systematic Evaluation of Chatbots</title>
-        <author>João Sedoc</author>
-        <author>Daphne Ippolito</author>
-        <author>Arun Kirubarajan</author>
-	   <author>Jai Thirani</author>
-	   <author>Lyle Ungar</author>
-	   <author>Chris Callison-Burch</author>
+        <author><first>João</first><last>Sedoc</last></author>
+        <author><first>Daphne</first><last>Ippolito</last></author>
+        <author><first>Arun</first><last>Kirubarajan</last></author>
+	   <author><first>Jai</first><last>Thirani</last></author>
+	   <author><first>Lyle</first><last>Ungar</last></author>
+	   <author><first>Chris</first><last>Callison-Burch</last></author>
 		 <booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>42-44</pages>
         <year>2018</year>
@@ -26603,10 +26603,10 @@
    
    <paper id="6710">
         <title>CheckYourMeal!: diet management with NLG</title>
-        <author>Luca Anselma</author>
-	   <author>Simone Donetti</author>
-	   <author>Alessandro Mazzei</author>
-	   <author>Andrea Pirone</author>  
+        <author><first>Luca</first><last>Anselma</last></author>
+	   <author><first>Simone</first><last>Donetti</last></author>
+	   <author><first>Alessandro</first><last>Mazzei</last></author>
+	   <author><first>Andrea</first><last>Pirone</last></author>  
 		<booktitle>Proceedings of the Workshop on Intelligent Interactive Systems and Language Generation (2IS&#38;NLG) </booktitle>
         <pages>45-47</pages>
         <year>2018</year>
@@ -26619,9 +26619,9 @@
 
    <paper id="6900">
     <title>Proceedings of the Workshop on NLG for Human–Robot Interaction</title>
-    <editor>Mary Ellen Foster</editor>
-    <editor>Hendrik Buschmeier</editor>
-    <editor>Dimitra Gkatzia</editor>
+    <editor><first>Mary Ellen</first><last>Foster</last></editor>
+    <editor><first>Hendrik</first><last>Buschmeier</last></editor>
+    <editor><first>Dimitra</first><last>Gkatzia</last></editor>
     <month>November</month>
     <year>2018</year>
     <address>Tilburg, The Netherlands</address>
@@ -26800,11 +26800,11 @@
   </paper>
 
    <paper id="7000">
-	      <editor>Arne Jönsson</editor>
-        <editor>Evelina Rennes</editor>
-        <editor>Horacio Saggion</editor>
-        <editor>Sanja Stajner</editor>
-				<editor>Victoria Yaneva</editor>
+	      <editor><first>Arne</first><last>Jönsson</last></editor>
+        <editor><first>Evelina</first><last>Rennes</last></editor>
+        <editor><first>Horacio</first><last>Saggion</last></editor>
+        <editor><first>Sanja</first><last>Stajner</last></editor>
+				<editor><first>Victoria</first><last>Yaneva</last></editor>
 				<title>Proceedings of the 1st Workshop on Automatic Text Adaptation (ATA)</title>
         <year>2018</year>
         <month>November</month>
@@ -26816,7 +26816,7 @@
 
    <paper id="7001">
         <title>The Interface Between Readability and Automatic Text Simplification</title>
-        <author>Thomas François</author> 
+        <author><first>Thomas</first><last>François</last></author> 
 				<booktitle>Proceedings of the 1st Workshop on Automatic Text Adaptation (ATA)</booktitle>
         <pages>1-2</pages>
         <year>2018</year>
@@ -26829,8 +26829,8 @@
 
    <paper id="7002">	   
         <title>CLEAR - Simple Corpus for Medical French</title>
-        <author>Natalia Grabar</author>
-        <author>Rémi Cardon</author>
+        <author><first>Natalia</first><last>Grabar</last></author>
+        <author><first>Rémi</first><last>Cardon</last></author>
 					<booktitle>Proceedings of the 1st Workshop on Automatic Text Adaptation (ATA)</booktitle>
         <pages>3-9</pages>
         <year>2018</year>
@@ -26843,9 +26843,9 @@
 
    <paper id="7003">	   
         <title>Study of Readability of Health Documents with Eye-tracking Approaches</title>
-				<author>Natalia Grabar</author>
-        <author>Emmanuel Farce</author>
-        <author>Laurent Sparrow</author>
+				<author><first>Natalia</first><last>Grabar</last></author>
+        <author><first>Emmanuel</first><last>Farce</last></author>
+        <author><first>Laurent</first><last>Sparrow</last></author>
 			<booktitle>Proceedings of the 1st Workshop on Automatic Text Adaptation (ATA)</booktitle>
         <pages>10-20</pages>
         <year>2018</year>
@@ -26858,10 +26858,10 @@
 	
 <paper id="7004">
         <title>Assisted Lexical Simplification for French Native Children with Reading Difficulties</title>
-        <author>Firas Hmida</author>
-        <author>Mokhtar B. Billami</author>
-        <author>Thomas François</author> 
-	    <author>Núria Gala</author>
+        <author><first>Firas</first><last>Hmida</last></author>
+        <author><first>Mokhtar B.</first><last>Billami</last></author>
+        <author><first>Thomas</first><last>François</last></author> 
+	    <author><first>Núria</first><last>Gala</last></author>
 				<booktitle>Proceedings of the 1st Workshop on Automatic Text Adaptation (ATA)</booktitle>
         <pages>21-28</pages>
         <year>2018</year>
@@ -26874,12 +26874,12 @@
 
    <paper id="7005">
 				<title>Reference-less Quality Estimation of Text Simplification Systems</title>
-        <author>Louis Martin</author>
-        <author>Samuel Humeau</author>
-				<author>Pierre-Emmanuel Mazaré</author>
-        <author>Éric De La Clergerie</author>
-				<author>Antoine Bordes</author>
-				<author>Benoît Sagot</author>
+        <author><first>Louis</first><last>Martin</last></author>
+        <author><first>Samuel</first><last>Humeau</last></author>
+				<author><first>Pierre-Emmanuel</first><last>Mazaré</last></author>
+        <author><first>Éric De La</first><last>Clergerie</last></author>
+				<author><first>Antoine</first><last>Bordes</last></author>
+				<author><first>Benoît</first><last>Sagot</last></author>
 				<booktitle>Proceedings of the 1st Workshop on Automatic Text Adaptation (ATA)</booktitle>
         <pages>29-38</pages>
         <year>2018</year>
@@ -26892,8 +26892,8 @@
 
    <paper id="7006">
         <title>Improving Machine Translation of English Relative Clauses with Automatic Text Simplification</title>
-        <author>Sanja Stanjer</author>
-        <author>Maja Popovíc</author>
+        <author><first>Sanja</first><last>Stanjer</last></author>
+        <author><first>Maja</first><last>Popovíc</last></author>
 				<booktitle>Proceedings of the 1st Workshop on Automatic Text Adaptation (ATA)</booktitle>
         <pages>39-48</pages>
         <year>2018</year>
@@ -26906,10 +26906,10 @@
 
   <paper id="7100">
         <title>Proceedings of the 7th workshop on NLP for Computer Assisted Language Learning</title>
-		<editor>Ildikó Pilán</editor>
-        <editor>Elena Volodina</editor>
-		<editor>David Alfter</editor>
-        <editor>Lars Borin</editor>
+		<editor><first>Ildikó</first><last>Pilán</last></editor>
+        <editor><first>Elena</first><last>Volodina</last></editor>
+		<editor><first>David</first><last>Alfter</last></editor>
+        <editor><first>Lars</first><last>Borin</last></editor>
         <month>November</month>
         <year>2018</year>
         <address>Stockholm, Sweden</address>

--- a/import/W19.xml
+++ b/import/W19.xml
@@ -2,18 +2,18 @@
  <volume id="W19">
    <paper id="0100">
         <title>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</title>
-        <editor>Gaja Jarosz</editor>
-        <editor>Max Nelson</editor>
-        <editor>Brendan O'Connor</editor>
-        <editor>Joe Pater</editor>
+        <editor><first>Gaja</first><last>Jarosz</last></editor>
+        <editor><first>Max</first><last>Nelson</last></editor>
+        <editor><first>Brendan</first><last>O'Connor</last></editor>
+        <editor><first>Joe</first><last>Pater</last></editor>
         <pages>i-ii</pages>
         <doi>10.7275/ntf6-xx21</doi>
    </paper>
 
    <paper id="0101">
         <title>Can Entropy Explain Successor Surprisal Effects in Reading?</title>
-        <author>Marten van Schijndel</author>
-        <author>Tal Linzen</author>
+        <author><first>Marten</first><last>van Schijndel</last></author>
+        <author><first>Tal</first><last>Linzen</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>1-7</pages>
         <doi>10.7275/qtbb-9d05</doi>
@@ -21,8 +21,8 @@
 
    <paper id="0102">
         <title>RedTyp: A Database of Reduplication with Computational Models</title>
-        <author>Hossep Dolatian</author>
-        <author>Jeffrey Heinz</author>
+        <author><first>Hossep</first><last>Dolatian</last></author>
+        <author><first>Jeffrey</first><last>Heinz</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>8-18</pages>
         <doi>10.7275/ckx7-s770</doi>
@@ -30,8 +30,8 @@
 
    <paper id="0103">
         <title>Unsupervised Learning of Cross-Lingual Symbol Embeddings Without Parallel Data</title>
-        <author>Mark Granroth-Wilding</author>
-        <author>Hannu Toivonen</author>
+        <author><first>Mark</first><last>Granroth-Wilding</last></author>
+        <author><first>Hannu</first><last>Toivonen</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>19-28</pages>
         <doi>10.7275/wx64-ea83</doi>
@@ -39,8 +39,8 @@
 
    <paper id="0104">
         <title>Q-Theory Representations are Logically Equivalent to Autosegmental Representations</title>
-        <author>Nick Danis</author>
-        <author>Adam Jardine</author>
+        <author><first>Nick</first><last>Danis</last></author>
+        <author><first>Adam</first><last>Jardine</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>29-38</pages>
         <doi>10.7275/tvj1-k306</doi>
@@ -48,9 +48,9 @@
 
    <paper id="0105">
         <title>Modeling Clausal Complementation for a Grammar Engineering Resource</title>
-        <author>Olga Zamaraeva</author>
-        <author>Kristen Howell</author>
-        <author>Emily M. Bender</author>
+        <author><first>Olga</first><last>Zamaraeva</last></author>
+        <author><first>Kristen</first><last>Howell</last></author>
+        <author><first>Emily M.</first><last>Bender</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>39-49</pages>
         <doi>10.7275/dygn-c796</doi>
@@ -58,8 +58,8 @@
 
    <paper id="0106">
         <title>Do RNNs learn human-like abstract word order preferences?</title>
-        <author>Richard Futrell</author>
-        <author>Roger P. Levy</author>
+        <author><first>Richard</first><last>Futrell</last></author>
+        <author><first>Roger P.</first><last>Levy</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>50-59</pages>
         <doi>10.7275/jb34-9986</doi>
@@ -67,7 +67,7 @@
 
    <paper id="0107">
         <title>Segmentation and UR Acquisition with UR Constraints </title>
-        <author>Max Nelson</author>
+        <author><first>Max</first><last>Nelson</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>60-68</pages>
         <doi>10.7275/zc9d-pn56</doi>
@@ -75,7 +75,7 @@
 
    <paper id="0108">
         <title>Constraint breeding during on-line incremental learning</title>
-        <author>Elliot Moreton</author>
+        <author><first>Elliot</first><last>Moreton</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>69-80</pages>
         <doi>10.7275/6f9x-6411</doi>
@@ -83,9 +83,9 @@
 
    <paper id="0109">
         <title>An Incremental Iterated Response Model of Pragmatics</title>
-        <author>Reuben Cohn-Gordon</author>
-        <author>Noah Goodman</author>
-        <author>Christopher Potts</author>
+        <author><first>Reuben</first><last>Cohn-Gordon</last></author>
+        <author><first>Noah</first><last>Goodman</last></author>
+        <author><first>Christopher</first><last>Potts</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>81-90</pages>
         <doi>10.7275/cprc-8x17</doi>
@@ -93,10 +93,10 @@
 
    <paper id="0110">
         <title>Learning Exceptionality and Variation with Lexically Scaled MaxEnt</title>
-        <author>Coral Hughto</author>
-        <author>Andrew Lamont</author>
-        <author>Brandon Prickett</author>
-        <author>Gaja Jarosz</author>
+        <author><first>Coral</first><last>Hughto</last></author>
+        <author><first>Andrew</first><last>Lamont</last></author>
+        <author><first>Brandon</first><last>Prickett</last></author>
+        <author><first>Gaja</first><last>Jarosz</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>91-101</pages>
         <doi>10.7275/y68s-kh12</doi>
@@ -104,7 +104,7 @@
 
    <paper id="0111">
         <title>Learning complex inflectional paradigms through blended gradient inputs</title>
-        <author>Eric R. Rosen</author>
+        <author><first>Eric R.</first><last>Rosen</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>102-112</pages>
         <doi>10.7275/ccwf-j606</doi>
@@ -112,8 +112,8 @@
 
    <paper id="0112">
         <title>Jabberwocky Parsing: Dependency Parsing with Lexical Noise</title>
-        <author>Jungo Kasai</author>
-        <author>Robert Frank</author>
+        <author><first>Jungo</first><last>Kasai</last></author>
+        <author><first>Robert</first><last>Frank</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>113-123</pages>
         <doi>10.7275/h12q-k754</doi>
@@ -121,7 +121,7 @@
 
    <paper id="0113">
         <title>Learnability and Overgeneration in Computational Syntax</title>
-        <author>Yiding Hao</author>
+        <author><first>Yiding</first><last>Hao</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>124-134</pages>
         <doi>10.7275/1qmz-bg76</doi>
@@ -129,8 +129,8 @@
 
    <paper id="0114">
         <title>A Conceptual Spaces Model of Socially Motivated Language Change</title>
-        <author>Heather Burnett</author>
-        <author>Olivier Bonami</author>
+        <author><first>Heather</first><last>Burnett</last></author>
+        <author><first>Olivier</first><last>Bonami</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>135-145</pages>
         <doi>10.7275/5vmp-cs05</doi>
@@ -138,7 +138,7 @@
 
    <paper id="0115">
         <title>Identifying Participation of Individual Verbs or VerbNet Classes in the Causative Alternation</title>
-        <author>Esther Seyffarth</author>
+        <author><first>Esther</first><last>Seyffarth</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>146-155</pages>
         <doi>10.7275/efvz-jy59</doi>
@@ -146,8 +146,8 @@
 
    <paper id="0116">
         <title>Using Sentiment Induction to Understand Variation in Gendered Online Communities</title>
-        <author>Lucy Li</author>
-        <author>Julia Mendelsohn</author>
+        <author><first>Lucy</first><last>Li</last></author>
+        <author><first>Julia</first><last>Mendelsohn</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>156-166</pages>
         <doi>10.7275/11wq-ep51</doi>
@@ -155,10 +155,10 @@
 
    <paper id="0117">
         <title>On the difficulty of a distributional semantics of spoken language</title>
-        <author>Grzegorz Chrupa&#322;a</author>
-        <author>Lieke Gelderloos</author>
-        <author>Ákos K&#225;d&#225;r</author>
-        <author>Afra Alishahi</author>
+        <author><first>Grzegorz</first><last>Chrupa&#322;a</last></author>
+        <author><first>Lieke</first><last>Gelderloos</last></author>
+        <author><first>Ákos</first><last>K&#225;d&#225;r</last></author>
+        <author><first>Afra</first><last>Alishahi</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>167-173</pages>
         <doi>10.7275/extq-7546</doi>
@@ -166,9 +166,9 @@
 
    <paper id="0118">
         <title>Distributional Effects of Gender Contrasts Across Categories</title>
-        <author>Timothee Mickus</author>
-        <author>Olivier Bonami</author>
-        <author>Denis Paperno</author>
+        <author><first>Timothee</first><last>Mickus</last></author>
+        <author><first>Olivier</first><last>Bonami</last></author>
+        <author><first>Denis</first><last>Paperno</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>174-184</pages>
         <doi>10.7275/g11b-3s25</doi>
@@ -176,8 +176,8 @@
 
    <paper id="0119">
         <title>Guess Who's Coming (and Who's Going): Bringing Perspective to the Rational Speech Acts Framework</title>
-        <author>Carolyn Jane Anderson</author>
-        <author>Brian W. Dillon</author>
+        <author><first>Carolyn Jane</first><last>Anderson</last></author>
+        <author><first>Brian W.</first><last>Dillon</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>185-194</pages>
         <doi>10.7275/9bn3-8x38</doi>
@@ -185,7 +185,7 @@
 
    <paper id="0120">
         <title>The organization of sound inventories: A study on obstruent gaps</title>
-        <author>Sheng-Fu Wang</author>
+        <author><first>Sheng-Fu</first><last>Wang</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>195-204</pages>
         <doi>10.7275/pbe8-zf60</doi>
@@ -193,8 +193,8 @@
 
    <paper id="0121">
         <title>C-Command Dependencies as TSL String Constraints</title>
-        <author>Thomas Graf</author>
-        <author>Nazila Shafiei</author>
+        <author><first>Thomas</first><last>Graf</last></author>
+        <author><first>Nazila</first><last>Shafiei</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>205-215</pages>
         <doi>10.7275/4rrx-x488</doi>
@@ -202,9 +202,9 @@
 
    <paper id="0122">
         <title>Modeling the Acquisition of Words with Multiple Meanings</title>
-        <author>Libby Barak</author>
-        <author>Sammy Floyd</author>
-        <author>Adele Goldberg</author>
+        <author><first>Libby</first><last>Barak</last></author>
+        <author><first>Sammy</first><last>Floyd</last></author>
+        <author><first>Adele</first><last>Goldberg</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>216-225</pages>
         <doi>10.7275/tr21-m273</doi>
@@ -212,7 +212,7 @@
 
    <paper id="0123">
         <title>Evaluation Order Effects in Dynamic Continuized CCG: From Negative Polarity Items to Balanced Punctuation</title>
-        <author>Michael White</author>
+        <author><first>Michael</first><last>White</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>226-235</pages>
         <doi>10.7275/kpch-rk05</doi>
@@ -220,10 +220,10 @@
 
    <paper id="0124">
         <title>Abstract Meaning Representation for Human-Robot Dialogue</title>
-        <author>Claire N. Bonial</author>
-        <author>Lucia Donatelli</author>
-        <author>Jessica Ervin</author>
-        <author>Clare R. Voss</author>
+        <author><first>Claire N.</first><last>Bonial</last></author>
+        <author><first>Lucia</first><last>Donatelli</last></author>
+        <author><first>Jessica</first><last>Ervin</last></author>
+        <author><first>Clare R.</first><last>Voss</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>236-246</pages>
         <doi>10.7275/v3c5-yd35</doi>
@@ -231,8 +231,8 @@
 
    <paper id="0125">
         <title>A Logical and Computational Methodology for Exploring Systems of Phonotactic Constraints</title>
-        <author>Dakotah Lambert</author>
-        <author>James Rogers</author>
+        <author><first>Dakotah</first><last>Lambert</last></author>
+        <author><first>James</first><last>Rogers</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>247-256</pages>
         <doi>10.7275/t0dv-9t05</doi>
@@ -240,8 +240,8 @@
 
    <paper id="0126">
         <title>Augmentic Compositional Models for Knowledge Base Completion Using Gradient Representations</title>
-        <author>Matthias R. Lalisse</author>
-        <author>Paul Smolensky</author>
+        <author><first>Matthias R.</first><last>Lalisse</last></author>
+        <author><first>Paul</first><last>Smolensky</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>257-266</pages>
         <doi>10.7275/8et8-qd83</doi>
@@ -249,9 +249,9 @@
 
    <paper id="0127">
         <title>Case assignment in TSL syntax: a case study</title>
-        <author>Mai Ha Vu</author>
-        <author>Nazila Shafiei</author>
-        <author>Thomas Graf</author>
+        <author><first>Mai Ha</first><last>Vu</last></author>
+        <author><first>Nazila</first><last>Shafiei</last></author>
+        <author><first>Thomas</first><last>Graf</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>267-276</pages>
         <doi>10.7275/sywz-xw23</doi>
@@ -259,9 +259,9 @@
 
    <paper id="0128">
         <title>On Evaluating the Generalization of LSTM Models in Formal Languages</title>
-        <author>Mirac Suzgun</author>
-        <author>Yonatan Belinkov</author>
-        <author>Stuart M. Shieber</author>
+        <author><first>Mirac</first><last>Suzgun</last></author>
+        <author><first>Yonatan</first><last>Belinkov</last></author>
+        <author><first>Stuart M.</first><last>Shieber</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>277-286</pages>
         <doi>10.7275/s02b-4d91</doi>
@@ -269,10 +269,10 @@
 
    <paper id="0129">
         <title>Verb Argument Structure Alternations in Word and Sentence Embeddings</title>
-        <author>Katharina Kann</author>
-        <author>Alex Warstadt</author>
-        <author>Adina Williams</author>
-        <author>Samuel R. Bowman</author>
+        <author><first>Katharina</first><last>Kann</last></author>
+        <author><first>Alex</first><last>Warstadt</last></author>
+        <author><first>Adina</first><last>Williams</last></author>
+        <author><first>Samuel R.</first><last>Bowman</last></author>
         <booktitle>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</booktitle>
         <pages>287-297</pages>
         <doi>10.7275/q5js-4y86</doi>

--- a/import/Y03.xml
+++ b/import/Y03.xml
@@ -2,7 +2,7 @@
   <paper id="1000">
     <title>Proceedings of the 17th Pacific Asia Conference on Language, Information and Computation</title>
     <editor><first>Dong Hong</first><last>Ji</last></editor>
-    <editor><first>Kim Teng</first><last></last>Lua</editor>
+    <editor><first>Kim Teng</first><last>Lua</last></editor>
     <month>October</month>
     <year>2003</year>
     <address>Sentosa, Singapore</address>

--- a/import/Y04.xml
+++ b/import/Y04.xml
@@ -327,7 +327,6 @@
     <title>A Unified Model of Thai Romanization and Word Segmentation</title>
     <author><first>Wirote</first><last>Aroonmanakun</last></author>
     <booktitle>Language, Information and Computation : Proceedings of the 18th Pacific Asia Conference, 8-10 December, 2004, Waseda University, Tokyo, Japan</booktitle>
-    <booktitle>Language, Information and Computation : Proceedings of the 18th Pacific Asia Conference, 8-10 December, 2004, Waseda University, Tokyo, Japan</booktitle>
     <month>December</month>
     <year>2004</year>
     <address>Waseda University, Tokyo, Japan</address>
@@ -336,7 +335,6 @@
     <url>http://www.aclweb.org/anthology/Y04-1021</url>
     <doi>http://hdl.handle.net/2065/574</doi>
     <bibtype>inproceedings</bibtype>
-    <booktitle>Language, Information and Computation : Proceedings of the 18th Pacific Asia Conference, 8-10 December, 2004, Waseda University, Tokyo, Japan</booktitle>
   </paper>
   <paper id="1022">
     <title>Scalar Meanings of the Concessive (-to), the Contrastive Topic Marker (-nun) and -man 'only' in Korean (and Japanese)</title>

--- a/import/Y96.xml
+++ b/import/Y96.xml
@@ -2,7 +2,7 @@
   <paper id="1000">
     <title>Proceedings of the 11th Pacific Asia Conference on Language, Information and Computation</title>
     <editor><first>Byung-Soo</first><last>Park</last></editor>
-    <editor><first>Jong-Bok</first><last></last>Kim</editor>
+    <editor><first>Jong-Bok</first><last>Kim</last></editor>
     <month>December</month>
     <year>1996</year>
     <address>Seoul, Korea</address>

--- a/import/schema.rnc
+++ b/import/schema.rnc
@@ -2,62 +2,58 @@
 
 b = element b { text }
 i = element i { text }
+sup = element SUP { xsd:NCName }
 first = element first { text }
 last = element last { text }
-von = element von { text }
 jr = element jr { text }
-Person = (text | first | jr | last | von)+
+Person = (first?, last, jr?)
+MarkupText = (text | b | i | sup)+
 Paper = element paper {
   attribute id { xsd:integer },
   attribute href { xsd:anyURI }?,
-  (element abstract { (text | b | i)+ }
-   | element address { text }
-   | element attachment {
+  (element abstract { MarkupText }?
+   & element address { text }?
+   & element attachment {
        attribute type { xsd:NCName }?,
        xsd:NCName
-     }
-   | element author { Person }
-   | element bibkey { text }
-   | element bibtype { xsd:NCName }
-   | element booktitle { text }
-   | element dataset { xsd:NCName }
-   | element doi { xsd:anyURI }
-   | element editor { (text | first | jr | last | von)+ }
-   | element erratum {
+     }*
+   & element author { Person }*
+   & element bibkey { text }?
+   & element bibtype { xsd:NCName }?
+   & element booktitle { text }?
+   & element dataset { xsd:NCName }?
+   & element doi { xsd:anyURI }?
+   & element editor { Person }*
+   & element erratum {
        attribute id { xsd:integer },
        xsd:NCName
-     }
-   | element href { xsd:anyURI }
-   | element ISBN { xsd:NMTOKEN }
-   | element isbn { xsd:NMTOKEN }
-   | element issue { xsd:integer }
-   | element journal { text }
-   | element month { text }
-   | element mrf {
+     }?
+   & element href { xsd:anyURI }?
+   & (element ISBN { xsd:NMTOKEN } | element isbn { xsd:NMTOKEN })?
+   & element issue { xsd:integer }?
+   & element journal { text }?
+   & element month { text }?
+   & element mrf {
        attribute src { xsd:NCName },
        xsd:NCName
-     }
-   | element pages { text }
-   | element presentation { xsd:NCName }
-   | element publisher { text }
-   | element revision {
+     }?
+   & element pages { text }?
+   & element presentation { xsd:NCName }?
+   & element publisher { text }?
+   & element revision {
        attribute id { xsd:integer },
        xsd:NCName
-     }
-   | element software { xsd:NCName }
-   | element title {
-       (text
-        | b
-        | i
-        | element SUP { xsd:NCName })+
-     }
-   | element url { xsd:anyURI }
-   | element video {
+     }?
+   & element software { xsd:NCName }?
+   & element title { MarkupText }
+   & element url { xsd:anyURI }?
+   & element video {
        attribute href { xsd:anyURI },
        attribute tag { text }
-     }
-   | element volume { xsd:integer }
-   | element year { xsd:integer })+
+     }*
+   & element volume { xsd:integer }?
+   & element year { xsd:integer }?
+   )
 }
 Volume = element volume {
   attribute id { xsd:NCName },

--- a/import/schema.rng
+++ b/import/schema.rng
@@ -11,6 +11,11 @@
       <text/>
     </element>
   </define>
+  <define name="sup">
+    <element name="SUP">
+      <data type="NCName"/>
+    </element>
+  </define>
   <define name="first">
     <element name="first">
       <text/>
@@ -21,24 +26,27 @@
       <text/>
     </element>
   </define>
-  <define name="von">
-    <element name="von">
-      <text/>
-    </element>
-  </define>
   <define name="jr">
     <element name="jr">
       <text/>
     </element>
   </define>
   <define name="Person">
+    <optional>
+      <ref name="first"/>
+    </optional>
+    <ref name="last"/>
+    <optional>
+      <ref name="jr"/>
+    </optional>
+  </define>
+  <define name="MarkupText">
     <oneOrMore>
       <choice>
         <text/>
-        <ref name="first"/>
-        <ref name="jr"/>
-        <ref name="last"/>
-        <ref name="von"/>
+        <ref name="b"/>
+        <ref name="i"/>
+        <ref name="sup"/>
       </choice>
     </oneOrMore>
   </define>
@@ -52,20 +60,18 @@
           <data type="anyURI"/>
         </attribute>
       </optional>
-      <oneOrMore>
-        <choice>
+      <interleave>
+        <optional>
           <element name="abstract">
-            <oneOrMore>
-              <choice>
-                <text/>
-                <ref name="b"/>
-                <ref name="i"/>
-              </choice>
-            </oneOrMore>
+            <ref name="MarkupText"/>
           </element>
+        </optional>
+        <optional>
           <element name="address">
             <text/>
           </element>
+        </optional>
+        <zeroOrMore>
           <element name="attachment">
             <optional>
               <attribute name="type">
@@ -74,112 +80,143 @@
             </optional>
             <data type="NCName"/>
           </element>
+        </zeroOrMore>
+        <zeroOrMore>
           <element name="author">
             <ref name="Person"/>
           </element>
+        </zeroOrMore>
+        <optional>
           <element name="bibkey">
             <text/>
           </element>
+        </optional>
+        <optional>
           <element name="bibtype">
             <data type="NCName"/>
           </element>
+        </optional>
+        <optional>
           <element name="booktitle">
             <text/>
           </element>
+        </optional>
+        <optional>
           <element name="dataset">
             <data type="NCName"/>
           </element>
+        </optional>
+        <optional>
           <element name="doi">
             <data type="anyURI"/>
           </element>
+        </optional>
+        <zeroOrMore>
           <element name="editor">
-            <oneOrMore>
-              <choice>
-                <text/>
-                <ref name="first"/>
-                <ref name="jr"/>
-                <ref name="last"/>
-                <ref name="von"/>
-              </choice>
-            </oneOrMore>
+            <ref name="Person"/>
           </element>
+        </zeroOrMore>
+        <optional>
           <element name="erratum">
             <attribute name="id">
               <data type="integer"/>
             </attribute>
             <data type="NCName"/>
           </element>
+        </optional>
+        <optional>
           <element name="href">
             <data type="anyURI"/>
           </element>
-          <element name="ISBN">
-            <data type="NMTOKEN"/>
-          </element>
-          <element name="isbn">
-            <data type="NMTOKEN"/>
-          </element>
+        </optional>
+        <optional>
+          <choice>
+            <element name="ISBN">
+              <data type="NMTOKEN"/>
+            </element>
+            <element name="isbn">
+              <data type="NMTOKEN"/>
+            </element>
+          </choice>
+        </optional>
+        <optional>
           <element name="issue">
             <data type="integer"/>
           </element>
+        </optional>
+        <optional>
           <element name="journal">
             <text/>
           </element>
+        </optional>
+        <optional>
           <element name="month">
             <text/>
           </element>
+        </optional>
+        <optional>
           <element name="mrf">
             <attribute name="src">
               <data type="NCName"/>
             </attribute>
             <data type="NCName"/>
           </element>
+        </optional>
+        <optional>
           <element name="pages">
             <text/>
           </element>
+        </optional>
+        <optional>
           <element name="presentation">
             <data type="NCName"/>
           </element>
+        </optional>
+        <optional>
           <element name="publisher">
             <text/>
           </element>
+        </optional>
+        <optional>
           <element name="revision">
             <attribute name="id">
               <data type="integer"/>
             </attribute>
             <data type="NCName"/>
           </element>
+        </optional>
+        <optional>
           <element name="software">
             <data type="NCName"/>
           </element>
-          <element name="title">
-            <oneOrMore>
-              <choice>
-                <text/>
-                <ref name="b"/>
-                <ref name="i"/>
-                <element name="SUP">
-                  <data type="NCName"/>
-                </element>
-              </choice>
-            </oneOrMore>
-          </element>
+        </optional>
+        <element name="title">
+          <ref name="MarkupText"/>
+        </element>
+        <optional>
           <element name="url">
             <data type="anyURI"/>
           </element>
+        </optional>
+        <zeroOrMore>
           <element name="video">
             <attribute name="href">
               <data type="anyURI"/>
             </attribute>
             <attribute name="tag"/>
           </element>
+        </zeroOrMore>
+        <optional>
           <element name="volume">
             <data type="integer"/>
           </element>
+        </optional>
+        <optional>
           <element name="year">
             <data type="integer"/>
           </element>
-        </choice>
-      </oneOrMore>
+        </optional>
+      </interleave>
     </element>
   </define>
   <define name="Volume">


### PR DESCRIPTION
This PR improves the authoritative XML in the following ways:

1. Fix errors described in #127 
2. Run the `bin/parsenames.pl` script on some XML files that were missing `<first></first><last></last>` elements. This is already causing issues on the live website; for example, [Martin van Schijndel](https://aclanthology.info/people/marten-van-schijndel-303a8589-195c-418f-9bf5-701221d96858) who published in W19 is not considered to be the same person as [Martin van Schijndel](https://aclanthology.info/people/marten-van-schijndel-bcdb2fd2-ba5a-4fa6-b91b-c9f246068d52).
3. Tighten up the RelaxNG schema. This involves:
  a) Enforcing that all person names must have `<first></first><last></last>` (and optionally `<jr></jr>`) annotations.
  b) Removing the deprecated `<von>` element.
  c) Making explicit that all elements inside a `<paper>` may only appear once, except where otherwise specified. Multiple elements are currently only allowed for `<author>`, `<editor>`, `<attachment>`, and `<video>`.
  d) Making all elements inside `<paper>` optional *except* for the `<title>` element.
4. Fix some minor errors uncovered by the new schema.

All XML files are successfully validated with this updated schema.