### PR TITLE
Added abstracts to EMNLP 2018 (D18). Also fixed a few titles.

### DIFF
--- a/import/D18.xml
+++ b/import/D18.xml
@@ -27,6 +27,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1–10</pages>
     <url>http://www.aclweb.org/anthology/D18-1001</url>
+    <abstract>This article deals with adversarial attacks towards deep learning systems for Natural Language Processing (NLP), in the context of privacy protection. We study a specific type of attack: an attacker eavesdrops on the hidden representations of a neural text classifier and tries to recover information about the input text. Such scenario may arise in situations when the computation of a neural network is shared across multiple devices, e.g. some hidden representation is computed by a user's device and sent to a cloud-based model. We measure the privacy of a hidden representation by the ability of an attacker to predict accurately specific private information from it and characterize the tradeoff between the privacy and the utility of neural representations. Finally, we propose several defense methods based on modified training objectives and show that they improve the privacy of neural representations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>coavoux-narayan-cohen:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305202770" tag="video" />
@@ -44,6 +45,7 @@
     <pages>11–21</pages>
     <url>http://www.aclweb.org/anthology/D18-1002</url>
     <attachment type="attachment">D18-1002.Attachment.pdf</attachment>
+    <abstract>Recent advances in Representation Learning and Adversarial Training seem to succeed in removing unwanted features from the learned representation. We show that demographic information of authors is encoded in---and can be recovered from---the intermediate representations learned by text-based neural classifiers. The implication is that decisions of classifiers trained on textual data are not agnostic to---and likely condition on---demographic attributes. When attempting to remove such demographic information using adversarial training, we find that while the adversarial component achieves chance-level development-set accuracy during training, a post-hoc classifier, trained on the encoded sentences from the first part, still manages to reach substantially higher classification accuracies on the same data. This behavior is consistent across several tasks, demographic properties and datasets. We explore several techniques to improve the effectiveness of the adversarial component. Our main conclusion is a cautionary one: do not rely on the adversarial training to achieve invariant representation to sensitive features.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>elazar-goldberg:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305203150" tag="video" />
@@ -62,6 +64,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>22–32</pages>
     <url>http://www.aclweb.org/anthology/D18-1003</url>
+    <abstract>Misinformation such as fake news is one of the big challenges of our society. Research on automated fact-checking has proposed methods based on supervised learning, but these approaches do not consider external evidence apart from labeled training instances. Recent approaches counter this deficit by considering external sources related to a claim. However, these methods require substantial feature modeling and rich lexicons. This paper overcomes these limitations of prior work with an end-to-end model for evidence-aware credibility assessment of arbitrary textual claims, without any human intervention. It presents a neural network model that judiciously aggregates signals from external evidence articles, the language of these articles and the trustworthiness of their sources. It also derives informative features for generating user-comprehensible explanations that makes the neural network predictions transparent to the end-user. Experiments with four datasets and ablation studies show the strength of our method.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>popat-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305203523" tag="video" />
@@ -79,6 +82,7 @@
     <pages>33–45</pages>
     <url>http://www.aclweb.org/anthology/D18-1004</url>
     <attachment type="attachment">D18-1004.Attachment.pdf</attachment>
+    <abstract>People use online platforms to seek out support for their informational and emotional needs. Here, we ask what effect does revealing one's gender have on receiving support. To answer this, we create (i) a new dataset and method for identifying supportive replies and (ii) new methods for inferring gender from text and name. We apply these methods to create a new massive corpus of 102M online interactions with gender-labeled users, each rated by degree of supportiveness.  Our analysis shows wide-spread and consistent disparity in support: identifying as a woman is associated with higher rates of support - but also higher rates of disparagement.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-jurgens:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305203914" tag="video" />
@@ -103,6 +107,7 @@
     <pages>46–56</pages>
     <url>http://www.aclweb.org/anthology/D18-1005</url>
     <attachment type="attachment">D18-1005.Attachment.zip</attachment>
+    <abstract>Gang-involved youth in cities such as Chicago have increasingly turned to social media to post about their experiences and intents online. In some situations, when they experience the loss of a loved one, their online expression of emotion may evolve into aggression towards rival gangs and ultimately into real-world violence. In this paper, we present a novel system for detecting Aggression and Loss in social media. Our system features the use of domain-specific resources automatically derived from a large unlabeled corpus, and contextual representations of the emotional and semantic content of the user's recent tweets as well as their interactions with other users. Incorporating context in our Convolutional Neural Network (CNN) leads to a significant improvement.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chang-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305204297" tag="video" />
@@ -123,6 +128,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>57–66</pages>
     <url>http://www.aclweb.org/anthology/D18-1006</url>
+    <abstract>Comprehending procedural text, e.g., a paragraph describing photosynthesis, requires modeling actions and the state changes they produce, so that questions about entities at different timepoints can be answered. Although several recent systems have shown impressive progress in this task, their predictions can be globally inconsistent or highly improbable. In this paper, we show how the predicted effects of actions in the context of a paragraph can be improved in two ways: (1) by incorporating global, commonsense constraints (e.g., a non-existent entity cannot be destroyed), and (2) by biasing reading with preferences from large-scale corpora (e.g., trees rarely move). Unlike earlier methods, we treat the problem as a neural structured prediction task, allowing hard and soft constraints to steer the model away from unlikely predictions. We show that the new model significantly outperforms earlier systems on a benchmark dataset for procedural text comprehension (+8\% relative gain), and that it also avoids some of the nonsensical predictions that earlier systems make.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tandon-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305193585" tag="video" />
@@ -144,6 +150,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>67–81</pages>
     <url>http://www.aclweb.org/anthology/D18-1007</url>
+    <abstract>We present a large-scale collection of diverse natural language inference (NLI) datasets that help provide insight into how well a sentence representation captures distinct types of reasoning. The collection results from recasting 13 existing datasets from 7 semantic phenomena into a common NLI structure, resulting in over half a million labeled context-hypothesis pairs in total. We refer to our collection as the DNC: Diverse Natural Language Inference Collection. The DNC is available online at https://www.decomp.net, and will grow over time as additional resources are recast and added from novel sources.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>poliak-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305194062" tag="video" />
@@ -163,6 +170,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>82–92</pages>
     <url>http://www.aclweb.org/anthology/D18-1008</url>
+    <abstract>To understand a sentence like ``whereas only 10\% of White Americans live at or below the poverty line, 28\% of African Americans do''  it is important not only to identify individual facts, e.g., poverty rates of distinct demographic groups, but also the higher-order relations between them, e.g., the disparity between them. In this paper, we propose the task of Textual Analogy Parsing (TAP) to model this higher-order meaning. Given a sentence such as the one above, TAP outputs a frame-style meaning representation which explicitly specifies what is shared (e.g., poverty rates) and what is compared (e.g., White Americans vs. African Americans, 10\% vs. 28\%) between its component facts. Such a meaning representation can enable new applications that rely on discourse understanding such as automated chart generation from quantitative text. We present a new dataset for TAP, baselines, and a model that successfully uses an ILP to enforce the structural constraints of the problem.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lamm-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305194870" tag="video" />
@@ -182,6 +190,7 @@
     <pages>93–104</pages>
     <url>http://www.aclweb.org/anthology/D18-1009</url>
     <attachment type="attachment">D18-1009.Attachment.zip</attachment>
+    <abstract>Given a partial description like ``she opened the hood of the car,'' humans can reason about the situation and anticipate what might come next (''then, she examined the engine''). In this paper, we introduce the task of grounded commonsense inference, unifying natural language inference and commonsense reasoning. We present SWAG, a new dataset with 113k multiple choice questions about a rich spectrum of grounded situations. To address the recurring challenges of the annotation artifacts and human biases found in many existing datasets, we propose Adversarial Filtering (AF), a novel procedure that constructs a de-biased dataset by iteratively training an ensemble of stylistic classifiers, and using them to filter the data. To account for the aggressive adversarial filtering, we use state-of-the-art language models to massively oversample a diverse set of potential counterfactuals. Empirical results demonstrate that while humans can solve the resulting inference problems with high accuracy (88\%), various competitive models struggle on our task. We provide comprehensive analysis that indicates significant opportunities for future research.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zellers-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305195438" tag="video" />
@@ -198,6 +207,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>105–114</pages>
     <url>http://www.aclweb.org/anthology/D18-1010</url>
+    <abstract>Determining whether a given claim is supported by evidence is a fundamental NLP problem that is best modeled as Textual Entailment. However, given a large collection of text, finding evidence that could support or refute a given claim is a challenge in itself, amplified by the fact that different evidence might be needed to support or refute a claim. Nevertheless, most prior work decouples evidence finding from determining the truth value of the claim given the evidence. We propose to consider these two aspects jointly. We develop  TwoWingOS (two-wing  optimization strategy), a system that, while identifying appropriate evidence for a claim, also determines whether or not the claim is supported by the evidence. Given the claim, TwoWingOS attempts to identify a subset of the evidence candidates; given the predicted evidence, it then attempts to determine the truth value of the corresponding claim entailment problem. We treat this problem as coupled optimization problems, training a joint model for it. TwoWingOS offers two advantages: (i) Unlike pipeline systems it facilitates flexible-size evidence set, and (ii) Joint training  improves both the claim entailment and the evidence identification. Experiments on a  benchmark dataset show state-of-the-art performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yin-roth:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305195990" tag="video" />
@@ -215,6 +225,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>115–124</pages>
     <url>http://www.aclweb.org/anthology/D18-1011</url>
+    <abstract>In this paper we address the problem of learning multimodal word representations by integrating textual, visual and auditory inputs. Inspired by the re-constructive and associative nature of human memory, we propose a novel associative multichannel autoencoder (AMA). Our model first learns the associations between textual and perceptual modalities, so as to predict the missing perceptual information of concepts. Then the textual and predicted perceptual representations are fused through reconstructing their original and associated embeddings. Using a gating mechanism our model assigns different weights to each modality according to the different concepts. Results on six benchmark concept similarity tests show that the proposed method significantly outperforms strong unimodal baselines and state-of-the-art multimodal models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-zhang-zong:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305209813" tag="video" />
@@ -232,6 +243,7 @@
     <pages>125–136</pages>
     <url>http://www.aclweb.org/anthology/D18-1012</url>
     <attachment type="attachment">D18-1012.Attachment.pdf</attachment>
+    <abstract>Current dialogue systems focus more on textual and speech context knowledge and are usually based on two speakers. Some recent work has investigated static image-based dialogue. However, several real-world human interactions also involve dynamic visual context (similar to videos) as well as dialogue exchanges among multiple speakers. To move closer towards such multimodal conversational skills and visually-situated applications, we introduce a new video-context, many-speaker dialogue dataset based on live-broadcast soccer game videos and chats from Twitch.tv. This challenging testbed allows us to develop visually-grounded dialogue models that should generate relevant temporal and spatial event language from the live video, while also being relevant to the chat history. For strong baselines, we also present several discriminative and generative models, e.g., based on tridirectional attention flow (TriDAF). We evaluate these models via retrieval ranking-recall, automatic phrase-matching metrics, as well as human evaluation studies. We also present dataset analyses, model ablations, and visualizations to understand the contribution of different modalities and model components.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pasunuru-bansal:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305210347" tag="video" />
@@ -251,6 +263,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>137–149</pages>
     <url>http://www.aclweb.org/anthology/D18-1013</url>
+    <abstract>The encode-decoder framework has shown recent success in image captioning. Visual attention, which is good at detailedness, and semantic attention, which is good at comprehensiveness, have been separately proposed to ground the caption on the image. In this paper, we propose the Stepwise Image-Topic Merging Network (simNet) that makes use of the two kinds of attention at the same time. At each time step when generating the caption, the decoder adaptively merges the attentive information in the extracted topics and the image according to the generated context, so that the visual information and the semantic information can be effectively combined. The proposed approach is evaluated on two benchmark datasets and reaches the state-of-the-art performances.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/305210529" tag="video" />
@@ -270,6 +283,7 @@
     <pages>150–161</pages>
     <url>http://www.aclweb.org/anthology/D18-1014</url>
     <attachment type="attachment">D18-1014.Attachment.zip</attachment>
+    <abstract>Computational modeling of human multimodal language is an emerging research area in natural language processing spanning the language, visual and acoustic modalities. Comprehending multimodal language requires modeling not only the interactions within each modality (intra-modal interactions) but more importantly the interactions between modalities (cross-modal interactions). In this paper, we propose the Recurrent Multistage Fusion Network (RMFN) which decomposes the fusion problem into multiple stages, each of them focused on a subset of multimodal signals for specialized, effective fusion. Cross-modal interactions are modeled using this multistage fusion approach which builds upon intermediate representations of previous stages. Temporal and intra-modal interactions are modeled by integrating our proposed fusion approach with a system of recurrent neural networks. The RMFN displays state-of-the-art performance in modeling human multimodal language across three public datasets relating to multimodal sentiment analysis, emotion recognition, and speaker traits recognition. We provide visualizations to show that each stage of fusion focuses on a different subset of multimodal signals, learning increasingly discriminative multimodal representations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liang-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305210831" tag="video" />
@@ -289,6 +303,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>162–171</pages>
     <url>http://www.aclweb.org/anthology/D18-1015</url>
+    <abstract>We introduce an effective and efficient method that grounds (i.e., localizes) natural sentences in long, untrimmed video sequences. Specifically, a novel Temporal GroundNet (TGN) is proposed to temporally capture the evolving fine-grained frame-by-word interactions between video and sentence. TGN sequentially scores a set of temporal candidates ended at each frame based on the exploited frame-by-word interactions, and finally grounds the segment corresponding to the sentence. Unlike traditional methods treating the overlapping segments separately in a sliding window fashion, TGN aggregates the historical information and generates the final grounding result in one single pass. We extensively evaluate our proposed TGN on three public datasets with significant improvements over the state-of-the-arts. We further show the consistent effectiveness and efficiency of TGN through an ablation study and a runtime test.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/305211326" tag="video" />
@@ -308,6 +323,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>172–181</pages>
     <url>http://www.aclweb.org/anthology/D18-1016</url>
+    <abstract>We introduce PreCo, a large-scale English dataset for coreference resolution. The dataset is designed to embody the core challenges in coreference, such as entity representation, by alleviating the challenge of low overlap between training and test sets and enabling separated analysis of mention detection and mention clustering. To strengthen the training-test overlap, we collect a large corpus of 38K documents and 12.5M words which are mostly from the vocabulary of English-speaking preschoolers. Experiments show that with higher training-test overlap, error analysis on PreCo is more efficient than the one on OntoNotes, a popular existing dataset. Furthermore, we annotate singleton mentions making it possible for the first time to quantify the influence that a mention detector makes on coreference resolution performance. The dataset is freely available at https://preschool-lab.github.io/PreCo/.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306353798" tag="video" />
@@ -327,6 +343,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>182–192</pages>
     <url>http://www.aclweb.org/anthology/D18-1017</url>
+    <abstract>Named entity recognition (NER) is an important task in natural language processing area, which needs to determine entities boundaries and classify them into pre-defined categories. For Chinese NER task, there is only a very small amount of annotated data available. Chinese NER task and Chinese word segmentation (CWS) task have many similar word boundaries. There are also specificities in each task. However, existing methods for Chinese NER either do not exploit word boundary information from CWS or cannot filter the specific information of CWS. In this paper, we propose a novel adversarial transfer learning framework to make full use of task-shared boundaries information and prevent the task-specific features of  CWS. Besides, since arbitrary character can provide important cues when predicting entity type, we exploit self-attention to explicitly capture long range dependencies between two tokens. Experimental results on two different widely used datasets show that our proposed model significantly and consistently outperforms other state-of-the-art methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>cao-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/306354811" tag="video" />
@@ -344,6 +361,7 @@
     <pages>193–203</pages>
     <url>http://www.aclweb.org/anthology/D18-1018</url>
     <attachment type="attachment">D18-1018.Attachment.pdf</attachment>
+    <abstract>Coreference resolution is an intermediate step for text understanding. It is used in tasks and domains for which we do not necessarily have coreference annotated corpora. Therefore, generalization is of special importance for coreference resolution. However, while recent coreference resolvers have notable improvements on the CoNLL dataset, they struggle to generalize properly to new domains or datasets. In this paper, we investigate the role of linguistic features in building more generalizable coreference resolvers. We show that generalization improves only slightly by merely using a set of additional linguistic features. However, employing features and subsets of their values that are informative for coreference resolution, considerably improves generalization. Thanks to better generalization, our system achieves state-of-the-art results in out-of-domain evaluations, e.g., on WikiCoref,  our system, which is trained on CoNLL, achieves on-par performance with a system designed for this dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>moosavi-strube:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306355512" tag="video" />
@@ -361,6 +379,7 @@
     <pages>204–214</pages>
     <url>http://www.aclweb.org/anthology/D18-1019</url>
     <attachment type="attachment">D18-1019.Attachment.zip</attachment>
+    <abstract>In this work, we propose a novel segmental hypergraph representation to model overlapping entity mentions that are prevalent in many practical datasets. We show that our model built on top of such a new representation is able to capture features and interactions that cannot be captured by previous models while maintaining a low time complexity for inference. We also present a theoretical analysis to formally assess how our representation is better than alternative representations reported in the literature in terms of representational power. Coupled with neural networks for feature learning, our model achieves the state-of-the-art performance in three benchmark datasets annotated with overlapping mentions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-lu:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306356485" tag="video" />
@@ -380,6 +399,7 @@
     <pages>215–226</pages>
     <url>http://www.aclweb.org/anthology/D18-1020</url>
     <attachment type="attachment">D18-1020.Attachment.pdf</attachment>
+    <abstract>We introduce a family of multitask variational methods for semi-supervised sequence labeling. Our model family consists of a latent-variable generative model and a discriminative labeler. The generative models use latent variables to define the conditional probability of a word given its context, drawing inspiration from word prediction objectives commonly used in learning word embeddings. The labeler helps inject discriminative information into the latent space. We explore several latent variable configurations, including ones with hierarchical structure, which enables the model to account for both  label-specific and word-specific information. Our models consistently outperform standard sequential baselines on 8 sequence labeling datasets, and improve further with unlabeled data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/306357379" tag="video" />
@@ -401,6 +421,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>227–237</pages>
     <url>http://www.aclweb.org/anthology/D18-1021</url>
+    <abstract>Jointly representation learning of words and entities benefits many NLP tasks, but has not been well explored in cross-lingual settings. In this paper, we propose a novel method for joint representation learning of cross-lingual words and entities. It captures mutually complementary knowledge, and enables cross-lingual inferences among knowledge bases and texts. Our method does not require parallel corpus, and automatically generates comparable data via distant supervision using multi-lingual knowledge bases. We utilize two types of regularizers to align cross-lingual words and entities, and design knowledge attention and cross-lingual attention to further reduce noises. We conducted a series of experiments on three tasks: word translation, entity relatedness, and cross-lingual entity linking. The results, both qualitative and quantitative, demonstrate the significance of our method.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>cao-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -416,6 +437,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>238–249</pages>
     <url>http://www.aclweb.org/anthology/D18-1022</url>
+    <abstract>While cross-domain and cross-language transfer have long been prominent topics in NLP research, their combination has hardly been explored. In this work we consider this problem, and propose a framework that builds on pivot-based learning, structure-aware Deep Neural Networks (particularly LSTMs and CNNs) and bilingual word embeddings, with the goal of training a model on labeled data from one (language, domain) pair so that it can be effectively applied to another (language, domain) pair. We consider two setups, differing with respect to the unlabeled data available for model training. In the full setup the model has access to unlabeled data from both pairs, while in the lazy setup, which is more realistic for truly resource-poor languages, unlabeled data is available for both domains but only for the source language. We design our model for the lazy setup so that for a given target domain, it can train once on the source language and then be applied to any target language without re-training. In experiments with nine English-German and nine English-French domain pairs our best model substantially outperforms previous models even when it is trained in the lazy setup and previous models are trained in the full setup.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ziser-reichart:2018:EMNLP</bibkey>
   </paper>
@@ -434,6 +456,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>250–260</pages>
     <url>http://www.aclweb.org/anthology/D18-1023</url>
+    <abstract>We construct a multilingual common semantic space based on distributional semantics, where words from multiple languages are projected into a shared space via which all available resources and knowledge can be shared across multiple languages. Beyond word alignment, we introduce multiple cluster-level alignments and enforce the word clusters to be consistently distributed across multiple languages. We exploit three signals for clustering: (1) neighbor words in the monolingual word embedding space; (2) character-level information; and (3) linguistic properties (e.g., apposition, locative suffix) derived from linguistic structure knowledge bases available for thousands of languages. We introduce a new cluster-consistent correlational neural network to construct the common semantic space by aligning words as well as clusters. Intrinsic evaluation on monolingual and multilingual QVEC tasks shows our approach achieves significantly higher correlation with linguistic features which are extracted from manually crafted lexical resources than state-of-the-art multi-lingual embedding learning methods do. Using low-resource language name tagging as a case study for extrinsic evaluation, our approach achieves up to 14.6\% absolute F-score gain over the state of the art on cross-lingual direct transfer. Our approach is also shown to be robust even when the size of bilingual dictionary is small.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -449,6 +472,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>261–270</pages>
     <url>http://www.aclweb.org/anthology/D18-1024</url>
+    <abstract>Multilingual Word Embeddings (MWEs) represent words from multiple languages in a single distributional vector space. Unsupervised MWE (UMWE) methods acquire multilingual embeddings without cross-lingual supervision, which is a significant advantage over traditional supervised approaches and opens many new possibilities for low-resource languages. Prior art for learning UMWEs, however, merely relies on a number of independently trained Unsupervised Bilingual Word Embeddings (UBWEs) to obtain multilingual embeddings. These methods fail to leverage the interdependencies that exist among many languages. To address this shortcoming, we propose a fully unsupervised framework for learning MWEs that directly exploits the relations between all language pairs. Our model substantially outperforms previous approaches in the experiments on multilingual word translation and cross-lingual word similarity. In addition, our model even beats supervised approaches trained with cross-lingual resources.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-cardie:2018:EMNLP</bibkey>
   </paper>
@@ -464,6 +488,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>271–281</pages>
     <url>http://www.aclweb.org/anthology/D18-1025</url>
+    <abstract>This paper proposes a modularized sense induction and representation learning model that jointly learns bilingual sense embeddings that align well in the vector space, where the cross-lingual signal in the English-Chinese parallel corpus is exploited to capture the collocation and distributed characteristics in the language pair. The model is evaluated on the Stanford Contextual Word Similarity (SCWS) dataset to ensure the quality of monolingual sense embeddings. In addition, we introduce Bilingual Contextual Word Similarity (BCWS), a large and high-quality dataset for evaluating cross-lingual sense embeddings, which is the first attempt of measuring whether the learned embeddings are indeed aligned well in the vector space. The proposed approach shows the superior quality of sense embeddings evaluated in both monolingual and bilingual spaces.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chi-chen:2018:EMNLP</bibkey>
   </paper>
@@ -482,6 +507,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>282–293</pages>
     <url>http://www.aclweb.org/anthology/D18-1026</url>
+    <abstract>Semantic specialization is a process of fine-tuning pre-trained distributional word vectors using external lexical knowledge (e.g., WordNet) to accentuate a particular semantic relation in the specialized vector space. While post-processing specialization methods are applicable to arbitrary distributional vectors, they are limited to updating only the vectors of words occurring in external lexicons (i.e., seen words), leaving the vectors of all other words unchanged. We propose a novel approach to specializing the full distributional vocabulary. Our adversarial post-specialization method propagates the external lexical knowledge to the full distributional space. We exploit words seen in the resources as training examples for learning a global specialization function. This function is learned by combining a standard L2-distance loss with a adversarial loss: the adversarial component produces more realistic output vectors. We show the effectiveness and robustness of the proposed method across three languages and on three tasks: word similarity, dialog state tracking, and lexical simplification. We report consistent improvements over distributional word vectors and vectors specialized by other state-of-the-art specialization frameworks. Finally, we also propose a cross-lingual transfer method for zero-shot specialization which successfully specializes a full target distributional space without any lexical knowledge in the target language and without any bilingual data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ponti-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -499,6 +525,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>294–304</pages>
     <url>http://www.aclweb.org/anthology/D18-1027</url>
+    <abstract>Cross-lingual word embeddings are becoming increasingly important in multilingual NLP. Recently, it has been shown that these embeddings can be effectively learned by aligning two disjoint monolingual vector spaces through linear transformations, using no more than a small bilingual dictionary as supervision. In this work, we propose to apply an additional transformation after the initial alignment step, which moves cross-lingual synonyms towards a middle point between them. By applying this transformation our aim is to obtain a better cross-lingual integration of the vector spaces. In addition, and perhaps surprisingly, the monolingual spaces also improve by this transformation. This is in contrast to the original alignment, which is typically learned such that the structure of the monolingual spaces is preserved. Our experiments confirm that the resulting cross-lingual embeddings outperform state-of-the-art models in both monolingual and cross-lingual evaluation tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>doval-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -517,6 +544,7 @@
     <pages>305–315</pages>
     <url>http://www.aclweb.org/anthology/D18-1028</url>
     <attachment type="attachment">D18-1028.Attachment.pdf</attachment>
+    <abstract>We release a corpus of 43 million atomic edits across 8 languages. These edits are mined from Wikipedia edit history and consist of instances in which a human editor has inserted a single contiguous phrase into, or deleted a single contiguous phrase from, an existing sentence. We use the collected data to show that the language generated during editing differs from the language that we observe in standard corpora, and that models trained on edits encode different aspects of semantics and discourse than models trained on raw text. We release the full corpus as a resource to aid ongoing research in semantics, discourse, and representation learning.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>faruqui-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -535,6 +563,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>316–327</pages>
     <url>http://www.aclweb.org/anthology/D18-1029</url>
+    <abstract>A key challenge in cross-lingual NLP is developing general language-independent architectures that are equally applicable to any language. However, this ambition is largely hampered by the variation in structural and semantic properties, i.e. the typological profiles of the world's languages. In this work, we analyse the implications of this variation on the language modeling (LM) task. We present a large-scale study of state-of-the art n-gram based and neural language models on 50 typologically diverse languages covering a wide variety of morphological systems. Operating in the full vocabulary LM setup focused on word-level prediction, we demonstrate that a coarse typology of morphological systems is predictive of absolute LM performance. Moreover, fine-grained typological features such as exponence, flexivity, fusion, and inflectional synthesis are borne out to be responsible for the proliferation of low-frequency phenomena which are organically difficult to model by statistical architectures, or for the meaning ambiguity of character n-grams. Our study strongly suggests that these features have to be taken into consideration during the construction of next-level language-agnostic LM architectures, capable of handling morphologically complex languages such as Tamil or Korean.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gerz-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -555,6 +584,7 @@
     <pages>328–337</pages>
     <url>http://www.aclweb.org/anthology/D18-1030</url>
     <attachment type="attachment">D18-1030.Attachment.pdf</attachment>
+    <abstract>We address fine-grained multilingual language identification: providing a language code for every token in a sentence, including codemixed text containing multiple languages. Such text is prevalent online, in documents, social media, and message boards. We show that a feed-forward network with a simple globally constrained decoder can accurately and rapidly label both codemixed and monolingual text in 100 languages and 100 language pairs. This model outperforms previously published multilingual approaches in terms of both accuracy and speed, yielding an 800x speed-up and a 19.5\% averaged absolute gain on three codemixed datasets. It furthermore outperforms several benchmark systems on monolingual language identification.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -573,6 +603,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>338–348</pages>
     <url>http://www.aclweb.org/anthology/D18-1031</url>
+    <abstract>Sentiment expression in microblog posts can be affected by user's personal character, opinion bias, political stance and so on. Most of existing personalized microblog sentiment classification methods suffer from the insufficiency of discriminative tweets for personalization learning. We observed that microblog users have consistent individuality and opinion bias in different languages. Based on this observation, in this paper we propose a novel user-attention-based Convolutional Neural Network (CNN) model with adversarial cross-lingual learning framework. The user attention mechanism is leveraged in CNN model to capture user's language-specific individuality from the posts. Then the attention-based CNN model is incorporated into a novel adversarial cross-lingual learning framework, in which with the help of user properties as bridge between languages, we can extract the language-specific features and language-independent features to enrich the user post representation so as to alleviate the data insufficiency problem. Results on English and Chinese microblog datasets confirm that our method outperforms state-of-the-art baseline algorithms with large margins.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -590,6 +621,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>349–357</pages>
     <url>http://www.aclweb.org/anthology/D18-1032</url>
+    <abstract>Multilingual knowledge graphs (KGs) such as DBpedia and YAGO contain structured knowledge of entities in several distinct languages, and they are useful resources for cross-lingual AI and NLP applications. Cross-lingual KG alignment is the task of matching entities with their counterparts in different languages, which is an important way to enrich the cross-lingual links in multilingual KGs. In this paper, we propose a novel approach for cross-lingual KG alignment via graph convolutional networks (GCNs). Given a set of pre-aligned entities, our approach trains GCNs to embed entities of each language into a unified vector space. Entity alignments are discovered based on the distances between entities in the embedding space. Embeddings can be learned from both the structural and attribute information of entities, and the results of structure embedding and attribute embedding are combined to get accurate alignments. In the experiments on aligning real multilingual KGs, our approach gets the best performance compared with other embedding-based KG alignment approaches.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -609,6 +641,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>358–368</pages>
     <url>http://www.aclweb.org/anthology/D18-1033</url>
+    <abstract>Sememes are defined as the minimum semantic units of human languages. As important knowledge sources, sememe-based linguistic knowledge bases have been widely used in many NLP tasks. However, most languages still do not have sememe-based linguistic knowledge bases. Thus we present a task of cross-lingual lexical sememe prediction, aiming to automatically predict sememes for words in other languages. We propose a novel framework to model correlations between sememes and multi-lingual words in low-dimensional semantic space for sememe prediction. Experimental results on real-world datasets show that our proposed model achieves consistent and significant improvements as compared to baseline methods in cross-lingual sememe prediction. The codes and data of this paper are available at https://github.com/thunlp/CL-SP.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>qi-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -627,6 +660,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>369–379</pages>
     <url>http://www.aclweb.org/anthology/D18-1034</url>
+    <abstract>For languages with no annotated resources, unsupervised transfer of natural language processing models such as named-entity recognition (NER) from resource-rich languages would be an appealing capability. However, differences in  words and word order across languages make it a challenging problem. To improve mapping of lexical items across languages, we propose a method that finds translations based on bilingual word embeddings. To improve robustness to word order differences, we propose to use self-attention, which allows for a degree of flexibility with respect to word order. We demonstrate that these methods achieve state-of-the-art or competitive NER performance on commonly tested languages under a cross-lingual setting, with much lower resource requirements than past approaches. We also evaluate the challenges of applying these methods to Uyghur, a low-resource language.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xie-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -644,6 +678,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>380–390</pages>
     <url>http://www.aclweb.org/anthology/D18-1035</url>
+    <abstract>Beam search is a widely used approximate search strategy for neural network decoders, and it generally outperforms simple greedy decoding on tasks like machine translation. However, this improvement comes at substantial computational cost. In this paper, we propose a flexible new method that allows us to reap nearly the full benefits of beam search with nearly no additional computational cost. The method revolves around a small neural network actor that is trained to observe and manipulate the hidden state of a previously-trained decoder. To train this actor network, we introduce the use of a pseudo-parallel corpus built using the output of beam search on a base model, ranked by a target quality metric like BLEU. Our method is inspired by earlier work on this problem, but requires no reinforcement learning, and can be trained reliably on a range of models. Experiments on three parallel corpora and three architectures show that the method yields substantial improvements in translation quality and speed over each base system.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -662,6 +697,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>391–400</pages>
     <url>http://www.aclweb.org/anthology/D18-1036</url>
+    <abstract>One of the weaknesses of Neural Machine Translation (NMT) is in handling lowfrequency and ambiguous words, which we refer as troublesome words. To address this problem, we propose a novel memoryenhanced NMT method. First, we investigate different strategies to define and detect the troublesome words. Then, a contextual memory is constructed to memorize which target words should be produced in what situations. Finally, we design a hybrid model to dynamically access the contextual memory so as to correctly translate the troublesome words. The extensive experiments on Chineseto- English and English-to-German translation tasks demonstrate that our method significantly outperforms the strong baseline models in translation quality, especially in handling troublesome words.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhao-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -678,6 +714,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>401–413</pages>
     <url>http://www.aclweb.org/anthology/D18-1037</url>
+    <abstract>The addition of syntax-aware decoding in Neural Machine Translation (NMT) systems requires an effective tree-structured neural network, a syntax-aware attention model and a language generation model that is sensitive to sentence structure. Recent approaches resort to sequential decoding by adding additional neural network units to capture bottom-up structural information, or serialising structured data into sequence. We exploit a top-down tree-structured model called DRNN (Doubly-Recurrent Neural Networks) first proposed by Alvarez-Melis and Jaakola (2017) to create an NMT model called Seq2DRNN that combines a sequential encoder with tree-structured decoding augmented with a syntax-aware attention model. Unlike previous approaches to syntax-based NMT which use dependency parsing models our method uses constituency parsing which we argue provides useful information for translation. In addition, we use the syntactic structure of the sentence to add new connections to the tree-structured decoder neural network (Seq2DRNN+SynC). We compare our NMT model with sequential and state of the art syntax-based NMT models and show that our model produces more fluent translations with better reordering. Since our model is capable of doing translation and constituency parsing at the same time we also compare our parsing accuracy against other neural parsing models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>g-shavarani-sarkar:2018:EMNLP</bibkey>
   </paper>
@@ -699,6 +736,7 @@
     <pages>414–424</pages>
     <url>http://www.aclweb.org/anthology/D18-1038</url>
     <attachment type="attachment">D18-1038.Attachment.pdf</attachment>
+    <abstract>Task-oriented dialog systems are becoming pervasive, and many companies heavily rely on them to complement human agents for customer service in call centers. With globalization, the need for providing cross-lingual customer support becomes more urgent than ever. However, cross-lingual support poses great challenges---it requires a large amount of additional annotated data from native speakers. In order to bypass the expensive human annotation and achieve the first step towards the ultimate goal of building a universal dialog system, we set out to build a cross-lingual state tracking framework. Specifically, we assume that there exists a source language with dialog belief tracking annotations while the target languages have no annotated dialog data of any form. Then, we pre-train a state tracker for the source language as a teacher, which is able to exploit easy-to-access parallel data. We then distill and transfer its own knowledge to the student state tracker in target languages. We specifically discuss two types of common parallel resources: bilingual corpus and bilingual dictionary, and design different transfer learning strategies accordingly. Experimentally, we successfully use English state tracker as the teacher to transfer its knowledge to both Italian and German trackers and achieve promising results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP5</bibkey>
   </paper>
@@ -716,6 +754,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>425–435</pages>
     <url>http://www.aclweb.org/anthology/D18-1039</url>
+    <abstract>We propose a simple modification to existing neural machine translation (NMT) models that enables using a single universal model to translate between multiple languages while allowing for language specific parameterization, and that can also be used for domain adaptation. Our approach requires no changes to the model architecture of a standard NMT system, but instead introduces a new component, the contextual parameter generator (CPG), that generates the parameters of the system (e.g., weights in a neural network). This parameter generator accepts source and target language embeddings as input, and generates the parameters for the encoder and the decoder, respectively. The rest of the model remains unchanged and is shared across all languages. We show how this simple modification enables the system to use monolingual data for training and also perform zero-shot translation. We further show it is able to surpass state-of-the-art performance for both the IWSLT-15 and IWSLT-17 datasets and that the learned language embeddings are able to uncover interesting relationships between languages.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>platanios-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -731,6 +770,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>436–446</pages>
     <url>http://www.aclweb.org/anthology/D18-1040</url>
+    <abstract>Neural Machine Translation has achieved state-of-the-art performance for several language pairs using a combination of parallel and synthetic data. Synthetic data is often generated by back-translating sentences randomly sampled from monolingual data using a reverse translation model. While back-translation has been shown to be very effective in many cases, it is not entirely clear why. In this work, we explore different aspects of back-translation, and show that words with high prediction loss during training benefit most from the addition of synthetic data. We introduce several variations of sampling strategies targeting difficult-to-predict words using prediction losses and frequencies of words. In addition, we also target the contexts of difficult words and sample sentences that are similar in context. Experimental results for the WMT news translation task show that our method improves translation quality by up to 1.7 and 1.2 Bleu points over back-translation using random sampling for German-English and English-German, respectively.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>fadaee-monz:2018:EMNLP</bibkey>
   </paper>
@@ -751,6 +791,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>447–457</pages>
     <url>http://www.aclweb.org/anthology/D18-1041</url>
+    <abstract>With great practical value, the study of Multi-domain Neural Machine Translation (NMT) mainly focuses on using mixed-domain parallel sentences to construct a unified model that allows translation to switch between different domains. Intuitively, words in a sentence are related to its domain to varying degrees, so that they will exert disparate impacts on the multi-domain NMT modeling. Based on this intuition, in this paper, we devote to distinguishing and exploiting word-level domain contexts for multi-domain NMT. To this end, we jointly model NMT with monolingual attention-based domain classification tasks and improve NMT as follows: 1) Based on the sentence representations produced by a domain classifier and an adversarial domain classifier, we generate two gating vectors and use them to construct domain-specific and domain-shared annotations, for later translation predictions via different attention models; 2) We utilize the attention weights derived from target-side domain classifier to adjust the weights of target words in the training objective, enabling domain-related words to have greater impacts during model training. Experimental results on Chinese-English and English-French multi-domain translation tasks demonstrate the effectiveness of the proposed model. Source codes of this paper are available on Github https://github.com/DeepLearnXMU/WDCNMT.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zeng-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -768,6 +809,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>458–468</pages>
     <url>http://www.aclweb.org/anthology/D18-1042</url>
+    <abstract>We introduce a novel discriminative latent-variable model for the task of bilingual lexicon induction. Our model combines the bipartite matching dictionary prior of Haghighi et al. (2008) with a state-of-the-art embedding-based approach. To train the model, we derive an efficient Viterbi EM algorithm. We provide empirical improvements on six language pairs under two metrics and show that the prior theoretically and empirically helps to mitigate the hubness problem. We also demonstrate how previous work may be viewed as a similarly fashioned latent-variable model, albeit with a different prior.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ruder-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -783,6 +825,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>469–478</pages>
     <url>http://www.aclweb.org/anthology/D18-1043</url>
+    <abstract>Unsupervised word translation from non-parallel inter-lingual corpora has attracted much research interest. Very recently, neural network methods trained with adversarial loss functions achieved high accuracy on this task. Despite the impressive success of the recent techniques, they suffer from the typical drawbacks of generative adversarial models: sensitivity to hyper-parameters, long training time and lack of interpretability. In this paper, we make the observation that two sufficiently similar distributions can be aligned correctly with iterative matching methods. We present a novel method that first aligns the second moment of the word distributions of the two languages and then iteratively refines the alignment. Extensive experiments on word translation of European and Non-European languages show that our method achieves better performance than recent state-of-the-art deep adversarial approaches and is competitive with the supervised baseline. It is also efficient, easy to parallelize on CPU and interpretable.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hoshen-wolf:2018:EMNLP</bibkey>
   </paper>
@@ -799,6 +842,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>479–488</pages>
     <url>http://www.aclweb.org/anthology/D18-1044</url>
+    <abstract>Existing approaches to neural machine translation are typically autoregressive models. While these models attain state-of-the-art translation quality, they are suffering from low parallelizability and thus slow at decod- ing long sequences. In this paper, we propose a novel model for fast sequence generation — the semi-autoregressive Transformer (SAT). The SAT keeps the autoregressive property in global but relieves in local and thus are able to produce multiple successive words in parallel at each time step. Experiments conducted on English-German and Chinese- English translation tasks show that the SAT achieves a good balance between translation quality and decoding speed. On WMT'14 English-German translation, the SAT achieves 5.58× speedup while maintaining 88\% trans- lation quality, significantly better than the previous non-autoregressive methods. When produces two words at each time step, the SAT is almost lossless (only 1\% degeneration in BLEU score).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-zhang-chen:2018:EMNLP</bibkey>
   </paper>
@@ -816,6 +860,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>489–500</pages>
     <url>http://www.aclweb.org/anthology/D18-1045</url>
+    <abstract>An effective method to improve neural machine translation with monolingual data is to augment the parallel training corpus with back-translations of target language sentences. This work broadens the understanding of back-translation and investigates a number of methods to generate synthetic source sentences. We find that in all but resource poor settings back-translations obtained via sampling or noised beam outputs are most effective. Our analysis shows that sampling or noisy synthetic data gives a much stronger training signal than data generated by beam or greedy search. We also compare how synthetic data compares to genuine bitext and study various domain effects. Finally, we scale to hundreds of millions of monolingual sentences and achieve a new state of the art of 35 BLEU on the WMT'14 English-German test set.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>edunov-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -832,6 +877,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>501–511</pages>
     <url>http://www.aclweb.org/anthology/D18-1046</url>
+    <abstract>Generating the English transliteration of a name written in a foreign script is an important and challenging step in multilingual knowledge acquisition and information extraction. Existing approaches to transliteration generation require a large (&gt;5000) number of training examples. This difficulty contrasts with transliteration discovery, a somewhat easier task that involves picking a plausible transliteration from a given list. In this work, we present a bootstrapping algorithm that uses constrained discovery to improve generation, and can be used with as few as 500 training examples, which we show can be sourced from annotators in a matter of hours. This opens the task to languages for which large number of training examples are unavailable. We evaluate transliteration generation performance itself, as well the improvement it brings to cross-lingual candidate generation for entity linking, a typical downstream task. We present a comprehensive evaluation of our approach on nine languages, each written in a unique script.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>upadhyay-kodner-roth:2018:EMNLP</bibkey>
   </paper>
@@ -846,6 +892,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>512–522</pages>
     <url>http://www.aclweb.org/anthology/D18-1047</url>
+    <abstract>Inducing multilingual word embeddings by learning a linear map between embedding spaces of different languages achieves remark- able accuracy on related languages. How- ever, accuracy drops substantially when trans- lating between distant languages. Given that languages exhibit differences in vocabu- lary, grammar, written form, or syntax, one would expect that embedding spaces of dif- ferent languages have different structures es- pecially for distant languages. With the goal of capturing such differences, we propose a method for learning neighborhood sensitive maps, NORMA. Our experiments show that NORMA outperforms current state-of-the-art methods for word translation between distant languages.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>nakashole:2018:EMNLP</bibkey>
   </paper>
@@ -863,6 +910,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>523–532</pages>
     <url>http://www.aclweb.org/anthology/D18-1048</url>
+    <abstract>Although end-to-end neural machine translation (NMT) has achieved remarkable progress in the recent years, the idea of adopting multi-pass decoding mechanism into conventional NMT is not well explored. In this paper, we propose a novel architecture called adaptive multi-pass decoder,  which introduces a flexible multi-pass polishing mechanism to extend the capacity of NMT via reinforcement learning. More specifically, we adopt an extra policy network to automatically choose a suitable and effective number of decoding passes, according to the complexity of source sentences and the quality of the generated translations. Extensive experiments on Chinese-English translation demonstrate the effectiveness of our proposed adaptive multi-pass decoder upon the conventional NMT with a significant improvement about 1.55 BLEU.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>geng-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -883,6 +931,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>533–542</pages>
     <url>http://www.aclweb.org/anthology/D18-1049</url>
+    <abstract>Although the Transformer translation model (Vaswani et al., 2017) has achieved state-of-the-art performance in a variety of translation tasks, how to use document-level context to deal with discourse phenomena problematic for Transformer still remains a challenge. In this work, we extend the Transformer model with a new context encoder to represent document-level context, which is then incorporated into the original encoder and decoder. As large-scale document-level parallel corpora are usually not available, we introduce a two-step training method to take full advantage of abundant sentence-level parallel corpora and limited document-level parallel corpora. Experiments on the NIST Chinese-English datasets and the IWSLT French-English datasets show that our approach improves over Transformer significantly.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -898,6 +947,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>543–553</pages>
     <url>http://www.aclweb.org/anthology/D18-1050</url>
+    <abstract>Noisy or non-standard input text can cause disastrous mistranslations in most modern Machine Translation (MT) systems, and there has been growing research interest in creating noise-robust MT systems. However, as of yet there are no publicly available parallel corpora of with naturally occurring noisy inputs and translations, and thus previous work has resorted to evaluating on synthetically created datasets. In this paper, we propose a benchmark dataset for Machine Translation of Noisy Text (MTNT), consisting of noisy comments on Reddit (www.reddit.com) and professionally sourced translations. We commissioned translations of English comments into French and Japanese, as well as French and Japanese comments into English, on the order of 7k-37k sentences per language pair. We qualitatively and quantitatively examine the types of noise included in this dataset, then demonstrate that existing MT models fail badly on a number of noise-related phenomena, even after performing adaptation on a small training set of in-domain data. This indicates that this dataset can provide an attractive testbed for methods tailored to handling noisy text in MT.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>michel-neubig:2018:EMNLP</bibkey>
   </paper>
@@ -913,6 +963,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>554–558</pages>
     <url>http://www.aclweb.org/anthology/D18-1051</url>
+    <abstract>The SimpleQuestions dataset is one of the most commonly used benchmarks for studying single-relation factoid questions. In this paper, we present new evidence that this benchmark can be nearly solved by standard methods. First, we show that ambiguity in the data bounds performance at 83.4\%; many questions have more than one equally plausible interpretation. Second, we introduce a baseline that sets a new state-of-the-art performance level at 78.1\% accuracy, despite using standard methods. Finally, we report an empirical analysis showing that the upperbound is loose; roughly a quarter of the remaining errors are also not resolvable from the linguistic signal. Together, these results suggest that the SimpleQuestions dataset is nearly solved.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>petrochuk-zettlemoyer:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305204813" tag="video" />
@@ -932,6 +983,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>559–564</pages>
     <url>http://www.aclweb.org/anthology/D18-1052</url>
+    <abstract>We formalize a new modular variant of current question answering tasks by enforcing complete independence of the document encoder from the question encoder. This formulation addresses a key challenge in machine comprehension by building a standalone representation of the document discourse. It additionally leads to a significant scalability advantage since the encoding of the answer candidate phrases in the document can be pre-computed and indexed offline for efficient retrieval. We experiment with baseline models for the new task, which achieve a reasonable accuracy but significantly underperform unconstrained QA models. We invite the QA research community to engage in Phrase-Indexed Question Answering (PIQA, pika) for closing the gap. The leaderboard is  at: nlp.cs.washington.edu/piqa</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>seo-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305205055" tag="video" />
@@ -951,6 +1003,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>565–569</pages>
     <url>http://www.aclweb.org/anthology/D18-1053</url>
+    <abstract>Recently, open-domain question answering (QA) has been combined with machine comprehension models to find answers in a large knowledge source. As open-domain QA requires retrieving relevant documents from text corpora to answer questions, its performance largely depends on the performance of document retrievers. However, since traditional information retrieval systems are not effective in obtaining documents with a high probability of containing answers, they lower the performance of QA systems. Simply extracting more documents increases the number of irrelevant documents, which also degrades the performance of QA systems. In this paper, we introduce Paragraph Ranker which ranks paragraphs of retrieved documents for a higher answer recall with less noise. We show that ranking paragraphs and aggregating answers using Paragraph Ranker improves performance of open-domain QA pipeline on the four open-domain QA datasets by 7.8\% on average.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lee-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305205289" tag="video" />
@@ -970,6 +1023,7 @@
     <pages>570–575</pages>
     <url>http://www.aclweb.org/anthology/D18-1054</url>
     <attachment type="attachment">D18-1054.Attachment.zip</attachment>
+    <abstract>In recent years many deep neural networks have been proposed to solve Reading Comprehension (RC) tasks. Most of these models suffer from reasoning over long documents and do not trivially generalize to cases where the answer is not present as a span in a given document. We present a novel neural-based architecture that is capable of extracting relevant regions based on a given question-document pair and generating a well-formed answer. To show the effectiveness of our architecture, we conducted several experiments on the recently proposed and challenging RC dataset `NarrativeQA'. The proposed architecture outperforms state-of-the-art results by 12.62\% (ROUGE-L) relative improvement.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>indurthi-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305205548" tag="video" />
@@ -986,6 +1040,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>576–581</pages>
     <url>http://www.aclweb.org/anthology/D18-1055</url>
+    <abstract>State-of-the-art systems in deep question answering proceed as follows: (1)an initial document retrieval selects relevant documents, which (2) are then processed by a neural network in order to extract the final answer. Yet the exact interplay between both components is poorly understood, especially concerning the number of candidate documents that should be retrieved. We show that choosing a static number of documents - as used in prior research - suffers from a noise-information trade-off and yields suboptimal results. As a remedy, we propose an adaptive document retrieval model. This learns the optimal candidate number for document retrieval, conditional on the size of the corpus and the query. We report extensive experimental results showing that our adaptive approach outperforms state-of-the-art methods on multiple benchmark datasets, as well as in the context of corpora with variable sizes.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kratzwald-feuerriegel:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305205847" tag="video" />
@@ -1003,6 +1058,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>582–586</pages>
     <url>http://www.aclweb.org/anthology/D18-1056</url>
+    <abstract>This paper presents a challenge to the community: Generative adversarial networks (GANs) can perfectly align independent English word embeddings induced using the same algorithm, based on distributional information alone; but fails to do so, for two different embeddings algorithms. Why is that? We believe understanding why, is key to understand both modern word embedding algorithms and the limitations and instability dynamics of GANs. This paper shows that (a) in all these cases, where alignment fails, there exists a linear transform between the two embeddings (so algorithm biases do not lead to non-linear differences), and (b) similar effects can not easily be obtained by varying hyper-parameters. One plausible suggestion based on our initial experiments is that the differences in the inductive biases of the embedding  algorithms lead to an optimization landscape that is riddled with local optima, leading to a very small basin of convergence, but we present this more as a challenge paper than a technical contribution.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hartmann-kementchedjhieva-sgaard:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305196498" tag="video" />
@@ -1021,6 +1077,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>587–593</pages>
     <url>http://www.aclweb.org/anthology/D18-1057</url>
+    <abstract>Most models for learning word embeddings are trained based on the context information of words, more precisely first order co-occurrence relations. In this paper, a metric is designed to estimate second order co-occurrence relations based on context overlap. The estimated values are further used as the augmented data to enhance the learning of word embeddings by joint training with existing neural word embedding models. Experimental results show that better word vectors can be obtained for word similarity tasks and some downstream NLP tasks by the enhanced approach.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhuang-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305196755" tag="video" />
@@ -1037,6 +1094,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>594–600</pages>
     <url>http://www.aclweb.org/anthology/D18-1058</url>
+    <abstract>Capturing the semantic relations of words in a vector space contributes to many natural language processing tasks. One promising approach exploits lexico-syntactic patterns as features of word pairs. In this paper, we propose a novel model of this pattern-based approach, neural latent relational analysis (NLRA). NLRA can generalize co-occurrences of word pairs and lexico-syntactic patterns, and obtain embeddings of the word pairs that do not co-occur. This overcomes the critical data sparseness problem encountered in previous pattern-based models. Our experimental results on measuring relational similarity demonstrate that NLRA outperforms the previous pattern-based models. In addition, when combined with a vector offset model, NLRA achieves a performance comparable to that of the state-of-the-art model that exploits additional semantic relational data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>washio-kato:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305197006" tag="video" />
@@ -1054,6 +1112,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>601–606</pages>
     <url>http://www.aclweb.org/anthology/D18-1059</url>
+    <abstract>We approach the problem of generalizing pre-trained word embeddings beyond fixed-size vocabularies without using additional contextual information. We propose a subword-level word vector generation model that views words as bags of character \$n\$-grams.  The model is simple, fast to train and provides good vectors for rare or unseen words. Experiments show that our model achieves state-of-the-art performances in English word similarity task and in joint prediction of part-of-speech tag and morphosyntactic attributes in 23 languages, suggesting our model's ability in capturing the relationship between words' textual representations and their embeddings.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhao-mudgal-liang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305197257" tag="video" />
@@ -1072,6 +1131,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>607–613</pages>
     <url>http://www.aclweb.org/anthology/D18-1060</url>
+    <abstract>We present end-to-end neural models for detecting metaphorical word use in context. We show that relatively standard BiLSTM models which operate on complete sentences work well in this setting, in comparison to previous work that used more restricted forms of linguistic context. These models establish a new state-of-the-art on existing verb metaphor detection benchmarks, and show strong performance on jointly predicting the metaphoricity of all words in a running text.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gao-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305197464" tag="video" />
@@ -1088,6 +1148,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>614–620</pages>
     <url>http://www.aclweb.org/anthology/D18-1061</url>
+    <abstract>a cross-lingual neural part-of-speech tagger that learns from disparate sources of distant supervision, and realistically scales to hundreds of low-resource languages. The model exploits annotation projection, instance selection, tag dictionaries, morphological lexicons, and distributed representations, all in a uniform framework. The approach is simple, yet surprisingly effective, resulting in a new state of the art without access to any gold annotated data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>plank-agi:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305211701" tag="video" />
@@ -1105,6 +1166,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>621–626</pages>
     <url>http://www.aclweb.org/anthology/D18-1062</url>
+    <abstract>Bilingual lexicon extraction has been studied for decades and most previous methods have relied on parallel corpora or bilingual dictionaries. Recent studies have shown that it is possible to build a bilingual dictionary by aligning monolingual word embedding spaces in an unsupervised way. With the recent advances in generative models, we propose a novel approach which builds cross-lingual dictionaries via latent variable models and adversarial training with no parallel corpora. To demonstrate the effectiveness of our approach, we evaluate our approach on several language pairs and the experimental results show that our model could achieve competitive and even superior performance compared with several state-of-the-art models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dou-zhou-huang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305211999" tag="video" />
@@ -1122,6 +1184,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>627–632</pages>
     <url>http://www.aclweb.org/anthology/D18-1063</url>
+    <abstract>Word translation, or bilingual dictionary induction, is an important capability that impacts many multilingual language processing tasks. Recent research has shown that  word translation can be achieved in an unsupervised manner, without parallel seed dictionaries or aligned corpora. However, state of the art methods unsupervised bilingual dictionary induction are based on generative adversarial models, and as such suffer from their well known problems of instability and hyper-parameter sensitivity. We present a statistical dependency-based approach to bilingual dictionary induction that is unsupervised -- no seed dictionary or parallel corpora required; and introduces no adversary -- therefore being much easier to train. Our method performs comparably to adversarial alternatives and outperforms prior non-adversarial methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mukherjee-yamada-hospedales:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305212238" tag="video" />
@@ -1140,6 +1203,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>633–639</pages>
     <url>http://www.aclweb.org/anthology/D18-1064</url>
+    <abstract>This paper proposes an adversarial training method for the multi-task and multi-lingual joint modeling needed for utterance intent classification. In joint modeling, common knowledge can be efficiently utilized among multiple tasks or multiple languages. This is achieved by introducing both language-specific networks shared among different tasks and task-specific networks shared among different languages. However, the shared networks are often specialized in majority tasks or languages, so performance degradation must be expected for some minor data sets. In order to improve the invariance of shared networks, the proposed method introduces both language-specific task adversarial networks and task-specific language adversarial networks; both are leveraged for purging the task or language dependencies of the shared networks. The effectiveness of the adversarial training proposal is demonstrated using Japanese and English data sets for three different utterance intent classification tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>masumura-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305212477" tag="video" />
@@ -1157,6 +1221,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>640–645</pages>
     <url>http://www.aclweb.org/anthology/D18-1065</url>
+    <abstract>In this paper we show that a simple beam approximation of the joint distribution between attention and output is an easy, accurate, and efficient attention mechanism for sequence to sequence learning. The method combines the advantage of sharp focus in hard attention and the implementation ease of soft attention. On five translation tasks we show effortless and consistent gains in BLEU  compared to existing attention mechanisms.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shankar-garg-sarawagi:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305212816" tag="video" />
@@ -1175,6 +1240,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>646–651</pages>
     <url>http://www.aclweb.org/anthology/D18-1066</url>
+    <abstract>We present a neural network-based joint approach for emotion classification and emotion cause detection, which attempts to capture mutual benefits across the two sub-tasks of emotion analysis. Considering that emotion classification and emotion cause detection need different kinds of features (affective and event-based separately), we propose a joint encoder which uses a unified framework to extract features for both sub-tasks and a joint model trainer which simultaneously learns two models for the two sub-tasks separately. Our experiments on Chinese microblogs show that the joint approach is very promising.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP6</bibkey>
     <video href="https://vimeo.com/306358514" tag="video" />
@@ -1192,6 +1258,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>652–658</pages>
     <url>http://www.aclweb.org/anthology/D18-1067</url>
+    <abstract>Identifying optimistic and pessimistic viewpoints and users from Twitter is useful for providing better social support to those who need such support, and for minimizing the negative influence among users and maximizing the spread of positive attitudes and ideas. In this paper, we explore a range of deep learning models to predict optimism and pessimism in Twitter at both tweet and user level and show that these models substantially outperform traditional machine learning classifiers used in prior work. In addition, we show evidence that a sentiment classifier would not be sufficient for accurately predicting optimism and pessimism in Twitter. Last, we study the verb tense usage as well as the presence of polarity words in optimistic and pessimistic tweets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>caragea-dinu-dumitru:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306359438" tag="video" />
@@ -1209,6 +1276,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>659–664</pages>
     <url>http://www.aclweb.org/anthology/D18-1068</url>
+    <abstract>Newspapers need to attract readers with headlines, anticipating their readers' preferences. These preferences rely on topical, structural, and lexical factors. We model each of these factors in a multi-task GRU network to predict headline popularity. We find that pre-trained word embeddings provide significant improvements over untrained embeddings, as do the combination of two auxiliary tasks, news-section prediction and part-of-speech tagging. However, we also find that performance is very similar to that of a simple Logistic Regression model over character n-grams. Feature analysis reveals structural patterns of headline popularity, including the use of forward-looking deictic expressions and second person pronouns.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lamprinidis-hardt-hovy:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306360116" tag="video" />
@@ -1227,6 +1295,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>665–670</pages>
     <url>http://www.aclweb.org/anthology/D18-1069</url>
+    <abstract>Inferring the agreement/disagreement relation in debates, especially in online debates, is one of the fundamental tasks in argumentation mining. The expressions of agreement/disagreement usually rely on argumentative expressions in text as well as interactions between participants in debates. Previous works usually lack the capability of jointly modeling these two factors. To alleviate this problem, this paper proposes a hybrid neural attention model which combines self and cross attention mechanism to locate salient part from textual context and interaction between users. Experimental results on three (dis)agreement inference datasets show that our model outperforms the state-of-the-art models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP7</bibkey>
     <video href="https://vimeo.com/306360792" tag="video" />
@@ -1243,6 +1312,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>671–677</pages>
     <url>http://www.aclweb.org/anthology/D18-1070</url>
+    <abstract>Most text-classification approaches represent the input based on textual features, either feature-based or continuous. However, this ignores strong non-linguistic similarities like homophily: people within a demographic group use language more similar to each other than to non-group members. We use homophily cues to retrofit text-based author representations with non-linguistic information, and introduce a trade-off parameter. This approach increases in-class similarity between authors, and improves classification performance by making classes more linearly separable. We evaluate the effect of our method on two author-attribute prediction tasks with various training-set sizes and parameter settings. We find that our method can significantly improve classification performance, especially when the number of labels is large and limited labeled data is available. It is potentially applicable as preprocessing step to any text-classification task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hovy-fornaciari:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306361301" tag="video" />
@@ -1259,6 +1329,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>678–683</pages>
     <url>http://www.aclweb.org/anthology/D18-1071</url>
+    <abstract>Traditional neural language models tend to generate generic replies with poor logic and no emotion. In this paper, a syntactically constrained bidirectional-asynchronous approach for emotional conversation generation (E-SCBA) is proposed to address this issue. In our model, pre-generated emotion keywords and topic keywords are asynchronously introduced into the process of decoding. It is much different from most existing methods which generate replies from the first word to the last. Through experiments, the results indicate that our approach not only improves the diversity of replies, but gains a boost on both logic and emotion compared with baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-sun:2018:EMNLP</bibkey>
   </paper>
@@ -1279,6 +1350,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>684–689</pages>
     <url>http://www.aclweb.org/anthology/D18-1072</url>
+    <abstract>The lack of labeled data is one of the main challenges when building a task-oriented dialogue system. Existing dialogue datasets usually rely on human labeling, which is expensive, limited in size, and in low coverage. In this paper, we instead propose our framework auto-dialabel to automatically cluster the dialogue intents and slots. In this framework, we collect a set of context features, leverage an autoencoder for feature assembly, and adapt a dynamic hierarchical clustering method for intent and slot labeling. Experimental results show that our framework can promote human labeling cost to a great extent, achieve good intent clustering accuracy (84.1\%), and provide reasonable and instructive slot labeling results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shi-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -1294,6 +1366,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>690–695</pages>
     <url>http://www.aclweb.org/anthology/D18-1073</url>
+    <abstract>The use of connectionist approaches in conversational agents has been progressing rapidly due to the availability of large corpora. However current generative dialogue models often lack coherence and are content poor.  This work proposes an architecture to incorporate unstructured knowledge sources to enhance the next utterance prediction in chit-chat type of generative dialogue models. We focus on Sequence-to-Sequence (Seq2Seq) conversational agents trained with the Reddit News dataset, and consider incorporating external knowledge from  Wikipedia summaries as well as from the NELL knowledge base. Our experiments show faster training time and improved perplexity when leveraging external knowledge.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>parthasarathi-pineau:2018:EMNLP</bibkey>
   </paper>
@@ -1313,6 +1386,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>696–701</pages>
     <url>http://www.aclweb.org/anthology/D18-1074</url>
+    <abstract>Categorizing patient's intentions in conversational assessment can help decision making in clinical treatments. Many conversation corpora span broaden a series of time stages. However, it is not clear that how the themes shift in the conversation impact on the performance of human intention categorization (eg., patients might show different behaviors during the beginning versus the end). This paper proposes a method that models the temporal factor by using domain adaptation on clinical dialogue corpora, Motivational Interviewing (MI). We deploy Bi-LSTM and topic model jointly to learn language usage change across different time sessions. We conduct experiments on the MI corpora to show the promising improvement after considering temporality in the classification task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -1331,6 +1405,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>702–707</pages>
     <url>http://www.aclweb.org/anthology/D18-1075</url>
+    <abstract>Generating semantically coherent responses is still a major challenge in dialogue generation. Different from conventional text generation tasks, the mapping between inputs and responses in conversations is more complicated, which highly demands the understanding of utterance-level semantic dependency, a relation between the whole meanings of inputs and outputs. To address this problem, we propose an Auto-Encoder Matching  (AEM) model to learn such  dependency. The model contains two auto-encoders and one mapping module. The auto-encoders learn the semantic representations of inputs and responses, and the mapping module learns to connect the utterance-level representations. Experimental results from automatic and human evaluations demonstrate that our model is capable of generating responses of high coherence and fluency compared to baseline models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>luo-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -1348,6 +1423,7 @@
     <pages>708–713</pages>
     <url>http://www.aclweb.org/anthology/D18-1076</url>
     <attachment type="attachment">D18-1076.Attachment.zip</attachment>
+    <abstract>This paper introduces a document grounded dataset for conversations. We define ``Document Grounded Conversations'' as conversations that are about the contents of a specified document. In this dataset the specified documents were Wikipedia articles about popular movies. The dataset contains 4112 conversations with an average of 21.43 turns per conversation. This positions this dataset to not only provide a relevant chat history while generating responses but also provide a source of information that the models could use. We describe two neural architectures that provide benchmark performance on the task of generating the next response. We also evaluate our models for engagement and fluency, and find that the information from the document helps in generating more engaging and fluent responses.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhou-prabhumoye-black:2018:EMNLP</bibkey>
   </paper>
@@ -1365,6 +1441,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>714–718</pages>
     <url>http://www.aclweb.org/anthology/D18-1077</url>
+    <abstract>The main goal of this paper is to develop out-of-domain (OOD) detection for dialog systems. We propose to use only in-domain (IND) sentences to build a generative adversarial network (GAN) of which the discriminator generates low scores for OOD sentences. To improve basic GANs, we apply feature matching loss in the discriminator, use domain-category analysis as an additional task in the discriminator, and remove the biases in the generator. Thereby, we reduce the huge effort of collecting OOD sentences for training OOD detection. For evaluation, we experimented OOD detection on a multi-domain dialog system. The experimental results showed the proposed method was most accurate compared to the existing methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ryu-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -1388,6 +1465,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>719–724</pages>
     <url>http://www.aclweb.org/anthology/D18-1078</url>
+    <abstract>This paper presents a task for machine listening comprehension in the argumentation domain and a corresponding dataset in English. We recorded 200 spontaneous speeches arguing for or against 50 controversial topics. For each speech, we formulated a question, aimed at confirming or rejecting the occurrence of potential arguments in the speech. Labels were collected by listening to the speech and marking which arguments were mentioned by the speaker. We applied baseline methods addressing the task, to be used as a benchmark for future work over this dataset. All data used in this work is freely available for research.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mirkin-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -1407,6 +1485,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>725–731</pages>
     <url>http://www.aclweb.org/anthology/D18-1079</url>
+    <abstract>We tackle discourse-level relation recognition, a problem of determining semantic relations between text spans. Implicit relation recognition is challenging due to the lack of explicit relational clues. The increasingly popular neural network techniques have been proven effective for semantic encoding, whereby widely employed to boost semantic relation discrimination. However, learning to predict semantic relations at a deep level heavily relies on a great deal of training data, but the scale of the publicly available data in this field is limited. In this paper, we follow Rutherford and Xue (2015) to expand the training data set using the corpus of explicitly-related arguments, by arbitrarily dropping the overtly presented discourse connectives. On the basis, we carry out an experiment of sampling, in which a simple active learning approach is used, so as to take the informative instances for data expansion. The goal is to verify whether the selective use of external data not only reduces the time consumption of retraining but also ensures a better system performance. Using the expanded training data, we retrain a convolutional neural network (CNN) based classifer which is a simplified version of Qin et al. (2016)'s stacking gated relation recognizer. Experimental results show that expanding the training set with small-scale carefully-selected external data yields substantial performance gain, with the improvements of about 4\% for accuracy and 3.6\% for F-score. This allows a weak classifier to achieve a comparable performance against the state-of-the-art systems.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -1425,6 +1504,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>732–737</pages>
     <url>http://www.aclweb.org/anthology/D18-1080</url>
+    <abstract>Split and rephrase is the task of breaking down a sentence into shorter ones that together convey the same meaning. We extract a rich new dataset for this task by mining Wikipedia's edit history: WikiSplit contains one million naturally occurring sentence rewrites, providing sixty times more distinct split examples and a ninety times larger vocabulary than the WebSplit corpus introduced by Narayan et al. (2017) as a benchmark for this task. Incorporating WikiSplit as training data produces a model with qualitatively better predictions that score 32 BLEU points above the prior best result on the WebSplit benchmark.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>botha-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -1442,6 +1522,7 @@
     <pages>738–744</pages>
     <url>http://www.aclweb.org/anthology/D18-1081</url>
     <attachment type="attachment">D18-1081.Attachment.zip</attachment>
+    <abstract>BLEU is widely considered to be an informative metric for text-to-text generation, including Text Simplification (TS). TS includes both lexical and structural aspects. In this paper we show that BLEU is not suitable for the evaluation of sentence splitting, the major structural simplification operation. We manually compiled a sentence splitting gold standard corpus containing multiple structural paraphrases, and performed a correlation analysis with human judgments. We find low or no correlation between BLEU and the grammaticality and meaning preservation parameters where sentence splitting is involved. Moreover, BLEU often negatively correlates with simplicity, essentially penalizing simpler sentences.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sulem-abend-rappoport:2018:EMNLP</bibkey>
   </paper>
@@ -1457,6 +1538,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>745–750</pages>
     <url>http://www.aclweb.org/anthology/D18-1082</url>
+    <abstract>How to generate relevant and informative responses is one of the core topics in response generation area. Following the task formulation of machine translation, previous works mainly consider response generation task as a mapping from a source sentence to a target sentence. To realize this mapping, existing works tend to design intuitive but complex models. However, the relevant information existed in large dialogue corpus is mainly overlooked. In this paper, we propose Sequence to Sequence with Prototype Memory Network (S2SPMN) to exploit the relevant information provided by the large dialogue corpus to enhance response generation. Specifically, we devise two simple approaches in S2SPMN to select the relevant information (named prototypes) from the dialogue corpus. These prototypes are then saved into prototype memory network (PMN). Furthermore, a hierarchical attention mechanism is devised to extract the semantic information from the PMN to assist the response generation process. Empirical studies reveal the advantage of our model over several classical and strong baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pei-li:2018:EMNLP</bibkey>
   </paper>
@@ -1475,6 +1557,7 @@
     <pages>751–756</pages>
     <url>http://www.aclweb.org/anthology/D18-1083</url>
     <attachment type="attachment">D18-1083.Attachment.zip</attachment>
+    <abstract>Recently, Reinforcement Learning (RL) approaches have demonstrated advanced performance in image captioning by directly optimizing the metric used for testing.  However, this shaped reward introduces learning biases, which reduces the readability of generated text.  In addition, the large sample space makes training unstable and slow.To alleviate these issues, we propose a simple coherent solution that constrains the action space using an n-gram language prior.  Quantitative and qualitative evaluations on benchmarks show that RL with the simple add-on module performs favorably against its counterpart in terms of both readability and speed of convergence. Human evaluation results show that our model is more human readable and graceful. The implementation will become publicly available upon the acceptance of the paper.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>guo-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -1491,6 +1574,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>757–761</pages>
     <url>http://www.aclweb.org/anthology/D18-1084</url>
+    <abstract>Image paragraph captioning models aim to produce detailed descriptions of a source image. These models use similar techniques as standard image captioning models, but they have encountered issues in text generation, notably a lack of diversity between sentences, that have limited their effectiveness. In this work, we consider applying sequence-level training for this task. We find that standard self-critical training produces poor results, but when combined with an integrated penalty on trigram repetition produces much more diverse paragraphs. This simple training approach improves on the best result on the Visual Genome paragraph captioning dataset from 16.9 to 30.6 CIDEr, with gains on METEOR and BLEU as well, without requiring any architectural changes.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>melaskyriazi-rush-han:2018:EMNLP</bibkey>
   </paper>
@@ -1508,6 +1592,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>762–767</pages>
     <url>http://www.aclweb.org/anthology/D18-1085</url>
+    <abstract>ROUGE is one of the first and most widely used evaluation metrics for text summarization. However, its assessment merely relies on surface similarities between peer and model summaries. Consequently, ROUGE is unable to fairly evaluate summaries including lexical variations and paraphrasing. We propose a graph-based approach adopted into ROUGE to evaluate summaries based on both lexical and semantic similarities. Experiment results over TAC AESOP datasets show that exploiting the lexico-semantic similarity of the words used in summaries would significantly help ROUGE correlate better with human judgments.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shafieibavani-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -1523,6 +1608,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>768–773</pages>
     <url>http://www.aclweb.org/anthology/D18-1086</url>
+    <abstract>Recent work on abstractive summarization has made progress with neural encoder-decoder architectures. However, such models are often challenged due to their lack of explicit semantic modeling of the source document and its summary. In this paper, we extend previous work on abstractive summarization using Abstract Meaning Representation (AMR) with a neural language generation stage which we guide using the source document. We demonstrate that this guidance improves summarization results by 7.4 and 10.5 points in ROUGE-2 using gold standard AMR parses and parses obtained from an off-the-shelf parser respectively. We also find that the summarization performance on later parses is 2 ROUGE-2 points higher than that of a well-established neural encoder-decoder approach trained on a larger dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hardy-vlachos:2018:EMNLP</bibkey>
   </paper>
@@ -1543,6 +1629,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>774–778</pages>
     <url>http://www.aclweb.org/anthology/D18-1087</url>
+    <abstract>Practical summarization systems are expected to produce summaries of varying lengths, per user needs. While a couple of early summarization benchmarks tested systems across multiple summary lengths, this practice was mostly abandoned due to the assumed cost of producing reference summaries of multiple lengths. In this paper, we raise the research question of whether reference summaries of a single length can be used to reliably evaluate system summaries of multiple lengths. For that, we have analyzed a couple of datasets as a case study, using several variants of the ROUGE metric that are standard in summarization evaluation. Our findings indicate that the evaluation protocol in question is indeed competitive. This result paves the way to practically evaluating varying-length summaries with simple, possibly existing, summarization benchmarks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shapira-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -1560,6 +1647,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>779–784</pages>
     <url>http://www.aclweb.org/anthology/D18-1088</url>
+    <abstract>Extractive summarization models need sentence level labels, which are usually created with rule-based methods since most summarization datasets only have document summary pairs. These labels might be suboptimal. We propose a latent variable extractive model, where sentences are viewed as latent variables and sentences with activated variables are used to infer gold summaries. During training, the loss can come directly from gold summaries. Experiments on CNN/Dailymail dataset show our latent extractive model outperforms a strong extractive baseline trained on rule-based labels and also performs competitively with several recent models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -1576,6 +1664,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>785–790</pages>
     <url>http://www.aclweb.org/anthology/D18-1089</url>
+    <abstract>Many modern neural document summarization systems based on encoder-decoder networks are designed to produce abstractive summaries. We attempted to verify the degree of abstractiveness of modern neural abstractive summarization systems by calculating overlaps in terms of various types of units. Upon the observation that many abstractive systems tend to be near-extractive in practice, we also implemented a pure copy system, which achieved comparable results as abstractive summarizers while being far more computationally efficient. These findings suggest the possibility for future efforts towards more efficient systems that could better utilize the vocabulary in the original document.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-yao-yan:2018:EMNLP</bibkey>
   </paper>
@@ -1593,6 +1682,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>791–797</pages>
     <url>http://www.aclweb.org/anthology/D18-1090</url>
+    <abstract>Automatic essay scoring (AES) is the task of assigning grades to essays without human interference. Existing systems for AES are typically trained to predict the score of each single essay at a time without considering the rating schema. In order to address this issue, we propose a reinforcement learning framework for essay scoring that incorporates quadratic weighted kappa as guidance to optimize the scoring system. Experiment results on benchmark datasets show the effectiveness of our framework.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -1608,6 +1698,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>798–803</pages>
     <url>http://www.aclweb.org/anthology/D18-1091</url>
+    <abstract>Understanding search queries is a hard problem as it involves dealing with ``word salad'' text ubiquitously issued by users. However, if a query resembles a well-formed question, a natural language processing pipeline is able to perform more accurate interpretation, thus reducing downstream compounding errors. Hence, identifying whether or not a query is well formed can enhance query understanding. Here, we introduce a new task of identifying a well-formed natural language question. We construct and release a dataset of 25,100 publicly available questions classified into well-formed and non-wellformed categories and report an accuracy of 70.7\% on the test set. We also show that our classifier can be used to improve the performance of neural sequence-to-sequence models for generating questions for reading comprehension.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>faruqui-das:2018:EMNLP</bibkey>
   </paper>
@@ -1623,6 +1714,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>804–810</pages>
     <url>http://www.aclweb.org/anthology/D18-1092</url>
+    <abstract>Deep neural networks reach state-of-the-art performance for wide range of natural language processing, computer vision and speech applications. Yet, one of the biggest challenges is running these complex networks on devices such as mobile phones or smart watches with tiny memory footprint and low computational capacity. We propose on-device Self-Governing Neural Networks (SGNNs), which learn compact projection vectors with local sensitive hashing. The key advantage of SGNNs over existing work is that they surmount the need for pre-trained word embeddings and complex networks with huge parameters. We conduct extensive evaluation on dialog act classification and show significant improvement over state-of-the-art results. Our findings show that SGNNs are effective at capturing low-dimensional semantic text representations, while maintaining high accuracy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ravi-kozareva:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/305197775" tag="video" />
@@ -1641,6 +1733,7 @@
     <pages>811–816</pages>
     <url>http://www.aclweb.org/anthology/D18-1093</url>
     <attachment type="attachment">D18-1093.Attachment.zip</attachment>
+    <abstract>We focus on the multi-label categorization task for short texts and explore the use of a hierarchical structure (HS) of categories. In contrast to the existing work using non-hierarchical flat model, the method leverages the hierarchical relations between the pre-defined categories to tackle the data sparsity problem. The lower the HS level, the less the categorization performance. Because the number of training data per category in a lower level is much smaller than that in an upper level. We propose an approach which can effectively utilize the data in the upper levels to contribute the categorization in the lower levels by applying the Convolutional Neural Network (CNN) with a fine-tuning technique. The results using two benchmark datasets show that proposed method, Hierarchical Fine-Tuning based CNN (HFT-CNN) is competitive with the state-of-the-art CNN based methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shimura-li-fukumoto:2018:EMNLP</bibkey>
   </paper>
@@ -1659,6 +1752,7 @@
     <pages>817–823</pages>
     <url>http://www.aclweb.org/anthology/D18-1094</url>
     <attachment type="attachment">D18-1094.Attachment.zip</attachment>
+    <abstract>Deep neural networks have been displaying superior  performance over traditional supervised classifiers in text classification. They learn to extract useful features automatically when sufficient amount of data is presented. However, along with the growth in the number of documents comes the increase in the number of categories, which often results in poor performance of the multiclass classifiers. In this work, we use external knowledge in the form of topic category taxonomies to aide the classification by introducing a deep hierarchical neural attention-based classifier.  Our model performs better than or comparable to state-of-the-art hierarchical models at significantly lower computational cost while maintaining high interpretability.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sinha-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -1677,6 +1771,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>824–829</pages>
     <url>http://www.aclweb.org/anthology/D18-1095</url>
+    <abstract>We propose Labeled Anchors, an interactive and supervised topic model based on the anchor words algorithm (Arora et al., 2013). Labeled Anchors is similar to Supervised Anchors (Nguyen et al., 2014) in that it extends the vector-space representation of words to include document labels. However, our formulation also admits a classifier which requires no training beyond inferring topics, which means our approach is also fast enough to be interactive. We run a small user study that demonstrates that untrained users can interactively update topics in order to improve classification accuracy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lund-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -1693,6 +1788,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>830–836</pages>
     <url>http://www.aclweb.org/anthology/D18-1096</url>
+    <abstract>Topic models are evaluated based on their ability to describe documents well (i.e. low perplexity) and to produce topics that carry coherent semantic meaning. In topic modeling so far, perplexity is a direct optimization target. However, topic coherence, owing to its challenging computation, is not optimized for and is only evaluated after training. In this work, under a neural variational inference framework, we propose methods to incorporate a topic coherence objective into the training process. We demonstrate that such a coherence-aware topic model exhibits a similar level of perplexity as baseline models but achieves substantially higher topic coherence.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ding-nallapati-xiang:2018:EMNLP</bibkey>
   </paper>
@@ -1709,6 +1805,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>837–843</pages>
     <url>http://www.aclweb.org/anthology/D18-1097</url>
+    <abstract>Text normalization is an important enabling technology for several NLP tasks. Recently, neural-network-based approaches have outperformed well-established models in this task. However, in languages other than English, there has been little exploration in this direction. Both the scarcity of annotated data and the complexity of the language increase the difficulty of the problem. To address these challenges, we use a sequence-to-sequence model with character-based attention, which in addition to its self-learned character embeddings, uses word embeddings pre-trained with an approach that also models subword information. This provides the neural model with access to more linguistic information especially suitable for text normalization, without large parallel corpora. We show that providing the model with word-level features bridges the gap for the neural network approach to achieve a state-of-the-art F1 score on a standard Arabic language correction shared task dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>watson-zalmout-habash:2018:EMNLP</bibkey>
   </paper>
@@ -1726,6 +1823,7 @@
     <pages>844–849</pages>
     <url>http://www.aclweb.org/anthology/D18-1098</url>
     <attachment type="attachment">D18-1098.Attachment.pdf</attachment>
+    <abstract>Topic coherence is increasingly being used to evaluate topic models and filter topics for end-user applications. Topic coherence measures how well topic words relate to each other, but offers little insight on the utility of the topics in describing the documents.  In this paper, we explore the topic intrusion task --- the task of guessing an outlier topic given a document and a few topics --- and propose a method to automate it. We improve upon the state-of-the-art substantially, demonstrating its viability as an alternative method for topic model evaluation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bhatia-lau-baldwin:2018:EMNLP</bibkey>
   </paper>
@@ -1742,6 +1840,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>850–855</pages>
     <url>http://www.aclweb.org/anthology/D18-1099</url>
+    <abstract>The text in many web documents is organized into a hierarchy of section titles and corresponding prose content, a structure which provides potentially exploitable information on discourse structure and topicality. However, this organization is generally discarded during text collection, and collecting it is not straightforward: the same visual organization can be implemented in a myriad of different ways in the underlying HTML. To remedy this, we present a flexible system for automatically extracting the hierarchical section titles and prose organization of web documents irrespective of differences in HTML representation. This system uses features from syntax, semantics, discourse and markup to build two models which classify HTML text into section titles and prose text. When tested on three different domains of web text, our domain-independent system achieves an overall precision of 0.82 and a recall of 0.98. The domain-dependent variation produces very high precision (0.99) at the expense of recall (0.75). These results exhibit a robust level of accuracy suitable for enhancing question answering, information extraction, and summarization.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mysoregopinath-wilson-sadeh:2018:EMNLP</bibkey>
   </paper>
@@ -1760,6 +1859,7 @@
     <pages>856–861</pages>
     <url>http://www.aclweb.org/anthology/D18-1100</url>
     <attachment type="attachment">D18-1100.Attachment.pdf</attachment>
+    <abstract>In this work, we examine methods for data augmentation for text-based tasks such as neural machine translation (NMT). We formulate the design of a data augmentation policy with desirable properties as an optimization problem, and derive a generic analytic solution. This solution not only subsumes some existing augmentation schemes, but also leads to an extremely simple data augmentation strategy for NMT: randomly replacing words in both the source sentence and the target sentence with other random words from their corresponding vocabularies. We name this method SwitchOut. Experiments on three translation datasets of different scales show that SwitchOut yields consistent improvements of about 0.5 BLEU, achieving better or comparable performances to strong alternatives such as word dropout (Sennrich et al., 2016a). Code to implement this method is included in the appendix.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP4</bibkey>
     <video href="https://vimeo.com/305206127" tag="video" />
@@ -1777,6 +1877,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>862–868</pages>
     <url>http://www.aclweb.org/anthology/D18-1101</url>
+    <abstract>Unsupervised learning of cross-lingual word embedding offers elegant matching of words across languages, but has fundamental limitations in translating sentences. In this paper, we propose simple yet effective methods to improve word-by-word translation of cross-lingual embeddings, using only monolingual corpora but without any back-translation. We integrate a language model for context-aware search, and use a novel denoising autoencoder to handle reordering. Our system surpasses state-of-the-art unsupervised translation systems without costly iterative training. We also analyze the effect of vocabulary size and denoising type on the translation performance, which provides better understanding of learning the cross-lingual word embedding and its usage in translation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kim-geng-ney:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305206383" tag="video" />
@@ -1794,6 +1895,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>869–874</pages>
     <url>http://www.aclweb.org/anthology/D18-1102</url>
+    <abstract>Decipherment of homophonic substitution ciphers using language models is a well-studied task in NLP. Previous work in this topic scores short local spans of possible plaintext decipherments using n-gram language models. The most widely used technique is the use of beam search with n-gram language models proposed by Nuhn et al.(2013). We propose a beam search algorithm that scores the entire candidate plaintext at each step of the decipherment using a neural language model. We augment beam search with a novel rest cost estimation that exploits the prediction power of a neural language model. We compare against the state of the art n-gram based methods on many different decipherment tasks. On challenging ciphers such as the Beale cipher we provide significantly better error rates with much smaller beam sizes.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kambhatla-mansouribigvand-sarkar:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305206655" tag="video" />
@@ -1810,6 +1912,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>875–880</pages>
     <url>http://www.aclweb.org/anthology/D18-1103</url>
+    <abstract>This paper examines the problem of adapting neural machine translation systems to new, low-resourced languages (LRLs) as effectively and rapidly as possible. We propose methods based on starting with massively multilingual ``seed models'', which can be trained ahead-of-time, and then continuing training on data related to the LRL. We contrast a number of strategies, leading to a novel, simple, yet effective method of ``similar-language regularization'', where we jointly train on both a LRL of interest and a similar high-resourced language to prevent over-fitting to small LRL data. Experiments demonstrate that massively multilingual models, even without any explicit adaptation, are surprisingly effective, achieving BLEU scores of up to 15.5 with no data from the LRL, and that the proposed similar-language regularization method improves over other adaptation methods by 1.7 BLEU points average over 4 LRL settings.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>neubig-hu:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305207187" tag="video" />
@@ -1827,6 +1930,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>881–886</pages>
     <url>http://www.aclweb.org/anthology/D18-1104</url>
+    <abstract>We propose and compare methods for gradient-based domain adaptation of self-attentive neural machine translation models. We demonstrate that a large proportion of model parameters can be frozen during adaptation with minimal or no reduction in translation quality by encouraging structured sparsity in the set of offset tensors during learning via group lasso regularization. We evaluate this technique for both batch and incremental adaptation across multiple data sets and language pairs. Our system architecture--combining a state-of-the-art self-attentive model with compact domain adaptation--provides high quality personalized machine translation that is both space and time efficient.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wuebker-simianer-denero:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305207608" tag="video" />
@@ -1843,6 +1947,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>887–893</pages>
     <url>http://www.aclweb.org/anthology/D18-1105</url>
+    <abstract>Deep neural networks reach state-of-the-art performance for wide range of natural language processing, computer vision and speech applications. Yet, one of the biggest challenges is running these complex networks on devices such as mobile phones or smart watches with tiny memory footprint and low computational capacity. We propose on-device Self-Governing Neural Networks (SGNNs), which learn compact projection vectors with local sensitive hashing. The key advantage of SGNNs over existing work is that they surmount the need for pre-trained word embeddings and complex networks with huge parameters. We conduct extensive evaluation on dialog act classification and show significant improvement over state-of-the-art results. Our findings show that SGNNs are effective at capturing low-dimensional semantic text representations, while maintaining high accuracy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ravi-kozareva:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305197775" tag="video" />
@@ -1859,6 +1964,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>894–899</pages>
     <url>http://www.aclweb.org/anthology/D18-1106</url>
+    <abstract>In large-scale domain classification for natural language understanding, leveraging each user's domain enablement information, which refers to the preferred or authenticated domains by the user, with attention mechanism has been shown to improve the overall domain classification performance. In this paper, we propose a supervised enablement attention mechanism, which utilizes sigmoid activation for the attention weighting so that the attention can be computed with more expressive power without the weight sum constraint of softmax attention. The attention weights are explicitly encouraged to be similar to the corresponding elements of the output one-hot vector, and self-distillation is used to leverage the attention information of the other enabled domains. By evaluating on the actual utterances from a large-scale IPDA, we show that our approach significantly improves domain classification performance</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kim-kim:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305198062" tag="video" />
@@ -1876,6 +1982,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>900–904</pages>
     <url>http://www.aclweb.org/anthology/D18-1107</url>
+    <abstract>In the sentence classification task, context formed from sentences adjacent to the sentence being classified can provide important information for classification. This context is, however, often ignored. Where methods do make use of context, only small amounts are considered, making it difficult to scale. We present a new method for sentence classification, Context-LSTM-CNN, that makes use of potentially large contexts. The method also utilizes long-range dependencies within the sentence being classified, using an LSTM, and short-span features, using a stacked CNN. Our experiments demonstrate that this approach consistently improves over previous methods on two different datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>song-petrak-roberts:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305198319" tag="video" />
@@ -1894,6 +2001,7 @@
     <pages>905–911</pages>
     <url>http://www.aclweb.org/anthology/D18-1108</url>
     <attachment type="attachment">D18-1108.Attachment.zip</attachment>
+    <abstract>Deep NLP models benefit from underlying structures in the data---e.g., parse trees---typically extracted using off-the-shelf parsers. Recent attempts to jointly learn the latent structure encounter a tradeoff: either make factorization assumptions that limit expressiveness, or sacrifice end-to-end differentiability. Using the recently proposed SparseMAP inference, which retrieves a sparse distribution over latent structures, we propose a novel approach for end-to-end learning of latent structure predictors jointly with a downstream predictor. To the best of our knowledge, our method is the first to enable unrestricted dynamic computation graph construction from the global latent structure, while maintaining differentiability.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>niculae-martins-cardie:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305198410" tag="video" />
@@ -1909,6 +2017,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>912–917</pages>
     <url>http://www.aclweb.org/anthology/D18-1109</url>
+    <abstract>We introduce a class of convolutional neural networks (CNNs) that utilize recurrent neural networks (RNNs) as convolution filters. A convolution filter is typically implemented as a linear affine transformation followed by a non-linear function, which fails to account for language compositionality. As a result, it limits the use of high-order filters that are often warranted for natural language processing tasks. In this work, we model convolution filters with RNNs that naturally capture compositionality and long-term dependencies in language. We show that simple CNN architectures equipped with recurrent neural filters (RNFs) achieve results that are on par with the best published ones on the Stanford Sentiment Treebank and two answer sentence selection datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305198501" tag="video" />
@@ -1929,6 +2038,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>918–924</pages>
     <url>http://www.aclweb.org/anthology/D18-1110</url>
+    <abstract>Existing neural semantic parsers mainly utilize a sequence encoder, i.e., a sequential LSTM, to extract word order features while neglecting other valuable syntactic information such as dependency or constituent trees. In this paper, we first propose to use the syntactic graph to represent three types of syntactic information, i.e., word order, dependency and constituency features; then employ a graph-to-sequence model to encode the syntactic graph and decode a logical form. Experimental results on benchmark datasets show that our model is comparable to the state-of-the-art on Jobs640, ATIS, and Geo880. Experimental results on adversarial examples demonstrate the robustness of the model is also improved by encoding more syntactic information.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305213182" tag="video" />
@@ -1949,6 +2059,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>925–930</pages>
     <url>http://www.aclweb.org/anthology/D18-1111</url>
+    <abstract>In models to generate program source code from natural language, representing this code in a tree structure has been a common approach. However, existing methods often fail to generate complex code correctly due to a lack of ability to memorize large and complex structures. We introduce RECODE, a method based on subtree retrieval that makes it possible to explicitly reference existing code examples within a neural code generation model. First, we retrieve sentences that are similar to input sentences using a dynamic- programming-based sentence similarity scoring method. Next, we extract n-grams of action sequences that build the associated abstract syntax tree. Finally, we increase the probability of actions that cause the retrieved n-gram action subtree to be in the predicted code. We show that our approach improves the performance on two code generation tasks by up to +2.6 BLEU.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hayati-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305213468" tag="video" />
@@ -1968,6 +2079,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>931–936</pages>
     <url>http://www.aclweb.org/anthology/D18-1112</url>
+    <abstract>Previous work approaches the SQL-to-text generation task using vanilla Seq2Seq models, which may not fully capture the inherent graph-structured information in SQL query. In this paper, we propose a graph-to-sequence model to encode the global structure information into node embeddings. This model can effectively learn the correlation between the SQL query pattern and its interpretation. Experimental results on the WikiSQL dataset and Stackoverflow dataset show that our model outperforms the Seq2Seq and Tree2Seq baselines, achieving the state-of-the-art performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/305213739" tag="video" />
@@ -1984,6 +2096,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>937–943</pages>
     <url>http://www.aclweb.org/anthology/D18-1113</url>
+    <abstract>We study the automatic generation of syntactic paraphrases using four different models for generation: data-to-text generation, text-to-text generation, text reduction and text expansion, We derive training data for each of these tasks from the WebNLG dataset and we show (i) that conditioning generation on syntactic constraints effectively permits the generation of syntactically distinct paraphrases for the same input and (ii) that exploiting different types of input (data, text or data+text) further increases the number of distinct paraphrases that can be generated for a given input.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>colin-gardent:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305214075" tag="video" />
@@ -2003,6 +2116,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>944–955</pages>
     <url>http://www.aclweb.org/anthology/D18-1114</url>
+    <abstract>We present a model for semantic proto-role labeling (SPRL) using an adapted bidirectional LSTM encoding strategy that we call NeuralDavidsonian: predicate-argument structure is represented as pairs of hidden states corresponding to predicate and argument head tokens of the input sequence. We demonstrate: (1) state-of-the-art results in SPRL, and (2) that our network naturally shares parameters between attributes, allowing for learning new attribute types with limited added supervision.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>rudinger-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305214361" tag="video" />
@@ -2019,6 +2133,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>956–961</pages>
     <url>http://www.aclweb.org/anthology/D18-1115</url>
+    <abstract>Styles of leaders when they make decisions in groups vary, and the different styles affect the performance of the group. To understand the key words and speakers associated with decisions, we initially formalize the problem as one of predicting leaders' decisions from discussion with group members. As a dataset, we introduce conversational meeting records from a historical corpus, and develop a hierarchical RNN structure with attention and pre-trained speaker embedding in the form of a, Conversational Decision Making Model (CDMM). The CDMM outperforms other baselines to predict leaders' final decisions from the data. We explain why CDMM works better than other methods by showing the key words and speakers discovered from the attentions as evidence.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bak-oh:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306361321" tag="video" />
@@ -2036,6 +2151,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>962–967</pages>
     <url>http://www.aclweb.org/anthology/D18-1116</url>
+    <abstract>Discourse segmentation, which segments texts into Elementary Discourse Units, is a fundamental step in discourse analysis. Previous discourse segmenters rely on complicated hand-crafted features and are not practical in actual use. In this paper, we propose an end-to-end neural segmenter based on BiLSTM-CRF framework. To improve its accuracy, we address the problem of data insufficiency by transferring a word representation model that is trained on a large corpus. We also propose a restricted self-attention mechanism in order to capture useful information within a neighborhood. Experiments on the RST-DT corpus show that our model is significantly faster than previous methods, while achieving new state-of-the-art performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-li-yang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306361340" tag="video" />
@@ -2053,6 +2169,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>968–974</pages>
     <url>http://www.aclweb.org/anthology/D18-1117</url>
+    <abstract>Video content on social media platforms constitutes a major part of the communication between people, as it allows everyone to share their stories. However, if someone is unable to consume video, either due to a disability or network bandwidth, this severely limits their participation and communication. Automatically telling the stories using multi-sentence descriptions of videos would allow bridging this gap. To learn and evaluate such models,  we introduce VideoStory a new large-scale dataset for video description as a new challenge for multi-sentence video description. Our VideoStory captions dataset is complementary to prior work and contains 20k videos posted publicly on a social media platform amounting to 396 hours of video with 123k sentences, temporally aligned to the video.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gella-lewis-rohrbach:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306361803" tag="video" />
@@ -2072,6 +2189,7 @@
     <pages>975–980</pages>
     <url>http://www.aclweb.org/anthology/D18-1118</url>
     <attachment type="attachment">D18-1118.Attachment.zip</attachment>
+    <abstract>Visual reasoning is a special visual question answering problem that is multi-step and compositional by nature, and also requires intensive text-vision interactions. We propose CMM: Cascaded Mutual Modulation as a novel end-to-end visual reasoning model. CMM includes a multi-step comprehension process for both question and image. In each step, we use a Feature-wise Linear Modulation (FiLM) technique to enable textual/visual pipeline to mutually control each other. Experiments show that CMM significantly outperforms most related models, and reach state-of-the-arts on two visual reasoning benchmarks: CLEVR and NLVR, collected from both synthetic and natural languages. Ablation studies confirm the effectiveness of CMM to comprehend natural language logics under the guidence of images. Our code is available at https://github.com/FlamingHorizon/CMM-VR.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yao-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306362249" tag="video" />
@@ -2088,6 +2206,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>981–985</pages>
     <url>http://www.aclweb.org/anthology/D18-1119</url>
+    <abstract>There is growing interest in the language developed by agents interacting in emergent-communication settings. Earlier studies have focused on the agents' symbol usage, rather than on their representation of visual input. In this paper, we consider the referential games of Lazaridou et al. (2017), and investigate the representations the agents develop during their evolving interaction. We find that the agents establish successful communication by inducing visual representations that almost perfectly align with each other, but, surprisingly, do not capture the conceptual properties of the objects depicted in the input images. We conclude that, if we care about developing language-like communication systems, we must pay more attention to the visual semantics agents associate to the symbols they use.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bouchacourt-baroni:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306362292" tag="video" />
@@ -2109,6 +2228,7 @@
     <pages>986–992</pages>
     <url>http://www.aclweb.org/anthology/D18-1120</url>
     <attachment type="attachment">D18-1120.Attachment.zip</attachment>
+    <abstract>A capsule is a group of neurons, whose activity vector represents the instantiation parameters of a specific type of entity. In this paper, we explore the capsule networks used for relation extraction in a multi-instance multi-label learning framework and propose a novel neural approach based on   capsule networks with attention mechanisms. We evaluate our method with different benchmarks, and it is demonstrated that our method improves the precision of the predicted relations. Particularly, we show that capsule networks improve multiple entity pairs relation extraction.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -2127,6 +2247,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>993–998</pages>
     <url>http://www.aclweb.org/anthology/D18-1121</url>
+    <abstract>Entity typing aims to classify semantic types of an entity mention in a specific context. Most existing models obtain training data using distant supervision, and inevitably suffer from the problem of noisy labels. To address this issue, we propose entity typing with language model enhancement. It utilizes a language model to measure the compatibility between context sentences and labels, and thereby automatically focuses more on context-dependent labels. Experiments on benchmark datasets demonstrate that our method is capable of enhancing the entity typing model with information from the language model, and significantly outperforms the state-of-the-art baseline. Code and data for this paper can be found from https://github.com/thunlp/LME.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xin-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -2143,6 +2264,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>999–1004</pages>
     <url>http://www.aclweb.org/anthology/D18-1122</url>
+    <abstract>Detecting events and classifying them into predefined types is an important step in knowledge extraction from natural language texts. While the neural network models have generally led the state-of-the-art, the differences in performance between different architectures have not been rigorously studied. In this paper we present a novel GRU-based model that combines syntactic information along with temporal structure through an attention mechanism. We show that it is competitive with other neural network architectures through empirical evaluations under different random initializations and training-validation-test splits of ACE2005 dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>orr-tadepalli-fern:2018:EMNLP</bibkey>
   </paper>
@@ -2161,6 +2283,7 @@
     <pages>1005–1010</pages>
     <url>http://www.aclweb.org/anthology/D18-1123</url>
     <attachment type="attachment">D18-1123.Attachment.pdf</attachment>
+    <abstract>Publication information in a researcher's academic homepage provides insights about the researcher's expertise, research interests, and collaboration networks. We aim to extract all the publication strings from a given academic homepage. This is a challenging task because the publication strings in different academic homepages may be located at different positions with different structures. To capture the positional and structural diversity, we propose an end-to-end hierarchical model named PubSE based on Bi-LSTM-CRF. We further propose an alternating training method for training the model. Experiments on real data show that PubSE outperforms the state-of-the-art models by up to 11.8\% in F1-score.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP5</bibkey>
   </paper>
@@ -2178,6 +2301,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1011–1017</pages>
     <url>http://www.aclweb.org/anthology/D18-1124</url>
+    <abstract>It is common that entity mentions can contain other mentions recursively. This paper introduces a scalable transition-based method to model the nested structure of mentions. We first map a sentence with nested mentions to a designated forest where each mention corresponds to a constituent of the forest. Our shift-reduce based system then learns to construct the forest structure in a bottom-up manner through an action sequence whose maximal length is guaranteed to be  three times of the sentence length. Based on Stack-LSTM which is employed to efficiently and effectively represent the states of the system in a continuous space, our system is further incorporated with a character-based component to capture letter-level patterns.  Our model gets the state-of-the-art performances in ACE datasets, showing its effectiveness in detecting nested mentions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP5</bibkey>
   </paper>
@@ -2198,6 +2322,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1018–1023</pages>
     <url>http://www.aclweb.org/anthology/D18-1125</url>
+    <abstract>Relation Extraction suffers from dramatical performance decrease when training a model on one genre and directly applying it to a new genre, due to the distinct feature distributions. Previous studies address this problem by discovering a shared space across genres using manually crafted features, which requires great human effort. To effectively automate this process, we design a genre-separation network, which applies two encoders, one genre-independent and one genre-shared, to explicitly extract genre-specific and genre-agnostic features. Then we train a relation classifier using the genre-agnostic features on the source genre and directly apply to the target genre. Experiment results on three distinct genres of the ACE dataset show that our approach achieves up to 6.1\% absolute F1-score gain compared to previous methods. By incorporating a set of external linguistic features, our approach outperforms the state-of-the-art by 1.7\% absolute F1 gain. We make all programs of our model publicly available for research purpose</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shi-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -2213,6 +2338,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1024–1029</pages>
     <url>http://www.aclweb.org/anthology/D18-1126</url>
+    <abstract>To disambiguate between closely related concepts, entity linking systems need to effectively distill cues from their context, which may be quite noisy. We investigate several techniques for using these cues in the context of noisy entity linking on short texts. Our starting point is a state-of-the-art attention-based model from prior work; while this model's attention typically identifies context that is topically relevant, it fails to identify some of the most indicative surface strings, especially those exhibiting lexical overlap with the true title. Augmenting the model with convolutional networks over characters still leaves it largely unable to pick up on these cues compared to sparse features that target them directly, indicating that automatically learning how to identify relevant character-level context features is a hard problem. Our final system outperforms past work on the WikilinksNED test set by 2.8\% absolute.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mueller-durrett:2018:EMNLP</bibkey>
   </paper>
@@ -2230,6 +2356,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1030–1035</pages>
     <url>http://www.aclweb.org/anthology/D18-1127</url>
+    <abstract>The task of event detection involves identifying and categorizing event triggers. Contextual information has been shown effective on the task. However, existing methods which utilize contextual information only process the context once. We argue that the context can be better exploited by processing the context multiple times, allowing the model to perform complex reasoning and to generate better context representation, thus improving the overall performance. Meanwhile, dynamic memory network (DMN) has demonstrated promising capability in capturing contextual information and has been applied successfully to various tasks. In light of the multi-hop mechanism of the DMN to model the context, we propose the trigger detection dynamic memory network (TD-DMN) to tackle the event detection problem. We performed a five-fold cross-validation on the ACE-2005 dataset and experimental results show that the multi-hop mechanism does improve the performance and the proposed model achieves best F1 score compared to the state-of-the-art methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -2249,6 +2376,7 @@
     <pages>1036–1042</pages>
     <url>http://www.aclweb.org/anthology/D18-1128</url>
     <attachment type="attachment">D18-1128.Attachment.zip</attachment>
+    <abstract>A rich line of research attempts to make deep neural networks more transparent by generating human-interpretable 'explanations' of their decision process, especially for interactive tasks like Visual Question Answering (VQA). In this work, we analyze if existing explanations indeed make a VQA model --- its responses as well as failures --- more predictable to a human. Surprisingly, we find that they do not. On the other hand, we find that human-in-the-loop approaches that treat the model as a black-box do.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chandrasekaran-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2265,6 +2393,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1043–1048</pages>
     <url>http://www.aclweb.org/anthology/D18-1129</url>
+    <abstract>This work introduces fact salience: The task of generating a machine-readable representation of the most prominent information in a text document as a set of facts. We also present SalIE, the first fact salience system. SalIE is unsupervised and knowledge agnostic, based on open information extraction to detect facts in natural language text, PageRank to determine their relevance, and clustering to promote diversity. We compare SalIE with several baselines (including positional, standard for saliency tasks), and in an extrinsic evaluation, with state-of-the-art automatic text summarizers. SalIE outperforms baselines and text summarizers showing that facts are an effective way to compress information.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ponza-delcorro-weikum:2018:EMNLP</bibkey>
   </paper>
@@ -2282,6 +2411,7 @@
     <pages>1049–1055</pages>
     <url>http://www.aclweb.org/anthology/D18-1130</url>
     <attachment type="attachment">D18-1130.Attachment.pdf</attachment>
+    <abstract>Recent work has improved on modeling for reading comprehension tasks with simple approaches such as the Attention Sum-Reader; however, automatic systems still significantly trail human performance. Analysis suggests that many of the remaining hard instances are related to the inability to track entity-references throughout documents. This work focuses on these hard entity tracking cases with two extensions: (1) additional entity features, and (2) training with a multi-task tracking objective. We show that these simple modifications improve performance both independently and in combination, and we outperform the previous state of the art on the LAMBADA dataset by 8 pts, particularly on difficult entity examples. We also effectively match the performance of more complicated models on the named entity portion of the CBT dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hoang-wiseman-rush:2018:EMNLP</bibkey>
   </paper>
@@ -2300,6 +2430,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1056–1063</pages>
     <url>http://www.aclweb.org/anthology/D18-1131</url>
+    <abstract>We address the problem of detecting duplicate questions in forums, which is an important step towards automating the process of answering new questions. As finding and annotating such potential duplicates manually is very tedious and costly, automatic methods based on machine learning are a viable alternative. However, many forums do not have annotated data, i.e., questions labeled by experts as duplicates, and thus a promising solution is to use domain adaptation from another forum that has such annotations. Here we focus on adversarial domain adaptation, deriving important findings about when it performs well and what properties of the domains are important in this regard. Our experiments with StackExchange data show an average improvement of 5.6\% over the best baseline across multiple pairs of domains.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shah-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2318,6 +2449,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1064–1069</pages>
     <url>http://www.aclweb.org/anthology/D18-1132</url>
+    <abstract>Sequence-to-sequence (SEQ2SEQ) models have been successfully applied to automatic math word problem solving. Despite its simplicity, a drawback still remains: a math word problem can be correctly solved by more than one equations. This non-deterministic transduction harms the performance of maximum likelihood estimation. In this paper, by considering the uniqueness of expression tree, we propose an equation normalization method to normalize the duplicated equations. Moreover, we analyze the performance of three popular SEQ2SEQ models on the math word problem solving. We find that each model has its own specialty in solving problems, consequently an ensemble model is then proposed to combine their advantages. Experiments on dataset Math23K show that the ensemble model with equation normalization significantly outperforms the previous state-of-the-art methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP6</bibkey>
   </paper>
@@ -2334,6 +2466,7 @@
     <pages>1070–1076</pages>
     <url>http://www.aclweb.org/anthology/D18-1133</url>
     <attachment type="attachment">D18-1133.Attachment.zip</attachment>
+    <abstract>State-of-the-art networks that model relations between two pieces of text often use complex architectures and attention. In this paper, instead of focusing on architecture engineering, we take advantage of small amounts of labelled data that model semantic phenomena in text to encode matching features directly in the word representations. This greatly boosts the accuracy of our reference network, while keeping the model simple and fast to train. Our approach also beats a tree kernel model that uses similar input encodings, and neural models which use advanced attention and compare-aggregate mechanisms.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>nicosia-moschitti:2018:EMNLP</bibkey>
   </paper>
@@ -2350,6 +2483,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1077–1083</pages>
     <url>http://www.aclweb.org/anthology/D18-1134</url>
+    <abstract>Previous work on question-answering systems mainly focuses on answering individual questions, assuming they are independent and devoid of context. Instead, we investigate sequential question answering, asking multiple related questions. We present QBLink, a new dataset of fully human-authored questions. We extend existing strong question answering frameworks to include previous questions to improve the overall question-answering accuracy in open-domain question answering. The dataset is publicly available at \url{http://sequential.qanta.org}.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>elgohary-zhao-boydgraber:2018:EMNLP</bibkey>
   </paper>
@@ -2365,6 +2499,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1084–1090</pages>
     <url>http://www.aclweb.org/anthology/D18-1135</url>
+    <abstract>Recently, string kernels have obtained state-of-the-art results in various text classification tasks such as Arabic dialect identification or native language identification. In this paper, we apply two simple yet effective transductive learning approaches to further improve the results of string kernels. The first approach is based on interpreting the pairwise string kernel similarities between samples in the training set and samples in the test set as features. Our second approach is a simple self-training method based on two learning iterations. In the first iteration, a classifier is trained on the training set and tested on the test set, as usual. In the second iteration, a number of test samples (to which the classifier associated higher confidence scores) are added to the training set for another round of training. However, the ground-truth labels of the added test samples are not necessary. Instead, we use the labels predicted by the classifier in the first training iteration. By adapting string kernels to the test set, we report significantly better accuracy rates in English polarity classification and Arabic dialect identification.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ionescu-butnaru:2018:EMNLP</bibkey>
   </paper>
@@ -2380,6 +2515,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1091–1096</pages>
     <url>http://www.aclweb.org/anthology/D18-1136</url>
+    <abstract>We introduce a novel parameterized convolutional neural network for aspect level sentiment classification. Using parameterized filters and parameterized gates, we incorporate aspect information into convolutional neural networks (CNN). Experiments demonstrate that our parameterized filters and parameterized gates effectively capture the aspect-specific features, and our CNN-based models achieve excellent results on SemEval 2014 datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang-carley:2018:EMNLP</bibkey>
   </paper>
@@ -2398,6 +2534,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1097–1102</pages>
     <url>http://www.aclweb.org/anthology/D18-1137</url>
+    <abstract>In this paper, we target at improving the performance of multi-label emotion classification with the help of sentiment classification. Specifically, we propose a new transfer learning architecture to divide the sentence representation into two different feature spaces, which are expected to respectively capture the general sentiment words and the other important emotion-specific words via a dual attention mechanism. Experimental results on two benchmark datasets demonstrate the effectiveness of our proposed method.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yu-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -2415,6 +2552,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1103–1108</pages>
     <url>http://www.aclweb.org/anthology/D18-1138</url>
+    <abstract>The task of sentiment modification requires reversing the sentiment of the input and preserving the sentiment-independent content. However, aligned sentences with the same content but different sentiments are usually unavailable. Due to the lack of such parallel data, it is hard to extract sentiment independent content and reverse the sentiment in an unsupervised way. Previous work usually can not reconcile sentiment transformation and content preservation. In this paper, motivated by the fact the non-emotional context (e.g., ``staff'') provides strong cues for the occurrence of emotional words (e.g., ``friendly''), we propose a novel method that automatically extracts appropriate sentiment information from learned sentiment memories according to the specific context. Experiments show that our method substantially improves the content preservation degree and achieves the state-of-the-art performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP6</bibkey>
   </paper>
@@ -2432,6 +2570,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1109–1114</pages>
     <url>http://www.aclweb.org/anthology/D18-1139</url>
+    <abstract>In this work, we propose a new model for aspect-based sentiment analysis. In contrast to previous approaches, we jointly model the detection of aspects and the classification of their polarity in an end-to-end trainable neural network. We conduct experiments with different neural architectures and word representations on the recent GermEval 2017 dataset. We were able to show considerable performance gains by using the joint modeling approach in all settings compared to pipeline approaches. The combination of a convolutional neural network and fasttext embeddings outperformed the best submission of the shared task in 2017, establishing a new state of the art.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>schmitt-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2448,6 +2587,7 @@
     <pages>1115–1121</pages>
     <url>http://www.aclweb.org/anthology/D18-1140</url>
     <attachment type="attachment">D18-1140.Attachment.tgz</attachment>
+    <abstract>We explore two methods for representing authors in the context of textual sarcasm detection: a Bayesian approach that directly represents authors' propensities to be sarcastic, and a dense embedding approach that can learn interactions between the author and the text. Using the SARC dataset of Reddit comments, we show that augmenting a bidirectional RNN with these representations improves performance; the Bayesian approach suffices in homogeneous contexts, whereas the added power of the dense embeddings proves valuable in more diverse ones.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kolchinski-potts:2018:EMNLP</bibkey>
   </paper>
@@ -2465,6 +2605,7 @@
     <pages>1122–1127</pages>
     <url>http://www.aclweb.org/anthology/D18-1141</url>
     <attachment type="attachment">D18-1141.Attachment.zip</attachment>
+    <abstract>We carry out a syntactic analysis of two state-of-the-art sentiment analyzers, Google Cloud Natural Language and Stanford CoreNLP, to assess their classification accuracy on sentences with negative polarity items. We were motivated by the absence of studies investigating sentiment analyzer performance on sentences with polarity items, a common construct in human language. Our analysis focuses on two sentential structures: downward entailment and non-monotone quantifiers; and demonstrates weaknesses of Google Natural Language and CoreNLP in capturing polarity item information. We describe the particular syntactic phenomenon that these analyzers fail to understand that any ideal sentiment analyzer must. We also provide a set of 150 test sentences that any ideal sentiment analyzer must be able to understand.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>verma-kim-walter:2018:EMNLP</bibkey>
   </paper>
@@ -2483,6 +2624,7 @@
     <pages>1128–1132</pages>
     <url>http://www.aclweb.org/anthology/D18-1142</url>
     <attachment type="attachment">D18-1142.Attachment.zip</attachment>
+    <abstract>Are brand names such as Nike female or male? Previous research suggests that the sound of a person's first name is associated with the person's gender, but no research has tried to use this knowledge to assess the gender of brand names. We present a simple computational approach that uses sound symbolism to address this open issue. Consistent with previous research, a model trained on various linguistic features of name endings predicts human gender with high accuracy. Applying this model to a data set of over a thousand commercially-traded brands in 17 product categories, our results reveal an overall bias toward male names, cutting across both male-oriented product categories as well as female-oriented categories. In addition, we find variation within categories, suggesting that firms might be seeking to imbue their brands with differentiating characteristics as part of their competitive strategy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>moorthy-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2499,6 +2641,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1133–1138</pages>
     <url>http://www.aclweb.org/anthology/D18-1143</url>
+    <abstract>Fact-checking of textual sources needs to effectively extract relevant information from large knowledge bases. In this paper, we extend an existing pipeline approach to better tackle this problem. We propose a neural ranker using a decomposable attention model that dynamically selects sentences to achieve promising improvement in evidence retrieval F1 by 38.80\%, with (x65) speedup compared to a TF-IDF method. Moreover, we incorporate lexical tagging methods into our pipeline framework to simplify the tasks and render the model more generalizable. As a result, our framework achieves promising performance on a large-scale fact extraction and verification dataset with speedup.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lee-wu-fung:2018:EMNLP</bibkey>
   </paper>
@@ -2518,6 +2661,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1139–1145</pages>
     <url>http://www.aclweb.org/anthology/D18-1144</url>
+    <abstract>We leverage a popularity measure in social media as a distant label for extractive summarization of online conversations. In social media, users can vote, share, or bookmark a post they prefer. The number of these actions is regarded as a measure of popularity. However, popularity is not determined solely by content of a post, e.g., a text or an image it contains, but is highly based on its contexts, e.g., timing, and authority. We propose Disjunctive model that computes the contribution of content and context separately. For evaluation, we build a dataset where the informativeness of comments is annotated. We evaluate the results with ranking metrics, and show that our model outperforms the baseline models which directly use popularity as a measure of informativeness.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kano-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2538,6 +2682,7 @@
     <pages>1146–1152</pages>
     <url>http://www.aclweb.org/anthology/D18-1145</url>
     <attachment type="attachment">D18-1145.Attachment.pdf</attachment>
+    <abstract>Individuals express their locus of control, or ``control'', in their language when they identify whether or not they are in control of their circumstances. Although control is a core concept underlying rhetorical style, it is not clear whether control is expressed by how or by what authors write. We explore the roles of syntax and semantics in expressing users' sense of control --i.e. being ``controlled by'' or ``in control of'' their circumstances-- in a corpus of annotated Facebook posts. We present rich insights into these linguistic aspects and find that while the language signaling control is easy to identify, it is more challenging to label it is internally or externally controlled, with lexical features outperforming syntactic features at the task. Our findings could have important implications for studying self-expression in social media.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>rouhizadeh-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2552,6 +2697,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1153–1159</pages>
     <url>http://www.aclweb.org/anthology/D18-1146</url>
+    <abstract>To what extent could the sommelier profession, or wine stewardship, be displaced by machine leaning algorithms? There are at least three essential skills that make a qualified sommelier: wine theory, blind tasting, and beverage service, as exemplified in the rigorous certification processes of certified sommeliers and above (advanced and master) with the most authoritative body in the industry, the Court of Master Sommelier (hereafter CMS). We propose and train corresponding machine learning models that match these skills, and compare algorithmic results with real data collected from a large group of wine professionals. We find that our machine learning models outperform human sommeliers on most tasks — most notably in the section of blind tasting, where hierarchically supervised Latent Dirichlet Allocation outperforms sommeliers' judgment calls by over 6\% in terms of F1-score; and in the section of beverage service, especially wine and food pairing, a modified Siamese neural network based on BiLSTM achieves better results than sommeliers by 2\%. This demonstrates, contrary to popular opinion in the industry, that the sommelier profession is at least to some extent automatable, barring economic (Kleinberg et al., 2017) and psychological (Dietvorst et al., 2015) complications.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hu:2018:EMNLP</bibkey>
   </paper>
@@ -2567,6 +2713,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1160–1166</pages>
     <url>http://www.aclweb.org/anthology/D18-1147</url>
+    <abstract>Detecting fine-grained emotions in online health communities provides insightful information about patients' emotional states. However, current computational approaches to emotion detection from health-related posts focus only on identifying messages that contain emotions, with no emphasis on the emotion type, using a set of handcrafted features. In this paper, we take a step further and propose to detect fine-grained emotion types from health-related posts and show how high-level and abstract features derived from deep neural networks combined with lexicon-based features can be employed to detect emotions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>khanpour-caragea:2018:EMNLP</bibkey>
   </paper>
@@ -2587,6 +2734,7 @@
     <pages>1167–1172</pages>
     <url>http://www.aclweb.org/anthology/D18-1148</url>
     <attachment type="attachment">D18-1148.Attachment.zip</attachment>
+    <abstract>Nowcasting based on social media text promises to provide unobtrusive and near real-time predictions of community-level outcomes. These outcomes are typically regarding people, but the data is often aggregated without regard to users in the Twitter populations of each community. This paper describes a simple yet effective method for building community-level models using Twitter language aggregated by user. Results on four different U.S. county-level tasks, spanning demographic, health, and psychological outcomes show large and consistent improvements in prediction accuracies (e.g. from Pearson r=.73 to .82 for median income prediction or r=.37 to .47 for life satisfaction prediction) over the standard approach of aggregating all tweets. We make our aggregated and anonymized community-level data, derived from 37 billion tweets -- over 1 billion of which were mapped to counties, available for research.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>giorgi-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2604,6 +2752,7 @@
     <pages>1173–1182</pages>
     <url>http://www.aclweb.org/anthology/D18-1149</url>
     <attachment type="attachment">D18-1149.Attachment.pdf</attachment>
+    <abstract>We propose a conditional non-autoregressive neural sequence model based on iterative refinement. The proposed model is designed based on the principles of latent variable models and denoising autoencoders, and is generally applicable to any sequence generation task. We extensively evaluate the proposed model on machine translation (En-De and En-Ro) and image caption generation, and observe that it significantly speeds up decoding while maintaining the generation quality comparable to the autoregressive counterpart.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lee-mansimov-cho:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305207923" tag="video" />
@@ -2622,6 +2771,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1183–1191</pages>
     <url>http://www.aclweb.org/anthology/D18-1150</url>
+    <abstract>We propose a large margin criterion for training neural language models. Conventionally, neural language models are trained by minimizing perplexity (PPL) on grammatical sentences. However, we demonstrate that PPL may not be the best metric to optimize in some tasks, and further propose a large margin formulation. The proposed method aims to enlarge the margin between the ``good'' and ``bad'' sentences in a task-specific sense. It is trained end-to-end and can be widely applied to tasks that involve re-scoring of generated text. Compared with minimum-PPL training, our method gains up to 1.1 WER reduction for speech recognition and 1.0 BLEU increase for machine translation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/305208380" tag="video" />
@@ -2639,6 +2789,7 @@
     <pages>1192–1202</pages>
     <url>http://www.aclweb.org/anthology/D18-1151</url>
     <attachment type="attachment">D18-1151.Attachment.pdf</attachment>
+    <abstract>We present a data set for evaluating the grammaticality of the predictions of a language model. We automatically construct a large number of minimally different pairs of English sentences, each consisting of a grammatical and an ungrammatical sentence. The sentence pairs represent different variations of structure-sensitive phenomena: subject-verb agreement, reflexive anaphora and negative polarity items. We expect a language model to assign a higher probability to the grammatical sentence than the ungrammatical one. In an experiment using this data set, an LSTM language model performed poorly on many of the constructions. Multi-task training with a syntactic objective (CCG supertagging) improved the LSTM's accuracy, but a large gap remained between its performance and the accuracy of human participants recruited online. This suggests that there is considerable room for improvement over LSTMs in capturing syntax in a language model.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>marvin-linzen:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305208737" tag="video" />
@@ -2658,6 +2809,7 @@
     <pages>1203–1214</pages>
     <url>http://www.aclweb.org/anthology/D18-1152</url>
     <attachment type="attachment">D18-1152.Attachment.pdf</attachment>
+    <abstract>Despite the tremendous empirical success of neural models in natural language processing, many of them lack the strong intuitions that accompany classical machine learning approaches. Recently, connections have been shown between convolutional neural networks (CNNs) and weighted finite state automata (WFSAs), leading to new interpretations and insights. In this work, we show that some recurrent neural networks also share this connection to WFSAs. We characterize this connection formally, defining rational recurrences to be recurrent hidden state update functions that can be written as the Forward calculation of a finite set of WFSAs. We show that several recent neural models use rational recurrences. Our analysis provides a fresh view of these models and facilitates devising new neural architectures that draw inspiration from WFSAs. We present one such model, which performs better than two recent baselines on language modeling and text classification. Our results demonstrate that transferring intuitions from classical models like WFSAs can be an effective approach to designing and understanding neural models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>peng-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305209046" tag="video" />
@@ -2678,6 +2830,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1215–1225</pages>
     <url>http://www.aclweb.org/anthology/D18-1153</url>
+    <abstract>Many efforts have been made to facilitate natural language processing tasks with pre-trained language models (LMs), and brought significant improvements to various applications. To fully leverage the nearly unlimited corpora and capture linguistic information of multifarious levels, large-size LMs are required; but for a specific task, only parts of these information are useful. Such large-sized LMs, even in the inference stage, may cause heavy computation workloads, making them too time-consuming for large-scale applications. Here we propose to compress bulky LMs while preserving useful information with regard to a specific task. As different layers of the model keep different information, we develop a layer selection method for model pruning using sparsity-inducing regularization. By introducing the dense connectivity, we can detach any layer without affecting others, and stretch shallow and wide LMs to be deep and narrow. In model training, LMs are learned with layer-wise dropouts for better robustness. Experiments on two benchmark datasets demonstrate the effectiveness of our method.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/305209444" tag="video" />
@@ -2696,6 +2849,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1226–1236</pages>
     <url>http://www.aclweb.org/anthology/D18-1154</url>
+    <abstract>Identifying the salience (i.e. importance) of discourse units is an important task in language understanding. While events play important roles in text documents, little research exists on analyzing their saliency status. This paper empirically studies Event Salience and proposes two salience detection models based on discourse relations. The first is a feature based salience model that incorporates cohesion among discourse units. The second is a neural model that captures more complex interactions between discourse units. In our new large-scale event salience corpus, both methods significantly outperform the strong frequency baseline, while our neural model further improves the feature based one by a large margin. Our analyses demonstrate that our neural model captures interesting connections between salience and discourse unit relations (e.g., scripts and frame structures).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP4</bibkey>
     <video href="https://vimeo.com/305198570" tag="video" />
@@ -2712,6 +2866,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1237–1246</pages>
     <url>http://www.aclweb.org/anthology/D18-1155</url>
+    <abstract>The current leading paradigm for temporal information extraction from text consists of three phases: (1) recognition of events and temporal expressions, (2) recognition of temporal relations among them, and (3) time-line construction from the temporal relations. In contrast to the first two phases, the last phase, time-line construction, received little attention and is the focus of this work. In this paper, we propose a new method to construct a linear time-line from a set of (extracted) temporal relations. But more importantly, we propose a novel paradigm in which we directly predict start and end-points for events from the text, constituting a time-line without going through the intermediate step of prediction of temporal relations as in earlier work. Within this paradigm, we propose two models that predict in linear complexity, and a new training loss using TimeML-style annotations, yielding promising results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>leeuwenberg-moens:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305198795" tag="video" />
@@ -2729,6 +2884,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1247–1256</pages>
     <url>http://www.aclweb.org/anthology/D18-1156</url>
+    <abstract>Event extraction is of practical utility in natural language processing. In the real world, it is a common phenomenon that multiple events existing in the same sentence, where extracting them are more difficult than extracting a single event. Previous works on modeling the associations between events by sequential modeling methods suffer a lot from the low efficiency in capturing very long-range dependencies. In this paper, we propose a novel Jointly Multiple Events Extraction (JMEE) framework to jointly extract multiple event triggers and arguments by introducing syntactic shortcut arcs to enhance information flow and attention-based graph convolution networks to model graph information. The experiment results demonstrate that our proposed framework achieves competitive results compared with state-of-the-art methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-luo-huang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305198933" tag="video" />
@@ -2749,6 +2905,7 @@
     <pages>1257–1266</pages>
     <url>http://www.aclweb.org/anthology/D18-1157</url>
     <attachment type="attachment">D18-1157.Attachment.pdf</attachment>
+    <abstract>Distantly-supervised Relation Extraction (RE) methods train an extractor by automatically aligning relation instances in a Knowledge Base (KB) with unstructured text. In addition to relation instances, KBs often contain other relevant side information, such as aliases of relations (e.g., founded and co-founded are aliases for the relation founderOfCompany). RE models usually ignore such readily available side information. In this paper, we propose RESIDE, a distantly-supervised neural relation extraction method which utilizes additional side information from KBs for improved relation extraction. It uses entity type and relation alias information for imposing soft constraints while predicting relations. RESIDE employs Graph Convolution Networks (GCN) to encode syntactic information from text and improves performance even when limited side information is available. Through extensive experiments on benchmark datasets, we demonstrate RESIDE's effectiveness. We have made RESIDE's source code available to encourage reproducible research.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>vashishth-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305199302" tag="video" />
@@ -2768,6 +2925,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1267–1276</pages>
     <url>http://www.aclweb.org/anthology/D18-1158</url>
+    <abstract>Traditional approaches to the task of ACE event detection primarily regard multiple events in one sentence as independent ones and recognize them separately by using sentence-level information. However, events in one sentence are usually interdependent and sentence-level information is often insufficient to resolve ambiguities for some types of events. This paper proposes a novel framework dubbed as Hierarchical and Bias Tagging Networks with Gated Multi-level Attention Mechanisms (HBTNGMA) to solve the two problems simultaneously.  Firstly, we propose a hierachical and bias  tagging networks to detect multiple events in one sentence collectively. Then, we devise a gated multi-level attention to automatically extract and  dynamically fuse the sentence-level and document-level information. The experimental results on the widely used ACE 2005 dataset show that our approach significantly outperforms other state-of-the-art methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP8</bibkey>
     <video href="https://vimeo.com/305199664" tag="video" />
@@ -2785,6 +2943,7 @@
     <pages>1277–1291</pages>
     <url>http://www.aclweb.org/anthology/D18-1159</url>
     <attachment type="attachment">D18-1159.Attachment.zip</attachment>
+    <abstract>We present a complete, automated, and efficient approach for utilizing valency analysis in making dependency parsing decisions. It includes extraction of valency patterns, a probabilistic model for tagging these patterns, and a joint decoding process that explicitly considers the number and types of each token's syntactic dependents. On 53 treebanks representing 41 languages in the Universal Dependencies data, we find that incorporating valency information yields higher precision and F1 scores on the core arguments (subjects and complements) and functional relations (e.g., auxiliaries) that we employ for valency analysis. Precision on core arguments improves from 80.87 to 85.43. We further show that our approach can be applied to an ostensibly different formalism and dataset, Tree Adjoining Grammar as extracted from the Penn Treebank; there, we outperform the previous state-of-the-art labeled attachment score by 0.7. Finally, we explore the potential of extending valency patterns beyond their traditional domain by confirming their helpfulness in improving PP attachment decisions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shi-lee:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305214708" tag="video" />
@@ -2802,6 +2961,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1292–1302</pages>
     <url>http://www.aclweb.org/anthology/D18-1160</url>
+    <abstract>Unsupervised learning of syntactic structure is typically performed using generative models with discrete latent variables and multinomial parameters. In most cases, these models have not leveraged continuous word representations. In this work, we propose a novel generative model that jointly learns discrete syntactic structure and continuous word representations in an unsupervised fashion by cascading an invertible neural network with a structured generative prior. We show that the invertibility condition allows for efficient exact inference and marginal likelihood computation in our model so long as the prior is well-behaved. In experiments we instantiate our approach with both Markov and tree-structured priors, evaluating on two tasks: part-of-speech (POS) induction, and unsupervised dependency parsing without gold POS annotation. On the Penn Treebank, our Markov-structured model surpasses state-of-the-art results on POS induction. Similarly, we find that our tree-structured model achieves state-of-the-art performance on unsupervised dependency parsing for the difficult training condition where neither gold POS annotation nor punctuation-based constraints are available.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>he-neubig-bergkirkpatrick:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305215139" tag="video" />
@@ -2818,6 +2978,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1303–1313</pages>
     <url>http://www.aclweb.org/anthology/D18-1161</url>
+    <abstract>We introduce novel dynamic oracles for training two of the most accurate known shift-reduce algorithms for constituent parsing: the top-down and in-order transition-based parsers. In both cases, the dynamic oracles manage to notably increase their accuracy, in comparison to that obtained by performing classic static training. In addition, by improving the performance of the state-of-the-art in-order shift-reduce parser, we achieve the best accuracy to date (92.0 F1) obtained by a fully-supervised single-model greedy shift-reduce constituent parser on the WSJ benchmark.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>fernndezgonzlez-gmezrodrguez:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305215645" tag="video" />
@@ -2835,6 +2996,7 @@
     <pages>1314–1324</pages>
     <url>http://www.aclweb.org/anthology/D18-1162</url>
     <attachment type="attachment">D18-1162.Attachment.pdf</attachment>
+    <abstract>We introduce a method to reduce constituent parsing to sequence labeling. For each word w\_t, it generates a label that encodes: (1) the number of ancestors in the tree that the words w\_t and w\_{t+1} have in common, and (2) the nonterminal symbol at the lowest common ancestor. We first prove that the proposed encoding function is injective for any tree without unary branches. In practice, the approach is made extensible to all constituency trees by collapsing unary branches. We then use the PTB and CTB treebanks as testbeds and propose a set of fast baselines. We achieve 90\% F-score on the PTB test set, outperforming the Vinyals et al. (2015) sequence-to-sequence parser. In addition, sacrificing some accuracy, our approach achieves the fastest constituent parsing speeds reported to date on PTB by a wide margin.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gmezrodrguez-vilares:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305216237" tag="video" />
@@ -2852,6 +3014,7 @@
     <pages>1325–1337</pages>
     <url>http://www.aclweb.org/anthology/D18-1163</url>
     <attachment type="attachment">D18-1163.Attachment.pdf</attachment>
+    <abstract>To approximately parse an unfamiliar language, it helps to have a treebank of a similar language.  But what if the closest available treebank still has the wrong word order?  We show how to (stochastically) permute the constituents of an existing dependency treebank so that its surface part-of-speech statistics approximately match those of the target language.  The parameters of the permutation model can be evaluated for quality by dynamic programming and tuned by gradient descent (up to a local optimum).  This optimization procedure yields trees for a new artificial language that resembles the target language.  We show that delexicalized parsers for the target language can be successfully trained using such ``made to order'' artificial languages.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-eisner:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305216917" tag="video" />
@@ -2871,6 +3034,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1338–1346</pages>
     <url>http://www.aclweb.org/anthology/D18-1164</url>
+    <abstract>In Visual Question Answering, most existing approaches adopt the pipeline of representing an image via pre-trained CNNs, and then using the uninterpretable CNN features in conjunction with the question to predict the answer. Although such end-to-end models might report promising performance, they rarely provide any insight, apart from the answer, into the VQA process. In this work, we propose to break up the end-to-end VQA into two steps: explaining and reasoning, in an attempt towards a more explainable VQA by shedding light on the intermediate results between these two steps. To that end, we first extract attributes and generate descriptions as explanations for an image. Next, a reasoning module utilizes these explanations in place of the image to infer an answer. The advantages of such a breakdown include: (1) the attributes and captions can reflect what the system extracts from the image, thus can provide some insights for the predicted answer; (2) these intermediate results can help identify the inabilities of  the image understanding or the answer inference part when the predicted answer is wrong. We conduct extensive experiments on a popular VQA dataset and our system achieves comparable performance with the baselines, yet with added benefits of explanability and the inherent ability to further improve with higher quality explanations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/306362344" tag="video" />
@@ -2889,6 +3053,7 @@
     <pages>1347–1357</pages>
     <url>http://www.aclweb.org/anthology/D18-1165</url>
     <attachment type="attachment">D18-1165.Attachment.tgz</attachment>
+    <abstract>Active learning identifies data points to label that are expected to be the most useful in improving a supervised model. Opportunistic active learning incorporates active learning into interactive tasks that constrain possible queries during interactions. Prior work has shown that opportunistic active learning can be used to improve grounding of natural language descriptions in an interactive object retrieval task. In this work, we use reinforcement learning for such an object retrieval task, to learn a policy that effectively trades off task completion with model improvement that would benefit future tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>padmakumar-stone-mooney:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306362379" tag="video" />
@@ -2908,6 +3073,7 @@
     <pages>1358–1368</pages>
     <url>http://www.aclweb.org/anthology/D18-1166</url>
     <attachment type="attachment">D18-1166.Attachment.pdf</attachment>
+    <abstract>Understanding and reasoning about cooking recipes is a fruitful research direction towards enabling machines to interpret procedural text. In this work, we introduce RecipeQA, a dataset for multimodal comprehension of cooking recipes. It comprises of approximately 20K instructional recipes with multiple modalities such as titles, descriptions and aligned set of images. With over 36K automatically generated question-answer pairs, we design a set of comprehension and reasoning tasks that require joint understanding of images and text, capturing the temporal flow of events and making sense of procedural knowledge. Our preliminary results indicate that RecipeQA will serve as a challenging test bed and an ideal benchmark for evaluating machine comprehension systems.  The data and leaderboard are available at http://hucvl.github.io/recipeqa.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yagcioglu-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306363701" tag="video" />
@@ -2927,6 +3093,7 @@
     <pages>1369–1379</pages>
     <url>http://www.aclweb.org/anthology/D18-1167</url>
     <attachment type="attachment">D18-1167.Attachment.pdf</attachment>
+    <abstract>Recent years have witnessed an increasing interest in image-based question-answering (QA) tasks. However, due to data limitations, there has been much less work on video-based QA. In this paper, we present TVQA, a large-scale video QA dataset based on 6 popular TV shows. TVQA consists of 152,545 QA pairs from 21,793 clips, spanning over 460 hours of video. Questions are designed to be compositional in nature, requiring systems to jointly localize relevant moments within a clip, comprehend subtitle-based dialogue, and recognize relevant visual concepts. We provide analyses of this new dataset as well as several baselines and a multi-stream end-to-end trainable neural network framework for the TVQA task. The dataset is publicly available at http://tvqa.cs.unc.edu.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lei-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/306364803" tag="video" />
@@ -2948,6 +3115,7 @@
     <pages>1380–1390</pages>
     <url>http://www.aclweb.org/anthology/D18-1168</url>
     <attachment type="attachment">D18-1168.Attachment.pdf</attachment>
+    <abstract>Localizing moments in a longer video via natural language queries is a new, challenging task at the intersection of language and video understanding. Though moment localization with natural language is similar to other language and vision tasks like natural language object retrieval in images, moment localiza- tion offers an interesting opportunity to model temporal dependencies and reasoning in text. We propose a new model that explicitly reasons about different temporal segments in a video, and shows that temporal context is important for localizing phrases which include temporal language. To benchmark whether our model, and other recent video localization models, can effectively reason about temporal language, we collect the novel TEMPOral reasoning in video and language (TEMPO) dataset. Our dataset consists of two parts: a dataset with real videos and template sentences (TEMPO - Template Language) which allows for controlled studies on temporal language, and a human language dataset which consists of temporal sentences annotated by humans (TEMPO - Human Language).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hendricks-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306365884" tag="video" />
@@ -2967,6 +3135,7 @@
     <pages>1391–1401</pages>
     <url>http://www.aclweb.org/anthology/D18-1169</url>
     <attachment type="attachment">D18-1169.Attachment.zip</attachment>
+    <abstract>Rare word representation has recently enjoyed a surge of interest, owing to the crucial role that effective handling of infrequent words can play in accurate semantic understanding. However, there is a paucity of reliable benchmarks for evaluation and comparison of these techniques. We show in this paper that the only existing benchmark (the Stanford Rare Word dataset) suffers from low-confidence annotations and limited vocabulary; hence, it does not constitute a solid comparison framework. In order to fill this evaluation gap, we propose Cambridge Rare word Dataset (Card-660), an expert-annotated word similarity dataset which provides a highly reliable, yet challenging, benchmark for rare word representation techniques. Through a set of experiments we show that even the best mainstream word embeddings, with millions of words in their vocabularies, are unable to achieve performances higher than 0.43 (Pearson correlation) on the dataset, compared to a human-level upperbound of 0.90. We release the dataset and the annotation materials at https://pilehvar.github.io/card-660/.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pilehvar-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -2986,6 +3155,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1402–1411</pages>
     <url>http://www.aclweb.org/anthology/D18-1170</url>
+    <abstract>The goal of Word Sense Disambiguation (WSD) is to identify the correct meaning of a word in the particular context. Traditional supervised methods only use labeled data (context), while missing rich lexical knowledge such as the gloss which defines the meaning of a word sense. Recent studies have shown that incorporating glosses into neural networks for WSD has made significant improvement. However, the previous models usually build the context representation and gloss representation separately. In this paper, we find that the learning for the context and gloss representation can benefit from each other. Gloss can help to highlight the important words in the context, thus building a better context representation. Context can also help to locate the key words in the gloss of the correct word sense. Therefore, we introduce a co-attention mechanism to generate co-dependent representations for the context and gloss. Furthermore, in order to capture both word-level and sentence-level information, we extend the attention mechanism in a hierarchical fashion. Experimental results show that our model achieves the state-of-the-art results on several standard English all-words WSD test datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>luo-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -3002,6 +3172,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1412–1424</pages>
     <url>http://www.aclweb.org/anthology/D18-1171</url>
+    <abstract>We encounter metaphors every day, but only a few jump out on us and make us stumble. However, little effort has been devoted to investigating more novel metaphors in comparison to general metaphor detection efforts. We attribute this gap primarily to the lack of larger datasets that distinguish between conventionalized, i.e., very common, and novel metaphors. The goal of this paper is to alleviate this situation by introducing a crowdsourced novel metaphor annotation layer for an existing metaphor corpus. Further, we analyze our corpus and investigate correlations between novelty and features that are typically used in metaphor detection, such as concreteness ratings and more semantic features like the Potential for Metaphoricity. Finally, we present a baseline approach to assess novelty in metaphors based on our annotations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dodinh-wieland-gurevych:2018:EMNLP</bibkey>
   </paper>
@@ -3017,6 +3188,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1425–1434</pages>
     <url>http://www.aclweb.org/anthology/D18-1172</url>
+    <abstract>Accurately and efficiently estimating word similarities from text is fundamental in natural language processing. In this paper, we propose a fast and lightweight method for estimating similarities from streams by explicitly counting second-order co-occurrences. The method rests on the observation that words that are highly correlated with respect to such counts are also highly similar with respect to first-order co-occurrences. Using buffers of co-occurred words per word to count second-order co-occurrences, we can then estimate similarities in a single pass over data without having to do prohibitively expensive similarity calculations. We demonstrate that this approach is scalable, converges rapidly, behaves robustly under parameter changes, and that it captures word similarities on par with those given by state-of-the-art word embeddings.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>grnerup-gillblad:2018:EMNLP</bibkey>
   </paper>
@@ -3033,6 +3205,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1435–1444</pages>
     <url>http://www.aclweb.org/anthology/D18-1173</url>
+    <abstract>Distributional semantic models (DSMs) generally require sufficient examples for a word to learn a high quality representation. This is in stark contrast with human who can guess the meaning of a word from one or a few referents only. In this paper, we propose Mem2Vec, a memory based embedding learning method capable of acquiring high quality word representations from fairly limited context. Our method directly adapts the representations produced by a DSM with a longterm memory to guide its guess of a novel word. Based on a pre-trained embedding space, the proposed method delivers impressive performance on two challenging few-shot word similarity tasks. Embeddings learned with our method also lead to considerable improvements over strong baselines on NER and sentiment classification.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sun-wang-zong:2018:EMNLP</bibkey>
   </paper>
@@ -3049,6 +3222,7 @@
     <pages>1445–1454</pages>
     <url>http://www.aclweb.org/anthology/D18-1174</url>
     <attachment type="attachment">D18-1174.Attachment.zip</attachment>
+    <abstract>We present disambiguated skip-gram: a neural-probabilistic model for learning multi-sense distributed representations of words. Disambiguated skip-gram jointly estimates a skip-gram-like context word prediction model and a word sense disambiguation model. Unlike previous probabilistic models for learning multi-sense word embeddings, disambiguated skip-gram is end-to-end differentiable and can be interpreted as a simple feed-forward neural network. We also introduce an effective pruning strategy for the embeddings learned by disambiguated skip-gram. This allows us to control the granularity of representations learned by our model. In experimental evaluation disambiguated skip-gram improves state-of-the are results in several word sense induction benchmarks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>grzegorczyk-kurdziel:2018:EMNLP</bibkey>
   </paper>
@@ -3066,6 +3240,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1455–1465</pages>
     <url>http://www.aclweb.org/anthology/D18-1175</url>
+    <abstract>During natural disasters and conflicts, information about what happened is often confusing and messy, and distributed across many sources. We would like to be able to automatically identify relevant information and assemble it into coherent narratives of what happened. To make this task accessible to neural models, we introduce \emph{Story Salads}, mixtures of multiple documents that can be generated at scale. By exploiting the Wikipedia hierarchy, we can generate salads that exhibit challenging inference problems. Story salads give rise to a novel, challenging clustering task, where the objective is to group sentences from the same narratives. We demonstrate that simple bag-of-words similarity clustering falls short on this task, and that it is necessary to take into account global context and coherence.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP7</bibkey>
   </paper>
@@ -3082,6 +3257,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1466–1477</pages>
     <url>http://www.aclweb.org/anthology/D18-1176</url>
+    <abstract>While one of the first steps in many NLP systems is selecting what pre-trained word embeddings to use, we argue that such a step is better left for neural networks to figure out by themselves. To that end, we introduce dynamic meta-embeddings, a simple yet effective method for the supervised learning of embedding ensembles, which leads to state-of-the-art performance within the same model class on a variety of tasks. We subsequently show how the technique can be used to shed new light on the usage of word embeddings in NLP systems.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kiela-wang-cho:2018:EMNLP</bibkey>
   </paper>
@@ -3100,6 +3276,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1478–1487</pages>
     <url>http://www.aclweb.org/anthology/D18-1177</url>
+    <abstract>Several recent studies have shown the benefits of combining language and perception to infer word embeddings. These multimodal approaches either simply combine pre-trained textual and visual representations (e.g. features extracted from convolutional neural networks), or use the latter to bias the learning of textual word embeddings. In this work, we propose a novel probabilistic model to formalize how linguistic and perceptual inputs can work in concert to explain the observed word-context pairs in a text corpus. Our approach learns textual and visual representations jointly: latent visual factors couple together a  skip-gram model for co-occurrence in linguistic data and a generative latent variable model for visual data. Extensive experimental studies validate the proposed model. Concretely, on the tasks of assessing pairwise word similarity and image/caption retrieval, our approach attains equally competitive or stronger results when compared to other state-of-the-art multimodal models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ailem-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -3116,6 +3293,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1488–1498</pages>
     <url>http://www.aclweb.org/anthology/D18-1178</url>
+    <abstract>In this paper, we empirically evaluate the utility of transfer and multi-task learning on a challenging semantic classification task: semantic interpretation of noun--noun compounds. Through a comprehensive series of experiments and in-depth error analysis, we show that transfer learning via parameter initialization and multi-task learning via parameter sharing can help a neural classification model generalize over a highly skewed distribution of relations. Further, we demonstrate how dual annotation with two distinct sets of relations over the same set of compounds can be exploited to improve the overall accuracy of a neural classifier and its F1 scores on the less frequent, but more difficult relations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>fares-oepen-velldal:2018:EMNLP</bibkey>
   </paper>
@@ -3134,6 +3312,7 @@
     <pages>1499–1509</pages>
     <url>http://www.aclweb.org/anthology/D18-1179</url>
     <attachment type="attachment">D18-1179.Attachment.pdf</attachment>
+    <abstract>Contextual word representations derived from pre-trained bidirectional language models (biLMs) have recently been shown to provide significant improvements to the state of the art for a wide range of NLP tasks. How- ever, many questions remain as to how and why these models are so effective. In this paper, we present a detailed empirical study of how the choice of neural architecture (e.g. LSTM, CNN, or self attention) influences both end task accuracy and qualitative properties of the representations that are learned. We show there is a tradeoff between speed and accuracy, but all architectures learn high quality con- textual representations that outperform word embeddings for four challenging NLP tasks. Additionally, all architectures learn representations that vary with network depth, from exclusively morphological based at the word em- bedding layer through local syntax based in the lower contextual layers to longer range semantics such coreference at the upper layers. Together, these results suggest that unsupervised biLMs, independent of architecture, are learn- ing much more about the structure of language than previously appreciated.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>peters-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -3152,6 +3331,7 @@
     <pages>1510–1521</pages>
     <url>http://www.aclweb.org/anthology/D18-1180</url>
     <attachment type="attachment">D18-1180.Attachment.zip</attachment>
+    <abstract>Prepositions are highly polysemous, and their variegated senses encode significant semantic information. In this paper we match each preposition's left- and right context,  and their interplay to the geometry of the word vectors to the left and right of the preposition. Extracting these features from a large corpus and using them with machine learning models makes for an efficient preposition sense disambiguation (PSD) algorithm, which is comparable to and better than state-of-the-art on two benchmark datasets. Our reliance on no  linguistic tool allows us to scale the PSD  algorithm  to a large corpus and learn sense-specific preposition representations. The crucial abstraction of preposition senses as word representations permits their use in downstream applications--phrasal verb paraphrasing and preposition selection--with new state-of-the-art results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gong-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -3168,6 +3348,7 @@
     <pages>1522–1532</pages>
     <url>http://www.aclweb.org/anthology/D18-1181</url>
     <attachment type="attachment">D18-1181.Attachment.zip</attachment>
+    <abstract>Monolingual dictionaries are widespread and semantically rich resources. This paper presents a simple model that learns to compute word embeddings by processing dictionary definitions and trying to reconstruct them. It exploits the inherent recursivity of dictionaries by encouraging consistency between the representations it uses as inputs and the representations it produces as outputs. The resulting embeddings are shown to capture semantic similarity better than regular distributional methods and other dictionary-based methods. In addition, our method shows strong performance when trained exclusively on dictionary data and generalizes in one shot.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bosc-vincent:2018:EMNLP</bibkey>
   </paper>
@@ -3183,6 +3364,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1533–1542</pages>
     <url>http://www.aclweb.org/anthology/D18-1182</url>
+    <abstract>We propose Odd-Man-Out, a novel task which aims to test different properties of word representations. An Odd-Man-Out puzzle is composed of 5 (or more) words, and requires the system to choose the one which does not belong with the others. We show that this simple setup is capable of teasing out various properties of different popular lexical resources (like WordNet and pre-trained word embeddings), while being intuitive enough to annotate on a large scale. In addition, we propose a novel technique for training multi-prototype word representations, based on unsupervised clustering of ELMo embeddings, and show that it surpasses all other representations on all Odd-Man-Out collections.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>stanovsky-hopkins:2018:EMNLP</bibkey>
   </paper>
@@ -3202,6 +3384,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1543–1553</pages>
     <url>http://www.aclweb.org/anthology/D18-1183</url>
+    <abstract>Simile is a special type of metaphor, where comparators such as like and as are used to compare two objects. Simile recognition is to recognize simile sentences and extract simile components, i.e., the tenor and the vehicle. This paper presents a study of simile recognition in Chinese. We construct an annotated corpus for this research, which consists of 11.3k sentences that contain a comparator. We propose a neural network framework for jointly optimizing three tasks: simile sentence classification, simile component extraction and language modeling. The experimental results show that the neural network based approaches can outperform all rule-based and feature-based baselines. Both simile sentence classification and simile component extraction can benefit from multitask learning. The former can be solved very well, while the latter is more difficult.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP5</bibkey>
   </paper>
@@ -3218,6 +3401,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1554–1564</pages>
     <url>http://www.aclweb.org/anthology/D18-1184</url>
+    <abstract>Many tasks in natural language processing involve comparing two sentences to compute some notion of relevance, entailment, or similarity.  Typically this comparison is done either at the word level or at the sentence level, with no attempt to leverage the inherent structure of the sentence.   When sentence structure is used for comparison, it is obtained during a non-differentiable pre-processing step, leading to propagation of errors.  We introduce a model of structured alignments between sentences, showing how to compare two sentences by matching their latent structures.  Using a structured attention mechanism, our model matches candidate spans in the first sentence to candidate spans in the second sentence, simultaneously discovering the tree structure of each sentence. Our model  is fully differentiable and trained only on the matching objective. We evaluate this model on two  tasks, natural  entailment detection and answer sentence selection, and find that modeling latent tree structures results in superior performance. Analysis of the  learned sentence structures  shows they can reflect some syntactic phenomena.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-gardner-lapata:2018:EMNLP</bibkey>
   </paper>
@@ -3234,6 +3418,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1565–1575</pages>
     <url>http://www.aclweb.org/anthology/D18-1185</url>
+    <abstract>This paper presents a new deep learning architecture for Natural Language Inference (NLI). Firstly, we introduce a new architecture where alignment pairs are compared, compressed and then propagated to upper layers for enhanced representation learning. Secondly, we adopt factorization layers for efficient and expressive compression of alignment vectors into scalar features, which are then used to augment the base word representations. The design of our approach is aimed to be conceptually simple, compact and yet powerful. We conduct experiments on three popular benchmarks, SNLI, MultiNLI and SciTail, achieving competitive performance on all. A lightweight parameterization of our model also enjoys a 3 times reduction in parameter size compared to the existing state-of-the-art models, e.g., ESIM and DIIN, while maintaining competitive performance. Additionally, visual analysis shows that our propagated features are highly interpretable.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tay-luu-hui:2018:EMNLP1</bibkey>
   </paper>
@@ -3252,6 +3437,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1576–1585</pages>
     <url>http://www.aclweb.org/anthology/D18-1186</url>
+    <abstract>Attention-based neural models have achieved great success in natural language inference (NLI). In this paper, we propose the Convolutional Interaction Network (CIN), a general model to capture the interaction between two sentences, which can be an alternative to the attention mechanism for NLI. Specifically, CIN encodes one sentence with the filters dynamically generated based on another sentence. Since the filters may be designed to have various numbers and sizes, CIN can capture more complicated interaction patterns. Experiments on three large datasets demonstrate CIN's efficacy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gong-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -3267,6 +3453,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1586–1596</pages>
     <url>http://www.aclweb.org/anthology/D18-1187</url>
+    <abstract>State of the art models using deep neural networks have become very good in learning an accurate mapping from inputs to outputs. However, they still lack generalization capabilities in conditions that differ from the ones encountered during training. This is even more challenging in specialized, and knowledge intensive domains, where training data is limited. To address this gap, we introduce MedNLI - a dataset annotated by doctors, performing a natural language inference task (NLI), grounded in the medical history of patients. We present strategies to: 1) leverage transfer learning using datasets from the open domain, (e.g. SNLI) and 2) incorporate domain knowledge from external data and lexical sources (e.g. medical terminologies). Our results demonstrate performance gains using both strategies.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>romanov-shivade:2018:EMNLP</bibkey>
   </paper>
@@ -3289,6 +3476,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1597–1607</pages>
     <url>http://www.aclweb.org/anthology/D18-1188</url>
+    <abstract>In this paper, we study how to learn a semantic parser of state-of-the-art accuracy with less supervised training data. We conduct our study on WikiSQL, the largest hand-annotated semantic parsing dataset to date. First, we demonstrate that question generation is an effective method that empowers us to learn a state-of-the-art neural network based semantic parser with thirty percent of the supervised training data. Second, we show that applying question generation to the full supervised training data further improves the state-of-the-art model. In addition, we observe that there is a logarithmic relationship between the accuracy of a semantic parser and the amount of training data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>guo-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -3310,6 +3498,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1608–1618</pages>
     <url>http://www.aclweb.org/anthology/D18-1189</url>
+    <abstract>Recent research proposes syntax-based approaches to address the problem of generating programs from natural language specifications. These approaches typically train a sequence-to-sequence learning model using a syntax-based objective: maximum likelihood estimation (MLE). Such syntax-based approaches do not effectively address the goal of generating semantically correct programs, because these approaches fail to handle Program Aliasing, i.e., semantically equivalent programs may have many syntactically different forms. To address this issue, in this paper, we propose a semantics-based approach named SemRegex. SemRegex provides solutions for a subtask of the program-synthesis problem: generating regular expressions from natural language. Different from the existing syntax-based approaches, SemRegex trains the model by maximizing the expected semantic correctness of the generated regular expressions. The semantic correctness is measured using the DFA-equivalence oracle, random test cases, and distinguishing test cases. The experiments on three public datasets demonstrate the superiority of SemRegex over the existing state-of-the-art approaches.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhong-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -3325,6 +3514,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1619–1629</pages>
     <url>http://www.aclweb.org/anthology/D18-1190</url>
+    <abstract>Building a semantic parser quickly in a new domain is a fundamental challenge for conversational interfaces, as current semantic parsers require expensive supervision and lack the ability to generalize to new domains. In this paper, we introduce a zero-shot approach to semantic parsing that can parse utterances in unseen domains while only being trained on examples in other source domains. First, we map an utterance to an abstract, domain independent, logical form that represents the structure of the logical form, but contains slots instead of KB constants. Then, we replace slots with KB constants via lexical alignment scores and global inference. Our model reaches an average accuracy of 53.4\% on 7 domains in the OVERNIGHT dataset, substantially better than other zero-shot baselines, and performs as good as a parser trained on over 30\% of the target domain examples.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>herzig-berant:2018:EMNLP</bibkey>
   </paper>
@@ -3341,6 +3531,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1630–1642</pages>
     <url>http://www.aclweb.org/anthology/D18-1191</url>
+    <abstract>We present a simple and accurate span-based model for semantic role labeling (SRL). Our model directly takes into account all possible argument spans and scores them for each label. At decoding time, we greedily select higher scoring labeled spans. One advantage of our model is to allow us to design and use span-level features, that are difficult to use in token-based BIO tagging approaches. Experimental results demonstrate that our ensemble model achieves the state-of-the-art results, 87.4 F1 and 87.0 F1 on the CoNLL-2005 and 2012 datasets, respectively.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ouchi-shindo-matsumoto:2018:EMNLP</bibkey>
   </paper>
@@ -3358,6 +3549,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1643–1652</pages>
     <url>http://www.aclweb.org/anthology/D18-1192</url>
+    <abstract>Source code is rarely written in isolation. It depends significantly on the programmatic context, such as the class that the code would reside in. To study this phenomenon, we introduce the task of generating class member functions given English documentation and the programmatic context provided by the rest of the class. This task is challenging because the desired code can vary greatly depending on the functionality the class provides (e.g., a sort function may or may not be available when we are asked to ``return the smallest element'' in a particular member variable list). We introduce CONCODE, a new large dataset with over 100,000 examples consisting of Java classes from online code repositories, and develop a new encoder-decoder architecture that models the interaction between the method documentation and the class environment. We also present a detailed error analysis suggesting that there is significant room for future work on this task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>iyer-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -3378,6 +3570,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1653–1663</pages>
     <url>http://www.aclweb.org/anthology/D18-1193</url>
+    <abstract>Most existing studies in text-to-SQL tasks do not require generating complex SQL queries with multiple clauses or sub-queries, and generalizing to new, unseen databases. In this paper we propose SyntaxSQLNet, a syntax tree network to address the complex and cross-domain text-to-SQL generation task. SyntaxSQLNet employs a SQL specific syntax tree-based decoder with SQL generation path history and table-aware column attention encoders. We evaluate SyntaxSQLNet on a new large-scale text-to-SQL corpus containing databases with multiple tables and complex SQL queries containing multiple SQL clauses and nested queries. We use a database split setting where databases in the test set are unseen during training. Experimental results show that SyntaxSQLNet can handle a significantly greater number of complex SQL examples than prior work, outperforming the previous state-of-the-art model by 9.5\% in exact matching accuracy. To our knowledge, we are the first to study this complex text-to-SQL task. Our task and models with the latest updates are available at \url{https://yale-lily.github.io/seq2sql/spider}.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yu-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -3397,6 +3590,7 @@
     <pages>1664–1675</pages>
     <url>http://www.aclweb.org/anthology/D18-1194</url>
     <attachment type="attachment">D18-1194.Attachment.pdf</attachment>
+    <abstract>We introduce the task of cross-lingual decompositional semantic parsing: mapping content provided in a source language into a decompositional semantic analysis based on a target language. We present: (1) a form of decompositional semantic analysis designed to allow systems to target varying levels of structural complexity (shallow to deep analysis), (2) an evaluation metric to measure the similarity between system output and reference semantic analysis, (3) an end-to-end model with a novel annotating mechanism that supports intra-sentential coreference, and (4) an evaluation dataset on which our model outperforms strong baselines by at least 1.75 F1 score.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP7</bibkey>
   </paper>
@@ -3413,6 +3607,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1676–1690</pages>
     <url>http://www.aclweb.org/anthology/D18-1195</url>
+    <abstract>As humans, we often rely on language to learn language.   For example,  when corrected in a conversation, we may learn from that correction,  over  time  improving  our  language  fluency.   Inspired  by  this  observation,  we  propose a learning algorithm for training semantic parsers from supervision (feedback) expressed in  natural  language. Our  algorithm  learns  a semantic  parser  from  users'  corrections  such as ``no,  what  I  really  meant  was  before  his job, not after'', by also simultaneously learning to parse this natural language feedback in order to leverage it as a form of supervision. Unlike supervision with gold-standard logical forms, our method does not require the user to be familiar with the underlying logical formalism,  and unlike supervision from denotation, it does not require the user to know the correct answer to their query. This makes our learning algorithm naturally scalable in settings where existing conversational logs are available and can  be  leveraged  as  training  data.   We  construct a novel dataset of natural language feed- back in a conversational setting, and show that our method is effective at learning a semantic parser from such natural language supervision.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>labutov-yang-mitchell:2018:EMNLP</bibkey>
   </paper>
@@ -3430,12 +3625,13 @@
     <pages>1691–1701</pages>
     <url>http://www.aclweb.org/anthology/D18-1196</url>
     <attachment type="attachment">D18-1196.Attachment.zip</attachment>
+    <abstract>This paper introduces the surface construction labeling (SCL) task, which expands the coverage of Shallow Semantic Parsing (SSP) to include frames triggered by complex constructions. We present DeepCx, a neural, transition-based system for SCL. As a test case for the approach, we apply DeepCx to the task of tagging causal language in English, which relies on a wider variety of constructions than are typically addressed in SSP. We report substantial improvements over previous tagging efforts on a causal language dataset. We also propose ways DeepCx could be extended to still more difficult constructions and to other semantic domains once appropriate datasets become available.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dunietz-carbonell-levin:2018:EMNLP</bibkey>
   </paper>
 
   <paper id="1197">
-    <title>What It Takes to Achieve 100 Percent Condition Accuracy on WikiSQL</title>
+    <title>What It Takes to Achieve 100% Condition Accuracy on WikiSQL</title>
     <author><first>Semih</first><last>Yavuz</last></author>
     <author><first>Izzeddin</first><last>Gur</last></author>
     <author><first>Yu</first><last>Su</last></author>
@@ -3447,6 +3643,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1702–1711</pages>
     <url>http://www.aclweb.org/anthology/D18-1197</url>
+    <abstract>WikiSQL is a newly released dataset for studying the natural language sequence to SQL translation problem.  The SQL queries in WikiSQL are simple: Each involves one relation and does not have any join operation. Despite of its simplicity, none of the publicly reported structured query generation models can achieve an accuracy beyond 62\%, which is still far from enough for practical use. In this paper, we ask two questions, ``Why is the accuracy still low for such simple queries?'' and ``What does it take to achieve 100\% accuracy on WikiSQL?'' To limit the scope of our study, we focus on the WHERE clause in SQL. The answers will help us gain insights about the directions we should explore in order to further improve the translation accuracy. We will then investigate alternative solutions to realize the potential ceiling performance on WikiSQL. Our proposed solution can reach up to 88.6\% condition accuracy on the WikiSQL dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yavuz-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -3463,6 +3660,7 @@
     <pages>1712–1722</pages>
     <url>http://www.aclweb.org/anthology/D18-1198</url>
     <attachment type="attachment">D18-1198.Attachment.zip</attachment>
+    <abstract>This paper introduces a simple yet effective transition-based system for Abstract Meaning Representation (AMR) parsing. We argue that a well-defined search space involved in a transition system is crucial for building an effective parser. We propose to conduct the search in a refined search space based on a new compact AMR graph and an improved oracle. Our end-to-end parser achieves the state-of-the-art performance on various datasets with minimal additional information.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>guo-lu:2018:EMNLP</bibkey>
   </paper>
@@ -3478,6 +3676,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1723–1731</pages>
     <url>http://www.aclweb.org/anthology/D18-1199</url>
+    <abstract>Many idiomatic expressions can be interpreted figuratively or literally depending on their contexts. This paper proposes an unsupervised learning method for recognizing the intended usages of idioms. We treat the usages as a latent variable in probabilistic models and train them in a linguistically motivated feature space. Crucially, we show that distributional semantics is a helpful heuristic for distinguishing the literal usage of idioms, giving us a way to formulate a literal usage metric to estimate the likelihood that the idiom is intended literally. This information then serves as a form of distant supervision to guide the unsupervised training process for the probabilistic models. Experiments show that our overall model performs competitively against supervised methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-hwa:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305931117" tag="video" />
@@ -3495,6 +3694,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1732–1740</pages>
     <url>http://www.aclweb.org/anthology/D18-1200</url>
+    <abstract>The point of departure of this article is the claim that sense-specific vectors provide an advantage over normal vectors due to the polysemy that they presumably represent. This claim is based on performance gains observed in gold standard evaluation tests such as word similarity tasks. We demonstrate that this claim, at least as it is instantiated in prior art, is unfounded in two ways. Furthermore, we provide empirical data and an analytic discussion that may account for the previously reported improved performance. First, we show that ground-truth polysemy degrades performance in word similarity tasks. Therefore word similarity tasks are not suitable as an evaluation test for polysemy representation. Second, random assignment of words to senses is shown to improve performance in the same task. This and additional results point to the conclusion that performance gains as reported in previous work may be an artifact of random sense assignment, which is equivalent to sub-sampling and multiple estimation of word vector representations. Theoretical analysis shows that this may on its own be beneficial for the estimation of word similarity, by reducing the bias in the estimation of the cosine distance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dubossarsky-grossman-weinshall:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305931948" tag="video" />
@@ -3511,6 +3711,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1741–1751</pages>
     <url>http://www.aclweb.org/anthology/D18-1201</url>
+    <abstract>Semantic graphs, such as WordNet, are resources which curate natural language on two distinguishable layers. On the local level, individual relations between synsets (semantic building blocks) such as hypernymy and meronymy enhance our understanding of the words used to express their meanings. Globally, analysis of graph-theoretic properties of the entire net sheds light on the structure of human language as a whole. In this paper, we combine global and local properties of semantic graphs through the framework of Max-Margin Markov Graph Models (M3GM), a novel extension of Exponential Random Graph Model (ERGM) that scales to large multi-relational graphs. We demonstrate how such global modeling improves performance on the local task of predicting semantic relations between synsets, yielding new state-of-the-art results on the WN18RR dataset, a challenging version of WordNet link prediction in which ``easy'' reciprocal cases are removed. In addition, the M3GM model identifies multirelational motifs that are characteristic of well-formed lexical semantic ontologies.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pinter-eisenstein:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305933339" tag="video" />
@@ -3531,6 +3732,7 @@
     <pages>1752–1762</pages>
     <url>http://www.aclweb.org/anthology/D18-1202</url>
     <attachment type="attachment">D18-1202.Attachment.pdf</attachment>
+    <abstract>Adjectives like ``warm'', ``hot'', and ``scalding'' all describe temperature but differ in intensity. Understanding these differences between adjectives is a necessary part of reasoning about natural language. We propose a new paraphrase-based method to automatically learn the relative intensity relation that holds between a pair of scalar adjectives. Our approach analyzes over 36k adjectival pairs from the Paraphrase Database under the assumption that, for example, paraphrase pair ``really hot'' &lt;--&gt; ``scalding'' suggests that ``hot'' &lt; ``scalding''. We show that combining this paraphrase evidence with existing, complementary pattern- and lexicon-based approaches improves the quality of systems for automatically ordering sets of scalar adjectives and inferring the polarity of indirect answers to ``yes/no'' questions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>cocos-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305934622" tag="video" />
@@ -3550,6 +3752,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1763–1775</pages>
     <url>http://www.aclweb.org/anthology/D18-1203</url>
+    <abstract>In this paper, we propose a new kernel-based co-occurrence measure that can be applied to sparse linguistic expressions (e.g., sentences) with a very short learning time, as an alternative to pointwise mutual information (PMI). As well as deriving PMI from mutual information, we derive this new measure from the Hilbert--Schmidt independence criterion (HSIC); thus, we call the new measure the pointwise HSIC (PHSIC). PHSIC can be interpreted as a smoothed variant of PMI that allows various similarity metrics (e.g., sentence embeddings) to be plugged in as kernels. Moreover, PHSIC can be estimated by simple and fast (linear in the size of the data) matrix calculations regardless of whether we use linear or nonlinear kernels. Empirically, in a dialogue response selection task, PHSIC is learned thousands of times faster than an RNN-based PMI while outperforming PMI in accuracy. In addition, we also demonstrate that PHSIC is beneficial as a criterion of a data selection task for machine translation  owing to its ability to give high (low) scores to a consistent (inconsistent) pair with other pairs.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yokoi-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305935544" tag="video" />
@@ -3567,6 +3770,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1776–1786</pages>
     <url>http://www.aclweb.org/anthology/D18-1204</url>
+    <abstract>Conventional solutions to automatic related work summarization rely heavily on human-engineered features. In this paper, we develop a neural data-driven summarizer by leveraging the seq2seq paradigm, in which a joint context-driven attention mechanism is proposed to measure the contextual relevance within full texts and a heterogeneous bibliography graph simultaneously. Our motivation is to maintain the topic coherency between a related work section and its target document, where both the textual and graphic contexts play a big role in characterizing the relationship among scientific publications accurately. Experimental results on a large dataset show that our approach achieves a considerable improvement over a typical seq2seq summarizer and five classical summarization baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-liu-gao:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305686976" tag="video" />
@@ -3586,6 +3790,7 @@
     <pages>1787–1796</pages>
     <url>http://www.aclweb.org/anthology/D18-1205</url>
     <attachment type="attachment">D18-1205.Attachment.pdf</attachment>
+    <abstract>Information selection is the most important component in document summarization task. In this paper, we propose to extend the basic neural encoding-decoding framework with an information selection layer to explicitly model and optimize the information selection process in abstractive document summarization. Specifically, our information selection layer consists of two parts: gated global information filtering and local sentence selection. Unnecessary information in the original document is first globally filtered, then salient sentences are selected locally while generating each summary sentence sequentially. To optimize the information selection process directly, distantly-supervised training guided by the golden summary is also imported. Experimental results demonstrate that the explicit modeling and optimizing of the information selection process improves document summarization performance significantly, which enables our model to generate more informative and concise summaries, and thus significantly outperform state-of-the-art neural abstractive methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305885506" tag="video" />
@@ -3603,6 +3808,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1797–1807</pages>
     <url>http://www.aclweb.org/anthology/D18-1206</url>
+    <abstract>We introduce ``extreme summarization'', a new single-document summarization task which does not favor extractive strategies and calls for an abstractive modeling approach. The idea is to create a short, one-sentence news summary answering the question ``What is the article about?''. We collect a real-world, large-scale dataset for this task by harvesting online articles from the British Broadcasting Corporation (BBC). We propose a novel abstractive model which is conditioned on the article's topics and based entirely on convolutional neural networks.  We demonstrate experimentally that this architecture captures long-range dependencies in a document and recognizes pertinent content, outperforming an oracle extractive system and state-of-the-art abstractive approaches when evaluated automatically and by humans.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>narayan-cohen-lapata:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305885893" tag="video" />
@@ -3621,6 +3827,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1808–1817</pages>
     <url>http://www.aclweb.org/anthology/D18-1207</url>
+    <abstract>Abstractive text summarization aims to shorten long text documents into a human readable form that contains the most important facts from the original document. However, the level of actual abstraction as measured by novel phrases that do not appear in the source document remains low in existing approaches. We propose two techniques to improve the level of abstraction of generated summaries. First, we decompose the decoder into a contextual network that retrieves relevant parts of the source document, and a pretrained language model that incorporates prior knowledge about language generation. Second, we propose a novelty metric that is optimized directly through policy learning to encourage the generation of novel phrases. Our model achieves results comparable to state-of-the-art models, as determined by ROUGE scores and human evaluations, while achieving a significantly higher level of abstraction as measured by n-gram overlap with the source document.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kryciski-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305886179" tag="video" />
@@ -3639,6 +3846,7 @@
     <pages>1818–1828</pages>
     <url>http://www.aclweb.org/anthology/D18-1208</url>
     <attachment type="attachment">D18-1208.Attachment.pdf</attachment>
+    <abstract>We carry out experiments with deep learning models of summarization across the domains of news, personal stories, meetings, and medical articles in order to understand how content selection is performed. We find that many sophisticated features of state of the art extractive summarizers do not improve performance over simpler models. These results suggest that it is easier to create a summarizer for a new domain than previous work suggests and bring into question the benefit of deep learning models for summarization for those domains that do have massive datasets (i.e., news). At the same time, they suggest important questions for new research in summarization; namely, new forms of sentence representations or external knowledge sources are needed that are better suited to the sumarization task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kedzie-mckeown-daumeiii:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305886331" tag="video" />
@@ -3657,6 +3865,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1829–1838</pages>
     <url>http://www.aclweb.org/anthology/D18-1209</url>
+    <abstract>Network embeddings, which learns low-dimensional representations for each vertex in a large-scale network, have received considerable attention in recent years. For a wide range of applications, vertices in a network are typically accompanied by rich textual information such as user profiles, paper abstracts, etc. In this paper, we propose to incorporate semantic features into network embeddings by matching important words between text sequences for all pairs of vertices. We introduce an word-by-word alignment framework that measures the compatibility of embeddings between word pairs, and then adaptively accumulates these alignment features with a simple yet effective aggregation function. In experiments, we evaluate the proposed framework on three real-world benchmarks for downstream tasks, including link prediction and multi-label vertex classification. The experimental results demonstrate that our model outperforms state-of-the-art network embedding methods by a large margin.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shen-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/306030030" tag="video" />
@@ -3675,6 +3884,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1839–1848</pages>
     <url>http://www.aclweb.org/anthology/D18-1210</url>
+    <abstract>Convolutional neural networks (CNNs) have recently emerged as a popular building block for natural language processing (NLP). Despite their success, most existing CNN models employed in NLP share the  same learned (and static) set of filters for all input sentences. In this paper, we consider an approach of using a small meta network to learn context-sensitive convolutional filters for text processing. The role of meta network is to abstract the contextual information of a sentence or document into a set of input-sensitive filters. We further generalize this framework to model sentence pairs, where a bidirectional filter generation mechanism is introduced to encapsulate co-dependent sentence representations.  In our benchmarks on four different tasks,  including ontology classification, sentiment analysis, answer sentence selection, and paraphrase identification, our proposed model, a modified CNN with context-sensitive filters, consistently outperforms the standard CNN and attention-based CNN baselines. By visualizing the learned context-sensitive filters, we further validate and rationalize the effectiveness of proposed framework.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shen-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306040551" tag="video" />
@@ -3693,6 +3903,7 @@
     <pages>1849–1860</pages>
     <url>http://www.aclweb.org/anthology/D18-1211</url>
     <attachment type="attachment">D18-1211.Attachment.zip</attachment>
+    <abstract>We explore several new models for document relevance ranking, building upon the Deep Relevance Matching Model (DRMM) of Guo et al. (2016). Unlike DRMM, which uses context-insensitive encodings of terms and query-document term interactions, we inject rich context-sensitive encodings throughout our models, inspired by PACRR's (Hui et al., 2017) convolutional n-gram matching features, but extended in several ways including multiple views of query and document inputs. We test our models on datasets from the BIOASQ question answering challenge (Tsatsaronis et al., 2015) and TREC ROBUST 2004 (Voorhees, 2005), showing they outperform BM25-based baselines, DRMM, and PACRR.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mcdonald-brokos-androutsopoulos:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306041612" tag="video" />
@@ -3709,6 +3920,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1861–1870</pages>
     <url>http://www.aclweb.org/anthology/D18-1212</url>
+    <abstract>The existing studies in cross-language information retrieval (CLIR) mostly rely on general text representation models (e.g., vector space model or latent semantic analysis). These models are not optimized for the target retrieval task. In this paper, we follow the success of neural representation in natural language processing (NLP) and develop a novel text representation model based on adversarial learning, which seeks a task-specific embedding space for CLIR. Adversarial learning is implemented as an interplay between the generator process and the discriminator process. In order to adapt adversarial learning to CLIR, we design three constraints to direct representation learning, which are (1) a matching constraint capturing essential characteristics of cross-language ranking, (2) a translation constraint bridging language gaps, and (3) an adversarial constraint forcing both language and media invariant to be reached more efficiently and effectively. Through the joint exploitation of these constraints in an adversarial manner, the underlying cross-language semantics relevant to retrieval tasks are better preserved in the embedding space. Standard CLIR experiments show that our model significantly outperforms state-of-the-art continuous space models and is better than the strong machine translation baseline.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-cheng:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306042980" tag="video" />
@@ -3726,6 +3938,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1871–1880</pages>
     <url>http://www.aclweb.org/anthology/D18-1213</url>
+    <abstract>Knowledge of the creation date of documents facilitates several tasks such as summarization, event extraction, temporally focused information extraction etc. Unfortunately, for most of the documents on the Web, the time-stamp metadata is either missing or can't be trusted. Thus, predicting creation time from document content itself is an important task. In this paper, we propose Attentive Deep Document Dater (AD3), an attention-based neural document dating system which utilizes both context and temporal information in documents in a flexible and principled manner. We perform extensive experimentation on multiple real-world datasets to demonstrate the effectiveness of AD3 over neural and non-neural baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ray-dasgupta-talukdar:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306043956" tag="video" />
@@ -3742,6 +3955,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1881–1890</pages>
     <url>http://www.aclweb.org/anthology/D18-1214</url>
+    <abstract>Cross-lingual or cross-domain correspondences play key roles in tasks ranging from machine translation to transfer learning. Recently, purely unsupervised methods operating on monolingual embeddings have become effective alignment tools. Current state-of-the-art methods, however, involve multiple steps, including heuristic post-hoc refinement strategies. In this paper, we cast the correspondence problem directly as an optimal transport (OT) problem, building on the idea that word embeddings arise from metric recovery algorithms. Indeed, we exploit the Gromov-Wasserstein distance that measures how similarities between pairs of words relate across languages. We show that our OT objective can be estimated efficiently, requires little or no tuning, and results in performance comparable with the state-of-the-art in various unsupervised word translation tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>alvarezmelis-jaakkola:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305660461" tag="video" />
@@ -3758,6 +3972,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1891–1902</pages>
     <url>http://www.aclweb.org/anthology/D18-1215</url>
+    <abstract>Deep learning has emerged as a versatile tool for a wide range of NLP tasks, due to its superior capacity in representation learning. But its applicability is limited by the reliance on annotated examples, which are difficult to produce at scale. Indirect supervision has emerged as a promising direction to address this bottleneck, either by introducing labeling functions to automatically generate noisy examples from unlabeled text, or by imposing constraints over interdependent label decisions. A plethora of methods have been proposed, each with respective strengths and limitations. Probabilistic logic offers a unifying language to represent indirect supervision, but end-to-end modeling with probabilistic logic is often infeasible due to intractable inference and learning. In this paper, we propose deep probabilistic logic (DPL) as a general framework for indirect supervision, by composing probabilistic logic with deep learning. DPL models label decisions as latent variables, represents prior knowledge on their relations using weighted first-order logical formulas, and alternates between learning a deep neural network for the end task and refining uncertain formula weights for indirect supervision, using variational EM. This framework subsumes prior indirect supervision methods as special cases, and enables novel combination via infusion of rich domain and linguistic knowledge. Experiments on biomedical machine reading demonstrate the promise of this approach.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-poon:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305661315" tag="video" />
@@ -3777,6 +3992,7 @@
     <pages>1903–1913</pages>
     <url>http://www.aclweb.org/anthology/D18-1216</url>
     <attachment type="attachment">D18-1216.Attachment.zip</attachment>
+    <abstract>Attention-based models are successful when trained on large amounts of data. In this paper, we demonstrate that even in the low-resource scenario, attention can be learned effectively. To this end, we start with discrete human-annotated rationales and map them into continuous attention. Our central hypothesis is that this mapping is general across domains,  and thus can be transferred from resource-rich domains to low-resource ones. Our model jointly learns a domain-invariant representation and induces the desired mapping between rationales and attention. Our empirical results validate this hypothesis and show that our approach delivers significant gains over state-of-the-art baselines, yielding over 15\% average error reduction on benchmark datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bao-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305661928" tag="video" />
@@ -3796,6 +4012,7 @@
     <pages>1914–1925</pages>
     <url>http://www.aclweb.org/anthology/D18-1217</url>
     <attachment type="attachment">D18-1217.Attachment.zip</attachment>
+    <abstract>Unsupervised representation learning algorithms such as word2vec and ELMo improve the accuracy of many supervised NLP models, mainly because they can take advantage of large amounts of unlabeled text. However, the supervised models only learn from task-specific labeled data during the main training phase. We therefore propose Cross-View Training (CVT), a semi-supervised learning algorithm that improves the representations of a Bi-LSTM sentence encoder using a mix of labeled and unlabeled data. On labeled examples, standard supervised learning is used. On unlabeled examples, CVT teaches auxiliary prediction modules that see restricted views of the input (e.g., only part of a sentence) to match the predictions of the full model seeing the whole input. Since the auxiliary modules and the full model share intermediate representations, this in turn improves the full model. Moreover, we show that CVT is particularly effective when combined with multi-task learning. We evaluate CVT on five sequence tagging tasks, machine translation, and dependency parsing, achieving state-of-the-art results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>clark-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305662403" tag="video" />
@@ -3816,6 +4033,7 @@
     <pages>1926–1937</pages>
     <url>http://www.aclweb.org/anthology/D18-1218</url>
     <attachment type="attachment">D18-1218.Attachment.zip</attachment>
+    <abstract>The availability of large scale annotated corpora for coreference is essential to the development of the field. However, creating resources at the required scale via expert annotation would be too expensive. Crowdsourcing has been proposed as an alternative; but this approach has not been widely used for coreference. This paper addresses one crucial hurdle on the way to make this possible, by introducing a new model of annotation for aggregating crowdsourced anaphoric annotations. The model is evaluated along three dimensions: the accuracy of the inferred mention pairs, the quality of the post-hoc constructed silver chains, and the viability of using the silver chains as an alternative to the expert-annotated chains in training a state of the art coreference system. The results suggest that our model can extract from crowdsourced annotations coreference chains of comparable quality to those obtained with expert annotation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>paun-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -3830,6 +4048,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1938–1948</pages>
     <url>http://www.aclweb.org/anthology/D18-1219</url>
+    <abstract>Previous work on bridging anaphora resolution (Poesio et al., 2004; Hou et al., 2013) use syntactic preposition patterns to calculate word relatedness. However, such patterns only consider NPs' head nouns and hence do not fully capture the semantics of NPs. Recently, Hou (2018) created word embeddings (embeddings\_PP) to capture associative similarity (i.e., relatedness) between nouns by exploring the syntactic structure of noun phrases. But embeddings\_PP only contains word representations for nouns. In this paper, we create new word vectors by combining embeddings\_PP with GloVe. This new word embeddings (embeddings\_bridging) are a more general lexical knowledge resource for bridging and allow us to represent the meaning of an NP beyond its head easily. We therefore develop a deterministic approach for bridging anaphora resolution, which represents the semantics of an NP based on its head noun and modifications. We show that this simple approach achieves the competitive results compared to the best system in Hou et al. (2013) which explores Markov Logic Networks to model the problem. Additionally, we further improve the results for bridging anaphora resolution reported in Hou (2018) by combining our simple deterministic approach with Hou et al. (2013)'s best system MLN II.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hou:2018:EMNLP</bibkey>
   </paper>
@@ -3849,6 +4068,7 @@
     <pages>1949–1958</pages>
     <url>http://www.aclweb.org/anthology/D18-1220</url>
     <attachment type="attachment">D18-1220.Attachment.pdf</attachment>
+    <abstract>We introduce an automatic system that achieves state-of-the-art results on the Winograd Schema Challenge (WSC), a common sense reasoning task that requires diverse, complex forms of inference and knowledge. Our method uses a knowledge hunting module to gather text from the web, which serves as evidence for candidate problem resolutions. Given an input problem, our system generates relevant queries to send to a search engine, then extracts and classifies knowledge from the returned results and weighs them to make a resolution. Our approach improves F1 performance on the full WSC by 0.21 over the previous best and represents the first system to exceed 0.5 F1. We further demonstrate that the approach is competitive on the Choice of Plausible Alternatives (COPA) task, which suggests that it is generally applicable.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>emami-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -3865,6 +4085,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1959–1970</pages>
     <url>http://www.aclweb.org/anthology/D18-1221</url>
+    <abstract>This paper addresses the problem of mapping natural language text to knowledge base entities. The mapping process is approached as a composition of a phrase or a sentence into a point in a multi-dimensional entity space obtained from a knowledge graph. The compositional model is an LSTM equipped with a dynamic disambiguation mechanism on the input word embeddings (a Multi-Sense LSTM), addressing polysemy issues. Further, the knowledge base space is prepared by collecting random walks from a graph enhanced with textual features, which act as a set of semantic bridges between text and knowledge base entities. The ideas of this work are demonstrated on large-scale text-to-entity mapping and entity classification tasks, with state of the art results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kartsaklis-pilehvar-collier:2018:EMNLP</bibkey>
   </paper>
@@ -3882,6 +4103,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1971–1979</pages>
     <url>http://www.aclweb.org/anthology/D18-1222</url>
+    <abstract>Concepts, which represent a group of different instances sharing common properties, are essential information in knowledge representation. Most conventional knowledge embedding methods encode both entities (concepts and instances) and relations as vectors in a low dimensional semantic space equally, ignoring the difference between concepts and instances. In this paper, we propose a novel knowledge graph embedding model named TransC by differentiating concepts and instances. Specifically, TransC encodes each concept in knowledge graph as a sphere and each instance as a vector in the same semantic space. We use the relative positions to model the relations between concepts and instances (i.e.,instanceOf), and the relations between concepts and sub-concepts (i.e., subClassOf). We evaluate our model on both link prediction and triple classification tasks on the dataset based on YAGO. Experimental results show that TransC outperforms state-of-the-art methods, and captures the semantic transitivity for instanceOf and subClassOf relation. Our codes and datasets can be obtained from https:// github.com/davidlvxin/TransC.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lv-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -3901,6 +4123,7 @@
     <pages>1980–1990</pages>
     <url>http://www.aclweb.org/anthology/D18-1223</url>
     <attachment type="attachment">D18-1223.Attachment.pdf</attachment>
+    <abstract>Knowledge graphs (KG) are the key components of various natural language processing applications. To further expand KGs' coverage, previous studies on knowledge graph completion usually require a large number of positive examples for each relation. However, we observe long-tail relations are actually more common in KGs and those newly added relations often do not have many known triples for training. In this work, we aim at predicting new facts under a challenging setting where only one training instance is available. We propose a one-shot relational learning framework, which utilizes the knowledge distilled by embedding models and learns a matching metric by considering both the learned embeddings and one-hop graph structures. Empirically, our model yields considerable performance improvements over existing embedding models, and also eliminates the need of re-training the embedding models when dealing with newly added relations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xiong-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -3919,6 +4142,7 @@
     <pages>1991–2000</pages>
     <url>http://www.aclweb.org/anthology/D18-1224</url>
     <attachment type="attachment">D18-1224.Attachment.zip</attachment>
+    <abstract>Many important entity types in web documents, such as dates, times, email addresses, and course numbers, follow or closely resemble patterns that can be described by Regular Expressions (REs).  Due to a vast diversity of web documents and ways in which they are being generated, even seemingly straightforward tasks such as identifying mentions of date in a document become very challenging. It is reasonable to claim that it is impossible to create a RE that is capable of identifying such entities from web documents with perfect precision and recall. Rather than abandoning REs as a go-to approach for entity detection, this paper explores ways to combine the expressive power of REs, ability of deep learning to learn from large data, and human-in-the loop approach into a new integrated framework for entity identification from web data. The framework starts by creating or collecting the existing REs for a particular type of an entity. Those REs are then used over a large document corpus to collect weak labels for the entity mentions and a neural network is trained to predict those RE-generated weak labels. Finally, a human expert is asked to label a small set of documents and the neural network is fine tuned on those documents. The experimental evaluation on several entity identification problems shows that the proposed framework achieves impressive accuracy, while requiring very modest human effort.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP8</bibkey>
   </paper>
@@ -3935,6 +4159,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2001–2011</pages>
     <url>http://www.aclweb.org/anthology/D18-1225</url>
+    <abstract>Knowledge Graph (KG) embedding has emerged as an active area of research resulting in the development of several KG embedding methods. Relational facts in KG often show temporal dynamics, e.g., the fact (Cristiano\_Ronaldo, playsFor, Manchester\_United) is valid only from 2003 to 2009. Most of the existing KG embedding methods ignore this temporal dimension while learning embeddings of the KG elements. In this paper, we propose HyTE, a temporally aware KG embedding method which explicitly incorporates time in the entity-relation space by associating each timestamp with a corresponding hyperplane. HyTE not only performs KG inference using temporal guidance, but also predicts temporal scopes for relational facts with missing time annotations. Through extensive experimentation on temporal datasets extracted from real-world KGs, we demonstrate the effectiveness of our model over both traditional as well as temporal KG embedding methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dasgupta-ray-talukdar:2018:EMNLP</bibkey>
   </paper>
@@ -3950,6 +4175,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2012–2022</pages>
     <url>http://www.aclweb.org/anthology/D18-1226</url>
+    <abstract>Recent research efforts have shown that neural architectures can be effective in conventional information extraction tasks such as named entity recognition, yielding state-of-the-art results on standard newswire datasets. However, despite significant resources required for training such models, the performance of a  model trained on one domain typically degrades dramatically when applied to a different domain, yet extracting entities from new emerging domains such as social media can be of significant interest. In this paper, we empirically investigate effective methods for conveniently adapting an existing, well-trained neural NER model for a new domain. Unlike existing approaches, we propose lightweight yet effective methods for performing domain adaptation for neural models. Specifically, we introduce adaptation layers on top of existing neural architectures, where no re-training using the source domain data is required. We conduct extensive empirical studies and show that our approach significantly outperforms state-of-the-art methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lin-lu:2018:EMNLP</bibkey>
   </paper>
@@ -3967,6 +4193,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2023–2032</pages>
     <url>http://www.aclweb.org/anthology/D18-1227</url>
+    <abstract>In this paper, we study a new entity linking problem where both the entity mentions and the target entities are within a same social media platform. Compared with traditional entity linking problems that link mentions to a knowledge base, this new problem have less information about the target entities. However, if we can successfully link mentions to entities within a social media platform, we can improve a lot of applications such as comparative study in business intelligence and opinion leader finding. To study this problem, we constructed a dataset called Yelp-EL, where the business mentions in Yelp reviews are linked to their corresponding businesses on the platform. We conducted comprehensive experiments and analysis on this dataset with a learning to rank model that takes different types of features as input, as well as a few state-of-the-art entity linking approaches. Our experimental results show that two types of features that are not available in traditional entity linking: social features and location features, can be very helpful for this task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dai-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -3984,6 +4211,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2033–2042</pages>
     <url>http://www.aclweb.org/anthology/D18-1228</url>
+    <abstract>Having an entity annotated corpus of the clinical domain is one of the basic requirements for detection of clinical entities using machine learning (ML) approaches. Past researches have shown the superiority of statistical/ML approaches over the rule based approaches. But in order to take full advantage of the ML approaches, an accurately annotated corpus becomes an essential requirement. Though there are a few annotated corpora available either on a small data set, or covering a narrower domain (like cancer patients records, lab reports), annotation of a large data set representing the entire clinical domain has not been created yet. In this paper, we have described in detail the annotation guidelines, annotation process and our approaches in creating a CER (clinical entity recognition) corpus of 5,160 clinical documents from forty different clinical specialities. The clinical entities range across various types such as diseases, procedures, medications, medical devices and so on. We have classified them into eleven categories for annotation. Our annotation also reflects the relations among the group of entities that constitute larger concepts altogether.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>patel-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4003,6 +4231,7 @@
     <pages>2043–2053</pages>
     <url>http://www.aclweb.org/anthology/D18-1229</url>
     <attachment type="attachment">D18-1229.Attachment.zip</attachment>
+    <abstract>We challenge a common assumption in active learning, that a list-based interface populated by informative samples provides for efficient and effective data annotation. We show how a 2D scatterplot populated with diverse and representative samples can yield improved models given the same time budget. We consider this for bootstrapping-based information extraction, in particular named entity classification, where human and machine jointly label data. To enable effective data annotation in a scatterplot, we have developed an embedding-based bootstrapping model that learns the distributional similarity of entities through the patterns that match them in a large data corpus, while being discriminative with respect to human-labeled and machine-promoted entities. We conducted a user study to assess the effectiveness of these different interfaces, and analyze bootstrapping performance in terms of human labeling accuracy, label quantity, and labeling consensus across multiple users. Our results suggest that supervision acquired from the scatterplot interface, despite being noisier, yields improvements in classification performance compared with the list interface, due to a larger quantity of supervision acquired.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>berger-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4022,6 +4251,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2054–2064</pages>
     <url>http://www.aclweb.org/anthology/D18-1230</url>
+    <abstract>Recent advances in deep neural models allow us to build reliable named entity recognition (NER) systems without handcrafting features. However, such methods require large amounts of manually-labeled training data. There have been efforts on replacing human annotations with distant supervision (in conjunction with external dictionaries), but the generated noisy labels pose significant challenges on learning effective neural models. Here we propose two neural models to suit noisy distant supervision from the dictionary. First, under the traditional sequence labeling framework, we propose a revised fuzzy CRF layer to handle tokens with multiple possible labels. After identifying the nature of noisy labels in distant supervision, we go beyond the traditional framework and propose a novel, more effective neural model AutoNER with a new Tie or Break scheme. In addition, we discuss how to refine distant supervision for better NER performance. Extensive experiments on three benchmark datasets demonstrate that AutoNER achieves the best performance when only using dictionaries with no additional human effort, and delivers competitive results with state-of-the-art supervised benchmarks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shang-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4040,6 +4270,7 @@
     <pages>2065–2076</pages>
     <url>http://www.aclweb.org/anthology/D18-1231</url>
     <attachment type="attachment">D18-1231.Attachment.pdf</attachment>
+    <abstract>The problem of entity-typing has been studied predominantly as a supervised learning problems, mostly with task-specific annotations (for coarse types) and sometimes with distant supervision (for fine types). While such approaches have strong performance within datasets they often lack the flexibility to transfer across text genres and to generalize to new type taxonomies. In this work we propose a zero-shot entity typing approach that requires no annotated data and can flexibly identify newly defined types. Given a  type taxonomy, the entries of which we define as Boolean functions of freebase ``types,'' we ground a given mention to a set of {\em type-compatible} Wikipedia entries, and then infer the target mention's type using an inference algorithm that makes use of the types of these entries. We evaluate our system on a broad range of datasets, including standard fine-grained and coarse-grained entity typing datasets, and on a dataset in the biological domain. Our system is shown to be competitive with  state-of-the-art supervised NER systems, and to outperform them on out-of-training datasets. We also show that our system significantly outperforms other zero-shot fine typing systems.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhou-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -4060,6 +4291,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2077–2086</pages>
     <url>http://www.aclweb.org/anthology/D18-1232</url>
+    <abstract>Despite that current reading comprehension systems have achieved significant advancements, their promising performances are often obtained at the cost of making an ensemble of numerous models. Besides, existing approaches are also vulnerable to adversarial attacks. This paper tackles these problems by leveraging knowledge distillation, which aims to transfer knowledge from an ensemble model to a single model. We first demonstrate that vanilla knowledge distillation applied to answer span prediction is effective for reading comprehension systems. We then propose two novel approaches that not only penalize the prediction on confusing answers but also guide the training with alignment information distilled from the ensemble. Experiments show that our best student model has only a slight drop of 0.4\% F1 on the SQuAD test set compared to the ensemble teacher, while running 12x faster during inference. It even outperforms the teacher on adversarial SQuAD datasets and NarrativeQA benchmark.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hu-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -4082,6 +4314,7 @@
     <pages>2087–2097</pages>
     <url>http://www.aclweb.org/anthology/D18-1233</url>
     <attachment type="attachment">D18-1233.Attachment.zip</attachment>
+    <abstract>Most work in machine reading focuses on question answering problems where the answer is directly expressed in the text to read. However, many real-world question answering problems require the reading of text not because it contains the literal answer, but because it contains a recipe to derive an answer together with the reader's background knowledge. One example is the task of interpreting regulations to answer ``Can I...?'' or ``Do I have to...?'' questions such as ``I am working in Canada. Do I have to carry on paying UK National Insurance?'' after reading a UK government website about this topic. This task requires both the interpretation of rules and the application of background knowledge. It is further complicated due to the fact that, in practice, most questions are underspecified, and a human assistant will regularly have to ask clarification questions such as ``How long have you been working abroad?'' when the answer cannot be directly derived from the question and text. In this paper, we formalise this task and develop a crowd-sourcing strategy to collect 37k task instances based on real-world rules and crowd-generated questions and scenarios. We analyse the challenges of this task and assess its difficulty by evaluating the performance of rule-based and machine-learning baselines. We observe promising results when no background knowledge is necessary, and substantial room for improvement whenever background knowledge is needed.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>saeidi-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4099,6 +4332,7 @@
     <pages>2098–2108</pages>
     <url>http://www.aclweb.org/anthology/D18-1234</url>
     <attachment type="attachment">D18-1234.Attachment.pdf</attachment>
+    <abstract>Although natural language question answering over knowledge graphs have been studied in the literature, existing methods have some limitations in answering complex questions. To address that, in this paper, we propose a State Transition-based approach to translate a complex natural language question N to a semantic query graph (SQG), which is used to match the underlying knowledge graph to find the answers to question N. In order to generate SQG, we propose four primitive operations (expand, fold, connect and merge) and a learning-based state transition approach. Extensive experiments on several benchmarks (such as QALD, WebQuestions and ComplexQuestions) with two knowledge bases (DBpedia and Freebase) confirm the superiority of our approach compared with state-of-the-arts.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hu-zou-zhang:2018:EMNLP</bibkey>
   </paper>
@@ -4118,6 +4352,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2109–2118</pages>
     <url>http://www.aclweb.org/anthology/D18-1235</url>
+    <abstract>The task of machine reading comprehension (MRC) has evolved from answering simple questions from well-edited text to answering real questions from users out of web data. In the real-world setting, full-body text from multiple relevant documents in the top search results are provided as context for questions from user queries, including not only questions with a single, short, and factual answer, but also questions about reasons, procedures, and opinions. In this case, multiple answers could be equally valid for a single question and each answer may occur multiple times in the context, which should be taken into consideration when we build MRC system. We propose a multi-answer multi-task framework, in which different loss functions are used for multiple reference answers. Minimum Risk Training is applied to solve the multi-occurrence problem of a single answer. Combined with a simple heuristic passage extraction strategy for overlong documents, our model increases the ROUGE-L score on the DuReader dataset from 44.18, the previous state-of-the-art, to 51.09.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP6</bibkey>
   </paper>
@@ -4134,6 +4369,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2119–2130</pages>
     <url>http://www.aclweb.org/anthology/D18-1236</url>
+    <abstract>We propose the task of Open-Domain Information Narration (OIN) as the reverse task of Open Information Extraction (OIE), to implement the dual structure between language and knowledge in the open domain. Then, we develop an agent, called Orator, to accomplish the OIN task, and assemble the Orator and the recently proposed OIE agent --- Logician{\textasciitilde} into a dual system to utilize the duality structure with a reinforcement learning paradigm. Experimental results reveal the dual structure between OIE and OIN tasks helps to build better both OIE agents and OIN agents.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sun-li-li:2018:EMNLP</bibkey>
   </paper>
@@ -4153,6 +4389,7 @@
     <pages>2131–2140</pages>
     <url>http://www.aclweb.org/anthology/D18-1237</url>
     <attachment type="attachment">D18-1237.Attachment.pdf</attachment>
+    <abstract>Machine reading comprehension helps machines learn to utilize most of the human knowledge written in the form of text. Existing approaches made a significant progress comparable to human-level performance, but they are still limited in understanding, up to a few paragraphs, failing to properly comprehend lengthy document. In this paper, we propose a novel deep neural network architecture to handle a long-range dependency in RC tasks. In detail, our method has two novel aspects: (1) an advanced memory-augmented architecture and (2) an expanded gated recurrent unit with dense connections that mitigate potential information distortion occurring in the memory. Our proposed architecture is widely applicable to other models. We have performed extensive experiments with well-known benchmark datasets such as TriviaQA, QUASAR-T, and SQuAD. The experimental results demonstrate that the proposed method outperforms existing methods, especially for lengthy documents.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>back-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4169,6 +4406,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2141–2151</pages>
     <url>http://www.aclweb.org/anthology/D18-1238</url>
+    <abstract>Sequence encoders are crucial components in many neural architectures for learning to read and comprehend. This paper presents a new compositional encoder for reading comprehension (RC). Our proposed encoder is not only aimed at being fast but also expressive. Specifically, the key novelty behind our encoder is that it explicitly models across multiple granularities using a new dilated composition mechanism. In our approach, gating functions are learned by modeling relationships and reasoning over multi-granular sequence information, enabling compositional learning that is aware of both long and short term information. We conduct experiments on three RC datasets, showing that our proposed encoder demonstrates very promising results both as a standalone encoder as well as a complementary building block. Empirical results show that simple Bi-Attentive architectures augmented with our proposed encoder not only achieves state-of-the-art / highly competitive results but is also considerably faster than other published works.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tay-luu-hui:2018:EMNLP2</bibkey>
   </paper>
@@ -4185,6 +4423,7 @@
     <pages>2152–2161</pages>
     <url>http://www.aclweb.org/anthology/D18-1239</url>
     <attachment type="attachment">D18-1239.Attachment.pdf</attachment>
+    <abstract>Answering compositional questions requiring multi-step reasoning is challenging. We introduce an end-to-end differentiable model for interpreting questions about a knowledge graph (KG), which is inspired by formal approaches to semantics. Each span of text is represented by a denotation in a KG and a vector that captures ungrounded aspects of meaning. Learned composition modules recursively combine constituent spans, culminating in a grounding for the complete sentence which answers the question. For example, to interpret ``not green'', the model represents ``green'' as a set of KG entities and ``not'' as a trainable ungrounded vector---and then uses this vector to parameterize a composition function that performs a complement operation. For each sentence, we build a parse chart subsuming all possible parses, allowing the model to jointly learn both the composition operators and output structure by gradient descent from end-task supervision. The model learns a variety of challenging semantic operators, such as quantifiers, disjunctions and composed relations, and infers latent syntactic structure.  It also generalizes well to longer questions than seen in its training data, in contrast to RNN, its tree-based variants, and semantic parsing baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gupta-lewis:2018:EMNLP</bibkey>
   </paper>
@@ -4200,6 +4439,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2162–2173</pages>
     <url>http://www.aclweb.org/anthology/D18-1240</url>
+    <abstract>High-level semantics tasks, e.g., paraphrasing, textual entailment or question answering, involve modeling of text pairs. Before the emergence of neural networks, this has been mostly performed using intra-pair features, which incorporate similarity scores or rewrite rules computed between the members within the same pair. In this paper, we compute scalar products between vectors representing similarity between members of different pairs, in place of simply using a single vector for each pair. This allows us to obtain a representation specific to any pair of pairs, which delivers the state of the art in answer sentence selection. Most importantly, our approach can outperform much more complex algorithms based on neural networks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tymoshenko-moschitti:2018:EMNLP</bibkey>
   </paper>
@@ -4222,6 +4462,7 @@
     <pages>2174–2184</pages>
     <url>http://www.aclweb.org/anthology/D18-1241</url>
     <attachment type="attachment">D18-1241.Attachment.zip</attachment>
+    <abstract>We present QuAC, a dataset for Question Answering in Context that contains 14K information-seeking QA dialogs (100K questions in total). The dialogs involve two crowd workers: (1) a student who poses a sequence of freeform questions to learn as much as possible about a hidden Wikipedia text, and (2) a teacher who answers the questions by providing short excerpts from the text. QuAC introduces challenges not found in existing machine comprehension datasets: its questions are often more open-ended, unanswerable, or only meaningful within the dialog context, as we show in a detailed qualitative evaluation. We also report results for a number of reference models, including a recently state-of-the-art reading comprehension architecture extended to model dialog context. Our best model underperforms humans by 20 F1, suggesting that there is significant room for future work on this data. Dataset, baseline, and leaderboard available at http://quac.ai.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>choi-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4239,6 +4480,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2185–2194</pages>
     <url>http://www.aclweb.org/anthology/D18-1242</url>
+    <abstract>Answering complex questions that involve multiple entities and multiple relations using a standard knowledge base is an open and challenging task. Most existing KBQA approaches focus on simpler questions and do not work very well on complex questions because they were not able to simultaneously represent the question and the corresponding complex query structure. In this work, we encode such complex query structure into a uniform vector representation, and thus successfully capture the interactions between individual semantic components within a complex question. This approach consistently outperforms existing methods on complex questions while staying competitive on simple questions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>luo-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -4256,6 +4498,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2195–2204</pages>
     <url>http://www.aclweb.org/anthology/D18-1243</url>
+    <abstract>Extracting relations is critical for knowledge base completion and construction in which distant supervised methods are widely used to extract relational facts automatically with the existing knowledge bases. However, the automatically constructed datasets comprise amounts of low-quality sentences containing noisy words, which is neglected by current distant supervised methods resulting in unacceptable precisions. To mitigate this problem, we propose a novel word-level distant supervised approach for relation extraction. We first build Sub-Tree Parse(STP) to remove noisy words that are irrelevant to relations. Then we construct a neural network inputting the sub-tree while applying the entity-wise attention to identify the important semantic features of relational words in each instance. To make our model more robust against noisy words, we initialize our network with a priori knowledge learned from the relevant task of entity classification by transfer learning. We conduct extensive experiments using the corpora of New York Times(NYT) and Freebase. Experiments show that our approach is effective and improves the area of Precision/Recall(PR) from 0.35 to 0.39 over the state-of-the-art work.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP7</bibkey>
   </paper>
@@ -4273,6 +4516,7 @@
     <pages>2205–2215</pages>
     <url>http://www.aclweb.org/anthology/D18-1244</url>
     <attachment type="attachment">D18-1244.Attachment.pdf</attachment>
+    <abstract>Dependency trees help relation extraction models capture long-range relations between words. However, existing dependency-based models either neglect crucial information (e.g., negation) by pruning the dependency trees too aggressively, or are computationally inefficient because it is difficult to parallelize over different tree structures. We propose an extension of graph convolutional networks that is tailored for relation extraction, which pools information over arbitrary dependency structures efficiently in parallel. To incorporate relevant information while maximally removing irrelevant content, we further apply a novel pruning strategy to the input trees by keeping words immediately around the shortest path between the two entities among which a relation might hold. The resulting model achieves state-of-the-art performance on the large-scale TACRED dataset, outperforming existing sequence and dependency-based neural models. We also show through detailed analysis that this model has complementary strengths to sequence models, and combining them further improves the state of the art.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-qi-manning:2018:EMNLP</bibkey>
   </paper>
@@ -4290,6 +4534,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2216–2225</pages>
     <url>http://www.aclweb.org/anthology/D18-1245</url>
+    <abstract>Attention mechanism is often used in deep neural networks for distantly supervised rela- tion extraction (DS-RE) to distinguish valid from noisy instances. However, traditional 1- D vector attention model is insufficient for learning of different contexts in the selection of valid instances to predict the relationship for an entity pair. To alleviate this issue, we propose a novel multi-level structured (2- D matrix) self-attention mechanism for DS- RE in a multi-instance learning (MIL) frame- work using bidirectional recurrent neural net- works (BiRNN). In the proposed method, a structured word-level self-attention learns a 2- D matrix where each row vector represents a weight distribution for different aspects of an instance regarding two entities. Targeting the MIL issue, the structured sentence-level attention learns a 2-D matrix where each row vector represents a weight distribution on selection of different valid instances. Experiments conducted on two publicly available DS-RE datasets show that the proposed frame- work with multi-level structured self-attention mechanism significantly outperform baselines in terms of PR curves, P\@N and F1 measures.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>du-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -4307,6 +4552,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2226–2235</pages>
     <url>http://www.aclweb.org/anthology/D18-1246</url>
+    <abstract>Cross-sentence \$n\$-ary relation extraction detects relations among \$n\$ entities across multiple sentences. Typical methods formulate an input as a \textit{document graph}, integrating various intra-sentential and inter-sentential dependencies. The current state-of-the-art method splits the input graph into two DAGs, adopting a DAG-structured LSTM for each. Though being able to model rich linguistic knowledge by leveraging graph edges, important information can be lost in the splitting procedure. We propose a graph-state LSTM model, which uses a parallel state to model each word, recurrently enriching state values via message passing. Compared with DAG LSTMs, our graph LSTM keeps the original graph structure, and speeds up computation by allowing more parallelization. On a standard benchmark, our model shows the best result in the literature.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>song-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4325,6 +4571,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2236–2245</pages>
     <url>http://www.aclweb.org/anthology/D18-1247</url>
+    <abstract>Distantly supervised relation extraction employs existing knowledge graphs to automatically collect training data. While distant supervision is effective to scale relation extraction up to large-scale corpora, it inevitably suffers from the wrong labeling problem. Many efforts have been devoted to identifying valid instances from noisy data. However, most existing methods handle each relation in isolation, regardless of rich semantic correlations located in relation hierarchies. In this paper, we aim to incorporate the hierarchical information of relations for distantly supervised relation extraction and propose a novel hierarchical attention scheme. The multiple layers of our hierarchical attention scheme provide coarse-to-fine granularity to better identify valid instances, which is especially effective for extracting those long-tail relations. The experimental results on a large-scale benchmark dataset demonstrate that our models are capable of modeling the hierarchical information of relations and significantly outperform other baselines. The source code of this paper can be obtained from https://github.com/thunlp/HNRE.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>han-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -4346,6 +4593,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2246–2255</pages>
     <url>http://www.aclweb.org/anthology/D18-1248</url>
+    <abstract>Distant supervision is an effective method to generate large scale labeled data for relation extraction, which assumes that if a pair of entities appears in some relation of a Knowledge Graph (KG), all sentences containing those entities in a large unlabeled corpus are then labeled with that relation to train a relation classifier.  However, when the pair of entities has multiple relationships in the KG, this assumption may produce noisy relation labels.  This paper proposes a label-free distant supervision method, which makes no use of the relation labels under this inadequate assumption, but only uses the prior knowledge derived from the KG to supervise the learning of the classifier directly and softly. Specifically, we make use of the type information and the translation law derived from typical KG embedding model to learn embeddings for certain sentence patterns. As the supervision signal is only determined by the two aligned entities, neither hard relation labels nor extra noise-reduction model for the bag of sentences is needed in this way. The experiments show that the approach performs well in current distant supervision dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP8</bibkey>
   </paper>
@@ -4367,6 +4615,7 @@
     <pages>2256–2265</pages>
     <url>http://www.aclweb.org/anthology/D18-1249</url>
     <attachment type="attachment">D18-1249.Attachment.zip</attachment>
+    <abstract>We investigate the task of joint entity relation extraction. Unlike prior efforts, we propose a new lightweight joint learning paradigm based on minimum risk training (MRT). Specifically, our algorithm optimizes a global loss function which is flexible and effective to explore interactions between the entity model and the relation model. We implement a strong and simple neural network where the MRT is executed. Experiment results on the benchmark ACE05 and NYT datasets show that our model is able to achieve state-of-the-art joint extraction performances.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sun-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -4387,6 +4636,7 @@
     <pages>2266–2277</pages>
     <url>http://www.aclweb.org/anthology/D18-1250</url>
     <attachment type="attachment">D18-1250.Attachment.pdf</attachment>
+    <abstract>Experimental performance on the task of relation classification has generally improved using deep neural network architectures. One major drawback of reported studies is that individual models have been evaluated on a very narrow range of datasets, raising questions about the adaptability of the architectures, while making comparisons between approaches difficult. In this work, we present a systematic large-scale analysis of neural relation classification architectures on six benchmark datasets with widely varying characteristics. We propose a novel multi-channel LSTM model combined with a CNN that takes advantage of all currently popular linguistic and architectural features. Our 'Man for All Seasons' approach achieves state-of-the-art performance on two datasets. More importantly, in our view, the model allowed us to obtain direct insights into the continued challenges faced by neural language models on this task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>le-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4402,6 +4652,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2278–2287</pages>
     <url>http://www.aclweb.org/anthology/D18-1251</url>
+    <abstract>This paper presents a corpus and experimental results to extract possession relations over time. We work with Wikipedia articles about artworks, and extract possession relations along with temporal information indicating when these relations are true. The annotation scheme yields many possessors over time for a given artwork, and experimental results show that an LSTM ensemble can automate the task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chinnappa-blanco:2018:EMNLP</bibkey>
   </paper>
@@ -4418,6 +4669,7 @@
     <pages>2288–2297</pages>
     <url>http://www.aclweb.org/anthology/D18-1252</url>
     <attachment type="attachment">D18-1252.Attachment.pdf</attachment>
+    <abstract>Referring to entities in situated dialog is a collaborative process, whereby interlocutors often expand, repair and/or replace referring expressions in an iterative process, converging on conceptual pacts of referring language use in doing so. Nevertheless, much work on exophoric reference resolution (i.e. resolution of references to entities outside of a given text) follows a literary model, whereby individual referring expressions are interpreted as unique identifiers of their referents given the state of the dialog the referring expression is initiated. In this paper, we address this collaborative nature to improve dialogic reference resolution in two ways: First, we trained a words-as-classifiers logistic regression model of word semantics and incrementally adapt the model to idiosyncratic language between dyad partners during evaluation of the dialog. We then used these semantic models to learn the general referring ability of each word, which is independent of referent features. These methods facilitate accurate automatic reference resolution in situated dialog without annotation of referring expressions, even with little background data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shore-skantze:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305936322" tag="video" />
@@ -4438,6 +4690,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2298–2309</pages>
     <url>http://www.aclweb.org/anthology/D18-1253</url>
+    <abstract>Developing agents to engage in complex goal-oriented dialogues is challenging partly because the main learning signals are very sparse in long conversations. In this paper, we propose a divide-and-conquer approach that discovers and exploits the hidden structure of the task to enable efficient policy learning. First, given successful example dialogues, we propose the Subgoal Discovery Network (SDN) to divide a complex goal-oriented task into a set of simpler subgoals in an unsupervised fashion. We then use these subgoals to learn a multi-level policy by hierarchical reinforcement learning. We demonstrate our method by building a dialogue agent for the composite task of travel planning. Experiments with simulated and real users show that our approach performs competitively against a state-of-the-art method that requires human-defined subgoals. Moreover, we show that the learned subgoals are often human comprehensible.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tang-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/305937184" tag="video" />
@@ -4457,6 +4710,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2310–2321</pages>
     <url>http://www.aclweb.org/anthology/D18-1254</url>
+    <abstract>Modern automated dialog systems require complex dialog managers able to deal with user intent triggered by high-level semantic questions. In this paper, we propose a model for automatically clustering questions into user intents to help the design tasks. Since questions are short texts, uncovering their semantics to group them together can be very challenging. We approach the problem by using powerful semantic classifiers from question duplicate/matching research along with a novel idea of  supervised clustering methods based on structured output. We test our approach on two intent clustering corpora, showing an impressive improvement over previous methods for two languages/domains.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>haponchyk-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305938531" tag="video" />
@@ -4476,6 +4730,7 @@
     <pages>2322–2332</pages>
     <url>http://www.aclweb.org/anthology/D18-1255</url>
     <attachment type="attachment">D18-1255.Attachment.zip</attachment>
+    <abstract>Existing dialog datasets contain a sequence of utterances and responses without any explicit background knowledge associated with them. This has resulted in the development of models which treat conversation as a sequence-to-sequence generation task (i.e., given a sequence of utterances generate the response sequence). This is not only an overly simplistic view of conversation but it is also emphatically different from the way humans converse by heavily relying on their background knowledge about the topic (as opposed to simply relying on the previous sequence of utterances). For example, it is common for humans to (involuntarily) produce utterances which are copied or suitably modified from background articles they have read about the topic. To facilitate the development of such natural conversation models which mimic the human process of conversing, we create a new dataset containing movie chats wherein each response is explicitly generated by copying and/or modifying sentences from unstructured background knowledge such as plots, comments and reviews about the movie.  We establish baseline results on this dataset (90K utterances from 9K conversations) using three different models: (i) pure generation based models which ignore the background knowledge (ii) generation based models which learn to copy information from the background knowledge when required and (iii) span prediction based models which predict the appropriate response span in the background knowledge.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>moghe-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305939688" tag="video" />
@@ -4495,6 +4750,7 @@
     <pages>2333–2343</pages>
     <url>http://www.aclweb.org/anthology/D18-1256</url>
     <attachment type="attachment">D18-1256.Attachment.pdf</attachment>
+    <abstract>We consider negotiation settings in which two agents use natural language to bargain on goods. Agents need to decide on both high-level strategy (e.g., proposing \$50) and the execution of that strategy (e.g., generat- ing ``The bike is brand new. Selling for just \$50!''). Recent work on negotiation trains neural models, but their end-to-end nature makes it hard to control their strategy, and reinforcement learning tends to lead to de- generate solutions. In this paper, we pro- pose a modular approach based on coarse di- alogue acts (e.g., propose(price=50)) that de- couples strategy and generation. We show that we can flexibly set the strategy using su- pervised learning, reinforcement learning, or domain-specific knowledge without degener- acy, while our retrieval-based generation can maintain context-awareness and produce di- verse utterances. We test our approach on the recently proposed DEALORNODEAL game, and we also collect a richer dataset based on real items on Craigslist. Human evaluation shows that our systems achieve higher task success rate and more human-like negotiation behavior than previous approaches.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>he-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/305940786" tag="video" />
@@ -4513,6 +4769,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2344–2356</pages>
     <url>http://www.aclweb.org/anthology/D18-1257</url>
+    <abstract>Cloze tests are widely adopted in language exams to evaluate students' language proficiency. In this paper, we propose the first large-scale human-created cloze test dataset CLOTH, containing questions used in middle-school and high-school language exams. With missing blanks carefully created by teachers and candidate choices purposely designed to be nuanced, CLOTH requires a deeper language understanding and a wider attention span than previously automatically-generated cloze datasets. We test the performance of dedicatedly designed baseline models including a language model trained on the One Billion Word Corpus and show humans outperform them by a significant margin. We investigate the source of the performance gap, trace model deficiencies to some distinct properties of CLOTH, and identify the limited ability of comprehending the long-term context to be the key bottleneck.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xie-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305886563" tag="video" />
@@ -4531,6 +4788,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2357–2368</pages>
     <url>http://www.aclweb.org/anthology/D18-1258</url>
+    <abstract>We propose a novel methodology to generate domain-specific large-scale question answering (QA) datasets by re-purposing existing annotations for other NLP tasks. We demonstrate an instance of this methodology in generating a large-scale QA dataset for electronic medical records by leveraging existing expert annotations on clinical notes for various NLP tasks from the community shared i2b2 datasets. The resulting corpus (emrQA) has 1 million questions-logical form and 400,000+ question-answer evidence pairs. We characterize the dataset and explore its learning potential by training baseline models for question to logical form and question to answer mapping.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pampari-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305887077" tag="video" />
@@ -4553,6 +4811,7 @@
     <pages>2369–2380</pages>
     <url>http://www.aclweb.org/anthology/D18-1259</url>
     <attachment type="attachment">D18-1259.Attachment.pdf</attachment>
+    <abstract>Existing question answering (QA) datasets fail to train QA systems to perform complex reasoning and provide explanations for answers. We introduce HotpotQA, a new dataset with 113k Wikipedia-based question-answer pairs with four key features: (1) the questions require finding and reasoning over multiple supporting documents to answer; (2) the questions are diverse and not constrained to any pre-existing knowledge bases or knowledge schemas; (3) we provide sentence-level supporting facts required for reasoning, allowing QA systems to reason with strong supervision and explain the predictions; (4) we offer a new type of factoid comparison questions to test QA systems' ability to extract relevant facts and perform necessary comparison. We show that HotpotQA is challenging for the latest QA systems, and the supporting facts enable models to improve performance and make explainable predictions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/305887533" tag="video" />
@@ -4572,6 +4831,7 @@
     <pages>2381–2391</pages>
     <url>http://www.aclweb.org/anthology/D18-1260</url>
     <attachment type="attachment">D18-1260.Attachment.pdf</attachment>
+    <abstract>We present a new kind of question answering dataset, OpenBookQA, modeled after open book exams for assessing human understanding of a subject. The open book that comes with our questions is a set of 1326 elementary level science facts. Roughly 6000 questions probe an understanding of these facts and their application to novel situations. This requires combining an open book fact (e.g., metals conduct electricity) with broad common knowledge (e.g., a suit of armor is made of metal) obtained from other sources. While existing QA datasets over documents or knowledge bases, being generally self-contained, focus on linguistic understanding, OpenBookQA probes a deeper understanding of both the topic---in the context of common knowledge---and the language it is expressed in. Human performance on OpenBookQA is close to 92\%, but many state-of-the-art pre-trained QA methods perform surprisingly poorly, worse than several simple neural baselines we develop. Our oracle experiments designed to circumvent the knowledge retrieval bottleneck demonstrate the value of both the open book and additional facts. We leave it as a challenge to solve the retrieval problem in this multi-hop setting and to close the large gap to human performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mihaylov-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305887978" tag="video" />
@@ -4591,6 +4851,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2392–2400</pages>
     <url>http://www.aclweb.org/anthology/D18-1261</url>
+    <abstract>We propose a new dataset for evaluating question answering models with respect to their capacity to reason about beliefs. Our tasks are inspired by theory-of-mind experiments that examine whether children are able to reason about the beliefs of others, in particular when those beliefs differ from reality. We evaluate a number of recent neural models with memory augmentation. We find that all fail on our tasks, which require keeping track of inconsistent states of the world; moreover, the models' accuracy decreases notably when random sentences are introduced to the tasks at test.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>nematzadeh-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305888739" tag="video" />
@@ -4613,6 +4874,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2401–2411</pages>
     <url>http://www.aclweb.org/anthology/D18-1262</url>
+    <abstract>Semantic role labeling (SRL) aims to recognize the predicate-argument structure of a sentence. Syntactic information has been paid a great attention over the role of enhancing SRL. However, the latest advance shows that syntax would not be so important for SRL with the emerging much smaller gap between syntax-aware and syntax-agnostic SRL. To comprehensively explore the role of syntax for SRL task, we extend existing models and propose a unified framework to investigate more effective and more diverse ways of incorporating syntax into sequential neural networks. Exploring the effect of syntactic input quality on SRL performance, we confirm that high-quality syntactic parse could still effectively enhance syntactically-driven SRL. Using empirically optimized integration strategy, we even enlarge the gap between syntax-aware and syntax-agnostic SRL. Our framework achieves state-of-the-art results on CoNLL-2009 benchmarks both for English and Chinese, substantially outperforming all previous models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/306044975" tag="video" />
@@ -4629,6 +4891,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2412–2421</pages>
     <url>http://www.aclweb.org/anthology/D18-1263</url>
+    <abstract>We propose a novel approach to semantic dependency parsing (SDP) by casting the task as an instance of multi-lingual machine translation, where each semantic representation is a different foreign dialect. To that end, we first generalize syntactic linearization techniques to account for the richer semantic dependency graph structure. Following, we design a neural sequence-to-sequence framework which can effectively recover our graph linearizations, performing almost on-par with previous SDP state-of-the-art while requiring less parallel training annotations. Beyond SDP, our linearization technique opens the door to integration of graph-based semantic representations as features in neural models for downstream applications.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>stanovsky-dagan:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306045906" tag="video" />
@@ -4648,6 +4911,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2422–2430</pages>
     <url>http://www.aclweb.org/anthology/D18-1264</url>
+    <abstract>In this paper, we propose a new rich resource enhanced AMR aligner which produces multiple alignments and a new transition system for AMR parsing along with its oracle parser. Our aligner is further tuned by our oracle parser via picking the alignment that leads to the highest-scored achievable AMR graph. Experimental results show that our aligner outperforms the rule-based aligner in previous work by achieving higher alignment F1 score and consistently improving two open-sourced AMR parsers. Based on our aligner and transition system, we develop a transition-based AMR parser that parses a sentence into its AMR graph directly. An ensemble of our parsers with only words and POS tags as input leads to 68.4 Smatch F1 score, which outperforms the current state-of-the-art parser.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP8</bibkey>
     <video href="https://vimeo.com/306049123" tag="video" />
@@ -4665,6 +4929,7 @@
     <pages>2431–2441</pages>
     <url>http://www.aclweb.org/anthology/D18-1265</url>
     <attachment type="attachment">D18-1265.Attachment.zip</attachment>
+    <abstract>We propose a novel dependency-based hybrid tree model for semantic parsing, which converts natural language utterance into machine interpretable meaning representations. Unlike previous state-of-the-art models, the semantic information is interpreted as the latent dependency between the natural language words in our joint representation. Such dependency information can capture the interactions between the semantics and natural language words. We integrate a neural component into our model and propose an efficient dynamic-programming algorithm to perform tractable inference. Through extensive experiments on the standard multilingual GeoQuery dataset with eight languages, we demonstrate that our proposed approach is able to achieve state-of- the-art performance across several languages. Analysis also justifies the effectiveness of using our new dependency-based representation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>jie-lu:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306052219" tag="video" />
@@ -4684,6 +4949,7 @@
     <pages>2442–2452</pages>
     <url>http://www.aclweb.org/anthology/D18-1266</url>
     <attachment type="attachment">D18-1266.Attachment.pdf</attachment>
+    <abstract>Semantic parsing from denotations faces two key challenges in model training: (1) given only the denotations (e.g., answers), search for good candidate semantic parses, and (2) choose the best model update algorithm. We propose effective and general solutions to each of them. Using policy shaping, we bias the search procedure towards semantic parses that are more compatible to the text, which provide better supervision signals for training. In addition, we propose an update equation that generalizes three different families of learning algorithms, which enables fast model exploration. When experimented on a recently proposed sequential question answering dataset, our framework leads to a new state-of-the-art model that outperforms previous work by 5.0\% absolute on exact match accuracy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>misra-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/306053202" tag="video" />
@@ -4702,6 +4968,7 @@
     <pages>2453–2464</pages>
     <url>http://www.aclweb.org/anthology/D18-1267</url>
     <attachment type="attachment">D18-1267.Attachment.zip</attachment>
+    <abstract>In this paper we advocate the use of bilingual corpora which are abundantly available for training sentence compression models. Our approach borrows much of its machinery from neural machine translation and leverages bilingual pivoting: compressions are obtained by translating a source string into a foreign language and then back-translating it into the source while controlling the translation length. Our model can be trained for any language as long as a bilingual corpus is available and performs arbitrary rewrites without access to compression specific data.  We release. Moss, a new parallel Multilingual Compression dataset for English, German, and French which can be used to evaluate compression models across languages and genres.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mallinson-sennrich-lapata:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305663630" tag="video" />
@@ -4721,6 +4988,7 @@
     <pages>2465–2474</pages>
     <url>http://www.aclweb.org/anthology/D18-1268</url>
     <attachment type="attachment">D18-1268.Attachment.pdf</attachment>
+    <abstract>Cross-lingual transfer of word embeddings aims to establish the semantic mappings among words in different languages by learning the transformation functions over the corresponding word embedding spaces. Successfully solving this problem would benefit many downstream tasks such as to translate text classification models from resource-rich languages (e.g. English) to low-resource languages. Supervised methods for this problem rely on the availability of cross-lingual supervision, either using parallel corpora or bilingual lexicons as the labeled data for training, which may not be available for many low resource languages. This paper proposes an unsupervised learning approach that does not require any cross-lingual labeled data. Given two monolingual word embedding spaces for any language pair, our algorithm optimizes the transformation functions in both directions simultaneously based on distributional matching as well as minimizing the back-translation losses. We use a neural network implementation to calculate the Sinkhorn distance, a well-defined distributional similarity measure, and optimize our objective through back-propagation. Our evaluation on benchmark datasets for bilingual lexicon induction and cross-lingual word similarity prediction shows stronger or competitive performance of the proposed method compared to other state-of-the-art supervised and unsupervised baseline methods over many language pairs.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-EtAl:2018:EMNLP4</bibkey>
     <video href="https://vimeo.com/305664457" tag="video" />
@@ -4742,6 +5010,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2475–2485</pages>
     <url>http://www.aclweb.org/anthology/D18-1269</url>
+    <abstract>State-of-the-art natural language processing systems rely on supervision in the form of annotated data to learn competent models. These models are generally trained on data in a single language (usually English), and cannot be directly used beyond that language. Since collecting data in every language is not realistic, there has been a growing interest in cross-lingual language understanding (XLU) and low-resource cross-language transfer. In this work, we construct an evaluation set for XLU by extending the development and test sets of the Multi-Genre Natural Language Inference Corpus (MultiNLI) to 14 languages, including low-resource languages such as Swahili and Urdu. We hope that our dataset, dubbed XNLI, will catalyze research in cross-lingual sentence understanding by providing an informative standard evaluation task. In addition, we provide several baselines for multilingual sentence understanding, including two based on machine translation systems, and two that use parallel data to train aligned multilingual bag-of-words and LSTM encoders. We find that XNLI represents a practical and challenging evaluation suite, and that directly translating the test data yields the best performance among available baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>conneau-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305665271" tag="video" />
@@ -4760,6 +5029,7 @@
     <pages>2486–2495</pages>
     <url>http://www.aclweb.org/anthology/D18-1270</url>
     <attachment type="attachment">D18-1270.Attachment.pdf</attachment>
+    <abstract>Cross-lingual Entity Linking (XEL) aims to ground entity mentions written in any language to an English Knowledge Base (KB), such as Wikipedia. XEL for most languages is challenging, owing to limited availability of resources as supervision. We address this challenge by developing the first XEL approach that combines supervision from multiple languages jointly. This enables our approach to: (a) augment the limited supervision in the target language with additional supervision from a high-resource language (like English), and (b) train a single entity linking model for multiple languages, improving upon individually trained models for each language. Extensive evaluation on three benchmark datasets across 8 languages shows that our approach significantly improves over the current state-of-the-art. We also provide analyses in two limited resource settings: (a) zero-shot setting, when no supervision in the target language is available, and in (b) low-resource setting, when some supervision in the target language is available. Our analysis provides insights into the limitations of zero-shot XEL approaches in realistic scenarios, and shows the value of joint supervision in low-resource settings.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>upadhyay-gupta-roth:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305666173" tag="video" />
@@ -4783,6 +5053,7 @@
     <pages>2496–2506</pages>
     <url>http://www.aclweb.org/anthology/D18-1271</url>
     <attachment type="attachment">D18-1271.Attachment.zip</attachment>
+    <abstract>This paper proposes to study fine-grained coordinated cross-lingual text stream alignment through a novel information network decipherment paradigm. We use Burst Information Networks as media to represent text streams and present a simple yet effective network decipherment algorithm with diverse clues to decipher the networks for accurate text stream alignment. Experiments on Chinese-English news streams show our approach not only outperforms previous approaches on bilingual lexicon extraction from coordinated text streams but also can harvest high-quality alignments from large amounts of streaming data for endless language knowledge mining, which makes it promising to be a new paradigm for automatic language knowledge acquisition.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ge-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305667349" tag="video" />
@@ -4807,6 +5078,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2507–2516</pages>
     <url>http://www.aclweb.org/anthology/D18-1272</url>
+    <abstract>Homographic puns have a long history in human writing, widely used in written and spoken literature, which usually occur in a certain syntactic or stylistic structure. How to recognize homographic puns is an important research. However, homographic pun recognition does not solve very well in existing work. In this work, we first use WordNet to understand and expand word embedding for settling the polysemy of homographic puns, and then propose a WordNet-Encoded Collocation-Attention network model (WECA) which combined with the context weights for recognizing the puns. Our experiments on the SemEval2017 Task7 and Pun of the Day demonstrate that the proposed model is able to distinguish between homographic pun and non-homographic pun texts. We show the effectiveness of the model to present the capability of choosing qualitatively informative words. The results show that our model achieves the state-of-the-art performance on homographic puns recognition.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>diao-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4825,6 +5097,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2517–2527</pages>
     <url>http://www.aclweb.org/anthology/D18-1273</url>
+    <abstract>Chinese spelling check (CSC) is a challenging yet meaningful task, which not only serves as a preprocessing in many natural language processing(NLP) applications, but also facilitates reading and understanding of running texts in peoples' daily lives. However, to utilize data-driven approaches for CSC, there is one major limitation that annotated corpora are not enough in applying algorithms and building models. In this paper, we propose a novel approach of constructing CSC corpus with automatically generated spelling errors, which are either visually or phonologically resembled characters, corresponding to the OCR- and ASR-based methods, respectively. Upon the constructed corpus, different models are trained and evaluated for CSC with respect to three standard test sets. Experimental results demonstrate the effectiveness of the corpus, therefore confirm the validity of our approach.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP9</bibkey>
   </paper>
@@ -4840,6 +5113,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2528–2539</pages>
     <url>http://www.aclweb.org/anthology/D18-1274</url>
+    <abstract>Grammatical error correction (GEC) systems deployed in language learning environments are expected to accurately correct errors in learners' writing. However, in practice, they often produce spurious corrections and fail to correct many errors, thereby misleading learners. This necessitates the estimation of the quality of output sentences produced by GEC systems so that instructors can selectively intervene and re-correct the sentences which are poorly corrected by the system and ensure that learners get accurate feedback. We propose the first neural approach to automatic quality estimation of GEC output sentences that does not employ any hand-crafted features. Our system is trained in a supervised manner on learner sentences and corresponding GEC system outputs with quality score labels computed using human-annotated references. Our neural quality estimation models for GEC show significant improvements over a strong feature-based baseline. We also show that a state-of-the-art GEC system can be improved when quality scores are used as features for re-ranking the N-best candidates.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chollampatt-ng:2018:EMNLP</bibkey>
   </paper>
@@ -4860,6 +5134,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2540–2549</pages>
     <url>http://www.aclweb.org/anthology/D18-1275</url>
+    <abstract>Part-of-Speech (POS) tagging for Twitter has received considerable attention in recent years. Because most POS tagging methods are based on supervised models, they usually require a large amount of labeled data for training. However, the existing labeled datasets for Twitter are much smaller than those for newswire text. Hence, to help POS tagging for Twitter, most domain adaptation methods try to leverage newswire datasets by learning the shared features between the two domains. However, from a linguistic perspective, Twitter users not only tend to mimic the formal expressions of traditional media, like news, but they also appear to be developing linguistically informal styles. Therefore, POS tagging for the formal Twitter context can be learned together with the newswire dataset, while POS tagging for the informal Twitter context should be learned separately. To achieve this task, in this work, we propose a hypernetwork-based method to generate different parameters to separately model contexts with different expression styles. Experimental results on three different datasets show that our approach achieves better performance than state-of-the-art methods in most cases.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gui-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4881,6 +5156,7 @@
     <pages>2550–2561</pages>
     <url>http://www.aclweb.org/anthology/D18-1276</url>
     <attachment type="attachment">D18-1276.Attachment.zip</attachment>
+    <abstract>The configurational information in sentences of a free word order language such as Sanskrit is of limited use. Thus, the context of the entire sentence will be desirable even for basic processing tasks such as word segmentation. We propose a structured prediction framework that  jointly solves the word segmentation and morphological tagging tasks in Sanskrit. We build an energy based model where we adopt approaches generally employed in graph based parsing techniques (McDonald et al., 2005a; Carreras, 2007). Our model outperforms the state of the art with an F-Score of 96.92 (percentage improvement of 7.06\%) while using less than one tenth of the task-specific training data. We find that the use of a graph based approach instead of a traditional lattice-based sequential labelling approach leads to a percentage gain of 12.6\% in F-Score for the segmentation task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>krishna-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4898,6 +5174,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2562–2572</pages>
     <url>http://www.aclweb.org/anthology/D18-1277</url>
+    <abstract>English part-of-speech taggers regularly make egregious errors related to noun-verb ambiguity, despite having achieved 97\%+ accuracy on the WSJ Penn Treebank since 2002. These mistakes have been difficult to quantify and make taggers less useful to downstream tasks such as translation and text-to-speech synthesis. This paper creates a new dataset of over 30,000 naturally-occurring non-trivial examples of noun-verb ambiguity. Taggers within 1\% of each other when measured on the WSJ have accuracies ranging from 57\% to 75\% accuracy on this challenge set. Enhancing the strongest existing tagger with contextual word embeddings and targeted training data improves its accuracy to 89\%, a 14\% absolute (52\% relative) improvement. Downstream, using just this enhanced tagger yields a 28\% reduction in error over the prior best learned model for homograph disambiguation for textto-speech synthesis.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>elkahky-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4915,6 +5192,7 @@
     <pages>2573–2583</pages>
     <url>http://www.aclweb.org/anthology/D18-1278</url>
     <attachment type="attachment">D18-1278.Attachment.zip</attachment>
+    <abstract>When parsing morphologically-rich languages with neural models, it is beneficial to model input at the character level, and it has been claimed that this is because character-level models learn morphology. We test these claims by comparing character-level models to an oracle with access to explicit morphological analysis on twelve languages with varying morphological typologies. Our results highlight many strengths of character-level models, but also show that they are poor at disambiguating some words, particularly in the face of case syncretism. We then demonstrate that explicitly modeling morphological case improves our best model, showing that character-level models can benefit from targeted forms of explicit morphological modeling.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>vania-grivas-lopez:2018:EMNLP</bibkey>
   </paper>
@@ -4932,6 +5210,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2584–2593</pages>
     <url>http://www.aclweb.org/anthology/D18-1279</url>
+    <abstract>Character-based neural models have recently proven very useful for many NLP tasks. However, there is a gap of sophistication between methods for learning representations of sentences and words. While, most character models for learning representations of sentences are deep and complex, models for learning representations of words are shallow and simple. Also, in spite of considerable research on learning character embeddings, it is still not clear which kind of architecture is the best for capturing character-to-word representations. To address these questions, we first investigate the gaps between methods for learning word and sentence representations. We conduct detailed experiments and comparisons on different state-of-the-art convolutional models, and also investigate the advantages and disadvantages of their constituents. Furthermore, we propose IntNet, a funnel-shaped wide convolutional neural architecture with no down-sampling for learning representations of the internal structure of words by composing their characters from limited, supervised training corpora. We evaluate our proposed model on six sequence labeling datasets, including named entity recognition, part-of-speech tagging, and syntactic chunking. Our in-depth analysis shows that IntNet significantly outperforms other character embedding models and obtains new state-of-the-art performance without relying on any external knowledge or resources.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xin-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -4950,6 +5229,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2594–2604</pages>
     <url>http://www.aclweb.org/anthology/D18-1280</url>
+    <abstract>Emotion recognition in conversations is crucial for building empathetic machines. Present works in this domain do not explicitly consider the inter-personal influences that thrive in the emotional dynamics of dialogues. To this end, we propose Interactive COnversational memory Network (ICON), a multimodal emotion detection framework that extracts multimodal features from conversational videos and hierarchically models the self- and inter-speaker emotional influences into global memories. Such memories generate contextual summaries which aid in predicting the emotional orientation of utterance-videos. Our model outperforms state-of-the-art networks on multiple classification and regression tasks in two benchmark datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hazarika-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -4966,6 +5246,7 @@
     <pages>2605–2615</pages>
     <url>http://www.aclweb.org/anthology/D18-1281</url>
     <attachment type="attachment">D18-1281.Attachment.pdf</attachment>
+    <abstract>Thanks to the success of object detection technology, we can retrieve objects of the specified classes even from huge image collections. However, the current state-of-the-art object detectors (such as Faster R-CNN) can only handle pre-specified classes.  In addition, large amounts of positive and negative visual samples are required for training.  In this paper, we address the problem of open-vocabulary object retrieval and localization, where the target object is specified by a textual query (e.g., a word or phrase).  We first propose Query-Adaptive R-CNN, a simple extension of Faster R-CNN adapted to open-vocabulary queries, by transforming the text embedding vector into an object classifier and localization regressor.  Then, for discriminative training, we then propose negative phrase augmentation (NPA) to mine hard negative samples which are visually similar to the query and at the same time semantically mutually exclusive of the query.  The proposed method can retrieve and localize objects specified by a textual query from one million images in only 0.5 seconds with high precision.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hinami-satoh:2018:EMNLP</bibkey>
   </paper>
@@ -4981,6 +5262,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2616–2626</pages>
     <url>http://www.aclweb.org/anthology/D18-1282</url>
+    <abstract>We address the task of visual semantic role labeling (vSRL), the identification of the participants of a situation or event in a visual scene, and their labeling with their semantic relations to the event or situation. We render candidate participants as image regions of objects, and train a model which learns to ground roles in the regions which depict the corresponding participant. Experimental results demonstrate that we can train a vSRL model without reliance on prohibitive image-based role annotations, by utilizing noisy data which we extract automatically from image captions using a linguistic SRL system. Furthermore, our model induces frame---semantic visual representations, and their comparison to previous work on supervised visual verb sense disambiguation yields overall better results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>silberer-pinkal:2018:EMNLP</bibkey>
   </paper>
@@ -4998,6 +5280,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2627–2637</pages>
     <url>http://www.aclweb.org/anthology/D18-1283</url>
+    <abstract>To enable collaboration and communication between humans and agents, this paper investigates learning to acquire commonsense evidence for action justification. In particular, we have developed an approach based on the generative Conditional Variational Autoencoder(CVAE) that models object relations/attributes of the world as latent variables and jointly learns a performer that predicts actions and an explainer that gathers commonsense evidence to justify the action. Our empirical results have shown that, compared to a typical attention-based model, CVAE achieves significantly higher performance in both action prediction and justification. A human subject study further shows that the commonsense evidence gathered by CVAE can be communicated to humans to achieve a significantly higher common ground between humans and agents.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -5015,6 +5298,7 @@
     <pages>2638–2646</pages>
     <url>http://www.aclweb.org/anthology/D18-1284</url>
     <attachment type="attachment">D18-1284.Attachment.zip</attachment>
+    <abstract>The ability to infer persona from dialogue can have applications in areas ranging from computational narrative analysis to personalized dialogue generation. We introduce neural models to learn persona embeddings in a supervised character trope classification task. The models encode dialogue snippets from IMDB into representations that can capture the various categories of film characters.  The best-performing models use a multi-level attention mechanism over a set of utterances. We also utilize prior knowledge in the form of textual descriptions of the different tropes. We apply the learned embeddings to find similar characters across different movies, and cluster movies according to the distribution of the embeddings. The use of short conversational text as input, and the ability to learn from prior knowledge using memory, suggests these methods could be applied to other domains.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chu-vijayaraghavan-roy:2018:EMNLP</bibkey>
   </paper>
@@ -5033,6 +5317,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2647–2656</pages>
     <url>http://www.aclweb.org/anthology/D18-1285</url>
+    <abstract>We develop a semantic parser that is trained in a grounded setting using pairs of videos captioned with sentences. This setting is both data-efficient, requiring little annotation, and similar to the experience of children where they observe their environment and listen to speakers. The semantic parser recovers the meaning of English sentences despite not having access to any annotated sentences. It does so despite the ambiguity inherent in vision where a sentence may refer to any combination of objects, object properties, relations or actions taken by any agent in a video. For this task, we collected a new dataset for grounded language acquisition. Learning a grounded semantic parser — turning sentences into logical forms using captioned videos — can significantly expand the range of data that parsers can be trained on, lower the effort of training a semantic parser, and ultimately lead to a better understanding of child language acquisition.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ross-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5054,6 +5339,7 @@
     <pages>2657–2666</pages>
     <url>http://www.aclweb.org/anthology/D18-1286</url>
     <attachment type="attachment">D18-1286.Attachment.zip</attachment>
+    <abstract>We propose an end-to-end deep learning model for translating free-form natural language instructions to a high-level plan for behavioral robot navigation. We use attention models to connect information from both the user instructions and a topological representation of the environment. We evaluate our model's performance on a new dataset containing 10,050 pairs of navigation instructions. Our model significantly outperforms baseline approaches. Furthermore, our results suggest that it is possible to leverage the environment map as a relevant knowledge base to facilitate the translation of free-form navigational instruction.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zang-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5074,6 +5360,7 @@
     <pages>2667–2678</pages>
     <url>http://www.aclweb.org/anthology/D18-1287</url>
     <attachment type="attachment">D18-1287.Attachment.zip</attachment>
+    <abstract>We propose to decompose instruction execution to goal prediction and action generation. We  design a model that maps raw visual observations to goals using LINGUNET, a language-conditioned image generation network, and then generates the actions required to complete them. Our model is trained from demonstration only without external resources. To evaluate our approach, we introduce two benchmarks for instruction following: LANI, a navigation task;  and CHAI, where an agent executes household instructions. Our evaluation demonstrates the advantages of our model decomposition, and illustrates the challenges posed by our new benchmarks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>misra-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -5089,6 +5376,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2679–2689</pages>
     <url>http://www.aclweb.org/anthology/D18-1288</url>
+    <abstract>Researchers in computational psycholinguistics frequently use linear models to study time series data generated by human subjects. However, time series may violate the assumptions of these models through temporal diffusion, where stimulus presentation has a lingering influence on the response as the rest of the experiment unfolds. This paper proposes a new statistical model that borrows from digital signal processing by recasting the predictors and response as convolutionally-related signals, using recent advances in machine learning to fit latent impulse response functions (IRFs) of arbitrary shape. A synthetic experiment shows successful recovery of true latent IRFs, and psycholinguistic experiments reveal plausible, replicable, and fine-grained estimates of latent temporal dynamics, with comparable or improved prediction quality to widely-used alternatives.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shain-schuler:2018:EMNLP</bibkey>
   </paper>
@@ -5107,6 +5395,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2690–2699</pages>
     <url>http://www.aclweb.org/anthology/D18-1289</url>
+    <abstract>In this paper, we present a crowdsourcing-based approach to model the human perception of sentence complexity. We collect a large corpus of sentences rated with judgments of complexity for two typologically-different languages, Italian and English. We test our approach in two experimental scenarios aimed to investigate the contribution of a wide set of lexical, morpho-syntactic and syntactic phenomena in predicting i) the degree of agreement among annotators independently from the assigned judgment and ii) the perception of sentence complexity.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>brunato-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5122,6 +5411,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2700–2710</pages>
     <url>http://www.aclweb.org/anthology/D18-1290</url>
+    <abstract>Web queries with question intent manifest a complex syntactic structure and the processing of this structure is important for their interpretation. Pinter et al. (2016) has formalized the grammar of these queries and proposed semi-supervised algorithms for the adaptation of parsers originally designed to parse according to the standard dependency grammar, so that they can account for the unique forest grammar of queries. However, their algorithms rely on resources typically not available outside of big web corporates. We propose a new BiLSTM query parser that: (1) Explicitly accounts for the unique grammar of web queries; and (2) Utilizes named entity (NE) information from a BiLSTM NE tagger, that can be jointly trained with the parser. In order to train our model we annotate the query treebank of Pinter et al. (2016) with NEs. When trained on 2500 annotated queries our parser achieves UAS of 83.5\% and segmentation F1- score of 84.5, substantially outperforming existing state-of-the-art parsers.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>malca-reichart:2018:EMNLP</bibkey>
   </paper>
@@ -5139,6 +5429,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2711–2720</pages>
     <url>http://www.aclweb.org/anthology/D18-1291</url>
+    <abstract>We provide a comprehensive analysis of the interactions between pre-trained word embeddings, character models and POS tags in a transition-based dependency parser. While previous studies have shown POS information to be less important in the presence of character models, we show that in fact there are complex interactions between all three techniques. In isolation each produces large improvements over a baseline system using randomly initialised word embeddings only, but combining them quickly leads to diminishing returns. We categorise words by frequency, POS tag and language in order to systematically investigate how each of the techniques affects parsing quality. For many word categories, applying any two of the three techniques is almost as good as the full combined system. Character models tend to be more important for low-frequency open-class words, especially in morphologically rich languages, while POS tags can help disambiguate high-frequency function words. We also show that large character embedding sizes help even for languages with small character sets, especially in morphologically rich languages.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>smith-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5157,6 +5448,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2721–2731</pages>
     <url>http://www.aclweb.org/anthology/D18-1292</url>
+    <abstract>There have been several recent attempts to improve the accuracy of grammar induction systems by bounding the recursive complexity of the induction model. Modern depth-bounded grammar inducers have been shown to be more accurate than early unbounded PCFG inducers, but this technique has never been compared against unbounded induction within the same system, in part because most previous depth-bounding models are built around sequence models, the complexity of which grows exponentially with the maximum allowed depth. The present work instead applies depth bounds within a chart-based Bayesian PCFG inducer, where bounding can be switched on and off, and then samples trees with or without bounding. Results show that depth-bounding is indeed significantly effective in limiting the search space of the inducer and thereby increasing accuracy of resulting parsing model, independent of the contribution of modern Bayesian induction techniques. Moreover, parsing results on English, Chinese and German show that this bounded model is able to produce parse trees more accurately than or competitively with state-of-the-art constituency grammar induction models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>jin-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5174,6 +5466,7 @@
     <pages>2732–2741</pages>
     <url>http://www.aclweb.org/anthology/D18-1293</url>
     <attachment type="attachment">D18-1293.Attachment.zip</attachment>
+    <abstract>In natural language processing, a common task is to compute the probability of a phrase appearing in a document or to calculate the probability of all phrases matching a given pattern. For instance, one computes affix (prefix, suffix, infix, etc.) probabilities of a string or a set of strings with respect to a probability distribution of patterns. The problem of computing infix probabilities of strings when the pattern distribution is given by a probabilistic context-free grammar or by a probabilistic finite automaton is already solved, yet it was open to compute the infix probabilities in an incremental manner. The incremental computation is crucial when a new query is built from a previous query. We tackle this problem and suggest a method that computes infix probabilities incrementally for probabilistic finite automata by representing all the probabilities of matching strings as a series of transition matrix calculations. We show that the proposed approach is theoretically faster than the previous method and, using real world data, demonstrate that our approach has vastly better performance in practice.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>cognetta-han-kwon:2018:EMNLP</bibkey>
   </paper>
@@ -5191,6 +5484,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2742–2753</pages>
     <url>http://www.aclweb.org/anthology/D18-1294</url>
+    <abstract>We propose a novel strategy to encode the syntax parse tree of sentence into a learnable distributed representation. The proposed syntax encoding scheme is provably information-lossless. In specific, an embedding vector is constructed for each word in the sentence, encoding the path in the syntax tree corresponding to the word. The one-to-one correspondence between these ``syntax-embedding'' vectors and the words (hence their embedding vectors) in the sentence makes it easy to integrate such a representation with all word-level NLP models. We empirically show the benefits of the syntax embeddings on the Authorship Attribution domain, where our  approach improves upon the prior art and achieves new performance records on five benchmarking data sets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP9</bibkey>
   </paper>
@@ -5206,6 +5500,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2754–2763</pages>
     <url>http://www.aclweb.org/anthology/D18-1295</url>
+    <abstract>The paper introduces end-to-end neural network models that tokenize Sanskrit by jointly splitting compounds and resolving phonetic merges (Sandhi). Tokenization of Sanskrit depends on local phonetic and distant semantic features that are incorporated using convolutional and recurrent elements. Contrary to most previous systems, our models do not require feature engineering or extern linguistic resources, but operate solely on parallel versions of raw and segmented text. The models discussed in this paper clearly improve over previous approaches to Sanskrit word segmentation. As they are language agnostic, we will demonstrate that they also outperform the state of the art for the related task of German compound splitting.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hellwig-nehrdich:2018:EMNLP</bibkey>
   </paper>
@@ -5223,6 +5518,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2764–2768</pages>
     <url>http://www.aclweb.org/anthology/D18-1296</url>
+    <abstract>We propose to generalize language models for conversational speech recognition to allow them to operate across utterance boundaries and speaker changes, thereby capturing conversation-level phenomena such as adjacency pairs, lexical entrainment, and topical coherence. The model consists of a long-short-term memory (LSTM) recurrent network that reads the entire word-level history of a conversation, as well as information about turn taking and speaker overlap, in order to predict each next word. The model is applied in a rescoring framework, where the word history prior to the current utterance is approximated with preliminary recognition results. In experiments in the conversational telephone speech domain (Switchboard) we find that such a model gives substantial perplexity reductions over a standard LSTM-LM with utterance scope, as well as improvements in word error rate.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xiong-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305942129" tag="video" />
@@ -5243,6 +5539,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2769–2774</pages>
     <url>http://www.aclweb.org/anthology/D18-1297</url>
+    <abstract>Sequence-to-sequence neural generation models have achieved promising performance on short text conversation tasks. However, they tend to generate generic/dull responses, leading to unsatisfying dialogue experience.  We observe that in the conversation tasks, each query could have multiple responses, which forms a 1-to-n or m-to-n relationship in the view of the total corpus. The objective function used in standard sequence-to-sequence models will be dominated by loss terms with generic patterns. Inspired by this observation, we introduce a statistical re-weighting method that assigns different weights for the multiple responses of the same query, and trains the common neural generation model with the weights. Experimental results on a large Chinese dialogue corpus show that our method improves the acceptance rate of generated responses compared with several baseline models and significantly reduces the number of generated generic responses.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-EtAl:2018:EMNLP9</bibkey>
     <video href="https://vimeo.com/305942945" tag="video" />
@@ -5261,6 +5558,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2775–2779</pages>
     <url>http://www.aclweb.org/anthology/D18-1298</url>
+    <abstract>Current dialogue systems fail at being engaging for users, especially when trained end-to-end without relying on proactive reengaging scripted strategies. Zhang et al. (2018) showed that the engagement level of end-to-end dialogue models increases when conditioning them on text personas providing some personalized back-story to the model. However, the dataset used in Zhang et al. (2018) is synthetic and only contains around 1k different personas. In this paper we introduce a new dataset providing 5 million personas and 700 million persona-based dialogues. Our experiments show that, at this scale, training using personas still improves the performance of end-to-end systems. In addition, we show that other tasks benefit from the wide coverage of our dataset by fine-tuning our model on the data from Zhang et al. (2018) and achieving state-of-the-art results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mazare-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305943582" tag="video" />
@@ -5279,6 +5577,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2780–2786</pages>
     <url>http://www.aclweb.org/anthology/D18-1299</url>
+    <abstract>Dialogue state tracker is the core part of a spoken dialogue system. It estimates the beliefs of possible user's goals at every dialogue turn. However, for most current approaches, it's difficult to scale to large dialogue domains. They have one or more of following limitations: (a) Some models don't work in the situation where slot values in ontology changes dynamically; (b) The number of model parameters is proportional to the number of slots; (c) Some models extract features based on hand-crafted lexicons. To tackle these challenges, we propose StateNet, a universal dialogue state tracker. It is independent of the number of values, shares parameters across all slots, and uses pre-trained word vectors instead of explicit semantic dictionaries. Our experiments on two datasets show that our approach not only overcomes the limitations, but also significantly outperforms the performance of state-of-the-art approaches.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ren-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305944406" tag="video" />
@@ -5298,6 +5597,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2787–2792</pages>
     <url>http://www.aclweb.org/anthology/D18-1300</url>
+    <abstract>Task oriented dialog systems typically first parse user utterances to semantic frames comprised of intents and slots. Previous work on task oriented intent and slot-filling work has been restricted to one intent per query and one slot label per token, and thus cannot model complex compositional requests. Alternative semantic parsing systems have represented queries as logical forms, but these are challenging to annotate and parse. We propose a hierarchical annotation scheme for semantic parsing that allows the representation of compositional queries, and can be efficiently and accurately parsed by standard constituency parsing models. We release a dataset of 44k annotated queries (http://fb.me/semanticparsingdialog), and show that parsing models outperform sequence-to-sequence approaches on this dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gupta-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305945055" tag="video" />
@@ -5313,6 +5613,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2793–2798</pages>
     <url>http://www.aclweb.org/anthology/D18-1301</url>
+    <abstract>In this paper, we provide empirical evidence based on a rigourously studied mathematical model for bi-populated networks, that a glass ceiling within the field of NLP has developed since the mid 2000s.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>schluter:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305889955" tag="video" />
@@ -5330,6 +5631,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2799–2804</pages>
     <url>http://www.aclweb.org/anthology/D18-1302</url>
+    <abstract>Abusive language detection models tend to have a problem of being biased toward identity words of a certain group of people because of imbalanced training datasets. For example, ``You are a good woman'' was considered ``sexist'' when trained on an existing dataset. Such model bias is an obstacle for models to be robust enough for practical use. In this work, we measure them on models trained with different datasets, while analyzing the effect of different pre-trained word embeddings and model architectures. We also experiment with three mitigation methods: (1) debiased word embeddings, (2) gender swap data augmentation, and (3) fine-tuning with a larger corpus. These methods can effectively reduce model bias by 90-98\% and can be extended to correct model bias in other scenarios.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>park-shin-fung:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305891047" tag="video" />
@@ -5346,6 +5648,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2805–2811</pages>
     <url>http://www.aclweb.org/anthology/D18-1303</url>
+    <abstract>With the recent rise of \#MeToo, an increasing number of personal stories about sexual harassment and sexual abuse have been shared online. In order to push forward the fight against such harassment and abuse, we present the task of automatically categorizing and analyzing various forms of sexual harassment, based on stories shared on the online forum SafeCity. For the labels of groping, ogling, and commenting, our single-label CNN-RNN model achieves an accuracy of 86.5\%, and our multi-label model achieves a Hamming score of 82.5\%. Furthermore, we present analysis using LIME, first-derivative saliency heatmaps, activation clustering, and embedding visualization to interpret neural model predictions and demonstrate how this helps extract features that can help automatically fill out incident reports, identify unsafe areas, avoid unsafe practices, and 'pin the creeps'.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>karlekar-bansal:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305891772" tag="video" />
@@ -5362,6 +5665,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2812–2817</pages>
     <url>http://www.aclweb.org/anthology/D18-1304</url>
+    <abstract>As the incidence of Alzheimer's Disease (AD) increases, early detection becomes crucial. Unfortunately, datasets for AD assessment are often sparse and incomplete. In this work, we leverage the multiview nature of a small AD dataset, DementiaBank, to learn an embedding that captures different modes of cognitive impairment. We apply generalized canonical correlation analysis (GCCA) to our dataset and demonstrate the added benefit of using multiview embeddings in two downstream tasks: identifying AD and predicting clinical scores. By including multiview embeddings, we obtain an F1 score of 0.82 in the classification task and a mean absolute error of 3.42 in the regression task. Furthermore, we show that multiview embeddings can be obtained from other datasets as well.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pouprom-rudzicz:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305892345" tag="video" />
@@ -5382,6 +5686,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2818–2823</pages>
     <url>http://www.aclweb.org/anthology/D18-1305</url>
+    <abstract>We present a corpus that encompasses the complete history of conversations between contributors to Wikipedia, one of the largest online collaborative communities. By recording the intermediate states of conversations - including not only comments and replies, but also their modifications, deletions and restorations - this data offers an unprecedented view of online conversation. Our framework is designed to be language agnostic, and we show that it extracts high quality data in both Chinese and English. This level of detail supports new research questions pertaining to the process (and challenges) of large-scale online collaboration. We illustrate the corpus' potential with two case studies on English Wikipedia that highlight new perspectives on earlier work. First, we explore how a person's conversational behavior depends on how they relate to the discussion's venue. Second, we show that community moderation of toxic behavior happens at a higher rate than previously estimated.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hua-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305892676" tag="video" />
@@ -5401,6 +5706,7 @@
     <pages>2824–2829</pages>
     <url>http://www.aclweb.org/anthology/D18-1306</url>
     <attachment type="attachment">D18-1306.Attachment.pdf</attachment>
+    <abstract>Extracting typed entity mentions from text is a fundamental component to language understanding and reasoning. While there exist substantial labeled text datasets for multiple subsets of biomedical entity types—such as genes and proteins, or chemicals and diseases—it is rare to find large labeled datasets containing labels for all desired entity types together. This paper presents a method for training a single CRF extractor from multiple datasets with disjoint or partially overlapping sets of entity types. Our approach employs marginal likelihood training to insist on labels that are present in the data, while filling in ``missing labels''. This allows us to leverage all the available data within a single model. In experimental results on the Biocreative V CDR (chemicals/diseases), Biocreative VI ChemProt (chemicals/proteins) and MedMentions (19 entity types) datasets, we show that joint training on multiple datasets improves NER F1 over training in isolation, and our methods achieve state-of-the-art results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>greenberg-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306054703" tag="video" />
@@ -5419,6 +5725,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2830–2836</pages>
     <url>http://www.aclweb.org/anthology/D18-1307</url>
+    <abstract>Adversarial training (AT) is a regularization method that can be used to improve the robustness of neural network methods by adding small perturbations in the training data. We show how to use AT for the tasks of entity recognition and relation extraction. In particular, we demonstrate that applying AT to a general purpose baseline model for jointly extracting entities and relations, allows improving the state-of-the-art effectiveness on several datasets in different contexts (i.e., news, biomedical, and real estate data) and for different languages (English and Dutch).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bekoulis-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306055549" tag="video" />
@@ -5439,6 +5746,7 @@
     <pages>2837–2842</pages>
     <url>http://www.aclweb.org/anthology/D18-1308</url>
     <attachment type="attachment">D18-1308.Attachment.pdf</attachment>
+    <abstract>We propose a model for tagging unstructured texts with an arbitrary number of terms drawn from a tree-structured vocabulary (i.e., an ontology). We treat this as a special case of sequence-to-sequence learning in which the decoder begins at the root node of an ontological tree and recursively elects to expand child nodes as a function of the input text, the current node, and the latent decoder state. We demonstrate that this method yields state-of-the-art results on the important task of assigning MeSH terms to biomedical abstracts.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>singh-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306056257" tag="video" />
@@ -5455,6 +5763,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2843–2849</pages>
     <url>http://www.aclweb.org/anthology/D18-1309</url>
+    <abstract>We propose a simple deep neural model for nested named entity recognition (NER). Most NER models focused on flat entities and ignored nested entities, which failed to fully capture underlying semantic information in texts. The key idea of our model is to enumerate all possible regions or spans as potential entity mentions and classify them with deep neural networks. To reduce the computational costs and capture the information of the contexts around the regions, the model represents the regions using the outputs of shared underlying bidirectional long short-term memory. We evaluate our exhaustive model on the GENIA and JNLPBA corpora in biomedical domain, and the results show that our model outperforms state-of-the-art models on nested and flat NER, achieving 77.1\% and 78.4\% respectively in terms of F-score, without any external knowledge resources.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sohrab-miwa:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306057139" tag="video" />
@@ -5472,6 +5781,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2850–2856</pages>
     <url>http://www.aclweb.org/anthology/D18-1310</url>
+    <abstract>Conventional wisdom is that hand-crafted features are redundant for deep learning models, as they already learn adequate representations of text automatically from corpora. In this work, we test this claim by proposing a new method for exploiting handcrafted features as part of a novel hybrid learning approach, incorporating a feature auto-encoder loss component. We evaluate on the task of named entity recognition (NER), where we show that including manual features for part-of-speech, word shapes and gazetteers can improve the performance of a neural CRF model. We obtain a F 1 of 91.89 for the CoNLL-2003 English shared task, which significantly outperforms a collection of highly competitive baseline models. We also present an ablation study showing the importance of auto-encoding, over using features as either inputs or outputs alone, and moreover, show including the autoencoder components reduces training requirements to 60\%, while retaining the same predictive accuracy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wu-liu-cohn:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306112516" tag="video" />
@@ -5489,6 +5799,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2857–2863</pages>
     <url>http://www.aclweb.org/anthology/D18-1311</url>
+    <abstract>Pre-trained word embeddings and language model have been shown useful in a lot of tasks. However, both of them cannot directly capture word connections in a sentence, which is important for dependency parsing given its goal is to establish dependency relations between words. In this paper, we propose to implicitly capture word connections from unlabeled data by a word ordering model with self-attention mechanism. Experiments show that these implicit word connections do improve our parsing model. Furthermore, by combining with a pre-trained language model, our model gets state-of-the-art performance on the English PTB dataset, achieving 96.35\% UAS and 95.25\% LAS.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-chang-mansur:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305667813" tag="video" />
@@ -5506,6 +5817,7 @@
     <pages>2864–2870</pages>
     <url>http://www.aclweb.org/anthology/D18-1312</url>
     <attachment type="attachment">D18-1312.Attachment.pdf</attachment>
+    <abstract>This paper presents a simple framework for characterizing morphological complexity and how it encodes syntactic information. In particular, we propose a new measure of morpho-syntactic complexity in terms of governor-dependent preferential attachment that explains parsing performance. Through experiments on dependency parsing with data from Universal Dependencies (UD), we show that representations derived from morphological attributes deliver important parsing performance improvements over standard word form embeddings when trained on the same datasets. We also show that the new morpho-syntactic complexity measure is predictive of the gains provided by using morphological attributes over plain forms on parsing scores, making it a tool to distinguish languages using morphology as a syntactic marker from others.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dehouck-denis:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305925065" tag="video" />
@@ -5522,6 +5834,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2871–2876</pages>
     <url>http://www.aclweb.org/anthology/D18-1313</url>
+    <abstract>Neural sequence-to-sequence models have proven very effective for machine translation, but at the expense of model interpretability. To shed more light into the role played by linguistic structure in the process of neural machine translation, we perform a fine-grained analysis of how various source-side morphological features are captured at different levels of the NMT encoder while varying the target language. Differently from previous work, we find no correlation between the accuracy of source morphology encoding and translation quality. We do find that morphological features are only captured in context and only to the extent that they are directly transferable to the target words.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bisazza-tump:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305670159" tag="video" />
@@ -5538,6 +5851,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2877–2882</pages>
     <url>http://www.aclweb.org/anthology/D18-1314</url>
+    <abstract>We employ imitation learning to train a neural transition-based string transducer for morphological tasks such as inflection generation and lemmatization. Previous approaches to training this type of model either rely on an external character aligner for the production of gold action sequences, which results in a suboptimal model due to the unwarranted dependence on a single gold action sequence despite spurious ambiguity, or require warm starting with an MLE model. Our approach only requires a simple expert policy, eliminating the need for a character aligner or warm start. It also addresses familiar MLE training biases and leads to strong and state-of-the-art performance on several benchmarks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>makarov-clematide:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305671668" tag="video" />
@@ -5554,6 +5868,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2883–2889</pages>
     <url>http://www.aclweb.org/anthology/D18-1315</url>
+    <abstract>The Paradigm Cell Filling Problem in morphology asks to complete word inflection tables from partial ones. We implement novel neural models for this task, evaluating them on 18 data sets in 8 languages, showing performance that is comparable with previous work with far less training data.  We also publish a new dataset for this task and code implementing the system described in this paper.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>silfverberg-hulden:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305674091" tag="video" />
@@ -5575,6 +5890,7 @@
     <pages>2890–2896</pages>
     <url>http://www.aclweb.org/anthology/D18-1316</url>
     <attachment type="attachment">D18-1316.Attachment.pdf</attachment>
+    <abstract>Deep neural networks (DNNs) are vulnerable to adversarial examples, perturbations to correctly classified examples which can cause the model to misclassify. In the image domain, these perturbations can often be made virtually indistinguishable to human perception, causing humans and state-of-the-art models to disagree. However, in the natural language domain, small perturbations are clearly perceptible, and the replacement of a single word can drastically alter the semantics of the document. Given these challenges, we use a black-box population-based optimization algorithm to generate semantically and syntactically similar adversarial examples that fool well-trained sentiment analysis and textual entailment models with success rates of 97\% and 70\%, respectively. We additionally demonstrate that 92.3\% of the successful sentiment analysis adversarial examples are classified to their original label by 20 human annotators, and that the examples are perceptibly quite similar. Finally, we discuss an attempt to use adversarial training as a defense, but fail to yield improvement, demonstrating the strength and diversity of our adversarial examples. We hope our findings encourage researchers to pursue improving the robustness of DNNs in the natural language domain.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>alzantot-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5593,6 +5909,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2897–2903</pages>
     <url>http://www.aclweb.org/anthology/D18-1317</url>
+    <abstract>Multi-head attention is appealing for the ability to jointly attend to information from different representation subspaces at different positions. In this work, we introduce a disagreement regularization to explicitly encourage the diversity among multiple attention heads. Specifically, we propose three types of disagreement regularization, which respectively encourage the subspace, the attended positions, and the output representation associated with each attention head to be different from other heads. Experimental results on widely-used WMT14 English-German and WMT17 Chinese-English translation tasks demonstrate the effectiveness and universality of the proposed approach.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -5608,6 +5925,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2904–2909</pages>
     <url>http://www.aclweb.org/anthology/D18-1318</url>
+    <abstract>Several recent papers investigate Active Learning (AL) for mitigating the data dependence of deep learning for natural language processing. However, the applicability of AL to real-world problems remains an open question. While in supervised learning, practitioners can try many different methods, evaluating each against a validation set before selecting a model, AL affords no such luxury. Over the course of one AL run, an agent annotates its dataset exhausting its labeling budget. Thus, given a new task, we have no opportunity to compare models and acquisition functions. This paper provides a large-scale empirical study of deep active learning, addressing multiple tasks and, for each, multiple datasets, multiple models, and a full suite of acquisition functions. We find that across all settings, Bayesian active learning by disagreement, using uncertainty estimates provided either by Dropout or Bayes-by-Backprop significantly improves over i.i.d. baselines and usually outperforms classic uncertainty sampling.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>siddhant-lipton:2018:EMNLP</bibkey>
   </paper>
@@ -5625,6 +5943,7 @@
     <pages>2910–2915</pages>
     <url>http://www.aclweb.org/anthology/D18-1319</url>
     <attachment type="attachment">D18-1319.Attachment.zip</attachment>
+    <abstract>In natural language processing, a lot of the tasks are successfully solved with recurrent neural networks, but such models have a huge number of parameters. The majority of these parameters are often concentrated in the embedding layer, which size grows proportionally to the vocabulary length. We propose a Bayesian sparsification technique for RNNs which allows compressing the RNN dozens or hundreds of times without time-consuming hyperparameters tuning. We also generalize the model for vocabulary sparsification to filter out unnecessary words and compress the RNN even further. We show that the choice of the kept words is interpretable.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chirkova-lobacheva-vetrov:2018:EMNLP</bibkey>
   </paper>
@@ -5642,6 +5961,7 @@
     <pages>2916–2922</pages>
     <url>http://www.aclweb.org/anthology/D18-1320</url>
     <attachment type="attachment">D18-1320.Attachment.zip</attachment>
+    <abstract>Graphemes of most languages encode pronunciation, though some are more explicit than others. Languages like Spanish have a straightforward mapping between its graphemes and phonemes, while this mapping is more convoluted for languages like English. Spoken languages such as Cantonese present even more challenges in pronunciation modeling: (1) they do not have a standard written form, (2) the closest graphemic origins are logographic Han characters, of which only a subset of these logographic characters implicitly encodes pronunciation. In this work, we propose a multimodal approach to predict the pronunciation of Cantonese logographic characters, using neural networks with a geometric representation of logographs and pronunciation of cognates in historically related languages. The proposed framework improves performance by 18.1\% and 25.0\% respective to unimodal and multimodal baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>nguyen-ngo-chen:2018:EMNLP</bibkey>
   </paper>
@@ -5657,6 +5977,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2923–2929</pages>
     <url>http://www.aclweb.org/anthology/D18-1321</url>
+    <abstract>Chinese pinyin input method engine (IME) converts pinyin into character so that Chinese characters can be conveniently inputted into computer through common keyboard. IMEs work relying on its core component, pinyin-to-character conversion (P2C). Usually Chinese IMEs simply predict a list of character sequences for user choice only according to user pinyin input at each turn. However, Chinese inputting is a multi-turn online procedure, which can be supposed to be exploited for further user experience promoting. This paper thus for the first time introduces a sequence-to-sequence model with gated-attention mechanism for the core task in IMEs. The proposed neural P2C model is learned by encoding previous input utterance as extra context to enable our IME capable of predicting character sequence with incomplete pinyin input. Our model is evaluated in different benchmark datasets showing great user experience improvement compared to traditional models, which demonstrates the first engineering practice of building Chinese aided IME.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang-zhao:2018:EMNLP</bibkey>
   </paper>
@@ -5673,6 +5994,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2930–2935</pages>
     <url>http://www.aclweb.org/anthology/D18-1322</url>
+    <abstract>Recurrent neural network language models (RNNLMs) are the current standard-bearer for statistical language modeling.  However, RNNLMs only estimate probabilities for complete sequences of text, whereas some applications require context-independent phrase probabilities instead.  In this paper, we study how to compute an RNNLM's em marginal probability: the probability that the model assigns to a short sequence of text when the preceding context is not known. We introduce a simple method of altering the RNNLM training to make the model more accurate at marginal estimation. Our experiments demonstrate that the technique is effective compared to baselines including the traditional RNNLM probability and an importance sampling approach. Finally, we show how we can use the marginal estimation to improve an RNNLM by training the marginals to match n-gram probabilities from a larger corpus.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>noraset-downey-bing:2018:EMNLP</bibkey>
   </paper>
@@ -5690,6 +6012,7 @@
     <pages>2936–2941</pages>
     <url>http://www.aclweb.org/anthology/D18-1323</url>
     <attachment type="attachment">D18-1323.Attachment.pdf</attachment>
+    <abstract>Recent state-of-the-art neural language models share the representations of words given by the input and output mappings. We propose a simple modification to these architectures that decouples the hidden state from the word embedding prediction. Our architecture leads to comparable or better results compared to previous tied models and models without tying, with a much smaller number of parameters. We also extend our proposal to word2vec models, showing that tying is appropriate for general word prediction tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gulordava-aina-boleda:2018:EMNLP</bibkey>
   </paper>
@@ -5707,6 +6030,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2942–2946</pages>
     <url>http://www.aclweb.org/anthology/D18-1324</url>
+    <abstract>Neural language models are a critical component of state-of-the-art systems for machine translation, summarization, audio transcription, and other tasks. These language models are almost universally autoregressive in nature, generating sentences one token at a time from left to right. This paper studies the influence of token generation order on model quality via a novel two-pass language model that produces partially-filled sentence ``templates'' and then fills  in missing tokens. We compare various strategies for structuring these two passes and observe a surprisingly large variation in model quality. We find the most  effective strategy generates function words in the first pass followed by content words in the second. We believe these experimental results justify a more extensive investigation of the generation order for neural language models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ford-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5725,6 +6049,7 @@
     <pages>2947–2954</pages>
     <url>http://www.aclweb.org/anthology/D18-1325</url>
     <attachment type="attachment">D18-1325.Attachment.pdf</attachment>
+    <abstract>Neural Machine Translation (NMT) can be improved by including document-level contextual information. For this purpose, we propose a hierarchical attention model to capture the context in a structured and dynamic manner. The model is integrated in the original NMT architecture as another level of abstraction, conditioning on the NMT model's own previous hidden states. Experiments show that hierarchical attention significantly improves the BLEU score over a strong NMT baseline with the state-of-the-art in context-aware methods, and that both the encoder and decoder benefit from context in complementary ways.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>miculicich-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5743,6 +6068,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2955–2960</pages>
     <url>http://www.aclweb.org/anthology/D18-1326</url>
+    <abstract>Due to the benefits of model compactness, multilingual translation (including many-to-one, many-to-many and one-to-many) based on a universal encoder-decoder architecture attracts more and more attention. However, previous studies show that one-to-many translation based on this framework cannot perform on par with the individually trained models. In this work, we introduce three strategies to improve one-to-many multilingual translation by balancing the shared and unique features. Within the architecture of one decoder for all target languages, we first exploit the use of unique initial states for different target languages. Then, we employ language-dependent positional embeddings. Finally and especially, we propose to divide the hidden cells of the decoder into shared and language-dependent ones. The extensive experiments demonstrate that our proposed methods can obtain remarkable improvements over the strong baselines. Moreover, our strategies can achieve comparable or even better performance than the individually trained translation models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP10</bibkey>
   </paper>
@@ -5758,6 +6084,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2961–2966</pages>
     <url>http://www.aclweb.org/anthology/D18-1327</url>
+    <abstract>We introduce a novel multi-source technique for incorporating source syntax into neural machine translation using linearized parses. This is achieved by employing separate encoders for the sequential and parsed versions of the same source sentence; the resulting representations are then combined using a hierarchical attention mechanism. The proposed model improves over both seq2seq and parsed baselines by over 1 BLEU on the WMT17 English-German task. Further analysis shows that our multi-source syntactic model is able to translate successfully without any parsed input, unlike standard parsed methods. In addition, performance does not deteriorate as much on long sentences as for the baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>currey-heafield:2018:EMNLP</bibkey>
   </paper>
@@ -5775,6 +6102,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2967–2973</pages>
     <url>http://www.aclweb.org/anthology/D18-1328</url>
+    <abstract>Corpus-based approaches to machine translation rely on the availability of clean parallel corpora. Such resources are scarce, and because of the automatic processes involved in their preparation, they are often noisy. This paper describes an unsupervised method for detecting translation divergences in parallel sentences. We rely on a neural network that computes cross-lingual sentence similarity scores, which are then used to effectively filter out divergent translations. Furthermore, similarity scores predicted by the network are used to identify and fix some partial divergences, yielding additional parallel segments. We evaluate these methods for English-French and English-German machine translation tasks, and show that using filtered/corrected corpora actually improves MT performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pham-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5789,6 +6117,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2974–2978</pages>
     <url>http://www.aclweb.org/anthology/D18-1329</url>
+    <abstract>The promise of combining language and vision in multimodal machine translation is that systems will produce better translations by leveraging the image data. However, the evidence surrounding whether the images are useful is unconvincing due to inconsistencies between text-similarity metrics and human judgements. We present an adversarial evaluation to directly examine the utility of the image data in this task. Our evaluation tests whether systems perform better when paired with congruent images or incongruent images. This evaluation shows that only one out of three publicly available systems is sensitive to this perturbation of the data. We recommend that multimodal translation systems should be able to pass this sanity check in the future.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>elliott:2018:EMNLP</bibkey>
   </paper>
@@ -5808,6 +6137,7 @@
     <pages>2979–2984</pages>
     <url>http://www.aclweb.org/anthology/D18-1330</url>
     <attachment type="attachment">D18-1330.Attachment.zip</attachment>
+    <abstract>Continuous word representations learned separately on distinct languages can be aligned so that their words become comparable in a common space. Existing works typically solve a quadratic problem to learn a orthogonal matrix aligning a bilingual lexicon, and use a retrieval criterion for inference. In this paper, we propose an unified formulation that directly optimizes a retrieval criterion in an end-to-end fashion. Our experiments on standard benchmarks show that our approach outperforms the state of the art on word translation, with the biggest improvements observed for distant language pairs such as English-Chinese.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>joulin-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5826,6 +6156,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2985–2990</pages>
     <url>http://www.aclweb.org/anthology/D18-1331</url>
+    <abstract>Most of the Neural Machine Translation (NMT) models are based on the sequence-to-sequence (Seq2Seq) model with an encoder-decoder framework equipped with the attention mechanism. However, the conventional attention mechanism treats the decoding at each time step equally with the same matrix, which is problematic since the softness of the attention for different types of words (e.g. content words and function words) should differ. Therefore, we propose a new model with a mechanism called Self-Adaptive Control of Temperature (SACT) to control the softness of attention by means of an attention temperature. Experimental results on the Chinese-English translation and English-Vietnamese translation demonstrate that our model outperforms the baseline models, and the analysis and the case study show that our model can attend to the most relevant elements in the source-side contexts and generate the translation of high quality.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lin-EtAl:2018:EMNLP1</bibkey>
   </paper>
@@ -5843,6 +6174,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2991–2996</pages>
     <url>http://www.aclweb.org/anthology/D18-1332</url>
+    <abstract>In order to extract the best possible performance from asynchronous stochastic gradient descent one must increase the mini-batch size and scale the learning rate accordingly. In order to achieve further speedup we introduce a technique that delays gradient updates  effectively increasing the mini-batch size. Unfortunately with the increase of mini-batch size we worsen the stale gradient problem in asynchronous stochastic gradient descent (SGD) which makes the model convergence poor. We introduce local optimizers which mitigate the stale gradient problem and together with fine tuning our momentum we are able to train a shallow machine translation system 27\% faster than an optimized baseline with negligible penalty in BLEU.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bogoychev-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5860,6 +6192,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>2997–3002</pages>
     <url>http://www.aclweb.org/anthology/D18-1333</url>
+    <abstract>Pronouns are frequently omitted in pro-drop languages, such as Chinese, generally leading to significant challenges with respect to the production of complete translations. Recently, Wang et al. (2018) proposed a novel reconstruction-based approach to alleviating dropped pronoun (DP) translation problems for neural machine translation models. In this work, we improve the original model from two perspectives. First, we employ a shared reconstructor to better exploit encoder and decoder representations. Second, we jointly learn to translate and predict DPs in an end-to-end manner, to avoid the errors propagated from an external DP prediction model. Experimental results show that our approach significantly improves both translation performance and DP prediction accuracy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP11</bibkey>
   </paper>
@@ -5876,6 +6209,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3003–3008</pages>
     <url>http://www.aclweb.org/anthology/D18-1334</url>
+    <abstract>Speakers of different languages must attend to and encode strikingly different aspects of the world in order to use their language correctly (Sapir, 1921; Slobin, 1996). One such difference is related to the way gender is expressed in a language. Saying ``I am happy'' in English, does not encode any additional knowledge of the speaker that uttered the sentence. However, many other languages do have grammatical gender systems and so such knowledge would be encoded. In order to correctly translate such a sentence into, say, French, the inherent gender information needs to be retained/recovered. The same sentence would become either ``Je suis heureux'', for a male speaker or ``Je suis heureuse'' for a female one. Apart from morphological agreement, demographic factors (gender, age, etc.) also influence our use of language in terms of word choices or syntactic constructions (Tannen,  1991;  Pennebaker et al., 2003). We integrate gender information into NMT systems. Our contribution is two-fold: (1) the compilation of large datasets with speaker information for 20 language pairs, and (2) a simple set of experiments that incorporate gender information into NMT for multiple language pairs. Our experiments show that adding a gender feature to an NMT system significantly improves the translation quality for some language pairs.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>vanmassenhove-hardmeier-way:2018:EMNLP</bibkey>
   </paper>
@@ -5892,6 +6226,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3009–3015</pages>
     <url>http://www.aclweb.org/anthology/D18-1335</url>
+    <abstract>This work investigates an alternative model for neural machine translation (NMT) and proposes a novel architecture, where we employ a multi-dimensional long short-term memory (MDLSTM) for translation modelling. In the state-of-the-art methods, source and target sentences are treated as one-dimensional sequences over time, while we view translation as a two-dimensional (2D) mapping using an MDLSTM layer to define the correspondence between source and target words. We extend beyond the current sequence to sequence backbone NMT models to a 2D structure in which the source and target sentences are aligned with each other in a 2D grid. Our proposed topology shows consistent improvements over attention-based sequence to sequence model on two WMT 2017 tasks, German&lt;-&gt;English.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bahar-brix-ney:2018:EMNLP</bibkey>
   </paper>
@@ -5907,6 +6242,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3016–3021</pages>
     <url>http://www.aclweb.org/anthology/D18-1336</url>
+    <abstract>Autoregressive decoding is the only part of sequence-to-sequence models that prevents them from massive parallelization at inference time. Non-autoregressive models enable the decoder to generate all output symbols independently in parallel. We present a novel non-autoregressive architecture based on connectionist temporal classification and evaluate it on the task of neural machine translation. Unlike other non-autoregressive methods which operate in several steps, our model can be trained end-to-end. We conduct experiments on the WMT English-Romanian and English-German datasets. Our models achieve a significant speedup over the autoregressive models, keeping the translation quality comparable to other non-autoregressive models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>libovick-helcl:2018:EMNLP</bibkey>
   </paper>
@@ -5924,6 +6260,7 @@
     <pages>3022–3027</pages>
     <url>http://www.aclweb.org/anthology/D18-1337</url>
     <attachment type="attachment">D18-1337.Attachment.zip</attachment>
+    <abstract>Simultaneous speech translation aims to maintain translation quality while minimizing the delay between reading input and incrementally producing the output. We propose a new general-purpose prediction action which predicts future words in the input to improve quality and minimize delay in simultaneous translation. We train this agent using reinforcement learning with a novel reward function. Our agent with prediction has better translation quality and less delay compared to an agent-based simultaneous translation system without prediction.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>alinejad-siahbani-sarkar:2018:EMNLP</bibkey>
   </paper>
@@ -5942,6 +6279,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3028–3033</pages>
     <url>http://www.aclweb.org/anthology/D18-1338</url>
+    <abstract>While current state-of-the-art NMT models, such as RNN seq2seq and Transformers, possess a large number of parameters, they are still shallow in comparison to convolutional models used for both text and vision applications. In this work we attempt to train significantly (2-3x) deeper Transformer and Bi-RNN encoders for machine translation.  We propose a simple modification to the attention mechanism that eases the optimization of deeper models, and results in consistent gains of 0.7-1.1 BLEU on the benchmark WMT'14 English-German and WMT'15 Czech-English tasks for both architectures.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bapna-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -5957,6 +6295,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3034–3041</pages>
     <url>http://www.aclweb.org/anthology/D18-1339</url>
+    <abstract>Neural machine translation systems with subword vocabularies are capable of translating or copying unknown words. In this work, we show that they learn to copy words based on both the context in which the words appear as well as features of the words themselves. In contexts that are particularly copy-prone, they even copy words that they have already learned they should translate. We examine the influence of context and subword features on this and other types of copying behavior.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>knowles-koehn:2018:EMNLP</bibkey>
   </paper>
@@ -5972,6 +6311,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3042–3047</pages>
     <url>http://www.aclweb.org/anthology/D18-1340</url>
+    <abstract>Translation memories (TM) facilitate human translators to reuse existing repetitive translation fragments. In this paper, we propose a novel method to combine the strengths of both TM and neural machine translation (NMT) for high-quality translation. We treat the target translation of a TM match as an additional reference input and encode it into NMT with an extra encoder. A gating mechanism is further used to balance the impact of the TM match on the NMT decoder. Experiment results on the UN corpus demonstrate that when fuzzy matches are higher than 50\%, the quality of NMT translation can be significantly improved by over 10 BLEU points.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>cao-xiong:2018:EMNLP</bibkey>
   </paper>
@@ -5987,6 +6327,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3048–3053</pages>
     <url>http://www.aclweb.org/anthology/D18-1341</url>
+    <abstract>Automated Post-Editing (PE) is the task of automatically correct common and repetitive errors found in machine translation (MT) output. In this paper, we present a neural programmer-interpreter approach to this task, resembling the way that human perform post-editing using discrete edit operations, wich we refer to as programs. Our model outperforms previous neural models for inducing PE programs on the WMT17 APE task for German-English up to +1 BLEU score and -0.7 TER scores.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>vu-haffari:2018:EMNLP</bibkey>
   </paper>
@@ -6003,6 +6344,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3054–3059</pages>
     <url>http://www.aclweb.org/anthology/D18-1342</url>
+    <abstract>Beam search is widely used in neural machine translation, and usually improves translation quality compared to greedy search. It has been widely observed that, however, beam sizes larger than 5 hurt translation quality. We explain why this happens, and propose several methods to address this problem. Furthermore, we discuss the optimal stopping criteria for these methods. Results show that our hyperparameter-free methods outperform the widely-used hyperparameter-free heuristic of length normalization by +2.0 BLEU, and achieve the best results among all methods on Chinese-to-English translation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang-huang-ma:2018:EMNLP</bibkey>
   </paper>
@@ -6019,6 +6361,7 @@
     <pages>3060–3066</pages>
     <url>http://www.aclweb.org/anthology/D18-1343</url>
     <attachment type="attachment">D18-1343.Attachment.zip</attachment>
+    <abstract>Accurate and complete knowledge bases (KBs) are paramount in NLP. We employ mul-itiview learning for increasing the accuracy and coverage of entity type information in KBs. We rely on two metaviews: language and representation. For language, we consider high- resource and low-resource languages from Wikipedia. For representation, we consider representations based on the context distribution of the entity (i.e., on its embedding), on the entity's name (i.e., on its surface form) and on its description in Wikipedia. The two metaviews language and representation can be freely combined: each pair of language and representation (e.g., German embedding, English description, Spanish name) is a distinct view. Our experiments on entity typing with fine-grained classes demonstrate the effectiveness of multiview learning. We release MVET, a large multiview --- and, in particular, multilingual --- entity typing dataset we created. Mono- and multilingual fine-grained entity typing systems can be evaluated on this dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yaghoobzadeh-schtze:2018:EMNLP</bibkey>
   </paper>
@@ -6035,6 +6378,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3067–3072</pages>
     <url>http://www.aclweb.org/anthology/D18-1344</url>
+    <abstract>We compare three existing bilingual word embedding approaches, and a novel approach of training skip-grams on synthetic code-mixed text generated through linguistic models of code-mixing, on two tasks - sentiment analysis and POS tagging for code-mixed text. Our results show that while CVM and CCA based embeddings perform as well as the proposed embedding technique on semantic and syntactic tasks respectively, the proposed approach provides the best performance for both tasks overall. Thus, this study demonstrates that existing bilingual embedding techniques are not ideal for code-mixed text processing and there is a need for learning multilingual word embedding from the code-mixed text.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pratapa-choudhury-sitaram:2018:EMNLP</bibkey>
   </paper>
@@ -6052,6 +6396,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3073–3077</pages>
     <url>http://www.aclweb.org/anthology/D18-1345</url>
+    <abstract>Character-level patterns have been widely used as features in English Named Entity Recognition (NER) systems. However, to date there has been no direct investigation of the inherent differences between name and nonname tokens in text, nor whether this property holds across multiple languages. This paper analyzes the capabilities of corpus-agnostic Character-level Language Models (CLMs) in the binary task of distinguishing name tokens from non-name tokens. We demonstrate that CLMs provide a simple and powerful model for capturing these differences, identifying named entity tokens in a diverse set of languages at close to the performance of full NER systems. Moreover, by adding very simple CLM-based features we can significantly improve the performance of an off-the-shelf NER system for multiple languages.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yu-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -6068,6 +6413,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3078–3083</pages>
     <url>http://www.aclweb.org/anthology/D18-1346</url>
+    <abstract>This work focuses on building language models (LMs) for code-switched text. We propose two techniques that significantly improve these LMs: 1) A novel recurrent neural network unit with dual components that focus on each language in the code-switched text separately 2) Pretraining the LM using synthetic text from a generative model estimated using the training data. We demonstrate the effectiveness of our proposed techniques by reporting perplexities on a Mandarin-English task and derive significant reductions in perplexity.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>garg-parekh-jyothi:2018:EMNLP</bibkey>
   </paper>
@@ -6083,6 +6429,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3084–3089</pages>
     <url>http://www.aclweb.org/anthology/D18-1347</url>
+    <abstract>Code-switching, the use of more than one language within a single utterance, is ubiquitous in much of the world, but remains a challenge for NLP largely due to the lack of representative data for training models. In this paper, we present a novel model architecture that is trained exclusively on monolingual resources, but can be applied to unseen code-switched text at inference time.  The model accomplishes this by jointly maintaining separate word representations for each of the possible languages,  or scripts in the case of transliteration, allowing each to contribute to inferences without forcing the model to commit to a language.  Experiments on Hindi-English part-of-speech tagging demonstrate that our approach outperforms standard models when training on monolingual text without transliteration, and testing on code-switched text with alternate scripts.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ball-garrette:2018:EMNLP</bibkey>
   </paper>
@@ -6101,6 +6448,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3090–3099</pages>
     <url>http://www.aclweb.org/anthology/D18-1348</url>
+    <abstract>User intent detection plays a critical role in question-answering and dialog systems. Most previous works treat intent detection as a classification problem where utterances are labeled with predefined intents. However, it is labor-intensive and time-consuming to label users' utterances as intents are diversely expressed and novel intents will continually be involved. Instead, we study the zero-shot intent detection problem, which aims to detect emerging user intents where no labeled utterances are currently available. We propose two capsule-based architectures: IntentCapsNet that extracts semantic features from utterances and aggregates them to discriminate existing intents, and IntentCapsNet-ZSL which gives IntentCapsNet the zero-shot learning ability to discriminate emerging intents via knowledge transfer from existing intents. Experiments on two real-world datasets show that our model not only can better discriminate diversely expressed existing intents, but is also able to discriminate emerging intents when no labeled utterances are available.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xia-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305945714" tag="video" />
@@ -6117,6 +6465,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3100–3109</pages>
     <url>http://www.aclweb.org/anthology/D18-1349</url>
+    <abstract>Prevalent models based on artificial neural network (ANN) for sentence classification often classify sentences in isolation without considering the context in which sentences appear. This hampers the traditional sentence classification approaches to the problem of sequential sentence classification, where structured prediction is needed for better overall classification performance. In this work, we present a hierarchical sequential labeling network to make use of the contextual information within surrounding sentences to help classify the current sentence. Our model outperforms the state-of-the-art results by 2\%-3\% on two benchmarking datasets for sequential sentence classification in medical scientific abstracts.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>jin-szolovits:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305946571" tag="video" />
@@ -6137,6 +6486,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3110–3119</pages>
     <url>http://www.aclweb.org/anthology/D18-1350</url>
+    <abstract>In this study, we explore capsule networks with dynamic routing for text classification. We propose three strategies to stabilize the dynamic routing process to alleviate the disturbance of some noise capsules which may contain ``background'' information or have not been successfully trained. A series of experiments are conducted with capsule networks on six text classification benchmarks.  Capsule networks achieve state of the art on 4 out of 6 datasets, which shows the effectiveness of capsule networks for text classification. We additionally show that capsule networks exhibit significant improvement when transfer single-label to multi-label text classification over strong baseline methods. To the best of our knowledge, this is the first work that capsule networks have been empirically investigated for text modeling.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/305947408" tag="video" />
@@ -6157,6 +6507,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3120–3131</pages>
     <url>http://www.aclweb.org/anthology/D18-1351</url>
+    <abstract>Many classification models work poorly on short texts due to data sparsity. To address this issue, we propose topic memory networks for short text classification with a novel topic memory mechanism to encode latent topic representations indicative of class labels. Different from most prior work that focuses on extending features with external knowledge or pre-trained topics, our model jointly explores topic inference and text classification with memory networks in an end-to-end manner. Experimental results on four benchmark datasets show that our model outperforms state-of-the-art models on short text classification, meanwhile generates coherent topics.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zeng-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305947994" tag="video" />
@@ -6173,6 +6524,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3132–3142</pages>
     <url>http://www.aclweb.org/anthology/D18-1352</url>
+    <abstract>Large multi-label datasets contain labels that occur thousands of times (frequent group), those that occur only a few times (few-shot group), and labels that never appear in the training dataset (zero-shot group). Multi-label few- and zero-shot label prediction is mostly unexplored on datasets with large label spaces, especially for text classification. In this paper, we perform a fine-grained evaluation to understand how state-of-the-art methods perform on infrequent labels. Furthermore, we develop few- and zero-shot methods for multi-label text classification when there is a known structure over the label space, and evaluate them on two publicly available medical text datasets: MIMIC II and MIMIC III. For few-shot labels we achieve improvements of 6.2\% and 4.8\% in R\@10 for MIMIC II and MIMIC III, respectively, over prior efforts; the corresponding R\@10 improvements for zero-shot labels are 17.3\% and 19\%.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>rios-kavuluru:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305948835" tag="video" />
@@ -6191,6 +6543,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3143–3153</pages>
     <url>http://www.aclweb.org/anthology/D18-1353</url>
+    <abstract>Poetry is one of the most beautiful forms of human language art. As a crucial step towards computer creativity, automatic poetry generation has drawn researchers' attention for decades. In recent years, some neural models have made remarkable progress in this task. However, they are all based on maximum likelihood estimation, which only learns common patterns of the corpus and results in loss-evaluation mismatch. Human experts evaluate poetry in terms of some specific criteria, instead of word-level likelihood. To handle this problem, we directly model the criteria and use them as explicit rewards to guide gradient update by reinforcement learning, so as to motivate the model to pursue higher scores. Besides, inspired by writing theories, we propose a novel mutual reinforcement learning schema. We simultaneously train two learners (generators) which learn not only from the teacher (rewarder) but also from each other to further improve performance. We experiment on Chinese poetry. Based on a strong basic model, our method achieves better results and outperforms the current state-of-the-art method.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yi-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305925622" tag="video" />
@@ -6211,6 +6564,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3154–3163</pages>
     <url>http://www.aclweb.org/anthology/D18-1354</url>
+    <abstract>Combining the virtues of probability graphic models and neural networks, Conditional Variational Auto-encoder (CVAE) has shown promising performance in applications such as response generation. However, existing CVAE-based models often generate responses from a single latent variable which may not be sufficient to model high variability in responses. To solve this problem, we propose a novel model that sequentially introduces a series of latent variables to condition the generation of each word in the response sequence. In addition, the approximate posteriors of these latent variables are augmented with a backward Recurrent Neural Network (RNN), which allows the latent variables to capture long-term dependencies of future tokens in generation. To facilitate training, we supplement our model with an auxiliary objective that predicts the subsequent bag of words. Empirical experiments conducted on Opensubtitle and Reddit datasets show that the proposed model leads to significant improvement on both relevance and diversity over state-of-the-art baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>du-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305926196" tag="video" />
@@ -6230,6 +6584,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3164–3173</pages>
     <url>http://www.aclweb.org/anthology/D18-1355</url>
+    <abstract>Sentence simplification aims to reduce the complexity of a sentence while retaining its original meaning. Current models for sentence simplification adopted ideas from machine translation studies and implicitly learned simplification mapping rules from normal-simple sentence pairs. In this paper, we explore a novel model based on a multi-layer and multi-head attention architecture and we propose two innovative approaches to integrate the Simple PPDB (A Paraphrase Database for Simplification), an external paraphrase knowledge base for simplification that covers a wide range of real-world simplification rules. The experiments show that the integration provides two major benefits: (1) the integrated model outperforms multiple state-of-the-art baseline models for sentence simplification in the literature (2) through analysis of the rule utilization, the model seeks to select more accurate simplification rules. The code and models used in the paper are available at https://github.com/Sanqiang/text\_simplification.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhao-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/305927122" tag="video" />
@@ -6247,6 +6602,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3174–3187</pages>
     <url>http://www.aclweb.org/anthology/D18-1356</url>
+    <abstract>While neural, encoder-decoder models have had significant empirical success in text generation, there remain several unaddressed problems with this style of generation. Encoder-decoder models are largely (a) uninterpretable, and (b) difficult to control in terms of their phrasing or content. This work proposes a neural generation system using a hidden semi-markov model (HSMM) decoder, which learns latent, discrete templates jointly with learning to generate. We show that this model learns useful templates, and that these templates make generation both more interpretable and controllable. Furthermore, we show that this approach scales to real data sets and achieves strong performance nearing that of encoder-decoder text generation models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wiseman-shieber-rush:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305928599" tag="video" />
@@ -6264,6 +6620,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3188–3197</pages>
     <url>http://www.aclweb.org/anthology/D18-1357</url>
+    <abstract>Neural text generation, including neural machine translation, image captioning, and summarization, has been quite successful recently. However, during training time, typically only one reference is considered for each example, even though there are often multiple references available, e.g., 4 references in NIST MT evaluations, and 5 references in image captioning data. We first investigate several different ways of utilizing multiple human references during training. But more importantly, we then propose an algorithm to generate exponentially many pseudo-references by first compressing existing human references into lattices and then traversing them to generate new pseudo-references. These approaches lead to substantial improvements over strong baselines in both machine translation (+1.5 BLEU) and image captioning (+3.1 BLEU / +11.7 CIDEr).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zheng-ma-huang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305929800" tag="video" />
@@ -6283,6 +6640,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3198–3207</pages>
     <url>http://www.aclweb.org/anthology/D18-1358</url>
+    <abstract>The rapid development of knowledge graphs (KGs), such as Freebase and WordNet, has changed the paradigm for AI-related applications. However, even though these KGs are impressively large, most of them are suffering from incompleteness, which leads to performance degradation of AI applications. Most existing researches are focusing on knowledge graph embedding (KGE) models. Nevertheless, those models simply embed entities and relations into latent vectors without leveraging the rich information from the relation structure. Indeed, relations in KGs conform to a three-layer hierarchical relation structure (HRS), i.e., semantically similar relations can make up relation clusters and some relations can be further split into several fine-grained sub-relations. Relation clusters, relations and sub-relations can fit in the top, the middle and the bottom layer of three-layer HRS respectively. To this end, in this paper, we extend existing KGE models TransE, TransH and DistMult, to learn knowledge representations by leveraging the information from the HRS. Particularly, our approach is capable to extend other KGE models. Finally, the experiment results clearly validate the effectiveness of the proposed approach against baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP10</bibkey>
     <video href="https://vimeo.com/306112939" tag="video" />
@@ -6301,6 +6659,7 @@
     <pages>3208–3218</pages>
     <url>http://www.aclweb.org/anthology/D18-1359</url>
     <attachment type="attachment">D18-1359.Attachment.zip</attachment>
+    <abstract>Representing entities and relations in an embedding space is a well-studied approach for machine learning on relational data. Existing approaches, however, primarily focus on simple link structure between a finite set of entities, ignoring the variety of data types that are often used in knowledge bases, such as text, images, and numerical values. In this paper, we propose multimodal knowledge base embeddings (MKBE) that use different neural encoders for this variety of observed data, and combine them with existing relational models to learn embeddings of the entities and multimodal data. Further, using these learned embedings and different neural decoders, we introduce a novel multimodal imputation model to generate missing multimodal values, like text and images, from information in the knowledge base. We enrich existing relational datasets to create two novel benchmarks that contain additional information such as textual descriptions and images of the original entities. We demonstrate that our models utilize this additional information effectively to provide more accurate link prediction, achieving state-of-the-art results with a considerable gap of 5-7\$\%\$ over existing methods. Further, we evaluate the quality of our generated multimodal values via a user study.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pezeshkpour-chen-singh:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306113486" tag="video" />
@@ -6319,6 +6678,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3219–3232</pages>
     <url>http://www.aclweb.org/anthology/D18-1360</url>
+    <abstract>We introduce a multi-task setup of identifying entities, relations, and coreference clusters in scientific articles. We create SciERC, a dataset that includes annotations for all three tasks and develop a unified framework called SciIE with shared span representations. The multi-task setup reduces cascading errors between tasks and leverages cross-sentence relations through coreference links. Experiments show that our multi-task model outperforms previous models in scientific information extraction without using any domain-specific features. We further show that the framework supports construction of a scientific knowledge graph, which we use to analyze information in scientific literature.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>luan-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306113930" tag="video" />
@@ -6341,6 +6701,7 @@
     <pages>3233–3242</pages>
     <url>http://www.aclweb.org/anthology/D18-1361</url>
     <attachment type="attachment">D18-1361.Attachment.zip</attachment>
+    <abstract>The 20 Questions (Q20) game is a well known game which encourages deductive reasoning and creativity. In the game, the answerer first thinks of an object such as a famous person or a kind of animal. Then the questioner tries to guess the object by asking 20 questions. In a Q20 game system, the user is considered as the answerer while the system itself acts as the questioner which requires a good strategy of question selection to figure out the correct object and win the game. However, the optimal policy of question selection is hard to be derived due to the complexity and volatility of the game environment. In this paper, we propose a novel policy-based Reinforcement Learning (RL) method, which enables the questioner agent to learn the optimal policy of  question selection through continuous interactions with users. To facilitate training, we also propose to use a reward network to estimate the more informative reward. Compared to previous methods, our RL method is robust to noisy answers and does not rely on the Knowledge Base of objects. Experimental results show that our RL method clearly outperforms an entropy-based engineering system and has competitive performance in a noisy-free simulation environment.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hu-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306114592" tag="video" />
@@ -6359,6 +6720,7 @@
     <pages>3243–3253</pages>
     <url>http://www.aclweb.org/anthology/D18-1362</url>
     <attachment type="attachment">D18-1362.Attachment.pdf</attachment>
+    <abstract>Multi-hop reasoning is an effective approach for query answering (QA) over incomplete knowledge graphs (KGs). The problem can be formulated in a reinforcement learning (RL) setup, where a policy-based agent sequentially extends its inference path until it reaches a target. However, in an incomplete KG environment, the agent receives low-quality rewards corrupted by false negatives in the training data, which harms generalization at test time. Furthermore, since no golden action sequence is used for training, the agent can be misled by spurious search trajectories that incidentally lead to the correct answer. We propose two modeling advances to address both issues: (1) we reduce the impact of false negative supervision by adopting a pretrained one-hop embedding model to estimate the reward of unobserved facts; (2) we counter the sensitivity to spurious paths of on-policy RL by forcing the agent to explore a diverse set of paths using randomly generated edge masks. Our approach significantly improves over existing path-based KGQA models on several benchmark datasets and is comparable or better than embedding-based models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lin-socher-xiong:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306115211" tag="video" />
@@ -6376,6 +6738,7 @@
     <pages>3254–3264</pages>
     <url>http://www.aclweb.org/anthology/D18-1363</url>
     <attachment type="attachment">D18-1363.Attachment.zip</attachment>
+    <abstract>Neural state-of-the-art sequence-to-sequence (seq2seq) models often do not perform well for small training sets. We address paradigm completion, the morphological task of, given a partial paradigm, generating all missing forms. We propose two new methods for the minimal- resource setting: (i) Paradigm transduction: Since we assume only few paradigms available for training, neural seq2seq models are able to capture relationships between paradigm cells, but are tied to the idiosyncracies of the training set. Paradigm transduction mitigates this problem by exploiting the input subset of inflected forms at test time. (ii) Source selec- tion with high precision (SHIP): Multi-source models which learn to automatically select one or multiple sources to predict a target inflection do not perform well in the minimal-resource setting. SHIP is an alternative to identify a reliable source if training data is limited. On a 52-language benchmark dataset, we outperform the previous state of the art by up to 9.71\% absolute accuracy.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kann-schtze:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305676641" tag="video" />
@@ -6391,6 +6754,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3265–3274</pages>
     <url>http://www.aclweb.org/anthology/D18-1364</url>
+    <abstract>This paper focuses on the most basic implicational universals in phonological theory, called T-orders after Anttila and Andrus (2006). It shows that the T-orders predicted by stochastic (and partial order) Optimality Theory coincide with those predicted by categorical OT. Analogously, the T-orders predicted by stochastic Harmonic Grammar coincide with those predicted by categorical HG. In other words, these stochastic constraint-based frameworks do not tamper with the typological structure induced by the original categorical frameworks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>magri:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305679809" tag="video" />
@@ -6411,6 +6775,7 @@
     <pages>3275–3284</pages>
     <url>http://www.aclweb.org/anthology/D18-1365</url>
     <attachment type="attachment">D18-1365.Attachment.zip</attachment>
+    <abstract>Character-level features are currently used in different neural network-based natural language processing algorithms. However, little is known about the character-level patterns those models learn. Moreover, models are often compared only quantitatively while a qualitative analysis is missing. In this paper, we investigate which character-level patterns neural networks learn and if those patterns coincide with manually-defined word segmentations and annotations. To that end, we extend the contextual decomposition technique (Murdoch et al. 2018) to convolutional neural networks which allows us to compare convolutional neural networks and bidirectional long short-term memory networks. We evaluate and compare these models for the task of morphological tagging on three morphologically different languages and show that these models implicitly discover understandable linguistic rules.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>godin-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305681577" tag="video" />
@@ -6432,6 +6797,7 @@
     <pages>3285–3295</pages>
     <url>http://www.aclweb.org/anthology/D18-1366</url>
     <attachment type="attachment">D18-1366.Attachment.zip</attachment>
+    <abstract>Much work in Natural Language Processing (NLP) has been for resource-rich languages, making generalization to new, less-resourced languages challenging. We present two approaches for improving generalization to low-resourced languages by adapting continuous word representations using linguistically motivated subword units: phonemes, morphemes and graphemes. Our method requires neither parallel corpora nor bilingual dictionaries and provides a significant gain in performance over previous methods relying on these resources. We demonstrate the effectiveness of our approaches on Named Entity Recognition for four languages, namely Uyghur, Turkish, Bengali and Hindi, of which Uyghur and Bengali are low resource languages, and also perform experiments on Machine Translation. Exploiting subwords with transfer learning gives us a boost of +15.2 NER F1 for Uyghur and +9.7 F1 for Bengali. We also show improvements in the monolingual setting where we achieve (avg.) +3 F1 and (avg.) +1.35 BLEU.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chaudhary-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/305683572" tag="video" />
@@ -6450,6 +6816,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3296–3304</pages>
     <url>http://www.aclweb.org/anthology/D18-1367</url>
+    <abstract>Several NLP studies address the problem of figurative language, but among non-literal phenomena, they have neglected exaggeration. This paper presents a first computational approach to this figure of speech. We explore the possibility to automatically detect exaggerated sentences. First, we introduce HYPO, a corpus containing overstatements (or hyperboles) collected on the web and validated via crowdsourcing. Then, we evaluate a number of models trained on HYPO, and bring evidence that the task of hyperbole identification can be successfully performed based on a small set of semantic features.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>troiano-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6465,6 +6832,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3305–3315</pages>
     <url>http://www.aclweb.org/anthology/D18-1368</url>
+    <abstract>Capabilities to categorize a clause based on the type of situation entity (e.g., events, states and generic statements) the clause introduces to the discourse can benefit many NLP applications. Observing that the situation entity type of a clause depends on discourse functions the clause plays in a paragraph and the interpretation of discourse functions depends heavily on paragraph-wide contexts, we propose to build context-aware clause representations for predicting situation entity types of clauses. Specifically, we propose a hierarchical recurrent neural network model to read a whole paragraph at a time and jointly learn representations for all the clauses in the paragraph by extensively modeling context influences and inter-dependencies of clauses. Experimental results show that our model achieves the state-of-the-art performance for clause-level situation entity classification on the genre-rich MASC+Wiki corpus, which approaches human-level performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dai-huang:2018:EMNLP</bibkey>
   </paper>
@@ -6481,6 +6849,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3316–3325</pages>
     <url>http://www.aclweb.org/anthology/D18-1369</url>
+    <abstract>In news and discussions, many articles and posts are provided without their related previous articles or posts. Hence, it is difficult to understand the context from which the articles and posts have occurred. In this paper, we propose the Hierarchical Dirichlet Gaussian Marked Hawkes process (HD-GMHP) for reconstructing the narratives and thread structures of news articles and discussion posts. HD-GMHP unifies three modeling strategies in previous research: temporal characteristics, triggering event relations, and meta information of text in news articles and discussion threads. To show the effectiveness of the model, we perform experiments in narrative reconstruction and thread reconstruction with real world datasets: articles from the New York Times and a corpus of Wikipedia conversations. The experimental results show that HD-GMHP outperforms the baselines of LDA, HDP, and HDHP for both tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>seonwoo-oh-park:2018:EMNLP</bibkey>
   </paper>
@@ -6499,6 +6868,7 @@
     <pages>3326–3338</pages>
     <url>http://www.aclweb.org/anthology/D18-1370</url>
     <attachment type="attachment">D18-1370.Attachment.zip</attachment>
+    <abstract>Exponential growth in the number of scientific publications yields the need for effective automatic analysis of rhetorical aspects of scientific writing. Acknowledging the argumentative nature of scientific text, in this work we investigate the link between the argumentative structure of scientific publications and rhetorical aspects such as discourse categories or citation contexts. To this end, we (1) augment a corpus of scientific publications annotated with four layers of rhetoric annotations with argumentation annotations and (2) investigate neural multi-task learning architectures combining argument extraction with a set of rhetorical classification tasks. By coupling rhetorical classifiers with the extraction of argumentative components in a joint multi-task learning setting, we obtain significant performance gains for different rhetorical analysis tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lauscher-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6514,6 +6884,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3339–3349</pages>
     <url>http://www.aclweb.org/anthology/D18-1371</url>
+    <abstract>We design and build the first neural temporal dependency parser. It utilizes a neural ranking model with minimal feature engineering, and parses time expressions and events in a text into a temporal dependency tree structure. We evaluate our parser on two domains: news reports and narrative stories. In a parsing-only evaluation setup where gold time expressions and events are provided, our parser reaches 0.81 and 0.70 f-score on unlabeled and labeled parsing respectively, a result that is very competitive against alternative approaches. In an end-to-end evaluation setup where time expressions and events are automatically recognized, our parser beats two strong baselines on both data domains. Our experimental results and discussions shed light on the nature of temporal dependency structures in different domains and provide insights that we believe will be valuable to future research in this area.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-xue:2018:EMNLP</bibkey>
   </paper>
@@ -6531,6 +6902,7 @@
     <pages>3350–3359</pages>
     <url>http://www.aclweb.org/anthology/D18-1372</url>
     <attachment type="attachment">D18-1372.Attachment.zip</attachment>
+    <abstract>Understanding causal explanations - reasons given for happenings in one's life - has been found to be an important psychological factor linked to physical and mental health. Causal explanations are often studied through manual identification of phrases over limited samples of personal writing. Automatic identification of causal explanations in social media, while challenging in relying on contextual and sequential cues, offers a larger-scale alternative to expensive manual ratings and opens the door for new applications (e.g. studying prevailing beliefs about causes, such as climate change). Here, we explore automating causal explanation analysis, building on discourse parsing, and presenting two novel subtasks: causality detection (determining whether a causal explanation exists at all) and causal explanation identification (identifying the specific phrase that is the explanation). We achieve strong accuracies for both tasks but find different approaches best: an SVM for causality prediction (F1 = 0.791) and a hierarchy of Bidirectional LSTMs for causal explanation identification (F1 = 0.853). Finally, we explore applications of our complete pipeline (F1 = 0.868), showing demographic differences in mentions of causal explanation and that the association between a word and sentiment can change when it is used within a causal explanation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>son-bayas-schwartz:2018:EMNLP</bibkey>
   </paper>
@@ -6548,6 +6920,7 @@
     <pages>3360–3370</pages>
     <url>http://www.aclweb.org/anthology/D18-1373</url>
     <attachment type="attachment">D18-1373.Attachment.pdf</attachment>
+    <abstract>Multimodal learning has shown promising performance in content-based recommendation due to the auxiliary user and item information of multiple modalities such as text and images.  However, the problem of incomplete and missing modality is rarely explored and most existing methods fail in learning a recommendation model with missing or corrupted modalities. In this paper, we propose LRMM, a novel framework that mitigates not only the problem of missing modalities but also more generally the cold-start problem of recommender systems. We propose modality dropout (m-drop) and a multimodal sequential autoencoder (m-auto) to learn multimodal representations for complementing and imputing missing modalities. Extensive experiments on real-world Amazon data show that LRMM achieves state-of-the-art performance on rating prediction tasks. More importantly, LRMM is more robust to previous methods in alleviating data-sparsity and the cold-start problem.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-niepert-li:2018:EMNLP</bibkey>
   </paper>
@@ -6564,6 +6937,7 @@
     <pages>3371–3380</pages>
     <url>http://www.aclweb.org/anthology/D18-1374</url>
     <attachment type="attachment">D18-1374.Attachment.tgz</attachment>
+    <abstract>Background research is an essential part of document writing. Search engines are great for retrieving information once we know what to look for. However, the bigger challenge is often identifying topics for further research. Automated tools could help significantly in this discovery process and increase the productivity of the writer. In this paper, we formulate the problem of recommending topics to a writer. We consider this as a supervised learning problem and run a user study to validate this approach. We propose an evaluation metric and perform an empirical comparison of state-of-the-art models for extreme multi-label classification on a large data set. We demonstrate how a simple modification of the cross-entropy loss function leads to improved results of the deep learning models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lukasik-zens:2018:EMNLP</bibkey>
   </paper>
@@ -6581,6 +6955,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3381–3391</pages>
     <url>http://www.aclweb.org/anthology/D18-1375</url>
+    <abstract>Likability prediction of books has many uses. Readers,  writers, as well as the publishing industry, can all benefit from automatic book likability prediction systems. In order to make reliable decisions, these systems need to assimilate information from different aspects of a book in a sensible way. We propose a novel multimodal neural architecture that incorporates genre supervision to assign weights to individual feature types. Our proposed method is capable of dynamically tailoring weights given to feature types based on the characteristics of each book. Our architecture achieves competitive results and even outperforms state-of-the-art for this task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>maharjan-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6597,6 +6972,7 @@
     <pages>3392–3401</pages>
     <url>http://www.aclweb.org/anthology/D18-1376</url>
     <attachment type="attachment">D18-1376.Attachment.zip</attachment>
+    <abstract>The task of thread popularity prediction and tracking aims to recommend a few popular comments to subscribed users when a batch of new comments arrive in a discussion thread. This task has been formulated as a reinforcement learning problem, in which the reward of the agent is the sum of positive responses received by the recommended comments. In this work, we propose a novel approach to tackle this problem. First, we propose a deep neural network architecture to model the expected cumulative reward (Q-value) of a recommendation (action). Unlike the state-of-the-art approach, which treats an action as a sequence, our model uses an attention mechanism to integrate information from a set of comments. Thus, the prediction of Q-value is invariant to the permutation of the comments, which leads to a more consistent agent behavior. Second, we employ a greedy procedure to approximate the action that maximizes the predicted Q-value from a combinatorial action space. Different from the state-of-the-art approach, this procedure does not require an additional pre-trained model to generate candidate actions. Experiments on five real-world datasets show that our approach outperforms the state-of-the-art.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chan-king:2018:EMNLP</bibkey>
   </paper>
@@ -6616,6 +6992,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3402–3411</pages>
     <url>http://www.aclweb.org/anthology/D18-1377</url>
+    <abstract>Sentiment analysis has immense implications in e-commerce through user feedback mining. Aspect-based sentiment analysis takes this one step further by enabling businesses to extract aspect specific sentimental information. In this paper, we present a novel approach of incorporating the neighboring aspects related information into the sentiment classification of the target aspect using memory networks. We show that our method outperforms the state of the art by 1.6\% on average in two distinct domains: restaurant and laptop.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>majumder-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6631,6 +7008,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3412–3422</pages>
     <url>http://www.aclweb.org/anthology/D18-1378</url>
+    <abstract>We propose Limbic, an unsupervised probabilistic model that addresses the problem of discovering aspects and sentiments and associating them with authors of opinionated texts. Limbic combines three ideas, incorporating authors, discourse relations, and word embeddings. For discourse relations, Limbic adopts a generative process regularized by a Markov Random Field. To promote words with high semantic similarity into the same topic, Limbic captures semantic regularities from word embeddings via a generalized Pólya Urn process. We demonstrate that Limbic (1) discovers aspects associated with sentiments with high lexical diversity; (2) outperforms state-of-the-art models by a substantial margin in topic cohesion and sentiment classification.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-singh:2018:EMNLP</bibkey>
   </paper>
@@ -6647,6 +7025,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3423–3432</pages>
     <url>http://www.aclweb.org/anthology/D18-1379</url>
+    <abstract>Text might express or evoke multiple emotions with varying intensities. As such, it is crucial to predict and rank multiple relevant emotions by their intensities. Moreover, as emotions might be evoked by hidden topics, it is important to unveil and incorporate such topical information to understand how the emotions are evoked. We proposed a novel interpretable neural network approach for relevant emotion ranking. Specifically, motivated by transfer learning, the neural network is initialized to make the hidden layer approximate the behavior of topic models.  Moreover, a novel error function is defined to optimize the whole neural network for relevant emotion ranking. Experimental results on three real-world corpora show that the proposed approach performs remarkably better than the state-of-the-art emotion detection approaches and multi-label learning methods. Moreover, the extracted emotion-associated topic words indeed represent emotion-evoking events and are in line with our common-sense knowledge.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang-zhou-he:2018:EMNLP</bibkey>
   </paper>
@@ -6663,6 +7042,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3433–3442</pages>
     <url>http://www.aclweb.org/anthology/D18-1380</url>
+    <abstract>We propose a novel multi-grained attention network (MGAN) model for aspect level sentiment classification. Existing approaches mostly adopt coarse-grained attention mechanism, which may bring information loss if the aspect has multiple words or larger context. We propose a fine-grained attention mechanism, which can capture the word-level interaction between aspect and context. And then we leverage the fine-grained and coarse-grained attention mechanisms to compose the MGAN framework. Moreover, unlike previous works which train each aspect with its context separately, we design an aspect alignment loss to depict the aspect-level interactions among the aspects that have the same context. We evaluate the proposed approach on three datasets: laptop and restaurant are from SemEval 2014, and the last one is a twitter dataset. Experimental results show that the multi-grained attention network consistently outperforms the state-of-the-art methods on all three datasets. We also conduct experiments to evaluate the effectiveness of aspect alignment loss, which indicates the aspect-level interactions can bring extra useful information and further improve the performance.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>fan-feng-zhao:2018:EMNLP</bibkey>
   </paper>
@@ -6680,6 +7060,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3443–3453</pages>
     <url>http://www.aclweb.org/anthology/D18-1381</url>
+    <abstract>This paper proposes a new neural architecture that exploits readily available sentiment lexicon resources. The key idea is that that incorporating a word-level prior can aid in the representation learning process, eventually improving model performance. To this end, our model employs two distinctly unique components, i.e., (1) we introduce a lexicon-driven contextual attention mechanism to imbue lexicon words with long-range contextual information and (2), we introduce a contrastive co-attention mechanism that models contrasting polarities between all positive and negative words in a sentence. Via extensive experiments, we show that our approach outperforms many other neural baselines on sentiment classification tasks on multiple benchmark datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tay-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6699,6 +7080,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3454–3466</pages>
     <url>http://www.aclweb.org/anthology/D18-1382</url>
+    <abstract>Multi-modal sentiment analysis offers various challenges, one being the effective combination of different input modalities, namely text, visual and acoustic. In this paper, we propose a recurrent neural network based multi-modal attention framework that leverages the contextual information for utterance-level sentiment prediction. The proposed approach applies attention on multi-modal multi-utterance representations and tries to learn the contributing features amongst them. We evaluate our proposed approach on two multi-modal sentiment analysis benchmark datasets, viz.  CMU Multi-modal Opinion-level Sentiment Intensity (CMU-MOSI) corpus and the recently released CMU Multi-modal Opinion Sentiment and Emotion Intensity (CMU-MOSEI) corpus. Evaluation results show the effectiveness of our proposed approach with the accuracies of 82.31\% and 79.80\% for the MOSI and MOSEI datasets, respectively. These are approximately 2 and 1 points performance improvement over the state-of-the-art models for the datasets.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ghosal-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6717,6 +7099,7 @@
     <pages>3467–3476</pages>
     <url>http://www.aclweb.org/anthology/D18-1383</url>
     <attachment type="attachment">D18-1383.Attachment.pdf</attachment>
+    <abstract>We consider the cross-domain sentiment classification problem, where a sentiment classifier is to be learned from a source domain and to be generalized to a target domain. Our approach explicitly minimizes the distance between the source and the target instances in an embedded feature space. With the difference between source and target minimized, we then exploit additional information from the target domain by consolidating the idea of semi-supervised learning, for which, we jointly employ two regularizations --- entropy minimization and self-ensemble bootstrapping --- to incorporate the unlabeled target data for classifier refinement. Our experimental results demonstrate that the proposed approach can better leverage unlabeled data from the target domain and achieve substantial improvements over baseline methods in various experimental settings.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>he-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -6736,6 +7119,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3477–3486</pages>
     <url>http://www.aclweb.org/anthology/D18-1384</url>
+    <abstract>Many existing systems for analyzing and summarizing customer reviews about products or service are based on a number of prominent review aspects. Conventionally, the prominent review aspects of a product type are determined manually. This costly approach cannot scale to large and cross-domain services such as Amazon.com, Taobao.com or Yelp.com where there are a large number of product types and new products emerge almost every day. In this paper, we propose a novel framework, for extracting the most prominent aspects of a given product type from textual reviews. The proposed framework, ExtRA, extracts K most prominent aspect terms or phrases which do not overlap semantically automatically without supervision. Extensive experiments show that ExtRA is effective and achieves the state-of-the-art performance on a dataset consisting of different product types.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>luo-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -6752,6 +7136,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3487–3496</pages>
     <url>http://www.aclweb.org/anthology/D18-1385</url>
+    <abstract>With the increasing popularity of smart devices, rumors with multimedia content become more and more common on social networks. The multimedia information usually makes rumors look more convincing. Therefore, finding an automatic approach to verify rumors with multimedia content is a pressing task. Previous rumor verification research only utilizes multimedia as input features. We propose not to use the multimedia content but to find external information in other news platforms pivoting on it. We introduce a new features set, cross-lingual cross-platform features that leverage the semantic similarity between the rumors and the external information. When implemented, machine learning methods utilizing such features achieved the state-of-the-art rumor verification results.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wen-su-yu:2018:EMNLP</bibkey>
   </paper>
@@ -6768,6 +7153,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3497–3507</pages>
     <url>http://www.aclweb.org/anthology/D18-1386</url>
+    <abstract>We introduce an adversarial method for producing high-recall explanations of neural text classifier decisions. Building on an existing architecture for extractive explanations via hard attention, we add an adversarial layer which scans the residual of the attention for remaining predictive signal. Motivated by the important domain of detecting personal attacks in social media comments, we additionally demonstrate the importance of manually setting a semantically appropriate ``default'' behavior for the model by explicitly manipulating its bias term. We develop a validation set of human-annotated personal attacks to evaluate the impact of these changes.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>carton-mei-resnick:2018:EMNLP</bibkey>
   </paper>
@@ -6783,6 +7169,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3508–3517</pages>
     <url>http://www.aclweb.org/anthology/D18-1387</url>
+    <abstract>Website privacy policies represent the single most important source of information for users to gauge how their personal data are collected, used and shared by companies. However, privacy policies are often vague and people struggle to understand the content. Their opaqueness poses a significant challenge to both users and policy regulators. In this paper, we seek to identify vague content in privacy policies. We construct the first corpus of human-annotated vague words and sentences and present empirical studies on automatic vagueness detection. In particular, we investigate context-aware and context-agnostic models for predicting vague words, and explore auxiliary-classifier generative adversarial networks for characterizing sentence vagueness. Our experimental results demonstrate the effectiveness of proposed approaches. Finally, we provide suggestions for resolving vagueness and improving the usability of privacy policies.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lebanoff-liu:2018:EMNLP</bibkey>
   </paper>
@@ -6800,6 +7187,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3518–3527</pages>
     <url>http://www.aclweb.org/anthology/D18-1388</url>
+    <abstract>A news article's title, content and link structure often reveal its political ideology. However, most existing works on automatic political ideology detection only leverage textual cues. Drawing inspiration from recent advances in neural inference, we propose a novel attention based multi-view model to leverage cues from all of the above views to identify the ideology evinced by a news article. Our model draws on advances in representation learning in natural language processing and network science to capture cues from both textual content and the network structure of news articles. We empirically evaluate our model against a battery of baselines and show that our model outperforms state of the art by 10 percentage points F1 score.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kulkarni-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6818,6 +7206,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3528–3539</pages>
     <url>http://www.aclweb.org/anthology/D18-1389</url>
+    <abstract>We present a study on predicting the factuality of reporting and bias of news media. While previous work has focused on studying the veracity of claims or documents, here we are interested in characterizing entire news media. This is an under-studied, but arguably important research problem, both in its own right and as a prior for fact-checking systems. We experiment with a large list of news websites and with a rich set of features derived from (i) a sample of articles from the target news media, (ii) its Wikipedia page, (iii) its Twitter account, (iv) the structure of its URL, and (v) information about the Web traffic it attracts. The experimental results show sizable performance gains over the baseline, and reveal the importance of each feature type.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>baly-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6837,6 +7226,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3540–3549</pages>
     <url>http://www.aclweb.org/anthology/D18-1390</url>
+    <abstract>Legal Judgment Prediction (LJP) aims to predict the judgment result based on the facts of a case and becomes a promising application of artificial intelligence techniques in the legal field. In real-world scenarios, legal judgment usually consists of multiple subtasks, such as the decisions of applicable law articles, charges, fines, and the term of penalty. Moreover, there exist topological dependencies among these subtasks. While most existing works only focus on a specific subtask of judgment prediction and ignore the dependencies among subtasks, we formalize the dependencies among subtasks as a Directed Acyclic Graph (DAG) and propose a topological multi-task learning framework, \textsc{TopJudge}, which incorporates multiple subtasks and DAG dependencies into judgment prediction. We conduct experiments on several real-world large-scale datasets of criminal cases in the civil law system. Experimental results show that our model achieves consistent and significant improvements over baselines on all judgment prediction tasks. The source code can be obtained from https://github.com/thunlp/TopJudge.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhong-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -6854,6 +7244,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3550–3559</pages>
     <url>http://www.aclweb.org/anthology/D18-1391</url>
+    <abstract>Existing work on automated hate speech detection typically focuses on binary classification or on differentiating among a small set of categories. In this paper, we propose a novel method on a fine-grained hate speech classification task, which focuses on differentiating among 40 hate groups of 13 different hate group categories. We first explore the Conditional Variational Autoencoder (CVAE)  as a discriminative model and then extend it to a hierarchical architecture to utilize the additional hate category information for more accurate prediction. Experimentally, we show that incorporating the hate category information for training can significantly improve the classification performance and our proposed model outperforms commonly-used discriminative models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>qian-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6872,6 +7263,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3560–3569</pages>
     <url>http://www.aclweb.org/anthology/D18-1392</url>
+    <abstract>Predictive models over social media language have shown promise in capturing community outcomes, but approaches thus far largely neglect the socio-demographic context (e.g. age, education rates, race) of the community from which the language originates. For example, it may be inaccurate to assume people in Mobile, Alabama, where the population is relatively older, will use words the same way as those from San Francisco, where the median age is younger with a higher rate of college education. In this paper, we present residualized factor adaptation, a novel approach to community prediction tasks which both (a) effectively integrates community attributes, as well as (b) adapts linguistic features to community attributes (factors). We use eleven demographic and socioeconomic attributes, and evaluate our approach over five different community-level predictive tasks, spanning health (heart disease mortality, percent fair/poor health), psychology (life satisfaction), and economics (percent housing price increase, foreclosure rate). Our evaluation shows that residualized factor adaptation significantly improves 4 out of 5 community-level outcome predictions over prior state-of-the-art for incorporating socio-demographic contexts.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zamani-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -6892,12 +7284,13 @@
     <pages>3570–3580</pages>
     <url>http://www.aclweb.org/anthology/D18-1393</url>
     <attachment type="attachment">D18-1393.Attachment.pdf</attachment>
+    <abstract>Amidst growing concern over media manipulation, NLP attention has focused  on overt strategies like censorship and ``fake news''. Here, we draw on two concepts from political science literature to explore subtler strategies for government media manipulation: agenda-setting (selecting what topics to cover) and framing (deciding how topics are covered). We analyze 13 years (100K articles) of the Russian newspaper Izvestia and identify a strategy of distraction: articles mention the U.S. more frequently in the month directly following an economic downturn in Russia. We introduce embedding-based methods for cross-lingually projecting English frames to Russian, and discover that these articles emphasize U.S. moral failings and threats to the U.S. Our work offers new ways to identify subtle media manipulation strategies at the intersection of agenda-setting and framing.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>field-EtAl:2018:EMNLP</bibkey>
   </paper>
 
   <paper id="1394">
-    <title>Identifying the sentiment styles of YouTube’s vloggers</title>
+    <title>Identifying the sentiment styles of YouTube's vloggers</title>
     <author><first>Bennett</first><last>Kleinberg</last></author>
     <author><first>Maximilian</first><last>Mozes</last></author>
     <author><first>Isabelle</first><last>van der Vegt</last></author>
@@ -6909,6 +7302,7 @@
     <pages>3581–3590</pages>
     <url>http://www.aclweb.org/anthology/D18-1394</url>
     <attachment type="attachment">D18-1394.Attachment.pdf</attachment>
+    <abstract>Vlogs provide a rich public source of data in a novel setting. This paper examined the continuous sentiment styles employed in 27,333 vlogs using a dynamic intra-textual approach to sentiment analysis. Using unsupervised clustering, we identified seven distinct continuous sentiment trajectories characterized by fluctuations of sentiment throughout a vlog's narrative time. We provide a taxonomy of these seven continuous sentiment styles and found that vlogs whose sentiment builds up towards a positive ending are the most prevalent in our sample. Gender was associated with preferences for different continuous sentiment trajectories. This paper discusses the findings with respect to previous work and concludes with an outlook towards possible uses of the corpus, method and findings of this paper for related areas of research.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kleinberg-mozes-vandervegt:2018:EMNLP</bibkey>
   </paper>
@@ -6926,6 +7320,7 @@
     <pages>3591–3601</pages>
     <url>http://www.aclweb.org/anthology/D18-1395</url>
     <attachment type="attachment">D18-1395.Attachment.pdf</attachment>
+    <abstract>We address the task of native language identification in the context of social media content, where authors are highly-fluent, advanced nonnative speakers (of English). Using both linguistically-motivated features and the characteristics of the social media outlet, we obtain high accuracy on this challenging task. We provide a detailed analysis of the features that sheds light on differences between native and nonnative speakers, and among nonnative speakers with different backgrounds.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>goldin-rabinovich-wintner:2018:EMNLP</bibkey>
   </paper>
@@ -6947,6 +7342,7 @@
     <pages>3602–3611</pages>
     <url>http://www.aclweb.org/anthology/D18-1396</url>
     <attachment type="attachment">D18-1396.Attachment.pdf</attachment>
+    <abstract>Neural machine translation usually adopts autoregressive models and suffers from exposure bias as well as the consequent error propagation problem. Many previous works have discussed the relationship between error propagation and the \emph{accuracy drop} (i.e., the left part of the translated sentence is often better than its right part in left-to-right decoding models) problem. In this paper, we conduct a series of analyses to deeply understand this problem and get several interesting findings. (1) The role of error propagation on accuracy drop is overstated in the literature, although it indeed contributes to the accuracy drop problem. (2) Characteristics of a language play a more important role in causing the accuracy drop: the left part of the translation result in a right-branching language (e.g., English) is more likely to be more accurate than its right part, while the right part is more accurate for a left-branching language (e.g., Japanese). Our discoveries are confirmed on different model structures including Transformer and RNN, and in other sequence generation tasks such as text summarization.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wu-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/306146050" tag="video" />
@@ -6966,6 +7362,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3612–3621</pages>
     <url>http://www.aclweb.org/anthology/D18-1397</url>
+    <abstract>Recent studies have shown that reinforcement learning (RL) is an effective approach for improving the performance of neural machine translation (NMT) system.  However, due to its instability,  successfully RL training is challenging, especially in real-world systems where deep models and large datasets are leveraged. In this paper, taking several large-scale translation tasks as testbeds, we conduct a systematic study on how to train better NMT models using reinforcement learning. We provide a comprehensive comparison of several important factors (e.g., baseline reward, reward shaping) in RL training. Furthermore, to fill in the gap that it remains unclear whether RL is still beneficial when monolingual data is used,  we propose a new method to leverage RL to further boost the performance of NMT systems trained with source/target monolingual data. By integrating all our findings, we obtain competitive results on WMT14 English- German, WMT17 English-Chinese, and WMT17 Chinese-English translation tasks, especially setting a state-of-the-art performance on WMT17 Chinese-English translation task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wu-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306147010" tag="video" />
@@ -6985,6 +7382,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3622–3631</pages>
     <url>http://www.aclweb.org/anthology/D18-1398</url>
+    <abstract>In this paper, we propose to extend the recently introduced model-agnostic meta-learning algorithm (MAML, Finn, et al., 2017) for low-resource neural machine translation (NMT). We frame low-resource translation as a meta-learning problem where we learn to adapt to low-resource languages based on multilingual high-resource language tasks. We use the universal lexical representation (Gu et al., 2018b) to overcome the input-output mismatch across different languages. We evaluate the proposed meta-learning  strategy  using  eighteen  European  languages  (Bg,  Cs,  Da,  De,  El,  Es,  Et, Fr, Hu, It, Lt,  Nl, Pl, Pt, Sk, Sl, Sv and Ru) as source tasks and five diverse languages (Ro,Lv, Fi, Tr and Ko) as target tasks. We show that the proposed approach significantly outperforms the multilingual, transfer learning based approach  (Zoph et al.,  2016) and enables us to train a competitive NMT system with only a fraction of training examples. For instance, the proposed approach can achieve as high as 22.04 BLEU on Romanian-English WMT'16 by seeing only 16,000 translated words ($\sim$600 parallel sentences)</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gu-EtAl:2018:EMNLP1</bibkey>
     <video href="https://vimeo.com/306147573" tag="video" />
@@ -7002,6 +7400,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3632–3642</pages>
     <url>http://www.aclweb.org/anthology/D18-1399</url>
+    <abstract>While modern machine translation has relied on large parallel corpora, a recent line of work has managed to train Neural Machine Translation (NMT) systems from monolingual corpora only (Artetxe et al., 2018c; Lample et al., 2018). Despite the potential of this approach for low-resource settings, existing systems are far behind their supervised counterparts, limiting their practical interest. In this paper, we propose an alternative approach based on phrase-based Statistical Machine Translation (SMT) that significantly closes the gap with supervised systems. Our method profits from the modular architecture of SMT: we first induce a phrase table from monolingual corpora through cross-lingual embedding mappings, combine it with an n-gram language model, and fine-tune hyperparameters through an unsupervised MERT variant. In addition, iterative backtranslation improves results further, yielding, for instance, 14.08 and 26.22 BLEU points in WMT 2014 English-German and English-French, respectively, an improvement of more than 7-10 BLEU points over previous unsupervised systems, and closing the gap with supervised SMT (Moses trained on Europarl) down to 2-5 BLEU points. Our implementation is available at https://github.com/artetxem/monoses.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>artetxe-labaka-agirre:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306148376" tag="video" />
@@ -7021,6 +7420,7 @@
     <pages>3643–3653</pages>
     <url>http://www.aclweb.org/anthology/D18-1400</url>
     <attachment type="attachment">D18-1400.Attachment.zip</attachment>
+    <abstract>We introduce a novel multimodal machine translation model that utilizes parallel visual and textual information. Our model jointly optimizes the learning of a shared visual-language embedding and a translator. The model leverages a visual attention grounding mechanism that links the visual semantics with the corresponding textual semantics. Our approach achieves competitive state-of-the-art results on the Multi30K and the Ambiguous COCO datasets. We also collected a new multilingual multimodal product description dataset to simulate a real-world international online shopping scenario.  On this dataset, our visual attention grounding model outperforms other methods by a large margin.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhou-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306149028" tag="video" />
@@ -7044,6 +7444,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3654–3663</pages>
     <url>http://www.aclweb.org/anthology/D18-1401</url>
+    <abstract>In an e-commerce environment, user-oriented question-answering (QA) text pair could carry rich sentiment information. In this study, we propose a novel task/method to address QA sentiment analysis. In particular, we create a high-quality annotated corpus with specially-designed annotation guidelines for QA-style sentiment classification. On the basis, we propose a three-stage hierarchical matching network to explore deep sentiment information in a QA text pair. First, we segment both the question and answer text into sentences and construct a number of [Q-sentence, A-sentence] units in each QA text pair. Then, by leveraging a QA bidirectional matching layer, the proposed approach can learn the matching vectors of each [Q-sentence, A-sentence] unit. Finally, we characterize the importance of the generated matching vectors via a self-matching attention layer. Experimental results, comparing with a number of state-of-the-art baselines, demonstrate the impressive effectiveness of the proposed approach for QA-style sentiment classification.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shen-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/306126825" tag="video" />
@@ -7064,6 +7465,7 @@
     <pages>3664–3674</pages>
     <url>http://www.aclweb.org/anthology/D18-1402</url>
     <attachment type="attachment">D18-1402.Attachment.zip</attachment>
+    <abstract>Argument mining is a core technology for automating argument search in large document collections. Despite its usefulness for this task, most current approaches are designed for use only with specific text types and fall short when applied to heterogeneous texts.  In this paper, we propose a new sentential annotation scheme that is reliably applicable by crowd workers to arbitrary Web texts. We source annotations for over 25,000 instances covering eight controversial topics. We show that integrating topic information into bidirectional long short-term memory networks outperforms vanilla BiLSTMs by more than 3 percentage points in F1 in two- and three-label cross-topic settings. We also show that these results can be further improved by leveraging additional data for topic relevance using multi-task learning.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>stab-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306127543" tag="video" />
@@ -7081,6 +7483,7 @@
     <pages>3675–3686</pages>
     <url>http://www.aclweb.org/anthology/D18-1403</url>
     <attachment type="attachment">D18-1403.Attachment.zip</attachment>
+    <abstract>We present a neural framework for opinion summarization from online product reviews which is knowledge-lean and only requires light supervision (e.g., in the form of product domain labels and user-provided ratings). Our method combines two weakly supervised components to identify salient opinions and form extractive summaries from multiple reviews: an aspect extractor trained under a multi-task objective, and a sentiment predictor based on multiple instance learning. We introduce an opinion summarization dataset that includes a training set of product reviews from six diverse domains and human-annotated development and test sets with gold standard aspect annotations, salience labels, and opinion summaries. Automatic evaluation shows significant improvements over baselines, and a large-scale study indicates that our opinion summaries are preferred by human judges according to multiple criteria.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>angelidis-lapata:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306128219" tag="video" />
@@ -7101,6 +7504,7 @@
     <pages>3687–3697</pages>
     <url>http://www.aclweb.org/anthology/D18-1404</url>
     <attachment type="attachment">D18-1404.Attachment.zip</attachment>
+    <abstract>Emotions are expressed in nuanced ways, which varies by collective or individual experiences, knowledge, and beliefs. Therefore, to understand emotion, as conveyed through text, a robust mechanism capable of capturing and modeling different linguistic nuances and phenomena is needed. We propose a semi-supervised, graph-based algorithm to produce rich structural descriptors which serve as the building blocks for constructing contextualized affect representations from text. The pattern-based representations are further enriched with word embeddings and evaluated through several emotion recognition tasks. Our experimental results demonstrate that the proposed method outperforms state-of-the-art techniques on emotion recognition tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>saravia-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306129121" tag="video" />
@@ -7118,6 +7522,7 @@
     <pages>3698–3707</pages>
     <url>http://www.aclweb.org/anthology/D18-1405</url>
     <attachment type="attachment">D18-1405.Attachment.pdf</attachment>
+    <abstract>Noise Contrastive Estimation (NCE) is a powerful parameter estimation method for log-linear models, which avoids calculation of the partition function or its derivatives at each training step, a computationally demanding step in many cases. It is closely related to negative sampling methods, now widely used in NLP. This paper considers NCE-based estimation of conditional models. Conditional models are frequently encountered in practice; however there has not been a rigorous theoretical analysis of NCE in this setting, and we will argue there are subtle but important questions when generalizing NCE to the conditional case. In particular, we analyze two variants of NCE for conditional models: one based on a classification objective, the other based on a ranking objective. We show that the ranking-based variant of NCE gives consistent parameter estimates under weaker assumptions than the classification-based method; we analyze the statistical efficiency of the ranking-based and classification-based variants of NCE; finally we describe experiments on synthetic data and language modeling showing the effectiveness and tradeoffs of both methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ma-collins:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306156327" tag="video" />
@@ -7136,6 +7541,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3708–3718</pages>
     <url>http://www.aclweb.org/anthology/D18-1406</url>
+    <abstract>Maximum-likelihood estimation (MLE) is one of the most widely used approaches for training structured prediction models for text-generation based natural language processing applications. However, besides exposure bias, models trained with MLE suffer from wrong objective problem where they are trained to maximize the word-level correct next step prediction, but are evaluated with respect to sequence-level discrete metrics such as ROUGE and BLEU. Several variants of policy-gradient methods address some of these problems by optimizing for final discrete evaluation metrics and showing improvements over MLE training for downstream tasks like text summarization and machine translation. However, policy-gradient methods suffers from high sample variance, making the training process very difficult and unstable.  In this paper, we present an alternative direction towards mitigating this problem by introducing a new objective (CaLcs) based on a differentiable surrogate of longest common subsequence (LCS) measure that captures sequence-level structure similarity. Experimental results on abstractive summarization and machine translation validate the effectiveness of the proposed approach.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yavuz-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306157322" tag="video" />
@@ -7157,6 +7563,7 @@
     <pages>3719–3728</pages>
     <url>http://www.aclweb.org/anthology/D18-1407</url>
     <attachment type="attachment">D18-1407.Attachment.zip</attachment>
+    <abstract>One way to interpret neural model predictions is to highlight the most important input features---for example, a heatmap visualization over the words in an input sentence.  In existing interpretation methods for NLP, a word's importance is determined by either input perturbation---measuring the decrease in model confidence when that word is removed---or by the gradient with respect to that word.  To understand the limitations of these methods, we use input reduction, which iteratively removes the least important word from the input. This exposes pathological behaviors of neural models: the remaining words appear nonsensical to humans and are not the ones determined as important by interpretation methods. As we confirm with human experiments, the reduced examples lack information to support the prediction of any label, but models still make the same predictions with high confidence.  To explain these counterintuitive results, we draw connections to adversarial examples and confidence calibration: pathological behaviors reveal difficulties in interpreting neural models trained with maximum likelihood.  To mitigate their deficiencies, we fine-tune the models by encouraging high entropy outputs on reduced examples.  Fine-tuned models become more interpretable under input reduction, without accuracy loss on regular examples.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>feng-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306158589" tag="video" />
@@ -7175,6 +7582,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3729–3738</pages>
     <url>http://www.aclweb.org/anthology/D18-1408</url>
+    <abstract>Universal sentence encoding is a hot topic in recent NLP research. Attention mechanism has been an integral part in many sentence encoding models, allowing the models to capture context dependencies regardless of the distance between the elements in the sequence. Fully attention-based models have recently attracted enormous interest due to their highly parallelizable computation and significantly less training time. However, the memory consumption of their models grows quadratically with the sentence length, and the syntactic information is neglected. To this end, we propose Phrase-level Self-Attention Networks (PSAN) that perform self-attention across words inside a phrase to capture context dependencies at the phrase level, and use the gated memory updating mechanism to refine each word's representation hierarchically with longer-term context dependencies captured in a larger phrase. As a result, the memory consumption can be reduced because the self-attention is performed at the phrase level instead of the sentence level. At the same time, syntactic information can be easily integrated in the model. Experiment results show that PSAN can achieve the state-of-the-art performance across a plethora of NLP tasks including binary and multi-class classification, natural language inference and sentence similarity.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wu-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/306159624" tag="video" />
@@ -7195,6 +7603,7 @@
     <pages>3739–3748</pages>
     <url>http://www.aclweb.org/anthology/D18-1409</url>
     <attachment type="attachment">D18-1409.Attachment.pdf</attachment>
+    <abstract>In this work, we propose a novel method for training neural networks to perform single-document extractive summarization without heuristically-generated extractive labels. We call our approach BanditSum as it treats extractive summarization as a contextual bandit (CB) problem, where the model receives a document to summarize (the context), and chooses a sequence of sentences to include in the summary (the action). A policy gradient reinforcement learning algorithm is used to train the model to select sequences of sentences that maximize ROUGE score. We perform a series of experiments demonstrating that BanditSum is able to achieve ROUGE scores that are better than or comparable to the state-of-the-art for extractive summarization, and converges using significantly fewer update steps than competing approaches. In addition, we show empirically that BanditSum performs significantly better than competing approaches when good summary sentences appear late in the source document.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dong-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306160623" tag="video" />
@@ -7211,6 +7620,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3749–3760</pages>
     <url>http://www.aclweb.org/anthology/D18-1410</url>
+    <abstract>Current lexical simplification approaches rely heavily on heuristics and corpus level features  that do not always align with human judgment. We create a human-rated word-complexity lexicon of 15,000 English words and propose a novel neural readability ranking model with a Gaussian-based feature vectorization layer that utilizes these human ratings to measure the complexity of any given word or phrase. Our model performs better than the state-of-the-art systems for different lexical simplification tasks and evaluation datasets. Additionally, we also produce SimplePPDB++, a lexical resource of over 10 million simplifying paraphrase rules, by applying our model to the Paraphrase Database (PPDB).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>maddela-xu:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306116474" tag="video" />
@@ -7231,6 +7641,7 @@
     <pages>3761–3771</pages>
     <url>http://www.aclweb.org/anthology/D18-1411</url>
     <attachment type="attachment">D18-1411.Attachment.pdf</attachment>
+    <abstract>Previous work on grounded language learning did not fully capture the semantics underlying the correspondences between structured world state representations and texts, especially those between numerical values and lexical terms. In this paper, we attempt at learning explicit latent semantic annotations from paired structured tables and texts, establishing correspondences between various types of values and texts. We model the joint probability of data fields, texts, phrasal spans, and latent annotations with an adapted semi-hidden Markov model, and impose a soft statistical constraint to further improve the performance. As a by-product, we leverage the induced annotations to extract templates for language generation. Experimental results suggest the feasibility of the setting in this study, as well as the effectiveness of our proposed framework.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>qin-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306117499" tag="video" />
@@ -7252,6 +7663,7 @@
     <pages>3772–3782</pages>
     <url>http://www.aclweb.org/anthology/D18-1412</url>
     <attachment type="attachment">D18-1412.Attachment.zip</attachment>
+    <abstract>We introduce the syntactic scaffold, an approach to incorporating syntactic information into semantic tasks. Syntactic scaffolds avoid expensive syntactic processing at runtime, only making use of a treebank during training, through a multitask objective. We improve over strong baselines on PropBank semantics, frame semantics, and coreference resolution, achieving competitive performance on all three tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>swayamdipta-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306118515" tag="video" />
@@ -7270,6 +7682,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3783–3792</pages>
     <url>http://www.aclweb.org/anthology/D18-1413</url>
+    <abstract>Scripts define knowledge about how everyday scenarios (such as going to a restaurant) are expected to unfold. One of the challenges to learning scripts is the hierarchical nature of the knowledge. For example, a suspect arrested might plead innocent or guilty, and a very different track of events is then expected to happen. To capture this type of information, we propose an autoencoder model with a latent space defined by a hierarchy of categorical variables. We utilize a recently proposed vector quantization based approach, which allows continuous embeddings to be associated with each latent variable value. This permits the decoder to softly decide what portions of the latent hierarchy to condition on by attending over the value embeddings for a given setting. Our model effectively encodes and generates scripts, outperforming a recent language modeling-based method on several standard tasks, and allowing the autoencoder model to achieve substantially lower perplexity scores compared to the previous language modeling-based method.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>weber-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306119229" tag="video" />
@@ -7289,6 +7702,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3793–3802</pages>
     <url>http://www.aclweb.org/anthology/D18-1414</url>
+    <abstract>This paper studies semantic parsing for interlanguage (L2), taking semantic role labeling (SRL) as a case task and learner Chinese as a case language. We first manually annotate the semantic roles for a set of learner texts to derive a gold standard for automatic SRL. Based on the new data, we then evaluate three off-the-shelf SRL systems, i.e., the PCFGLA-parser-based, neural-parser-based and neural-syntax-agnostic systems, to gauge how successful SRL for learner Chinese can be. We find two non-obvious facts: 1) the L1-sentence-trained systems performs rather badly on the L2 data; 2) the performance drop from the L1 data to the L2 data of the two parser-based systems is much smaller, indicating the importance of syntactic parsing in SRL for interlanguages. Finally, the paper introduces a new agreement-based model to explore the semantic coherency information in the large-scale L2-L1 parallel data. We then show such information is very effective to enhance SRL for learner texts. Our model achieves an F-score of 72.06, which is a 2.02 point improvement over the best baseline.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lin-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306119942" tag="video" />
@@ -7310,6 +7724,7 @@
     <pages>3803–3812</pages>
     <url>http://www.aclweb.org/anthology/D18-1415</url>
     <attachment type="attachment">D18-1415.Attachment.zip</attachment>
+    <abstract>Reinforcement learning (RL) is an attractive solution for task-oriented dialog systems. However, extending RL-based systems to handle new intents and slots requires a system redesign. The high maintenance cost makes it difficult to apply RL methods to practical systems on a large scale. To address this issue, we propose a practical teacher-student framework to extend RL-based dialog systems without retraining from scratch. Specifically, the ``student'' is an extended dialog manager based on a new ontology, and the ``teacher'' is existing resources used for guiding the learning process of the ``student''. By specifying constraints held in the new dialog manager, we transfer knowledge of the ``teacher'' to the ``student'' without additional resources. Experiments show that the performance of the extended system is comparable to the system trained from scratch.  More importantly, the proposed framework makes no assumption about the unsupported intents and slots, which makes it possible to improve RL-based systems incrementally.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP12</bibkey>
   </paper>
@@ -7328,6 +7743,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3813–3823</pages>
     <url>http://www.aclweb.org/anthology/D18-1416</url>
+    <abstract>This paper presents a Discriminative Deep Dyna-Q (D3Q) approach to improving the effectiveness and robustness of Deep Dyna-Q (DDQ), a recently proposed framework that extends the Dyna-Q algorithm to integrate planning for task-completion dialogue policy learning. To obviate DDQ's high dependency on the quality of simulated experiences, we incorporate an RNN-based discriminator in D3Q to differentiate simulated experience from real user experience in order to control the quality of training data. Experiments show that D3Q significantly outperforms DDQ by controlling the quality of simulated experience used for planning. The effectiveness and robustness of D3Q is further demonstrated in a domain extension setting, where the agent's capability of adapting to a changing environment is tested.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>su-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7344,6 +7760,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3824–3833</pages>
     <url>http://www.aclweb.org/anthology/D18-1417</url>
+    <abstract>Spoken Language Understanding (SLU), which typically involves intent determination and slot filling, is a core component of spoken dialogue systems. Joint learning has shown to be effective in SLU given that slot tags and intents are supposed to share knowledge with each other. However, most existing joint learning methods only consider joint learning by sharing parameters on surface level rather than semantic level. In this work, we propose a novel self-attentive model with gate mechanism to fully utilize the semantic correlation between slot and intent. Our model first obtains intent-augmented embeddings based on neural network with self-attention mechanism. And then the intent semantic representation is utilized as the gate for labelling slot tags. The objectives of both tasks are optimized simultaneously via joint learning in an end-to-end way. We conduct experiment on popular benchmark ATIS. The results show that our model achieves state-of-the-art and outperforms other popular methods by a large margin in terms of both intent detection error rate and slot filling F1-score. This paper gives a new perspective for research on SLU.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-li-qi:2018:EMNLP</bibkey>
   </paper>
@@ -7361,6 +7778,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3834–3843</pages>
     <url>http://www.aclweb.org/anthology/D18-1418</url>
+    <abstract>In a dialog, there could be multiple valid next utterances at any point. The present end-to-end neural methods for dialog do not take this into account. They learn with the assumption that at any time there is only one correct next utterance. In this work, we focus on this problem in the goal-oriented dialog setting where there are different paths to reach a goal. We propose a new method, that uses a combination of supervised learning and reinforcement learning approaches to address this issue. We also propose a new and more effective testbed, permuted-bAbI dialog tasks, by introducing multiple valid next utterances to the original-bAbI dialog tasks, which allows evaluation of end-to-end goal-oriented dialog systems in a more realistic setting. We show that there is a significant drop in performance of existing end-to-end neural methods from 81.5\% per-dialog accuracy on original-bAbI dialog tasks to 30.3\% on permuted-bAbI dialog tasks. We also show that our proposed method improves the performance and achieves 47.3\% per-dialog accuracy on permuted-bAbI dialog tasks. We also release permuted-bAbI dialog tasks, our proposed testbed, to the community for evaluating dialog systems in a goal-oriented setting.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>rajendran-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7378,6 +7796,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3844–3854</pages>
     <url>http://www.aclweb.org/anthology/D18-1419</url>
+    <abstract>Recent progress in dialogue generation has inspired a number of studies on dialogue systems that are capable of accomplishing tasks through natural language interactions. A promising direction among these studies is the use of reinforcement learning techniques, such as self-play, for training dialogue agents. However, current datasets are limited in size, and the environment for training agents and evaluating progress is relatively unsophisticated. We present AirDialogue, a large dataset that contains 301,427 goal-oriented conversations. To collect this dataset, we create a context-generator which provides travel and flight restrictions. We then ask human annotators to play the role of a customer or an agent and interact with the goal of successfully booking a trip given the restrictions. Key to our environment is the ease of evaluating the success of the dialogue, which is achieved by using ground-truth states (e.g., the flight being booked) generated by the restrictions. Any dialogue agent that does not generate the correct states is considered to fail. Our experimental results indicate that state-of-the-art dialogue models can only achieve a score of 0.17 while humans can reach a score of 0.91, which suggests significant opportunities for future improvement.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wei-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7397,6 +7816,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3855–3864</pages>
     <url>http://www.aclweb.org/anthology/D18-1420</url>
+    <abstract>We propose the task of Quantifiable Sequence Editing (QuaSE): editing an input sequence to generate an output sequence that satisfies a given numerical outcome value measuring a certain property of the sequence, with the requirement of keeping the main content of the input sequence. For example, an input sequence could be a word sequence, such as review sentence and advertisement text. For a review sentence, the outcome could be the review rating; for an advertisement, the outcome could be the click-through rate. The major challenge in performing QuaSE is how to perceive the outcome-related wordings, and only edit them to change the outcome. In this paper, the proposed framework contains two latent factors, namely, outcome factor and content factor, disentangled from the input sentence to allow convenient editing to change the outcome and keep the content. Our framework explores the pseudo-parallel sentences by modeling their content similarity and outcome differences to enable a better disentanglement of the latent factors, which allows generating an output to better satisfy the desired outcome and keep the content. The dual reconstruction structure further enhances the capability of generating expected output by exploiting the couplings of latent factors of pseudo-parallel sentences. For evaluation, we prepared a dataset of Yelp review sentences with the ratings as outcome. Extensive experimental results are reported and discussed to elaborate the peculiarities of our framework.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liao-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7414,6 +7834,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3865–3878</pages>
     <url>http://www.aclweb.org/anthology/D18-1421</url>
+    <abstract>Automatic generation of paraphrases from a given sentence is an important yet challenging task in natural language processing (NLP). In this paper, we present a deep reinforcement learning approach to paraphrase generation. Specifically, we propose a new framework for the task, which consists of a generator and an evaluator, both of which are learned from data. The generator, built as a sequence-to-sequence learning model, can produce paraphrases given a sentence. The evaluator, constructed as a deep matching model, can judge whether two sentences are paraphrases of each other. The generator is first trained by deep learning and then further fine-tuned by reinforcement learning in which the reward is given by the evaluator. For the learning of the evaluator, we propose two methods based on supervised learning and inverse reinforcement learning respectively, depending on the type of available training data. Experimental results on two datasets demonstrate the proposed models (the generators) can produce more accurate paraphrases and outperform the state-of-the-art methods in paraphrase generation in both automatic evaluation and human evaluation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP5</bibkey>
   </paper>
@@ -7432,6 +7853,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3879–3889</pages>
     <url>http://www.aclweb.org/anthology/D18-1422</url>
+    <abstract>Recent neural models for data-to-text generation are mostly based on data-driven end-to-end training over encoder-decoder networks. Even though the generated texts are mostly fluent and informative, they often generate descriptions that are not consistent with the input structured data. This is a critical issue especially in domains that require inference or calculations over raw data. In this paper, we attempt to improve the fidelity of neural data-to-text generation by utilizing pre-executed symbolic operations. We propose a framework called Operation-guided Attention-based sequence-to-sequence network (OpAtt), with a specifically designed gating mechanism as well as a quantization module for operation results to utilize information from pre-executed operations. Experiments on two sports datasets show our proposed method clearly improves the fidelity of the generated texts to the input structured data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>nie-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7452,6 +7874,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3890–3900</pages>
     <url>http://www.aclweb.org/anthology/D18-1423</url>
+    <abstract>It is a challenging task to automatically compose poems with not only fluent expressions but also aesthetic wording. Although much attention has been paid to this task and promising progress is made, there exist notable gaps between automatically generated ones with those created by humans, especially on the aspects of term novelty and thematic consistency. Towards filling the gap, in this paper, we propose a conditional variational autoencoder with adversarial training for classical Chinese poem generation, where the autoencoder part generates poems with novel terms and a discriminator is applied to adversarially learn their thematic consistency with their titles. Experimental results on a large poetry corpus confirm the validity and effectiveness of our model, where its automatic and human evaluation scores outperform existing models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP6</bibkey>
   </paper>
@@ -7469,6 +7892,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3901–3910</pages>
     <url>http://www.aclweb.org/anthology/D18-1424</url>
+    <abstract>Question generation, the task of automatically creating questions that can be answered by a certain span of text within a given passage, is important for question-answering and conversational systems in digital assistants such as Alexa, Cortana, Google Assistant and Siri. Recent sequence to sequence neural models have outperformed previous rule-based systems. Existing models mainly focused on using one or two sentences as the input. Long text has posed challenges for sequence to sequence neural models in question generation -- worse performances were reported if using the whole paragraph (with multiple sentences) as the input. In reality, however, it often requires the whole paragraph as context in order to generate high quality questions. In this paper, we propose a maxout pointer mechanism with gated self-attention encoder to address the challenges of processing long text inputs for question generation. With sentence-level inputs, our model outperforms previous approaches with either sentence-level or paragraph-level inputs. Furthermore, our model can effectively utilize paragraphs as inputs, pushing the state-of-the-art result from 13.9 to 16.3 (BLEU\_4).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhao-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -7495,6 +7919,7 @@
     <pages>3911–3921</pages>
     <url>http://www.aclweb.org/anthology/D18-1425</url>
     <attachment type="attachment">D18-1425.Attachment.zip</attachment>
+    <abstract>We present \textit{Spider}, a large-scale complex and cross-domain semantic parsing and text-to-SQL dataset annotated by 11 college students. It consists of 10,181 questions and 5,693 unique complex SQL queries on 200 databases with multiple tables covering 138 different domains. We define a new complex and cross-domain semantic parsing and text-to-SQL task so that different complicated SQL queries and databases appear in train and test sets. In this way, the task requires the model to generalize well to both new SQL queries and new database schemas. Therefore, Spider is distinct from most of the previous semantic parsing tasks because they all use a single database and have the exact same program in the train set and the test set. We experiment with various state-of-the-art models and the best model achieves only 9.7\% exact matching accuracy on a database split setting. This shows that Spider presents a strong challenge for future research. Our dataset and task with the most recent updates are publicly available at \url{https://yale-lily.github.io/seq2sql/spider}.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yu-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -7510,6 +7935,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3922–3929</pages>
     <url>http://www.aclweb.org/anthology/D18-1426</url>
+    <abstract>Generating text from structured data is important for various tasks such as question answering and dialog systems. We show that in at least one domain, without any supervision and only based on unlabeled text, we are able to build a Natural Language Generation (NLG) system with higher performance than supervised approaches. In our approach, we interpret the structured data as a corrupt representation of the desired output and use a denoising auto-encoder to reconstruct the sentence. We show how to introduce noise into training examples that do not contain structured data, and that the resulting denoising auto-encoder generalizes to generate correct sentences when given structured data.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>freitag-roy:2018:EMNLP</bibkey>
   </paper>
@@ -7530,6 +7956,7 @@
     <pages>3930–3939</pages>
     <url>http://www.aclweb.org/anthology/D18-1427</url>
     <attachment type="attachment">D18-1427.Attachment.zip</attachment>
+    <abstract>In this paper, we focus on the problem of question generation (QG). Recent neural network-based approaches employ the sequence-to-sequence model which takes an answer and its context as input and generates a relevant question as output. However, we observe two major issues with these approaches: (1) The generated interrogative words (or question words) do not match the answer type. (2) The model copies the context words that are far from and irrelevant to the answer, instead of the words that are close and relevant to the answer. To address these two issues, we propose an answer-focused and position-aware neural question generation model. (1) By answer-focused, we mean that we explicitly model question word generation by incorporating the answer embedding, which can help generate an interrogative word matching the answer type. (2) By position-aware, we mean that we model the relative distance between the context words and the answer. Hence the model can be aware of the position of the context words when copying them to generate a question. We conduct extensive experiments to examine the effectiveness of our model. The experimental results show that our model significantly improves the baseline and outperforms the state-of-the-art system.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sun-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -7547,6 +7974,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3940–3949</pages>
     <url>http://www.aclweb.org/anthology/D18-1428</url>
+    <abstract>Existing text generation methods tend to produce repeated and ''boring'' expressions. To tackle this problem, we propose a new text generation model, called Diversity-Promoting Generative Adversarial Network (DP-GAN). The proposed model assigns low reward for repeatedly generated text and high reward for ''novel'' and fluent text, encouraging the generator to produce diverse and informative text. Moreover, we propose a novel language-model based discriminator, which can better distinguish novel text from repeated text without the saturation problem compared with existing classifier-based discriminators. The experimental results on review generation and dialogue generation tasks demonstrate that our model can generate substantially more diverse and informative text than existing baselines.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-EtAl:2018:EMNLP5</bibkey>
   </paper>
@@ -7562,6 +7990,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3950–3959</pages>
     <url>http://www.aclweb.org/anthology/D18-1429</url>
+    <abstract>There has always been criticism for using \$n\$-gram based similarity metrics, such as BLEU, NIST, \textit{etc}, for evaluating the performance of NLG systems. However, these metrics continue to remain popular and are recently being used for evaluating the performance of systems which automatically generate questions from documents, knowledge graphs, images, \textit{etc}. Given the rising interest in such automatic question generation (AQG) systems, it is important to objectively examine whether these metrics are suitable for this task. In particular, it is important to verify whether such metrics used for evaluating AQG systems focus on \textit{answerability} of the generated question by preferring questions which contain all relevant information such as question type (Wh-types), entities, relations, \textit{etc}. In this work, we show that current automatic evaluation metrics based on \$n\$-gram similarity do not always correlate well with human judgments about \textit{answerability} of a question. To alleviate this problem and as a first step towards better evaluation metrics for AQG, we introduce a scoring function to capture \textit{answerability} and show that when this scoring function is integrated with existing metrics, they correlate significantly better with human judgments. The scripts and data developed as a part of this work are made publicly available.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>nema-khapra:2018:EMNLP</bibkey>
   </paper>
@@ -7580,6 +8009,7 @@
     <pages>3960–3969</pages>
     <url>http://www.aclweb.org/anthology/D18-1430</url>
     <attachment type="attachment">D18-1430.Attachment.txt</attachment>
+    <abstract>The ability to write diverse poems in different styles under the same poetic imagery is an important characteristic of human poetry writing. Most previous works on automatic Chinese poetry generation focused on improving the coherency among lines. Some work explored style transfer but suffered from expensive expert labeling of poem styles. In this paper, we target on stylistic poetry generation in a fully unsupervised manner for the first time. We propose a novel model which requires no supervised style labeling by incorporating mutual information, a concept in information theory, into modeling. Experimental results show that our model is able to generate stylistic poems without losing fluency and coherency.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -7597,6 +8027,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3970–3980</pages>
     <url>http://www.aclweb.org/anthology/D18-1431</url>
+    <abstract>Neural conversation models tend to generate safe, generic responses for most inputs.  This is due to the limitations of likelihood-based decoding objectives in generation tasks with diverse outputs, such as conversation. To address this challenge, we propose a simple yet effective approach for incorporating side information in the form of distributional constraints over the generated responses.  We propose two constraints that help generate more content rich responses that are based on a model of syntax and topics (Griffiths  et  al.,  2005) and semantic similarity (Arora et al., 2016). We evaluate our approach against a variety of competitive baselines, using both automatic metrics and human judgments, showing that our proposed approach generates responses that are much less generic without sacrificing plausibility. A working demo of our code can be found at \url{https://github.com/abaheti95/DC-NeuralConversation}.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>baheti-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7615,6 +8046,7 @@
     <pages>3981–3991</pages>
     <url>http://www.aclweb.org/anthology/D18-1432</url>
     <attachment type="attachment">D18-1432.Attachment.pdf</attachment>
+    <abstract>We present three enhancements to existing encoder-decoder models for open-domain conversational agents, aimed at effectively modeling coherence and promoting output diversity: (1) We introduce a measure of coherence as the GloVe embedding similarity between the dialogue context and the generated response, (2) we filter our training corpora based on the measure of coherence to obtain topically coherent and lexically diverse context-response pairs, (3) we then train a response generator using a conditional variational autoencoder model that incorporates the measure of coherence as a latent variable and uses a context gate to guarantee topical consistency with the context and promote lexical diversity. Experiments on the OpenSubtitles corpus show a substantial improvement over competitive neural models in terms of BLEU score as well as metrics of coherence and diversity.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-EtAl:2018:EMNLP6</bibkey>
   </paper>
@@ -7633,6 +8065,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>3992–4001</pages>
     <url>http://www.aclweb.org/anthology/D18-1433</url>
+    <abstract>Most previous efforts toward video captioning focus on generating generic descriptions, such as, ``A man is talking.'' We collect a news video dataset to generate enriched descriptions that include important background knowledge, such as named entities and related events, which allows the user to fully understand the video content. We develop an approach that uses video meta-data to retrieve topically related news documents for a video and extracts the events and named entities from these documents. Then, given the video as well as the extracted events and entities, we generate a description using a Knowledge-aware Video Description network. The model learns to incorporate entities found in the topically related documents into the description via an entity pointer network and the generation procedure is guided by the event and entity types from the topically related documents through a knowledge gate, which is a gating mechanism added to the model's decoder that takes a one-hot vector of these types. We evaluate our approach on the new dataset of news videos we have collected, establishing the first benchmark for this dataset as well as proposing a new metric to evaluate these descriptions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>whitehead-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7651,6 +8084,7 @@
     <pages>4002–4012</pages>
     <url>http://www.aclweb.org/anthology/D18-1434</url>
     <attachment type="attachment">D18-1434.Attachment.zip</attachment>
+    <abstract>Generating natural questions from an image is a semantic task that requires using visual and language modality to learn multimodal representations. Images can have multiple visual and language contexts that are relevant for generating questions namely places, captions, and tags. In this paper, we propose the use of exemplars for obtaining the relevant context. We obtain this by using a Multimodal Differential Network to produce natural and engaging questions. The generated questions show a remarkable similarity to the natural questions as validated by a human study. Further, we observe that the proposed approach substantially improves over state-of-the-art benchmarks on the quantitative metrics (BLEU, METEOR, ROUGE, and CIDEr).</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>patro-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7669,6 +8103,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4013–4023</pages>
     <url>http://www.aclweb.org/anthology/D18-1435</url>
+    <abstract>Current image captioning approaches generate descriptions which lack specific information, such as named entities that are involved in the images. In this paper we propose a new task which aims to generate informative image captions, given images and hashtags as in- put. We propose a simple but effective approach to tackle this problem. We first train a convolutional neural networks - long short term memory networks (CNN-LSTM) model to generate a template caption based on the in- put image. Then we use a knowledge graph based collective inference algorithm to fill in the template with specific named entities retrieved via the hashtags. Experiments on a new benchmark dataset collected from Flickr show that our model generates news-style image descriptions with much richer information. Our model outperforms unimodal baselines significantly with various evaluation metrics.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lu-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7684,6 +8119,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4024–4034</pages>
     <url>http://www.aclweb.org/anthology/D18-1436</url>
+    <abstract>In this paper, we introduce the task of automatically generating text to describe the differences between two similar images. We collect a new dataset by crowd-sourcing difference descriptions for pairs of image frames extracted from video-surveillance footage. Annotators were asked to succinctly describe all the differences in a short paragraph. As a result, our novel dataset provides an opportunity to explore models that align language and vision, and capture visual salience. The dataset may also be a useful benchmark for coherent multi-sentence generation. We perform a first-pass visual analysis that exposes clusters of differing pixels as a proxy for object-level differences. We propose a model that captures visual salience by using a latent variable to align clusters of differing pixels with output sentences. We find that, for both single-sentence generation and as well as multi-sentence generation, the proposed model outperforms the models that use attention alone.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>jhamtani-bergkirkpatrick:2018:EMNLP</bibkey>
   </paper>
@@ -7702,6 +8138,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4035–4045</pages>
     <url>http://www.aclweb.org/anthology/D18-1437</url>
+    <abstract>Despite continuously improving performance, contemporary image captioning models are prone to ``hallucinating'' objects that are not actually in a scene. One problem is that standard metrics only measure similarity to ground truth captions and may not fully capture image relevance. In this work, we propose a new image relevance metric to evaluate current models with veridical visual labels and assess their rate of object hallucination. We analyze how captioning model architectures and learning objectives contribute to object hallucination, explore when hallucination is likely due to image misclassification or language priors, and assess how well current sentence metrics capture object hallucination. We investigate these questions on the standard image captioning benchmark, MSCOCO, using a diverse set of models. Our analysis yields several interesting findings, including that models which score best on standard sentence metrics do not always have lower hallucination and that models which hallucinate more tend to make errors driven by language priors.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>rohrbach-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7717,6 +8154,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4046–4056</pages>
     <url>http://www.aclweb.org/anthology/D18-1438</url>
+    <abstract>Rapid growth of multi-modal documents on the Internet makes multi-modal summarization research necessary. Most previous research summarizes texts or images separately. Recent neural summarization research shows the strength of the Encoder-Decoder model in text summarization. This paper proposes an abstractive text-image summarization model using the attentional hierarchical Encoder-Decoder model to summarize a text document and its accompanying images simultaneously, and then to align the sentences and images in summaries. A multi-modal attentional mechanism is proposed to attend original sentences, images, and captions when decoding. The DailyMail dataset is extended by collecting images and captions from the Web.  Experiments show our model outperforms the neural abstractive and extractive text summarization methods that do not consider images. In addition, our model can generate informative summaries of images.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-zhuge:2018:EMNLP</bibkey>
   </paper>
@@ -7735,6 +8173,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4057–4066</pages>
     <url>http://www.aclweb.org/anthology/D18-1439</url>
+    <abstract>In this paper, we study automatic keyphrase generation. Although conventional approaches to this task show promising results, they neglect correlation among keyphrases, resulting in duplication and coverage issues. To solve these problems, we propose a new sequence-to-sequence architecture for keyphrase generation named CorrRNN, which captures correlation among multiple keyphrases in two ways. First, we employ a coverage vector to indicate whether the word in the source document has been summarized by previous phrases to improve the coverage for keyphrases. Second, preceding phrases are taken into account to eliminate duplicate phrases and improve result coherence. Experiment results show that our model significantly outperforms the state-of-the-art method on benchmark datasets in terms of both accuracy and diversity.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP9</bibkey>
   </paper>
@@ -7751,6 +8190,7 @@
     <pages>4067–4077</pages>
     <url>http://www.aclweb.org/anthology/D18-1440</url>
     <attachment type="attachment">D18-1440.Attachment.pdf</attachment>
+    <abstract>A good neural sequence-to-sequence summarization model should have a strong encoder that can distill and memorize the important information from long input texts so that the decoder can generate salient summaries based on the encoder's memory. In this paper, we aim to improve the memorization capabilities of the encoder of a pointer-generator model by adding an additional 'closed-book' decoder without attention and pointer mechanisms. Such a decoder forces the encoder to be more selective in the information encoded in its memory state because the decoder can't rely on the extra information provided by the attention and possibly copy modules, and hence improves the entire model. On the CNN/Daily Mail dataset, our 2-decoder model outperforms the baseline significantly in terms of ROUGE and METEOR metrics, for both cross-entropy and reinforced setups (and on human evaluation). Moreover, our model also achieves higher scores in a test-only DUC-2002 generalizability setup. We further present a memory ability test, two saliency metrics, as well as several sanity-check ablations (based on fixed-encoder, gradient-flow cut, and model capacity) to prove that the encoder of our 2-decoder model does in fact learn stronger memory representations than the baseline encoder.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>jiang-bansal:2018:EMNLP</bibkey>
   </paper>
@@ -7768,6 +8208,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4078–4087</pages>
     <url>http://www.aclweb.org/anthology/D18-1441</url>
+    <abstract>Recent neural sequence-to-sequence models have shown significant progress on short text summarization. However, for document summarization, they fail to capture the long-term structure of both documents and multi-sentence summaries, resulting in information loss and repetitions. In this paper, we propose to leverage the structural information of both documents and multi-sentence summaries to improve the document summarization performance. Specifically, we import both structural-compression and structural-coverage regularization into the summarization process in order to capture the information compression and information coverage properties, which are the two most important structural properties of document summarization. Experimental results demonstrate that the structural regularization improves the document summarization performance significantly, which enables our model to generate more informative and concise summaries, and thus significantly outperforms state-of-the-art neural abstractive methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP7</bibkey>
   </paper>
@@ -7788,6 +8229,7 @@
     <pages>4088–4097</pages>
     <url>http://www.aclweb.org/anthology/D18-1442</url>
     <attachment type="attachment">D18-1442.Attachment.pdf</attachment>
+    <abstract>In this paper, we introduce Iterative Text Summarization (ITS), an iteration-based model for supervised extractive text summarization, inspired by the observation that it is often necessary for a human to read an article multiple times in order to fully understand and summarize its contents. Current summarization approaches read through a document only once to generate a document representation, resulting in a sub-optimal representation. To address this issue we introduce a model which iteratively polishes the document representation on many passes through the document. As part of our model, we also introduce a selective reading mechanism that decides more accurately the extent to which each sentence in the model should be updated. Experimental results on the CNN/DailyMail and DUC2002 datasets demonstrate that our model significantly outperforms state-of-the-art extractive systems when evaluated by machines and by humans.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP10</bibkey>
   </paper>
@@ -7804,6 +8246,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4098–4109</pages>
     <url>http://www.aclweb.org/anthology/D18-1443</url>
+    <abstract>Neural summarization produces outputs that are fluent and readable, but which can be poor at content selection, for instance often copying full sentences from the source document. This work explores the use of data-efficient content selectors to over-determine phrases in a source document that should be part of the summary. We use this selector as a bottom-up attention step to constrain the model to likely phrases. We show that this approach improves the ability to compress text, while still generating fluent summaries. This two-step process is both simpler and higher performing than other end-to-end content selection models, leading to significant improvements on ROUGE for both the  CNN-DM and NYT corpus. Furthermore, the content selector can be trained with as little as 1,000 sentences making it easy to transfer a trained summarizer to a new domain.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gehrmann-deng-rush:2018:EMNLP</bibkey>
   </paper>
@@ -7820,6 +8263,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4110–4119</pages>
     <url>http://www.aclweb.org/anthology/D18-1444</url>
+    <abstract>Convolutional neural networks (CNNs) have met great success in abstractive summarization, but they cannot effectively generate summaries of desired lengths. Because generated summaries are used in difference scenarios which may have space or length constraints, the ability to control the summary length in abstractive summarization is an important problem. In this paper, we propose an approach to constrain the summary length by extending a convolutional sequence to sequence model. The results show that this approach generates high-quality summaries with user defined length, and outperforms the baselines consistently in terms of ROUGE score, length variations and semantic similarity.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu-luo-zhu:2018:EMNLP</bibkey>
   </paper>
@@ -7837,6 +8281,7 @@
     <pages>4120–4130</pages>
     <url>http://www.aclweb.org/anthology/D18-1445</url>
     <attachment type="attachment">D18-1445.Attachment.zip</attachment>
+    <abstract>We propose a method to perform automatic document summarisation without using reference summaries. Instead, our method interactively learns from users' preferences. The merit of preference-based interactive summarisation is that preferences are easier for users to provide than reference summaries. Existing preference-based interactive learning methods suffer from high sample complexity, i.e. they need to interact with the oracle for many rounds in order to converge. In this work, we propose a new objective function, which enables us to leverage active learning, preference learning and reinforcement learning techniques in order to reduce the sample complexity. Both simulation and real-user experiments suggest that our method significantly advances the state of the art. Our source code is freely available at https://github.com/UKPLab/ emnlp2018-april.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gao-meyer-gurevych:2018:EMNLP</bibkey>
   </paper>
@@ -7853,6 +8298,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4131–4141</pages>
     <url>http://www.aclweb.org/anthology/D18-1446</url>
+    <abstract>Generating a text abstract from a set of documents remains a challenging task. The neural encoder-decoder framework has recently been exploited to summarize single documents, but its success can in part be attributed to the availability of large parallel data automatically acquired from the Web. In contrast, parallel data for multi-document summarization are scarce and costly to obtain. There is a pressing need to adapt an encoder-decoder model trained on single-document summarization data to work with multiple-document input. In this paper, we present an initial investigation into a novel adaptation method. It exploits the maximal marginal relevance method to select representative sentences from multi-document input, and leverages an abstractive encoder-decoder model to fuse disparate sentences to an abstractive summary. The adaptation method is robust and itself requires no training data. Our system compares favorably to state-of-the-art extractive and abstractive approaches judged by automatic metrics and human assessors.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lebanoff-song-liu:2018:EMNLP</bibkey>
   </paper>
@@ -7868,6 +8314,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4142–4153</pages>
     <url>http://www.aclweb.org/anthology/D18-1447</url>
+    <abstract>We study the problem of generating keyphrases that summarize the key points for a given document. While sequence-to-sequence (seq2seq) models have achieved remarkable performance on this task (Meng et al., 2017), model training often relies on large amounts of labeled data, which is only applicable to resource-rich domains. In this paper, we propose semi-supervised keyphrase generation methods by leveraging both labeled data and large-scale unlabeled samples for learning. Two strategies are proposed. First, unlabeled documents are first tagged with synthetic keyphrases obtained from unsupervised keyphrase extraction methods or a self-learning algorithm, and then combined with labeled samples for training. Furthermore, we investigate a multi-task learning framework to jointly learn to generate keyphrases as well as the titles of the articles. Experimental results show that our semi-supervised learning-based methods outperform a state-of-the-art model trained with labeled data only.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ye-wang:2018:EMNLP</bibkey>
   </paper>
@@ -7888,6 +8335,7 @@
     <pages>4154–4164</pages>
     <url>http://www.aclweb.org/anthology/D18-1448</url>
     <attachment type="attachment">D18-1448.Attachment.zip</attachment>
+    <abstract>Multimodal summarization has drawn much attention due to the rapid growth of multimedia data. The output of the current multimodal summarization systems is usually represented in texts. However, we have found through experiments that multimodal output can significantly improve user satisfaction for informativeness of summaries. In this paper, we propose a novel task, multimodal summarization with multimodal output (MSMO). To handle this task, we first collect a large-scale dataset for MSMO research. We then propose a multimodal attention model to jointly generate text and select the most relevant image from the multimodal input. Finally, to evaluate multimodal outputs, we construct a novel multimodal automatic evaluation (MMAE) method which considers both intra-modality salience and inter-modality relevance. The experimental results show the effectiveness of MMAE.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhu-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -7903,6 +8351,7 @@
     <pages>4165–4176</pages>
     <url>http://www.aclweb.org/anthology/D18-1449</url>
     <attachment type="attachment">D18-1449.Attachment.pdf</attachment>
+    <abstract>Ensemble methods, which combine multiple models at decoding time, are now widely known to be effective for text-generation tasks. However, they generally increase computational costs, and thus, there have been many studies on compressing or distilling ensemble models. In this paper, we propose an alternative, simple but effective unsupervised ensemble method, {\em post-ensemble}, that combines multiple models by selecting a majority-like output in post-processing. We theoretically prove that our method is closely related to kernel density estimation based on the von Mises-Fisher kernel. Experimental results on a news-headline-generation task show that the proposed method performs better than the current ensemble methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kobayashi:2018:EMNLP</bibkey>
   </paper>
@@ -7919,6 +8368,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4177–4186</pages>
     <url>http://www.aclweb.org/anthology/D18-1450</url>
+    <abstract>This paper tackles automation of the pyramid method, a reliable manual evaluation framework. To construct a pyramid, we transform human-made reference summaries into extractive reference summaries that consist of Elementary Discourse Units (EDUs) obtained from source documents and then weight every EDU by counting the number of extractive reference summaries that contain the EDU. A summary is scored by the correspondences between EDUs in the summary and those in the pyramid. Experiments on DUC and TAC data sets show that our methods strongly correlate with various manual evaluations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hirao-kamigaito-nagata:2018:EMNLP</bibkey>
   </paper>
@@ -7935,6 +8385,7 @@
     <pages>4187–4195</pages>
     <url>http://www.aclweb.org/anthology/D18-1451</url>
     <attachment type="attachment">D18-1451.Attachment.pdf</attachment>
+    <abstract>Auto-encoders compress input data into a latent-space representation and reconstruct the original data from the representation. This latent representation is not easily interpreted by humans. In this paper, we propose training an auto-encoder that encodes input text into human-readable sentences, and unpaired abstractive summarization is thereby achieved. The auto-encoder is composed of a generator and a reconstructor. The generator encodes the input text into a shorter word sequence, and the reconstructor recovers the generator input from the generator output. To make the generator output human-readable, a discriminator restricts the output of the generator to resemble human-written sentences. By taking the generator output as the summary of the input text, abstractive summarization is achieved without document-summary pairs as training data. Promising results are shown on both English and Chinese corpora.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-lee:2018:EMNLP</bibkey>
   </paper>
@@ -7951,6 +8402,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4196–4207</pages>
     <url>http://www.aclweb.org/anthology/D18-1452</url>
+    <abstract>We address jointly two important tasks for Question Answering in community forums: given a new question, (i) find related existing questions, and (ii) find relevant answers to this new question. We further use an auxiliary task to complement the previous two, i.e., (iii) find good answers with respect to the thread question in a question-comment thread. We use deep neural networks (DNNs) to learn meaningful task-specific embeddings, which we then incorporate into a conditional random field (CRF) model for the multitask setting, performing joint learning over a complex graph structure. While DNNs alone achieve competitive results when trained to produce the embeddings, the CRF, which makes use of the embeddings and the dependencies between the tasks, improves the results significantly and consistently across a variety of evaluation metrics, thus showing the complementarity of DNNs and structured learning.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>joty-mrquez-nakov:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306149753" tag="video" />
@@ -7969,6 +8421,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4208–4219</pages>
     <url>http://www.aclweb.org/anthology/D18-1453</url>
+    <abstract>A challenge in creating a dataset for machine reading comprehension (MRC) is to collect questions that require a sophisticated understanding of language to answer beyond using superficial cues. In this work, we investigate what makes questions easier across recent 12 MRC datasets with three question styles (answer extraction, description, and multiple choice). We propose to employ simple heuristics to split each dataset into easy and hard subsets and examine the performance of two baseline models for each of the subsets. We then manually annotate questions sampled from each subset with both validity and requisite reasoning skills to investigate which skills explain the difference between easy and hard questions. From this study, we observed that (i) the baseline performances for the hard subsets remarkably degrade compared to those of entire datasets, (ii) hard questions require knowledge inference and multiple-sentence reasoning in comparison with easy questions, and (iii) multiple-choice questions tend to require a broader range of reasoning skills than answer extraction and description questions. These results suggest that one might overestimate recent advances in MRC.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sugawara-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306150555" tag="video" />
@@ -7987,6 +8440,7 @@
     <pages>4220–4230</pages>
     <url>http://www.aclweb.org/anthology/D18-1454</url>
     <attachment type="attachment">D18-1454.Attachment.pdf</attachment>
+    <abstract>Reading comprehension QA tasks have seen a recent surge in popularity, yet most works have focused on fact-finding extractive QA. We instead focus on a more challenging multi-hop generative task (NarrativeQA), which requires the model to reason, gather, and synthesize disjoint pieces of information within the context to generate an answer. This type of multi-step reasoning also often requires understanding implicit relations, which humans resolve via external, background commonsense knowledge. We first present a strong generative baseline that uses a multi-attention mechanism to perform multiple hops of reasoning and a pointer-generator decoder to synthesize the answer. This model performs substantially better than previous generative models, and is competitive with current state-of-the-art span prediction models. We next introduce a novel system for selecting grounded multi-hop relational commonsense information from ConceptNet via a pointwise mutual information and term-frequency based scoring function. Finally, we effectively use this extracted commonsense information to fill in gaps of reasoning between context hops, using a selectively-gated attention mechanism. This boosts the model's performance significantly (also verified via human evaluation), establishing a new state-of-the-art for the task. We also show that our background knowledge enhancements are generalizable and improve performance on QAngaroo-WikiHop, another multi-hop reasoning dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>bauer-wang-bansal:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306151626" tag="video" />
@@ -8007,6 +8461,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4231–4242</pages>
     <url>http://www.aclweb.org/anthology/D18-1455</url>
+    <abstract>Open Domain Question Answering (QA) is evolving from complex pipelined systems to end-to-end deep neural networks. Specialized neural models have been developed for extracting answers from either text alone or Knowledge Bases (KBs) alone. In this paper we look at a more practical setting, namely QA over the combination of a KB and entity-linked text, which is appropriate when an incomplete KB is available with a large text corpus. Building on recent advances in graph representation learning we propose a novel model, GRAFT-Net, for extracting answers from a question-specific subgraph containing text and KB entities and relations. We construct a suite of benchmark tasks for this problem, varying the difficulty of questions, the amount of training data, and KB completeness. We show that GRAFT-Net is competitive with the state-of-the-art when tested using either KBs or text alone, and vastly outperforms existing methods in the combined setting.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sun-EtAl:2018:EMNLP3</bibkey>
     <video href="https://vimeo.com/306152381" tag="video" />
@@ -8023,6 +8478,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4243–4252</pages>
     <url>http://www.aclweb.org/anthology/D18-1456</url>
+    <abstract>Recently, there has been a surge of interest in reading comprehension-based (RC) question answering (QA). However, current approaches suffer from an impractical assumption that every question has a valid answer in the associated passage. A practical QA system must possess the ability to determine whether a valid answer exists in a given text passage. In this paper, we focus on developing QA systems that can extract an answer for a question if and only if the associated passage contains an answer. If the associated passage does not contain any valid answer, the QA system will correctly return Nil. We propose a novel nil-aware answer span extraction framework that is capable of returning Nil or a text span from the associated passage as an answer in a single step. We show that our proposed framework can be easily integrated with several recently proposed QA models developed for reading comprehension and can be trained in an end-to-end fashion. Our proposed nil-aware answer extraction neural network decomposes pieces of evidence into relevant and irrelevant parts and then combines them to infer the existence of any answer. Experiments on the NewsQA dataset show that the integration of our proposed framework significantly outperforms several strong baseline systems that use pipeline or threshold-based approaches.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kundu-ng:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306152896" tag="video" />
@@ -8042,6 +8498,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4253–4262</pages>
     <url>http://www.aclweb.org/anthology/D18-1457</url>
+    <abstract>Advanced neural machine translation (NMT) models generally implement encoder and decoder as multiple layers, which allows systems to model complex functions and capture complicated linguistic structures. However, only the top layers of encoder and decoder are leveraged in the subsequent process, which misses the opportunity to exploit the useful information embedded in other layers. In this work, we propose to simultaneously expose all of these signals with layer aggregation and multi-layer attention mechanisms. In addition, we introduce an auxiliary regularization term to encourage different layers to capture diverse information. Experimental results on widely-used WMT14 English-German and WMT17 Chinese-English translation data demonstrate the effectiveness and universality of the proposed approach.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>dou-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306130778" tag="video" />
@@ -8060,6 +8517,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4263–4272</pages>
     <url>http://www.aclweb.org/anthology/D18-1458</url>
+    <abstract>Recently, non-recurrent architectures (convolutional, self-attentional) have outperformed RNNs in neural machine translation. CNNs and self-attentional networks can connect distant words via shorter network paths than RNNs, and it has been speculated that this improves their ability to model long-range dependencies. However, this theoretical argument has not been tested empirically, nor have alternative explanations for their strong performance been explored in-depth. We hypothesize that the strong performance of CNNs and self-attentional networks could also be due to their ability to extract semantic features from the source text, and we evaluate RNNs, CNNs and self-attention networks on two tasks: subject-verb agreement (where capturing long-range dependencies is required) and word sense disambiguation (where semantic feature extraction is required). Our experimental results show that: 1) self-attentional networks and CNNs do not outperform RNNs in modeling subject-verb agreement over long distances; 2) self-attentional networks perform distinctly better than RNNs and CNNs on word sense disambiguation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tang-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306131741" tag="video" />
@@ -8080,6 +8538,7 @@
     <pages>4273–4283</pages>
     <url>http://www.aclweb.org/anthology/D18-1459</url>
     <attachment type="attachment">D18-1459.Attachment.zip</attachment>
+    <abstract>In this paper, we propose an additionsubtraction twin-gated recurrent network (ATR) to simplify neural machine translation. The recurrent units of ATR are heavily simplified to have the smallest number of weight matrices among units of all existing gated RNNs. With the simple addition and subtraction operation, we introduce a twin-gated mechanism to build input and forget gates which are highly correlated. Despite this simplification, the essential non-linearities and capability of modeling long-distance dependencies are preserved. Additionally, the proposed ATR is more transparent than LSTM/GRU due to the simplification. Forward self-attention can be easily established in ATR, which makes the proposed network interpretable. Experiments on WMT14 translation tasks demonstrate that ATR-based neural machine translation can yield competitive performance on English-German and English-French language pairs in terms of both translation quality and speed. Further experiments on NIST Chinese-English translation, natural language inference and Chinese word segmentation verify the generality and applicability of ATR on different natural language processing tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP11</bibkey>
     <video href="https://vimeo.com/306132998" tag="video" />
@@ -8099,6 +8558,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4284–4294</pages>
     <url>http://www.aclweb.org/anthology/D18-1460</url>
+    <abstract>Although neural machine translation has achieved promising results, it suffers from slow translation speed. The direct consequence is that a trade-off has to be made between translation quality and speed, thus its performance can not come into full play. We apply cube pruning, a popular technique to speed up dynamic programming, into neural machine translation to speed up the translation. To construct the equivalence class, similar target hidden states are combined, leading to less RNN expansion operations on the target side and less softmax operations over the large target vocabulary. The experiments show that, at the same or even better translation quality, our method can translate faster compared with naive beam search by 3.3x on GPUs and 3.5x on CPUs.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP12</bibkey>
     <video href="https://vimeo.com/306134160" tag="video" />
@@ -8118,6 +8578,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4295–4305</pages>
     <url>http://www.aclweb.org/anthology/D18-1461</url>
+    <abstract>Translating characters instead of words or word-fragments has the potential to simplify the processing pipeline for neural machine translation (NMT), and improve results by eliminating hyper-parameters and manual feature engineering. However, it results in longer sequences in which each symbol contains less information, creating both modeling and computational challenges. In this paper, we show that the modeling problem can be solved by standard sequence-to-sequence architectures of sufficient depth, and that deep models operating at the character level outperform identical models operating over word fragments. This result implies that alternative architectures for handling character input are better viewed as methods for reducing computation time than as improved ways of modeling longer sequences. From this perspective, we evaluate several techniques for character-level NMT, verify that they do not match the performance of our deep character baseline model, and evaluate the performance versus computation time tradeoffs they offer. Within this framework, we also perform the first evaluation for NMT of conditional computation over time, in which the model learns which timesteps can be skipped, rather than having them be dictated by a fixed schedule specified before training begins.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>cherry-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306134793" tag="video" />
@@ -8138,6 +8599,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4306–4315</pages>
     <url>http://www.aclweb.org/anthology/D18-1462</url>
+    <abstract>Narrative story generation is a challenging problem because it demands the generated sentences with tight semantic connections, which has not been well studied by most existing generative models. To address this problem, we propose a  skeleton-based model to promote the coherence of generated stories. Different from traditional models that generate a complete sentence at a stroke, the proposed model first generates the most critical phrases, called skeleton, and then expands the skeleton to a complete and fluent sentence. The skeleton is not manually defined, but learned by a reinforcement learning method. Compared to the state-of-the-art models, our skeleton-based model  can generate significantly more coherent text according to human evaluation and automatic evaluation. The G-score is improved by 20.1\% in human evaluation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-EtAl:2018:EMNLP7</bibkey>
     <video href="https://vimeo.com/306161720" tag="video" />
@@ -8157,6 +8619,7 @@
     <pages>4316–4327</pages>
     <url>http://www.aclweb.org/anthology/D18-1463</url>
     <attachment type="attachment">D18-1463.Attachment.pdf</attachment>
+    <abstract>Sequence-to-Sequence (seq2seq) models have become overwhelmingly popular in building end-to-end trainable dialogue systems. Though highly efficient in learning the backbone of human-computer communications, they suffer from the problem of strongly favoring short generic responses. In this paper, we argue that a good response should smoothly connect both the preceding dialogue history and the following conversations. We strengthen this connection by mutual information maximization. To sidestep the non-differentiability of discrete natural language tokens, we introduce an auxiliary continuous code space and map such code space to a learnable prior distribution for generation purpose. Experiments on two dialogue datasets validate the effectiveness of our model, where the generated responses are closely related to the dialogue context and lead to more interactive conversations.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shen-EtAl:2018:EMNLP4</bibkey>
     <video href="https://vimeo.com/306163081" tag="video" />
@@ -8174,6 +8637,7 @@
     <pages>4328–4339</pages>
     <url>http://www.aclweb.org/anthology/D18-1464</url>
     <attachment type="attachment">D18-1464.Attachment.pdf</attachment>
+    <abstract>We propose a local coherence model that captures the flow of what semantically connects adjacent sentences in a text. We represent the semantics of a sentence by a vector and capture its state at each word of the sentence. We model what relates two adjacent sentences based on the two most similar semantic states, each of which is in one of the sentences. We encode the perceived coherence of a text by a vector, which represents patterns of changes in salient information that relates adjacent sentences. Our experiments demonstrate that our approach is beneficial for two downstream tasks: Readability assessment, in which our model achieves new state-of-the-art results; and essay scoring, in which the combination of our coherence vectors and other task-dependent features significantly improves the performance of a strong essay scorer.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mesgar-strube:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306164201" tag="video" />
@@ -8192,6 +8656,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4340–4349</pages>
     <url>http://www.aclweb.org/anthology/D18-1465</url>
+    <abstract>In this paper, we propose a novel deep attentive sentence ordering network (referred as ATTOrderNet) which integrates self-attention mechanism with LSTMs in the encoding of input sentences. It enables us to capture global dependencies among sentences regardless of their input order and obtains a reliable representation of the sentence set. With this representation, a pointer network is exploited to generate an ordered sequence. The proposed model is evaluated on Sentence Ordering and Order Discrimination tasks. The extensive experimental results demonstrate its effectiveness and superiority to the state-of-the-art methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>cui-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306165142" tag="video" />
@@ -8210,6 +8675,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4350–4359</pages>
     <url>http://www.aclweb.org/anthology/D18-1466</url>
+    <abstract>When a reader is first introduced to an entity, its referring expression must describe the entity. For entities that are widely known, a single word or phrase often suffices. This paper presents the first study of how expressions that refer to the same entity develop over time. We track thousands of person and organization entities over 20 years of New York Times (NYT). As entities move from hearer-new (first introduction to the NYT audience) to hearer-old (common knowledge) status, we show empirically that the referring expressions along this trajectory depend on the type of the entity, and exhibit linguistic properties related to becoming common knowledge (e.g., shorter length, less use of appositives, more definiteness). These properties can also be used to build a model to predict how long it will take for an entity to reach hearer-old status. Our results reach 10-30\% absolute improvement over a majority-class baseline.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>stalinait-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306166016" tag="video" />
@@ -8226,6 +8692,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4360–4370</pages>
     <url>http://www.aclweb.org/anthology/D18-1467</url>
+    <abstract>In an online community, new words come and go: today's ``haha'' may be replaced by tomorrow's ``lol.'' Changes in online writing are usually studied as a social process, with innovations diffusing through a network of individuals in a speech community. But unlike other types of innovation, language change is shaped and constrained by the grammatical system in which it takes part. To investigate the role of social and structural factors in language change, we undertake a large-scale analysis of the frequencies of non-standard words in Reddit. Dissemination across many linguistic contexts is a predictor of success: words that appear in more linguistic contexts grow faster and survive longer. Furthermore, social dissemination plays a less important role in explaining word growth and decline than previously hypothesized.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>stewart-eisenstein:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306120421" tag="video" />
@@ -8242,6 +8709,7 @@
     <pages>4371–4382</pages>
     <url>http://www.aclweb.org/anthology/D18-1468</url>
     <attachment type="attachment">D18-1468.Attachment.pdf</attachment>
+    <abstract>Statistical phylogenetic models have allowed the quantitative analysis of the evolution of a single categorical feature and a pair of binary features, but correlated evolution involving multiple discrete features is yet to be explored. Here we propose latent representation-based analysis in which (1) a sequence of discrete surface features is projected to a sequence of independent binary variables and (2) phylogenetic inference is performed on the latent space. In the experiments, we analyze the features of linguistic typology, with a special focus on the order of subject, object and verb. Our analysis suggests that languages sharing the same word order are not necessarily a coherent group but exhibit varying degrees of diachronic stability depending on other features.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>murawaki:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306121200" tag="video" />
@@ -8258,6 +8726,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4383–4394</pages>
     <url>http://www.aclweb.org/anthology/D18-1469</url>
+    <abstract>Dialects are one of the main drivers of language variation, a major challenge for natural language processing tools. In most languages, dialects exist along a continuum, and are commonly discretized by combining the extent of several preselected linguistic variables. However, the selection of these variables is theory-driven and itself insensitive to change. We use Doc2Vec on a corpus of 16.8M anonymous online posts in the German-speaking area to learn continuous document representations of cities. These representations capture continuous regional linguistic distinctions, and can serve as input to downstream NLP tasks sensitive to regional variation. By incorporating geographic information via retrofitting and agglomerative clustering with structure, we recover dialect areas at various levels of granularity. Evaluating these clusters against an existing dialect map, we achieve a match of up to 0.77 V-score (harmonic mean of cluster completeness and homogeneity). Our results show that representation learning with retrofitting offers a robust general method to automatically expose dialectal differences and regional variation at a finer granularity than was previously possible.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>hovy-purschke:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306121832" tag="video" />
@@ -8275,6 +8744,7 @@
     <pages>4395–4404</pages>
     <url>http://www.aclweb.org/anthology/D18-1470</url>
     <attachment type="attachment">D18-1470.Attachment.pdf</attachment>
+    <abstract>This paper presents a set of dimensions to characterize the association between two people. We distinguish between interactions (when somebody refers to somebody in a conversation) and relationships (a sequence of interactions). We work with dialogue scripts from the TV show Friends, and do not impose any restrictions on the interactions and relationships. We introduce and analyze a new corpus, and present experimental results showing that the task can be automated.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>rashid-blanco:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306122681" tag="video" />
@@ -8294,6 +8764,7 @@
     <pages>4405–4414</pages>
     <url>http://www.aclweb.org/anthology/D18-1471</url>
     <attachment type="attachment">D18-1471.Attachment.zip</attachment>
+    <abstract>Vulgar words are employed in language use for several different functions, ranging from expressing aggression to signaling group identity or the informality of the communication. This versatility of usage of a restricted set of words is challenging for downstream applications and has yet to be studied quantitatively or using natural language processing techniques. We introduce a novel data set of 7,800 tweets from users with known demographic traits where all instances of vulgar words are annotated with one of the six categories of vulgar word use. Using this data set, we present the first analysis of the pragmatic aspects of vulgarity and how they relate to social factors. We build a model able to predict the category of a vulgar word based on the immediate context it appears in with 67.4 macro F1 across six classes. Finally, we demonstrate the utility of modeling the type of vulgar word use in context by using this information to achieve state-of-the-art performance in hate speech detection on a benchmark data set.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>holgate-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306123618" tag="video" />
@@ -8312,6 +8783,7 @@
     <pages>4415–4424</pages>
     <url>http://www.aclweb.org/anthology/D18-1472</url>
     <attachment type="attachment">D18-1472.Attachment.zip</attachment>
+    <abstract>Activation functions play a crucial role in neural networks because they are the nonlinearities which have been attributed to the success story of deep learning. One of the currently most popular activation functions is ReLU, but several competitors have recently been proposed or ‘discovered', including LReLU functions and swish. While most works compare newly proposed activation functions on few tasks (usually from image classification) and against few competitors (usually ReLU), we perform the first largescale comparison of 21 activation functions across eight different NLP tasks. We find that a largely unknown activation function performs most stably across all tasks, the so-called penalized tanh function. We also show that it can successfully replace the sigmoid and tanh gates in LSTM cells, leading to a 2 percentage point (pp) improvement over the standard choices on a challenging NLP task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>eger-youssef-gurevych:2018:EMNLP</bibkey>
   </paper>
@@ -8328,6 +8800,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4425–4438</pages>
     <url>http://www.aclweb.org/anthology/D18-1473</url>
+    <abstract>Character-level string-to-string transduction is an important component of various NLP tasks. The goal is to map an input string to an output string, where the strings may be of different lengths and have characters taken from different alphabets. Recent approaches have used sequence-to-sequence models with an attention mechanism to learn which parts of the input string the model should focus on during the generation of the output string. Both soft attention and hard monotonic attention have been used, but hard non-monotonic attention has only been used in other sequence modeling tasks and has required a stochastic approximation to compute the gradient. In this work, we introduce an exact, polynomial-time algorithm for marginalizing over the exponential number of non-monotonic alignments between two strings, showing that hard attention models can be viewed as neural reparameterizations of the classical IBM Model 1. We compare soft and hard non-monotonic attention experimentally and find that the exact algorithm significantly improves performance over the stochastic approximation and outperforms soft attention.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wu-shapiro-cotterell:2018:EMNLP</bibkey>
   </paper>
@@ -8343,6 +8816,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4439–4448</pages>
     <url>http://www.aclweb.org/anthology/D18-1474</url>
+    <abstract>We present LSTM-Shuttle, which applies human speed reading techniques to natural language processing tasks for accurate and efficient comprehension. In contrast to previous work, LSTM-Shuttle not only reads shuttling forward but also goes back. Shuttling forward enables high efficiency, and going backward gives the model a chance to recover lost information, ensuring better prediction. We evaluate LSTM-Shuttle on sentiment analysis, news classification, and cloze on IMDB, Rotten Tomatoes, AG, and Children's Book Test datasets. We show that LSTM-Shuttle predicts both better and more quickly. To demonstrate how LSTM-Shuttle actually behaves, we also analyze the shuttling operation and present a case study.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>fu-ma:2018:EMNLP</bibkey>
   </paper>
@@ -8362,6 +8836,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4449–4458</pages>
     <url>http://www.aclweb.org/anthology/D18-1475</url>
+    <abstract>Self-attention networks have proven to be of profound value for its strength of capturing global dependencies. In this work, we propose to model localness for self-attention networks, which enhances the ability of capturing useful local context. We cast localness modeling as a learnable Gaussian bias, which indicates the central and scope of the local region to be paid more attention. The bias is then incorporated into the original attention distribution to form a revised distribution. To maintain the strength of capturing long distance dependencies while enhance the ability of capturing short-range dependencies, we only apply localness modeling to lower layers of self-attention networks. Quantitative and qualitative analyses on Chinese-English and English-German translation tasks demonstrate the effectiveness and universality of the proposed approach.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yang-EtAl:2018:EMNLP5</bibkey>
   </paper>
@@ -8382,6 +8857,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4459–4469</pages>
     <url>http://www.aclweb.org/anthology/D18-1476</url>
+    <abstract>We introduce a novel type of text representation that preserves the 2D layout of a document. This is achieved by encoding each document page as a two-dimensional grid of characters. Based on this representation, we present a generic document understanding pipeline for structured documents. This pipeline makes use of a fully convolutional encoder-decoder network that predicts a segmentation mask and bounding boxes. We demonstrate its capabilities on an information extraction task from invoices and show that it significantly outperforms approaches based on sequential text or document images.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>katti-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -8401,6 +8877,7 @@
     <pages>4470–4481</pages>
     <url>http://www.aclweb.org/anthology/D18-1477</url>
     <attachment type="attachment">D18-1477.Attachment.pdf</attachment>
+    <abstract>Common recurrent neural architectures scale poorly due to the intrinsic difficulty in parallelizing their state computations. In this work, we propose the Simple Recurrent Unit (SRU), a light recurrent unit that balances model capacity and scalability. SRU is designed to provide expressive recurrence, enable highly parallelized implementation, and comes with careful initialization to facilitate training of deep models. We demonstrate the effectiveness of SRU on multiple NLP tasks. SRU achieves 5---9x speed-up over cuDNN-optimized LSTM on classification and question answering datasets, and delivers stronger results than LSTM and convolutional models. We also obtain an average of 0.7 BLEU improvement over the Transformer model (Vaswani et al., 2017) on translation by incorporating SRU into the architecture.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lei-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -8422,6 +8899,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4482–4491</pages>
     <url>http://www.aclweb.org/anthology/D18-1478</url>
+    <abstract>Pseudo relevance feedback (PRF) is commonly used to boost the performance of traditional information retrieval (IR) models by using top-ranked documents to identify and weight new query terms, thereby reducing the effect of query-document vocabulary mismatches. While neural retrieval models have recently demonstrated strong results for ad-hoc retrieval, combining them with PRF is not straightforward due to incompatibilities between existing PRF approaches and neural architectures. To bridge this gap, we propose an end-to-end neural PRF framework that can be used with existing neural IR models by embedding different neural models as building blocks. Extensive experiments on two standard test collections confirm the effectiveness of the proposed NPRF framework in improving the performance of two state-of-the-art neural IR models.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP8</bibkey>
   </paper>
@@ -8438,6 +8916,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4492–4502</pages>
     <url>http://www.aclweb.org/anthology/D18-1479</url>
+    <abstract>Learning a matching function between two text sequences is a long standing problem in NLP research. This task enables many potential applications such as question answering and paraphrase identification. This paper proposes Co-Stack Residual Affinity Networks (CSRAN), a new and universal neural architecture for this problem. CSRAN is a deep architecture, involving stacked (multi-layered) recurrent encoders. Stacked/Deep architectures are traditionally difficult to train, due to the inherent weaknesses such as difficulty with feature propagation and vanishing gradients. CSRAN incorporates two novel components to take advantage of the stacked architecture. Firstly, it introduces a new bidirectional alignment mechanism that learns affinity weights by fusing sequence pairs across stacked hierarchies. Secondly, it leverages a multi-level attention refinement component between stacked recurrent layers. The key intuition is that, by leveraging information across all network hierarchies, we can not only improve gradient flow but also improve overall performance. We conduct extensive experiments on six well-studied text sequence matching datasets, achieving state-of-the-art performance on all.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tay-luu-hui:2018:EMNLP3</bibkey>
   </paper>
@@ -8453,6 +8932,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4503–4513</pages>
     <url>http://www.aclweb.org/anthology/D18-1480</url>
+    <abstract>A hallmark of variational autoencoders (VAEs) for text processing is their combination of powerful encoder-decoder models, such as LSTMs, with simple latent distributions, typically multivariate Gaussians. These models pose a difficult optimization problem: there is an especially bad local optimum where the variational posterior always equals the prior and the model does not use the latent variable at all, a kind of ``collapse'' which is encouraged by the KL divergence term of the objective. In this work, we experiment with another choice of latent distribution, namely the von Mises-Fisher (vMF) distribution, which places mass on the surface of the unit hypersphere. With this choice of prior and posterior, the KL divergence term now only depends on the variance of the vMF distribution, giving us the ability to treat it as a fixed hyperparameter. We show that doing so not only averts the KL collapse, but consistently gives better likelihoods than Gaussians across a range of modeling conditions, including recurrent language modeling and bag-of-words document modeling. An analysis of the properties of our vMF representations shows that they learn richer and more nuanced structures in their latent representations than their Gaussian counterparts.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu-durrett:2018:EMNLP</bibkey>
   </paper>
@@ -8470,6 +8950,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4514–4523</pages>
     <url>http://www.aclweb.org/anthology/D18-1481</url>
+    <abstract>In order to learn universal sentence representations, previous methods focus on complex recurrent neural networks or supervised learning. In this paper, we propose a mean-max attention autoencoder (mean-max AAE) within the encoder-decoder framework. Our autoencoder rely entirely on the MultiHead self-attention mechanism to reconstruct the input sequence. In the encoding we propose a mean-max strategy that applies both mean and max pooling operations over the hidden vectors to capture diverse information of the input. To enable the information to steer the reconstruction process dynamically, the decoder performs attention over the mean-max representation. By training our model on a large collection of unlabelled data, we obtain high-quality representations of sentences. Experimental results on a broad range of 10 transfer tasks demonstrate that our model outperforms the state-of-the-art unsupervised single methods, including the classical skip-thoughts and the advanced skip-thoughts+LN model. Furthermore, compared with the traditional recurrent neural network, our mean-max AAE greatly reduce the training time.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP13</bibkey>
   </paper>
@@ -8492,6 +8973,7 @@
     <pages>4524–4534</pages>
     <url>http://www.aclweb.org/anthology/D18-1482</url>
     <attachment type="attachment">D18-1482.Attachment.zip</attachment>
+    <abstract>While the celebrated Word2Vec technique yields semantically rich representations for individual words, there has been relatively less success in extending to generate unsupervised sentences or documents embeddings. Recent work has demonstrated that a distance measure between documents called Word Mover's Distance (WMD) that aligns semantically similar words, yields unprecedented KNN classification accuracy. However, WMD is expensive to compute, and it is hard to extend its use beyond a KNN classifier. In this paper, we propose the Word Mover's Embedding (WME), a novel approach to building an unsupervised document (sentence) embedding from pre-trained word embeddings. In our experiments on 9 benchmark text classification datasets and 22 textual similarity tasks, the proposed technique consistently matches or outperforms state-of-the-art techniques, with significantly higher accuracy on problems of short length.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wu-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -8509,6 +8991,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4535–4544</pages>
     <url>http://www.aclweb.org/anthology/D18-1483</url>
+    <abstract>Clustering news across languages enables efficient media monitoring by aggregating articles from multilingual sources into coherent stories. Doing so in an online setting allows scalable processing of massive news streams. To this end, we describe a novel method for clustering an incoming stream of multilingual documents into monolingual and crosslingual clusters. Unlike typical clustering approaches that report results on datasets with a small and known number of labels, we tackle the problem of discovering an ever growing number of cluster labels in an online fashion, using real news datasets in multiple languages. In our formulation, the monolingual clusters group together documents while the crosslingual clusters group together monolingual clusters, one per language that appears in the stream. Our method is simple to implement, computationally efficient and produces state-of-the-art results on datasets in German, English and Spanish.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>miranda-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -8527,6 +9010,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4545–4553</pages>
     <url>http://www.aclweb.org/anthology/D18-1484</url>
+    <abstract>Multi-task learning in text classification leverages implicit correlations among related tasks to extract common features and yield performance gains. However, a large body of previous work treats labels of each task as independent and meaningless one-hot vectors, which cause a loss of potential label information. In this paper, we propose Multi-Task Label Embedding to convert labels in text classification into semantic vectors, thereby turning the original tasks into vector matching tasks. Our model utilizes semantic correlations among tasks and makes it convenient to scale or transfer when new tasks are involved. Extensive experiments on five benchmark datasets for text classification show that our model can effectively improve the performances of related tasks with semantic representations of labels and additional information from each other.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP14</bibkey>
   </paper>
@@ -8545,6 +9029,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4554–4564</pages>
     <url>http://www.aclweb.org/anthology/D18-1485</url>
+    <abstract>We propose a novel model for multi-label text classification, which is based on sequence-to-sequence learning. The model generates higher-level semantic unit representations with multi-level dilated convolution as well as a corresponding hybrid attention mechanism that extracts both the information at the word-level and the level of the semantic unit. Our designed dilated convolution effectively reduces dimension and supports an exponential expansion of receptive fields without loss of local information, and the attention-over-attention mechanism is able to capture more summary relevant information from the source context. Results of our experiments show that the proposed model has significant advantages over the baseline models on the dataset RCV1-V2 and Ren-CECps, and our analysis demonstrates that our model is competitive to the deterministic hierarchical models and it is more robust to classifying low-frequency labels</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lin-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -8563,6 +9048,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4565–4574</pages>
     <url>http://www.aclweb.org/anthology/D18-1486</url>
+    <abstract>Multi-task learning has an ability to share the knowledge among related tasks and implicitly increase the training data. However, it has long been frustrated by the interference among tasks. This paper investigates the performance of capsule network for text, and proposes a capsule-based multi-task learning architecture, which is unified, simple and effective. With the advantages of capsules for feature clustering, proposed task routing algorithm can cluster the features for each task in the network, which helps reduce the interference among tasks. Experiments on six text classification datasets demonstrate the effectiveness of our models and their characteristics for feature clustering.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>xiao-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -8578,6 +9064,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4575–4585</pages>
     <url>http://www.aclweb.org/anthology/D18-1487</url>
+    <abstract>Prevalence estimation is the task of inferring the relative frequency of classes of unlabeled examples in a group---for example, the proportion of a document collection with positive sentiment. Previous work has focused on aggregating and adjusting discriminative individual classifiers to obtain prevalence point estimates. But imperfect classifier accuracy ought to be reflected in uncertainty over the predicted prevalence for scientifically valid inference. In this work, we present (1) a generative probabilistic modeling approach to prevalence estimation, and (2) the construction and evaluation of prevalence confidence intervals; in particular, we demonstrate that an off-the-shelf discriminative classifier can be given a generative re-interpretation, by backing out an implicit individual-level likelihood function, which can be used to conduct fast and simple group-level Bayesian inference. Empirically, we demonstrate our approach provides better confidence interval coverage than an alternative, and is dramatically more robust to shifts in the class prior between training and testing.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>keith-oconnor:2018:EMNLP</bibkey>
   </paper>
@@ -8594,6 +9081,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4586–4598</pages>
     <url>http://www.aclweb.org/anthology/D18-1488</url>
+    <abstract>Causal understanding is essential for many kinds of decision-making, but causal inference from observational data has typically only been applied to structured, low-dimensional datasets. While text classifiers produce low-dimensional outputs, their use in causal inference has not previously been studied. To facilitate causal analyses based on language data, we consider the role that text classifiers can play in causal inference through established modeling mechanisms from the causality literature on missing data and measurement error. We demonstrate how to conduct causal analyses using text classifiers on simulated and Yelp data, and discuss the opportunities and challenges of future work that uses text data in causal inference.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wooddoughty-shpitser-dredze:2018:EMNLP</bibkey>
   </paper>
@@ -8610,6 +9098,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4599–4609</pages>
     <url>http://www.aclweb.org/anthology/D18-1489</url>
+    <abstract>This paper proposes a state-of-the-art recurrent neural network (RNN) language model that combines probability distributions computed not only from a final RNN layer but also middle layers. This method raises the expressive power of a language model based on the matrix factorization interpretation of language modeling introduced by Yang et al. (2018). Our proposed method improves the current state-of-the-art language model and achieves the best score on the Penn Treebank and WikiText-2, which are the standard benchmark datasets. Moreover, we indicate our proposed method contributes to application tasks: machine translation and headline generation.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>takase-suzuki-nagata:2018:EMNLP</bibkey>
   </paper>
@@ -8626,6 +9115,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4610–4619</pages>
     <url>http://www.aclweb.org/anthology/D18-1490</url>
+    <abstract>In recent years, the natural language processing community has moved away from task-specific feature engineering, i.e., researchers discovering ad-hoc feature representations for various tasks, in favor of general-purpose methods that learn the input representation by themselves. However, state-of-the-art approaches to disfluency detection in spontaneous speech transcripts currently still depend on an array of hand-crafted features, and other representations derived from the output of pre-existing systems such as language models or dependency parsers. As an alternative, this paper proposes a simple yet effective model for automatic disfluency detection, called an auto-correlational neural network (ACNN). The model uses a convolutional neural network (CNN) and augments it with a new auto-correlation operator at the lowest layer that can capture the kinds of ``rough copy'' dependencies that are characteristic of repair disfluencies in speech. In experiments, the ACNN model outperforms the baseline CNN on a disfluency detection task with a 5\% increase in f-score, which is close to the previous best result on this task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>jamshidlou-anderson-johnson:2018:EMNLP</bibkey>
   </paper>
@@ -8643,6 +9133,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4620–4630</pages>
     <url>http://www.aclweb.org/anthology/D18-1491</url>
+    <abstract>LSTMs are powerful tools for modeling contextual information, as evidenced by their success at the task of language modeling. However, modeling contexts in very high dimensional space can lead to poor generalizability. We introduce the Pyramidal Recurrent Unit (PRU), which enables learning representations in high dimensional space with more generalization power and fewer parameters. PRUs replace the linear transformation in LSTMs with more sophisticated interactions such as pyramidal or grouped linear transformations. This architecture gives strong results on word-level language modeling while reducing parameters significantly. In particular, PRU improves the perplexity of a recent state-of-the-art language model  by up to 1.3 points while learning 15-20\% fewer parameters. For similar number of model parameters, PRU outperforms all previous RNN models that exploit different gating mechanisms and transformations. We provide a detailed examination of the PRU and its behavior on the language modeling tasks. Our code is open-source and available at https://sacmehta.github.io/PRU/.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mehta-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -8661,6 +9152,7 @@
     <pages>4631–4641</pages>
     <url>http://www.aclweb.org/anthology/D18-1492</url>
     <attachment type="attachment">D18-1492.Attachment.zip</attachment>
+    <abstract>Neural networks with tree-based sentence encoders have shown better results on many downstream tasks. Most of existing tree-based encoders adopt syntactic parsing trees as the explicit structure prior. To study the effectiveness of different tree structures, we replace the parsing trees with trivial trees (i.e., binary balanced tree, left-branching tree and right-branching tree) in the encoders. Though trivial trees contain no syntactic information, those encoders get competitive or even better results on all of the ten downstream tasks we investigated. This surprising result indicates that explicit syntax guidance may not be the main contributor to the superior performances of tree-based neural sentence modeling. Further analysis show that tree modeling gives better results when crucial words are closer to the final representation. Additional experiments give more clues on how to design an effective tree-based encoder. Our code is open-source and available at https://github.com/ExplorerFreda/TreeEnc.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shi-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -8683,6 +9175,7 @@
     <pages>4642–4651</pages>
     <url>http://www.aclweb.org/anthology/D18-1493</url>
     <attachment type="attachment">D18-1493.Attachment.pdf</attachment>
+    <abstract>Most language modeling methods rely on large-scale data to statistically learn the sequential patterns of words. In this paper, we argue that words are atomic language units but not necessarily atomic semantic units. Inspired by HowNet, we use sememes, the minimum semantic units in human languages, to represent the implicit semantics behind words for language modeling, named Sememe-Driven Language Model (SDLM). More specifically, to predict the next word, SDLM first estimates the sememe distribution given textual context. Afterwards, it regards each sememe as a distinct semantic expert, and these experts jointly identify the most probable senses and the corresponding word. In this way, SDLM enables language models to work beyond word-level manipulation to fine-grained sememe-level semantics, and offers us more powerful tools to fine-tune language models and improve the interpretability as well as the robustness of language models. Experiments on language modeling and the downstream application of headline generation demonstrate the significant effectiveness of SDLM.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gu-EtAl:2018:EMNLP2</bibkey>
   </paper>
@@ -8701,6 +9194,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4652–4662</pages>
     <url>http://www.aclweb.org/anthology/D18-1494</url>
+    <abstract>Label-specific topics can be widely used for supporting personality psychology, aspect-level sentiment analysis, and cross-domain sentiment classification. To generate label-specific topics, several supervised topic models which adopt likelihood-driven objective functions have been proposed. However, it is hard for them to get a precise estimation on both topic discovery and supervised learning. In this study, we propose a supervised topic model based on the Siamese network, which can trade off label-specific word distributions with document-specific label distributions in a uniform framework. Experiments on real-world datasets validate that our model performs competitive in topic discovery quantitatively and qualitatively. Furthermore, the proposed model can effectively predict categorical or real-valued labels for new documents by generating word embeddings from a label-specific topical space.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -8717,6 +9211,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4663–4672</pages>
     <url>http://www.aclweb.org/anthology/D18-1495</url>
+    <abstract>Discovering the latent topics within texts has been a fundamental task for many applications. However, conventional topic models suffer different problems in different settings. The Latent Dirichlet Allocation (LDA) may not work well for short texts due to the data sparsity (i.e. the sparse word co-occurrence patterns in short documents). The Biterm Topic Model (BTM) learns topics by modeling the word-pairs named biterms in the whole corpus. This assumption is very strong when documents are long with rich topic information and do not exhibit the transitivity of biterms. In this paper, we propose a novel way called GraphBTM to represent biterms as graphs and design a Graph Convolutional Networks (GCNs) with residual connections to extract transitive features from biterms. To overcome the data sparsity of LDA and the strong assumption of BTM, we sample a fixed number of documents to form a mini-corpus as a sample. We also propose a dataset called All News extracted from 15 news publishers, in which documents are much longer than 20 Newsgroups. We present an amortized variational inference method for GraphBTM. Our method generates more coherent topics compared with previous approaches. Experiments show that the sampling strategy improves performance by a large margin.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhu-feng-li:2018:EMNLP</bibkey>
   </paper>
@@ -8733,6 +9228,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4673–4682</pages>
     <url>http://www.aclweb.org/anthology/D18-1496</url>
+    <abstract>In this paper, we propose a deep, globally normalized topic model that incorporates structural relationships connecting documents in socially generated corpora, such as online forums. Our model (1) captures discursive interactions along observed reply links in addition to traditional topic information, and (2) incorporates latent distributed representations arranged in a deep architecture, which enables a GPU-based mean-field inference procedure that scales efficiently to large data. We apply our model to a new social media dataset consisting of 13M comments mined from the popular internet forum Reddit, a domain that poses significant challenges to models that do not account for relationships connecting user comments.  We evaluate against existing methods across multiple metrics including perplexity and metadata prediction, and qualitatively analyze the learned interaction patterns.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>srivatsan-wojtowicz-bergkirkpatrick:2018:EMNLP</bibkey>
   </paper>
@@ -8752,6 +9248,7 @@
     <pages>4683–4693</pages>
     <url>http://www.aclweb.org/anthology/D18-1497</url>
     <attachment type="attachment">D18-1497.Attachment.pdf</attachment>
+    <abstract>We propose a method for learning disentangled representations of texts that code for distinct and complementary aspects, with the aim of affording efficient model transfer and interpretability. To induce disentangled embeddings, we propose an adversarial objective based on the (dis)similarity between triplets of documents with respect to specific aspects. Our motivating application is embedding biomedical abstracts describing clinical trials in a manner that disentangles the populations, interventions, and outcomes in a given trial. We show that our method learns representations that encode these clinically salient aspects, and that these can be effectively used to perform aspect-specific retrieval. We demonstrate that the approach generalizes beyond our motivating application in experiments on two multi-aspect review corpora.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>jain-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -8768,6 +9265,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4694–4703</pages>
     <url>http://www.aclweb.org/anthology/D18-1498</url>
+    <abstract>We propose a mixture-of-experts approach for unsupervised domain adaptation from multiple sources. The key idea is to explicitly capture the relationship between a target example and different source domains. This relationship, expressed by a point-to-set metric, determines how to combine predictors trained on various domains. The metric is learned in an unsupervised fashion using meta-training. Experimental results on sentiment analysis and part-of-speech tagging demonstrate that our approach consistently outperforms multiple baselines and can robustly handle negative transfer.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>guo-shah-barzilay:2018:EMNLP</bibkey>
   </paper>
@@ -8784,6 +9282,7 @@
     <pages>4704–4710</pages>
     <url>http://www.aclweb.org/anthology/D18-1499</url>
     <attachment type="attachment">D18-1499.Attachment.zip</attachment>
+    <abstract>It has been argued that humans rapidly adapt their lexical and syntactic expectations to match the statistics of the current linguistic context. We provide further support to this claim by showing that the addition of a simple adaptation mechanism to a neural language model improves our predictions of human reading times compared to a non-adaptive model. We analyze the performance of the model on controlled materials from psycholinguistic experiments and show that it adapts not only to lexical items but also to abstract syntactic structures.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>vanschijndel-linzen:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306153668" tag="video" />
@@ -8803,6 +9302,7 @@
     <pages>4711–4716</pages>
     <url>http://www.aclweb.org/anthology/D18-1500</url>
     <attachment type="attachment">D18-1500.Attachment.zip</attachment>
+    <abstract>Interpreting the performance of deep learning models beyond test set accuracy is challenging. Characteristics of individual data points are often not considered during evaluation, and each data point is treated equally. In this work we examine the impact of a test set question's difficulty to determine if there is a relationship between difficulty and performance. We model difficulty using well-studied psychometric methods on human response patterns. Experiments on Natural Language Inference (NLI) and Sentiment Analysis (SA) show that the likelihood of answering a question correctly is impacted by the question's difficulty. In addition, as DNNs are trained on larger datasets easy questions start to have a higher probability of being answered correctly than harder questions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lalor-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306154181" tag="video" />
@@ -8822,6 +9322,7 @@
     <pages>4717–4724</pages>
     <url>http://www.aclweb.org/anthology/D18-1501</url>
     <attachment type="attachment">D18-1501.Attachment.pdf</attachment>
+    <abstract>We investigate neural models' ability to capture lexicosyntactic inferences: inferences triggered by the interaction of lexical and syntactic information. We take the task of event factuality prediction as a case study and build a factuality judgment dataset for all English clause-embedding verbs in various syntactic contexts. We use this dataset, which we make publicly available, to probe the behavior of current state-of-the-art neural systems, showing that these systems make certain systematic errors that are clearly visible through the lens of factuality prediction.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>white-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306154470" tag="video" />
@@ -8839,6 +9340,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4725–4730</pages>
     <url>http://www.aclweb.org/anthology/D18-1502</url>
+    <abstract>In this paper, we propose a new approach to employ the fixed-size ordinally-forgetting encoding (FOFE) (Zhang et al., 2015b) in neural languages modelling, called dual-FOFE. The main idea of dual-FOFE is that it allows to use two different forgetting factors so that it can avoid the trade-off in choosing either a small or large values for the single forgetting factor. In our experiments, we have compared the dual-FOFE based neural network language models (NNLM) against the original FOFE counterparts and various traditional NNLMs. Our results on the challenging Google Billion word corpus show that both FOFE and dual FOFE yield very strong performance while significantly reducing the computational complexity over other NNLMs. Furthermore, the proposed dual-FOFE method further gives over 10\% improvement in perplexity over the original FOFE model.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>watcharawittayakul-xu-jiang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306154936" tag="video" />
@@ -8856,6 +9358,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4731–4736</pages>
     <url>http://www.aclweb.org/anthology/D18-1503</url>
+    <abstract>Recent work has shown that recurrent neural networks (RNNs) can implicitly capture and exploit hierarchical information when trained to solve common natural language processing tasks (Blevins et al., 2018) such as language modeling (Linzen et al., 2016; Gulordava et al., 2018) and neural machine translation (Shi et al., 2016). In contrast, the ability to model structured data with non-recurrent neural networks has received little attention despite their success in many NLP tasks (Gehring et al., 2017; Vaswani et al., 2017). In this work, we compare the two architectures—recurrent versus non-recurrent—with respect to their ability to model hierarchical structure and find that recurrency is indeed important for this purpose. The code and data used in our experiments is available at https://anonymized</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>tran-bisazza-monz:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306155520" tag="video" />
@@ -8873,6 +9376,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4737–4742</pages>
     <url>http://www.aclweb.org/anthology/D18-1504</url>
+    <abstract>Targeted sentiment analysis (TSA) aims at extracting targets and classifying their sentiment classes. Previous works only exploit word embeddings as features and do not explore more potentials of neural networks when jointly learning the two tasks. In this paper, we carefully design the hierarchical stack bidirectional gated recurrent units (HSBi-GRU) model to learn abstract features for both tasks, and we propose a HSBi-GRU based  joint model which allows the target label to have influence on their sentiment label. Experimental results on two datasets show that our joint learning model can outperform other baselines and demonstrate the effectiveness of HSBi-GRU in learning abstract features.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ma-li-wang:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306135717" tag="video" />
@@ -8891,6 +9395,7 @@
     <pages>4743–4751</pages>
     <url>http://www.aclweb.org/anthology/D18-1505</url>
     <attachment type="attachment">D18-1505.Attachment.zip</attachment>
+    <abstract>We analyze the performance of different sentiment classification models on syntactically complex inputs like A-but-B sentences. The first contribution of this analysis addresses reproducible research: to meaningfully compare different models, their accuracies must be averaged over far more random seeds than what has traditionally been reported. With proper averaging in place, we notice that the distillation model described in Hu et al. (2016), which incorporates explicit logic rules for sentiment classification, is ineffective. In contrast, using contextualized ELMo embeddings (Peters et al., 2018a) instead of logic rules yields significantly better performance. Additionally, we provide analysis and visualizations that demonstrate ELMo's ability to implicitly learn logic rules. Finally, a crowdsourced analysis reveals how ELMo outperforms baseline models even on sentences with ambiguous sentiment labels.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>krishna-jyothi-iyyer:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306136412" tag="video" />
@@ -8910,6 +9415,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4752–4757</pages>
     <url>http://www.aclweb.org/anthology/D18-1506</url>
+    <abstract>Emotion cause analysis has been a key topic in natural language processing. Existing methods ignore the contexts around the emotion word which can provide an emotion cause clue. Meanwhile, the clauses in a document play different roles on stimulating a certain emotion, depending on their content relevance. Therefore, we propose a co-attention neural network model for emotion cause analysis with emotional context awareness. The method encodes the clauses with a co-attention based bi-directional long short-term memory into high-level input representations, which are further fed into a convolutional layer for emotion cause analysis. Experimental results show that our approach outperforms the state-of-the-art baseline methods.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>li-EtAl:2018:EMNLP9</bibkey>
     <video href="https://vimeo.com/306136988" tag="video" />
@@ -8929,6 +9435,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4758–4765</pages>
     <url>http://www.aclweb.org/anthology/D18-1507</url>
+    <abstract>Computational detection and understanding of empathy is an important factor in advancing human-computer interaction. Yet to date, text-based empathy prediction has the following major limitations: It underestimates the psychological complexity of the phenomenon, adheres to a weak notion of ground truth where empathic states are ascribed by third parties, and lacks a shared corpus. In contrast, this contribution presents the first publicly available gold standard for empathy prediction. It is constructed using a novel annotation methodology which reliably captures empathy assessments by the writer of a statement using multi-item scales. This is also the first computational work distinguishing between multiple forms of empathy, empathic concern, and personal distress, as recognized throughout psychology. Finally, we present experimental results for three different predictive models, of which a CNN performs the best.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>buechel-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306137544" tag="video" />
@@ -8948,6 +9455,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4766–4771</pages>
     <url>http://www.aclweb.org/anthology/D18-1508</url>
+    <abstract>Human language has evolved towards newer forms of communication such as social media, where emojis (i.e., ideograms bearing a visual meaning) play a key role. While there is an increasing body of work aimed at the computational modeling of emoji semantics, there is currently little understanding about what makes a computational model represent or predict a given emoji in a certain way. In this paper we propose a label-wise attention mechanism with which we attempt to better understand the nuances underlying emoji prediction. In addition to advantages in terms of interpretability, we show that our proposed architecture improves over standard baselines in emoji prediction, and does particularly well when predicting infrequent emojis.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>barbieri-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306138266" tag="video" />
@@ -8967,6 +9475,7 @@
     <pages>4772–4777</pages>
     <url>http://www.aclweb.org/anthology/D18-1509</url>
     <attachment type="attachment">D18-1509.Attachment.pdf</attachment>
+    <abstract>Recent advances in Neural Machine Translation (NMT) show that adding syntactic information to NMT systems can improve the quality of their translations. Most existing work utilizes some specific types of linguistically-inspired tree structures, like constituency and dependency parse trees. This is often done via a standard RNN decoder that operates on a linearized target tree structure. However, it is an open question of what specific linguistic formalism, if any, is the best structural representation for NMT. In this paper, we (1) propose an NMT model that can naturally generate the topology of an arbitrary tree structure on the target side, and (2) experiment with various target tree structures. Our experiments show the surprising result that our model delivers the best improvements with balanced binary trees constructed without any linguistic knowledge; this model outperforms standard seq2seq models by up to 2.1 BLEU points, and other methods for incorporating target-side syntax by up to 0.7 BLEU.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-EtAl:2018:EMNLP13</bibkey>
     <video href="https://vimeo.com/306166768" tag="video" />
@@ -8984,6 +9493,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4778–4784</pages>
     <url>http://www.aclweb.org/anthology/D18-1510</url>
+    <abstract>Neural machine translation (NMT) models are usually trained with the word-level loss using the teacher forcing algorithm, which not only evaluates the translation improperly but also suffers from exposure bias. Sequence-level training under the reinforcement framework can mitigate the problems of the word-level loss, but its performance is unstable due to the high variance of the gradient estimation. On these grounds, we present a method with a differentiable sequence-level training objective based on probabilistic n-gram matching which can avoid the reinforcement framework. In addition, this method performs greedy search in the training which uses the predicted words as context just as at inference to alleviate the problem of exposure bias. Experiment results on the NIST Chinese-to-English translation tasks show that our method significantly outperforms the reinforcement-based algorithms and achieves an improvement of 1.5 BLEU points on average over a strong baseline system.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shao-chen-feng:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306167593" tag="video" />
@@ -9004,6 +9514,7 @@
     <pages>4785–4790</pages>
     <url>http://www.aclweb.org/anthology/D18-1511</url>
     <attachment type="attachment">D18-1511.Attachment.zip</attachment>
+    <abstract>In Neural Machine Translation (NMT), the decoder can capture the features of the entire prediction history with neural connections and representations. This means that partial hypotheses with different prefixes will be regarded differently no matter how similar they are. However, this might be inefficient since some partial hypotheses can contain only local differences that will not influence future predictions. In this work, we introduce recombination in NMT decoding based on the concept of the ``equivalence'' of partial hypotheses. Heuristically, we use a simple n-gram suffix based equivalence function and adapt it into beam search decoding. Through experiments on large-scale Chinese-to-English and English-to-Germen translation tasks, we show that the proposed method can obtain similar translation quality with a smaller beam size, making NMT decoding more efficient.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang-EtAl:2018:EMNLP15</bibkey>
     <video href="https://vimeo.com/306168250" tag="video" />
@@ -9022,6 +9533,7 @@
     <pages>4791–4796</pages>
     <url>http://www.aclweb.org/anthology/D18-1512</url>
     <attachment type="attachment">D18-1512.Attachment.pdf</attachment>
+    <abstract>Recent research suggests that neural machine translation achieves parity with professional human translation on the WMT Chinese--English news translation task. We empirically test this claim with alternative evaluation protocols, contrasting the evaluation of single sentences and entire documents. In a pairwise ranking experiment, human raters assessing adequacy and fluency show a stronger preference for human over machine translation when evaluating documents as compared to isolated sentences. Our findings emphasise the need to shift towards document-level evaluation as machine translation improves to the degree that errors which are hard or impossible to spot at the sentence-level become decisive in discriminating quality of different translation outputs.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lubli-sennrich-volk:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306169001" tag="video" />
@@ -9038,6 +9550,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4797–4802</pages>
     <url>http://www.aclweb.org/anthology/D18-1513</url>
+    <abstract>We compare the performance of the APT and AutoPRF metrics for pronoun translation against a manually annotated dataset comprising human judgements as to the correctness of translations of the PROTEST test suite. Although there is some correlation with the human judgements, a range of issues limit the performance of the automated metrics. Instead, we recommend the use of semi- automatic metrics and test suites in place of fully automatic metrics.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>guillou-hardmeier:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306169819" tag="video" />
@@ -9059,6 +9572,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4803–4809</pages>
     <url>http://www.aclweb.org/anthology/D18-1514</url>
+    <abstract>We present a Few-Shot Relation Classification Dataset (dataset), consisting of 70, 000 sentences on 100 relations derived from Wikipedia and annotated by crowdworkers. The relation of each sentence is first recognized by distant supervision methods, and then filtered by crowdworkers. We adapt the most recent state-of-the-art few-shot learning methods for relation classification and conduct thorough evaluation of these methods. Empirical results show that even the most competitive few-shot learning models struggle on this task, especially as compared with humans. We also show that a range of different reasoning skills are needed to solve our task. These results indicate that few-shot relation classification remains an open problem and still requires further research. Our detailed analysis points multiple directions for future research.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>han-EtAl:2018:EMNLP2</bibkey>
     <video href="https://vimeo.com/306124333" tag="video" />
@@ -9076,6 +9590,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4810–4815</pages>
     <url>http://www.aclweb.org/anthology/D18-1515</url>
+    <abstract>The best systems at the SemEval-16 and SemEval-17 community question answering shared tasks -- a task that amounts to question relevancy ranking -- involve complex pipelines and manual feature engineering. Despite this, many of these still fail at beating the IR baseline, i.e., the rankings provided by Google's search engine. We present a strong baseline for question relevancy ranking by training a simple multi-task feed forward network on a bag of 14 distance measures for the input question pair. This baseline model, which is fast to train and uses only language-independent features, outperforms the best shared task systems on the task of retrieving relevant previously asked questions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>gonzalez-augenstein-sgaard:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306167593" tag="video" />
@@ -9093,6 +9608,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4816–4821</pages>
     <url>http://www.aclweb.org/anthology/D18-1516</url>
+    <abstract>Research on link prediction in knowledge graphs has mainly focused on static multi-relational data. In this work we consider temporal knowledge graphs where relations between entities may only hold for a time interval or a specific point in time. In line with previous work on static knowledge graphs, we propose to address this problem by learning latent entity and relation type representations. To incorporate temporal information, we utilize recurrent neural networks to learn time-aware representations of relation types which can be used in conjunction with existing latent factorization methods. The proposed approach is shown to be robust to common challenges in real-world KGs: the sparsity and heterogeneity of temporal expressions. Experiments show the benefits of our approach on four temporal KGs. The data sets are available under a permissive BSD-3 license.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>garciaduran-dumani-niepert:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306125393" tag="video" />
@@ -9109,6 +9625,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4822–4828</pages>
     <url>http://www.aclweb.org/anthology/D18-1517</url>
+    <abstract>Event detection (ED) and word sense disambiguation (WSD) are two similar tasks in that they both involve identifying the classes (i.e. event types or word senses) of some word in a given sentence. It is thus possible to extract the knowledge hidden in the data for WSD, and utilize it to improve the performance on ED. In this work, we propose a method to transfer the knowledge learned on WSD to ED by matching the neural representations learned for the two tasks. Our experiments on two widely used datasets for ED demonstrate the effectiveness of the proposed method.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lu-nguyen:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306125936" tag="video" />
@@ -9125,6 +9642,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4829–4833</pages>
     <url>http://www.aclweb.org/anthology/D18-1518</url>
+    <abstract>In this work, we present a word embedding model that learns cross-sentence dependency for improving end-to-end co-reference resolution (E2E-CR). While the traditional E2E-CR model generates word representations by running long short-term memory (LSTM) recurrent neural networks on each sentence of an input article or conversation separately, we propose linear sentence linking and attentional sentence linking models to learn cross-sentence dependency. Both sentence linking strategies enable the LSTMs to make use of valuable information from context sentences while calculating the representation of the current input word. With this approach, the LSTMs learn word embeddings considering knowledge not only from the current sentence but also from the entire input document. Experiments show that learning cross-sentence dependency enriches information contained by the word representations, and improves the performance of the co-reference resolution model compared with our baseline.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>luo-glass:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306126460" tag="video" />
@@ -9143,6 +9661,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4834–4839</pages>
     <url>http://www.aclweb.org/anthology/D18-1519</url>
+    <abstract>Lexicon relation extraction given distributional representation of words is an important topic in NLP. We observe that the state-of-the-art projection-based methods cannot be generalized to handle unseen hypernyms. We propose to analyze it in the perspective of pollution and construct the corresponding indicator to measure it. We propose a word relation autoencoder (WRAE) model to address the challenge. Experiments on several hypernym-like lexicon datasets show that our model outperforms the competitors significantly.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP11</bibkey>
   </paper>
@@ -9157,6 +9676,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4840–4846</pages>
     <url>http://www.aclweb.org/anthology/D18-1520</url>
+    <abstract>In this paper, we propose a simple method for refining pretrained word embeddings using layer-wise relevance propagation. Given a target semantic representation one would like word vectors to reflect, our method first trains the mapping between the original word vectors and the target representation using a neural network. Estimated target values are then propagated backward toward word vectors, and a relevance score is computed for each dimension of word vectors. Finally, the relevance score vectors are used to refine the original word vectors so that they are projected into the subspace that reflects the information relevant to the target representation. The evaluation experiment using binary classification of word pairs demonstrates that the refined vectors by our method achieve the higher performance than the original vectors.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>utsumi:2018:EMNLP</bibkey>
   </paper>
@@ -9175,6 +9695,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4847–4853</pages>
     <url>http://www.aclweb.org/anthology/D18-1521</url>
+    <abstract>Word embedding models have become a fundamental component in a wide range of Natural Language Processing (NLP) applications. However, embeddings trained on human-generated corpora have been demonstrated to inherit strong gender stereotypes that reflect social constructs. To address this concern, in this paper, we propose a novel training procedure for learning gender-neutral word embeddings. Our approach aims to preserve gender information in certain dimensions of word vectors while compelling other dimensions to be free of gender influence. Based on the proposed method, we generate a Gender-Neutral variant of GloVe (GN-GloVe). Quantitative and qualitative experiments demonstrate that GN-GloVe successfully isolates gender information without sacrificing the functionality of the embedding model.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhao-EtAl:2018:EMNLP4</bibkey>
   </paper>
@@ -9195,6 +9716,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4854–4859</pages>
     <url>http://www.aclweb.org/anthology/D18-1522</url>
+    <abstract>We introduce a weakly supervised approach for inferring the property of abstractness of words and expressions in the complete absence of labeled data. Exploiting only minimal linguistic clues and the contextual usage of a concept as manifested in textual data, we train sufficiently powerful classifiers, obtaining high correlation with human labels. The results imply the applicability of this approach to additional properties of concepts, additional languages, and resource-scarce scenarios.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>rabinovich-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9210,6 +9732,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4860–4867</pages>
     <url>http://www.aclweb.org/anthology/D18-1523</url>
+    <abstract>An established method for Word Sense Induction (WSI) uses a language model to predict probable substitutes for target words, and induces senses by clustering these resulting substitute vectors. We replace the ngram-based language model (LM) with a recurrent one. Beyond being more accurate, the use of the recurrent LM allows us to effectively query it in a creative way, using what we call dynamic symmetric patterns. The combination of the RNN-LM and the dynamic symmetric patterns results in strong substitute vectors for WSI, allowing to surpass the current state-of-the-art on the SemEval 2013 WSI shared task by a large margin.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>amrami-goldberg:2018:EMNLP</bibkey>
   </paper>
@@ -9226,6 +9749,7 @@
     <pages>4868–4874</pages>
     <url>http://www.aclweb.org/anthology/D18-1524</url>
     <attachment type="attachment">D18-1524.Attachment.zip</attachment>
+    <abstract>Natural language inference has been shown to be an effective supervised task for learning generic sentence embeddings. In order to better understand the components that lead to effective representations, we propose a lightweight version of InferSent, called InferLite, that does not use any recurrent layers and operates on a collection of pre-trained word embeddings. We show that a simple instance of our model that makes no use of context, word ordering or position can still obtain competitive performance on the majority of downstream prediction tasks, with most performance gaps being filled by adding local contextual information through temporal convolutions. Our models can be trained in under 1 hour on a single GPU and allows for fast inference of new representations. Finally we describe a semantic hashing layer that allows our model to learn generic binary codes for sentences.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kiros-chan:2018:EMNLP</bibkey>
   </paper>
@@ -9242,6 +9766,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4875–4880</pages>
     <url>http://www.aclweb.org/anthology/D18-1525</url>
+    <abstract>This paper addresses the problem of representation learning. Using an autoencoder framework, we propose and evaluate several loss functions that can be used as an alternative to the commonly used cross-entropy reconstruction loss. The proposed loss functions use similarities between words in the embedding space, and can be used to train any neural model for text generation. We show that the introduced loss functions amplify semantic diversity of reconstructed sentences, while preserving the original meaning of the input. We test the derived autoencoder-generated representations on paraphrase detection and language inference tasks and demonstrate performance improvement compared to the traditional cross-entropy loss.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kovaleva-rumshisky-romanov:2018:EMNLP</bibkey>
   </paper>
@@ -9261,6 +9786,7 @@
     <pages>4881–4889</pages>
     <url>http://www.aclweb.org/anthology/D18-1526</url>
     <attachment type="attachment">D18-1526.Attachment.pdf</attachment>
+    <abstract>We investigate the effects of multi-task learning using the recently introduced task of semantic tagging. We employ semantic tagging as an auxiliary task for three different NLP tasks: part-of-speech tagging, Universal Dependency parsing, and Natural Language Inference. We compare full neural network sharing, partial neural network sharing, and what we term the learning what to share setting where negative transfer between tasks is less likely. Our findings show considerable improvements for all tasks, particularly in the learning what to share setting which shows consistent gains across all tasks.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>abdou-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9279,6 +9805,7 @@
     <pages>4890–4895</pages>
     <url>http://www.aclweb.org/anthology/D18-1527</url>
     <attachment type="attachment">D18-1527.Attachment.pdf</attachment>
+    <abstract>Conventional word embedding models do not leverage information from document meta-data, and they do not model uncertainty. We address these concerns with a model that incorporates document covariates to estimate conditional word embedding distributions. Our model allows for (a) hypothesis tests about the meanings of terms, (b) assessments as to whether a word is near or far from another conditioned on different covariate values, and (c) assessments as to whether estimated differences are statistically significant.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>han-EtAl:2018:EMNLP3</bibkey>
   </paper>
@@ -9296,6 +9823,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4896–4901</pages>
     <url>http://www.aclweb.org/anthology/D18-1528</url>
+    <abstract>When processing a text, humans and machines must disambiguate between different uses of the pronoun it, including non-referential, nominal anaphoric or clause anaphoric ones. In this paper we use eye-tracking data to learn how humans perform this disambiguation and use this knowledge to improve the automatic classification of it. We show that by using gaze data and a POS-tagger we are able to significantly outperform a common baseline and classify between three categories of it with an accuracy comparable to that of linguistic-based approaches.  In addition, the discriminatory power of specific gaze features informs the way humans process the pronoun, which, to the best of our knowledge, has not been explored using data from a natural reading task.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>yaneva-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9312,6 +9840,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4902–4908</pages>
     <url>http://www.aclweb.org/anthology/D18-1529</url>
+    <abstract>A wide variety of neural-network architectures have been proposed for the task of Chinese word segmentation. Surprisingly, we find that a bidirectional LSTM model, when combined with standard deep learning techniques and best practices, can achieve better accuracy on many of the popular datasets as compared to models based on more complex neuralnetwork architectures. Furthermore, our error analysis shows that out-of-vocabulary words remain challenging for neural-network models, and many of the remaining errors are unlikely to be fixed through architecture changes. Instead, more effort should be made on exploring resources for further improvement.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ma-ganchev-weiss:2018:EMNLP</bibkey>
   </paper>
@@ -9331,6 +9860,7 @@
     <pages>4909–4914</pages>
     <url>http://www.aclweb.org/anthology/D18-1530</url>
     <attachment type="attachment">D18-1530.Attachment.zip</attachment>
+    <abstract>In Sanskrit, small words (morphemes) are combined to form compound words through a process known as Sandhi. Sandhi splitting is the process of splitting a given compound word into its constituent morphemes. Although rules governing word splitting exists in the language, it is highly challenging to identify the location of the splits in a compound word. Though existing Sandhi splitting systems incorporate these pre-defined splitting rules, they have a low accuracy as the same compound word might be broken down in multiple ways to provide syntactically correct splits. In this research, we propose a novel deep learning architecture called Double Decoder RNN (DD-RNN), which (i) predicts the location of the split(s) with 95\% accuracy, and (ii) predicts the constituent words (learning the Sandhi splitting rules) with 79.5\% accuracy, outperforming the state-of-art by 20\%. Additionally, we show the generalization capability of our deep learning model, by showing competitive results in the problem of Chinese word segmentation, as well.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>aralikatte-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9346,6 +9876,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4915–4920</pages>
     <url>http://www.aclweb.org/anthology/D18-1531</url>
+    <abstract>Previous traditional approaches to unsupervised Chinese word segmentation (CWS) can be roughly classified into discriminative and generative models. The former uses the carefully designed goodness measures for candidate segmentation, while the latter focuses on finding the optimal segmentation of the highest generative probability. However, while there exists a trivial way to extend the discriminative models into neural version by using neural language models, those of generative ones are non-trivial. In this paper, we propose the segmental language models (SLMs) for CWS. Our approach explicitly focuses on the segmental nature of Chinese, as well as preserves several properties of language models. In SLMs, a context encoder encodes the previous context and a segment decoder generates each segment incrementally. As far as we know, we are the first to propose a neural model for unsupervised CWS and achieve competitive performance to the state-of-the-art statistical models on four different datasets from SIGHAN 2005 bakeoff.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sun-deng:2018:EMNLP</bibkey>
   </paper>
@@ -9364,6 +9895,7 @@
     <pages>4921–4928</pages>
     <url>http://www.aclweb.org/anthology/D18-1532</url>
     <attachment type="attachment">D18-1532.Attachment.zip</attachment>
+    <abstract>We present LemmaTag, a featureless neural network architecture that jointly generates part-of-speech tags and lemmas for sentences by using bidirectional RNNs with character-level and word-level embeddings. We demonstrate that both tasks benefit from sharing the encoding part of the network, predicting tag subcategories, and using the tagger output as an input to the lemmatizer. We evaluate our model across several languages with complex morphology, which surpasses state-of-the-art accuracy in both part-of-speech tagging and lemmatization in Czech, German, and Arabic.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kondratyuk-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9380,6 +9912,7 @@
     <pages>4929–4934</pages>
     <url>http://www.aclweb.org/anthology/D18-1533</url>
     <attachment type="attachment">D18-1533.Attachment.pdf</attachment>
+    <abstract>In contrast to the older writing system of the 19th century, modern Hawaiian orthography employs characters for long vowels and glottal stops. These extra characters account for about one-third of the phonemes in Hawaiian, so including them makes a big difference to reading comprehension and pronunciation. However, transliterating between older and newer texts is a laborious task when performed manually. We introduce two related methods to help solve this transliteration problem automatically. One approach is implemented, end-to-end, using finite state transducers (FSTs). The other is a hybrid deep learning approach, which approximately composes an FST with a recurrent neural network language model.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>shillingford-parkerjones:2018:EMNLP</bibkey>
   </paper>
@@ -9395,6 +9928,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4935–4939</pages>
     <url>http://www.aclweb.org/anthology/D18-1534</url>
+    <abstract>Consider two competitive machine learning models, one of which was considered state-of-the art, and the other a competitive baseline.  Suppose that by just permuting the examples of the training set, say by reversing the original order, by shuffling, or by mini-batching, you could report substantially better/worst performance for the system of your choice, by multiple percentage points.  In this paper, we illustrate this scenario for a trending NLP task: Natural Language Inference (NLI).  We show that for the two central NLI corpora today, the learning process of neural systems is far too sensitive to permutations of the data. In doing so we reopen the question of how to judge a good neural architecture for NLI, given the available dataset and perhaps, further, the soundness of the NLI task itself in its current state.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>schluter-varab:2018:EMNLP</bibkey>
   </paper>
@@ -9413,6 +9947,7 @@
     <pages>4940–4945</pages>
     <url>http://www.aclweb.org/anthology/D18-1535</url>
     <attachment type="attachment">D18-1535.Attachment.pdf</attachment>
+    <abstract>Most textual entailment models focus on lexical gaps between the premise text and the hypothesis, but rarely on knowledge gaps. We focus on filling these knowledge gaps in the Science Entailment task, by leveraging an external structured knowledge base (KB) of science facts. Our new architecture combines standard neural entailment models with a knowledge lookup module. To facilitate this lookup, we propose a fact-level decomposition of the hypothesis, and verifying the resulting sub-facts against both the textual premise and the structured KB. Our model, NSNet, learns to aggregate predictions from these heterogeneous data formats. On the SciTail dataset, NSNet outperforms a simpler combination of the two predictions by 3\% and the base entailment model by 5\%.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kang-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9432,6 +9967,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4946–4951</pages>
     <url>http://www.aclweb.org/anthology/D18-1536</url>
+    <abstract>This paper introduces the Bank Question (BQ) corpus, a Chinese corpus for sentence semantic equivalence identification (SSEI). The BQ corpus contains 120,000 question pairs from 1-year online bank custom service logs. To efficiently process and annotate questions from such a large scale of logs, this paper proposes a clustering based annotation method to achieve questions with the same intent. First, the deduplicated questions with the same answer are clustered into stacks by the Word Mover's Distance (WMD) based Affinity Propagation (AP) algorithm. Then, the annotators are asked to assign the clustered questions into different intent categories. Finally, the positive and negative question pairs for SSEI are selected in the same intent category and between different intent categories respectively. We also present six SSEI benchmark performance on our corpus, including state-of-the-art algorithms. As the largest manually annotated public Chinese SSEI corpus in the bank domain, the BQ corpus is not only useful for Chinese question semantic matching research, but also a significant resource for cross-lingual and cross-domain SSEI research. The corpus is available in public.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen-EtAl:2018:EMNLP12</bibkey>
   </paper>
@@ -9449,6 +9985,7 @@
     <pages>4952–4957</pages>
     <url>http://www.aclweb.org/anthology/D18-1537</url>
     <attachment type="attachment">D18-1537.Attachment.zip</attachment>
+    <abstract>Deep learning models have achieved remarkable success in natural language inference (NLI) tasks. While these models are widely explored, they are hard to interpret and it is often unclear how and why they actually work. In this paper, we take a step toward explaining such deep learning based models through a case study on a popular neural model for NLI. In particular, we propose to interpret the intermediate layers of NLI models by visualizing the saliency of attention and LSTM gating signals. We present several examples for which our methods are able to reveal interesting insights and identify the critical information contributing to the model decisions.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ghaeini-fern-tadepalli:2018:EMNLP</bibkey>
   </paper>
@@ -9466,6 +10003,7 @@
     <pages>4958–4963</pages>
     <url>http://www.aclweb.org/anthology/D18-1538</url>
     <attachment type="attachment">D18-1538.Attachment.pdf</attachment>
+    <abstract>Neural models have shown several state-of-the-art performances on Semantic Role Labeling (SRL). However, the neural models require an immense amount of semantic-role corpora and are thus not well suited for low-resource languages or domains. The paper proposes a semi-supervised semantic role labeling method that outperforms the state-of-the-art in limited SRL training corpora. The method is based on explicitly enforcing syntactic constraints by augmenting the training objective with a syntactic-inconsistency loss component and uses SRL-unlabeled instances to train a joint-objective LSTM. On CoNLL-2012 English section, the proposed semi-supervised training with 1\%, 10\% SRL-labeled data and varying amounts of SRL-unlabeled data achieves +1.58, +0.78 F1, respectively, over the pre-trained models that were trained on SOTA architecture with ELMo on the same SRL-labeled data. Additionally, by using the syntactic-inconsistency loss on inference time, the proposed model achieves +3.67, +2.1 F1 over pre-trained model on 1\%, 10\% SRL-labeled data, respectively.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>mehta-lee-carbonell:2018:EMNLP</bibkey>
   </paper>
@@ -9483,6 +10021,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4964–4969</pages>
     <url>http://www.aclweb.org/anthology/D18-1539</url>
+    <abstract>When the semantics of a sentence are not representable in a semantic parser's output schema, parsing will inevitably fail. Detection of these instances is commonly treated as an out-of-domain classification problem. However, there is also a more subtle scenario in which the test data is drawn from the same domain. In addition to formalizing this problem of domain-adjacency, we present a comparison of various baselines that could be used to solve it. We also propose a new simple sentence representation that emphasizes words which are unexpected. This approach improves the performance of a downstream semantic parser run on in-domain and domain-adjacent instances.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>ferguson-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9501,6 +10040,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4970–4976</pages>
     <url>http://www.aclweb.org/anthology/D18-1540</url>
+    <abstract>The web provides a rich, open-domain environment with textual, structural, and spatial properties. We propose a new task for grounding language in this environment: given a natural language command (e.g., ``click on the second article''), choose the correct element on the web page (e.g., a hyperlink or text box). We collected a dataset of over 50,000 commands that capture various phenomena such as functional references (e.g. ``find who made this site''), relational reasoning (e.g. ``article by john''), and visual reasoning (e.g. ``top-most article''). We also implemented and analyzed three baseline models that capture different phenomena present in the dataset.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>pasupat-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9517,6 +10057,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>4977–4983</pages>
     <url>http://www.aclweb.org/anthology/D18-1541</url>
+    <abstract>Grammatical error correction, like other machine learning tasks, greatly benefits from large quantities of high quality training data, which is typically expensive to produce. While writing a program to automatically generate realistic grammatical errors would be difficult, one could learn the distribution of naturally-occurring errors and attempt to introduce them into other datasets. Initial work on inducing errors in this way using statistical machine translation has shown promise; we investigate cheaply constructing synthetic samples, given a small corpus of human-annotated data, using an off-the-rack attentive sequence-to-sequence model and a straight-forward post-processing procedure. Our approach yields error-filled artificial data that helps a vanilla bi-directional LSTM to outperform the previous state of the art at grammatical error detection, and a previously introduced model to gain further improvements of over 5\% F0.5 score. When attempting to determine if a given sentence is synthetic, a human annotator at best achieves 39.39 F1 score, indicating that our model generates mostly human-like instances.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kasewa-stenetorp-riedel:2018:EMNLP</bibkey>
   </paper>
@@ -9533,6 +10074,7 @@
     <pages>4984–4991</pages>
     <url>http://www.aclweb.org/anthology/D18-1542</url>
     <attachment type="attachment">D18-1542.Attachment.pdf</attachment>
+    <abstract>Recently introduced neural network parsers allow for new approaches to circumvent data sparsity issues by modeling character level information and by exploiting raw data in a semi-supervised setting. Data sparsity is especially prevailing when transferring to non-standard domains. In this setting,  lexical normalization has often been used in the past to circumvent data sparsity. In this paper, we investigate whether these new neural approaches provide similar functionality as lexical normalization, or whether they are complementary. We provide experimental results which show that a separate normalization component improves performance of a neural network parser even if it has access to character level information as well as external word embeddings. Further improvements are obtained by a straightforward but novel approach in which the top-N best candidates provided by the normalization component are available to the parser.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>vandergoot-vannoord:2018:EMNLP</bibkey>
   </paper>
@@ -9551,6 +10093,7 @@
     <pages>4992–4997</pages>
     <url>http://www.aclweb.org/anthology/D18-1543</url>
     <attachment type="attachment">D18-1543.Attachment.pdf</attachment>
+    <abstract>Previous work has suggested that parameter sharing between transition-based neural dependency parsers for related languages can lead to better performance, but there is no consensus on what parameters to share. We present an evaluation of 27 different parameter sharing strategies across 10 languages, representing five pairs of related languages, each pair from a different language family. We find that sharing transition classifier parameters always helps, whereas the usefulness of sharing word and/or character LSTM parameters varies. Based on this result, we propose an architecture where the transition classifier is shared, and the sharing of word and character parameters is controlled by a parameter that can be tuned on validation data. This model is linguistically motivated and obtains significant improvements over a monolingually trained baseline. We also find that sharing transition classifier parameters helps when training a parser on unrelated language pairs, but we find that, in the case of unrelated languages, sharing too many parameters does not help.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>delhoneux-EtAl:2018:EMNLP</bibkey>
   </paper>
@@ -9568,6 +10111,7 @@
     <pages>4998–5003</pages>
     <url>http://www.aclweb.org/anthology/D18-1544</url>
     <attachment type="attachment">D18-1544.Attachment.zip</attachment>
+    <abstract>A substantial thread of recent work on latent tree learning has attempted to develop neural network models with parse-valued latent variables and train them on non-parsing tasks, in the hope of having them discover interpretable tree structure. In a recent paper, Shen et al. (2018) introduce such a model and report near-state-of-the-art results on the target task of language modeling, and the first strong latent tree learning result on constituency parsing. In an attempt to reproduce these results, we discover issues that make the original results hard to trust, including tuning and even training on what is effectively the test set. Here, we attempt to reproduce these results in a fair experiment and to extend them to two new datasets. We find that the results of this work are robust: All variants of the model under study outperform all latent tree learning baselines, and perform competitively with symbolic grammar induction systems. We find that this model represents the first empirical success for latent tree learning, and that neural network language modeling warrants further study as a setting for grammar induction.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>htut-cho-bowman:2018:EMNLP</bibkey>
   </paper>
@@ -9583,6 +10127,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>5004–5009</pages>
     <url>http://www.aclweb.org/anthology/D18-1545</url>
+    <abstract>Neural NLP systems achieve high scores in the presence of sizable training dataset. Lack of such datasets leads to poor system performances in the case low-resource languages. We present two simple text augmentation techniques using dependency trees, inspired from image processing. We ``crop'' sentences by removing dependency links, and we ``rotate'' sentences by moving the tree fragments around the root. We apply these techniques to augment the training sets of low-resource languages in Universal Dependencies project. We implement a character-level sequence tagging model and evaluate the augmented datasets on part-of-speech tagging task. We show that crop and rotate provides improvements over the models trained with non-augmented data for majority of the languages, especially for languages with rich case marking systems.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>sahin-steedman:2018:EMNLP</bibkey>
   </paper>
@@ -9598,6 +10143,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>5010–5015</pages>
     <url>http://www.aclweb.org/anthology/D18-1546</url>
+    <abstract>Many recent papers address reading comprehension, where examples consist of (question, passage, answer) tuples. Presumably, a model must combine information from both questions and passages to predict corresponding answers. However, despite intense interest in the topic, with hundreds of published papers vying for leaderboard dominance, basic questions about the difficulty of many popular benchmarks remain unanswered. In this paper, we establish sensible baselines for the bAbI, SQuAD, CBT, CNN, and Who-did-What datasets, finding that question- and passage-only models often perform surprisingly well. On 14 out of 20 bAbI tasks, passage-only models achieve greater than 50\% accuracy, sometimes matching the full model. Interestingly, while CBT provides 20-sentence passages, only the last is needed for accurate prediction. By comparison, SQuAD and CNN appear better-constructed.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>kaushik-lipton:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306140720" tag="video" />
@@ -9620,6 +10166,12 @@
     <pages>5016–5026</pages>
     <url>http://www.aclweb.org/anthology/D18-1547</url>
     <attachment type="attachment">D18-1547.Attachment.pdf</attachment>
+    <abstract>Even though machine learning has become the major scene in dialogue research community, the real breakthrough has been blocked by the scale of data available.
+To address this fundamental obstacle, we introduce the Multi-Domain Wizard-of-Oz dataset (MultiWOZ), a fully-labeled collection of human-human written conversations spanning over multiple domains and topics.
+At a size of 10k dialogues, it is at least one order of magnitude larger than all previous annotated task-oriented corpora.
+The contribution of this work apart from the open-sourced dataset is two-fold:
+firstly, a detailed description of the data collection procedure along with a summary of data structure and analysis is provided. The proposed data-collection pipeline is entirely based on crowd-sourcing without the need of hiring professional annotators;
+secondly, a set of benchmark results of belief tracking, dialogue act and response generation is reported, which shows the usability of the data and sets a baseline for future studies.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>budzianowski-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306141298" tag="video" />
@@ -9640,6 +10192,7 @@
     <pages>5027–5038</pages>
     <url>http://www.aclweb.org/anthology/D18-1548</url>
     <attachment type="attachment">D18-1548.Attachment.pdf</attachment>
+    <abstract>Current state-of-the-art semantic role labeling (SRL) uses a deep neural network with no explicit linguistic features. However, prior work has shown that gold syntax trees can dramatically improve SRL decoding, suggesting the possibility of increased accuracy from explicit modeling of syntax. In this work, we present linguistically-informed self-attention (LISA): a neural network model that combines multi-head self-attention with multi-task learning across dependency parsing, part-of-speech tagging, predicate detection and SRL.  Unlike previous models which require significant pre-processing to prepare linguistic features, LISA can incorporate syntax using merely raw tokens as input, encoding the sequence only once to simultaneously perform parsing, predicate detection and role labeling for all predicates. Syntax is incorporated by training one attention head to attend to syntactic parents for each token. Moreover, if a high-quality syntactic parse is already available, it can be beneficially injected at test time without re-training our SRL model. In experiments on CoNLL-2005 SRL, LISA achieves new state-of-the-art performance for a model using predicted predicates and standard word embeddings, attaining 2.5 F1 absolute higher than the previous state-of-the-art on newswire and more than 3.5 F1 on out-of-domain data, nearly 10\% reduction in error. On ConLL-2012 English SRL we also show an improvement of more than 2.5 F1. LISA also out-performs the state-of-the-art with contextually-encoded (ELMo) word representations, by nearly 1.0 F1 on news and more than 2.0 F1 on out-of-domain text.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>strubell-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306141078" tag="video" />
@@ -9660,6 +10213,7 @@
     <pages>5039–5049</pages>
     <url>http://www.aclweb.org/anthology/D18-1549</url>
     <attachment type="attachment">D18-1549.Attachment.pdf</attachment>
+    <abstract>Machine translation systems achieve near human-level performance on some languages, yet their effectiveness strongly relies on the availability of large amounts of parallel sentences, which hinders their applicability to the majority of language pairs. This work investigates how to learn to translate when having access to only large monolingual corpora in each language. We propose two model variants, a neural and a phrase-based model. Both versions leverage a careful initialization of the parameters, the denoising effect of language models and automatic generation of parallel data by iterative back-translation. These models are significantly better than methods from the literature, while being simpler and having fewer hyper-parameters. On the widely used WMT'14 English-French and WMT'16 German-English benchmarks, our models respectively obtain 28.1 and 25.2 BLEU points without using a single parallel sentence, outperforming the state of the art by more than 11 BLEU points. On low-resource languages like English-Urdu and English-Romanian, our methods achieve even better results than semi-supervised and supervised approaches leveraging the paucity of available bitexts. Our code for NMT and PBSMT is publicly available.</abstract>
     <bibtype>inproceedings</bibtype>
     <bibkey>lample-EtAl:2018:EMNLP</bibkey>
     <video href="https://vimeo.com/306145842" tag="video" />
@@ -9880,7 +10434,7 @@
   </paper>
 
   <paper id="2012">
-    <title>SentencePiece: A simple and language independent subword tokenizer and detokenizer for Neural Text Processing.</title>
+    <title>SentencePiece: A simple and language independent subword tokenizer and detokenizer for Neural Text Processing</title>
     <author><first>Taku</first><last>Kudo</last></author>
     <author><first>John</first><last>Richardson</last></author>
     <booktitle>Proceedings of the 2018 Conference on Empirical Methods in Natural Language Processing: System Demonstrations</booktitle>


### PR DESCRIPTION
The abstracts are exactly as they appeared on the conference website; no attempt was made to process TeX control sequences or special characters (\%, ``, '', etc.).

A few titles were also fixed:
- "Percent" changed to "%" to match the title in the PDF
- A curly apostrophe changed to a straight one
- Removed a trailing period