### PR TITLE
update links to Robyn Speer's papers that have new versions

### DIFF
--- a/import/S17.xml
+++ b/import/S17.xml
@@ -1708,7 +1708,7 @@
     <address>Vancouver, Canada</address>
     <publisher>Association for Computational Linguistics</publisher>
     <pages>85–89</pages>
-    <url>http://www.aclweb.org/anthology/S17-2008</url>
+    <url>http://www.aclweb.org/anthology/S17-2008v2</url>
     <doi>10.18653/v1/S17-2008</doi>
     <abstract>
       This paper describes Luminoso's participation in SemEval 2017 Task 2,

--- a/import/S18.xml
+++ b/import/S18.xml
@@ -6659,7 +6659,7 @@
       semantically-informed features to achieve an F1 score of 0.7368 on the
       task, close to the task’s high score of 0.75.
     </abstract>
-    <url>http://www.aclweb.org/anthology/S18-1162</url>
+    <url>http://www.aclweb.org/anthology/S18-1162v2</url>
     <doi>10.18653/v1/S18-1162</doi>
     <bibtype>inproceedings</bibtype>
     <bibkey>speer-lowryduda:2018:S18-1</bibkey>


### PR DESCRIPTION
This is a follow-up to #117. On the two papers that I updated the .pdf of, the ACL Anthology metadata now shows my correct name and contains a link to the updated version of the paper, but the "URL" field and the DOI still resolve to the old version of the paper.

I'm fixing the contents of the URL fields in this PR. I don't know whether that will update the DOI.