### PR TITLE
Automatic projection of curly braces from BibTeX to XML

### DIFF
--- a/bin/normalize_anth.py
+++ b/bin/normalize_anth.py
@@ -76,4 +76,4 @@ if __name__ == "__main__":
                         logging.info('{}{}{}{}{}'.format(oldstring[max(0,oi-ws):oi], red, oldstring[oi:oj], off, oldstring[oj:oj+ws]))
                         logging.info('{}{}{}{}{}'.format(newstring[max(0,ni-ws):ni], green, newstring[ni:nj], off, newstring[nj:nj+ws]))
                     
-    tree.write(args.outfile, encoding="UTF-8")
+    tree.write(args.outfile, encoding="UTF-8", xml_declaration=True)

--- a/bin/normalize_anth.py
+++ b/bin/normalize_anth.py
@@ -17,7 +17,7 @@ import lxml.etree as etree
 import re
 import difflib
 import logging
-from tex_unicode import unicodify_node
+from tex_unicode import convert_node
 
 logging.basicConfig(format='%(levelname)s:%(location)s %(message)s', level=logging.INFO)
 def filter(r):
@@ -55,7 +55,7 @@ if __name__ == "__main__":
                 continue
             
             try:
-                newnode = unicodify_node(oldnode)
+                newnode = convert_node(oldnode)
             except ValueError as e:
                 logging.error("unicodify raised exception {}".format(e))
                 continue

--- a/bin/patch_fixedcase.py
+++ b/bin/patch_fixedcase.py
@@ -41,7 +41,9 @@ if __name__ == "__main__":
                 if field not in entry.fields: continue
 
                 boldvalue = entry.fields[field]
-                bnewvalue = bibtex.find_fixed_case(boldvalue, conservative=True)
+                bnewvalue = tex_unicode.parse_latex(boldvalue)
+                bibtex.find_fixed_case(bnewvalue, conservative=True)
+                bnewvalue = tex_unicode.unparse_latex(bnewvalue, delete_root=True)
                 if bnewvalue != boldvalue:
                     xnode = xpaper.find(field)
                     if xnode is None:

--- a/bin/patch_fixedcase.py
+++ b/bin/patch_fixedcase.py
@@ -1,0 +1,67 @@
+import lxml.etree as etree, html
+import sys
+import os
+import logging
+import bibtex
+import tex_unicode
+
+def replace_node(old, new):
+    save_tail = old.tail
+    old.clear()
+    old.tag = new.tag
+    old.attrib.update(new.attrib)
+    old.text = new.text
+    old.extend(new)
+    old.tail = save_tail
+
+if __name__ == "__main__":
+    # Set up logging
+    logging.basicConfig(format='%(levelname)s:%(location)s %(message)s', level=logging.INFO)
+    location = ""
+    def filter(r):
+        r.location = location
+        return True
+    logging.getLogger().addFilter(filter)
+
+    xfilename, bdirname, outfilename = sys.argv[1:]
+    xtree = etree.parse(xfilename)
+    xroot = xtree.getroot()
+
+    for xpaper in xroot.findall('paper'):
+        fullid = "{}-{}".format(xroot.attrib['id'], xpaper.attrib['id'])
+        location = fullid
+        bfilename = os.path.join(bdirname, fullid+'.bib')
+        try:
+            bdata = bibtex.read_bibtex(bfilename)
+        except FileNotFoundError:
+            logging.warning("{} not found".format(bfilename))
+            continue
+        for entry in bdata.entries.values():
+            for field in ['title', 'booktitle']:
+                if field not in entry.fields: continue
+
+                boldvalue = entry.fields[field]
+                bnewvalue = bibtex.find_fixed_case(boldvalue, conservative=True)
+                if bnewvalue != boldvalue:
+                    xnode = xpaper.find(field)
+                    if xnode is None:
+                        logging.warning("{} missing from XML".format(field))
+                        continue
+
+                    xoldvalue = tex_unicode.contents(xnode)
+                    boldvalue = tex_unicode.convert_string(boldvalue)
+                    xoldvalue = " ".join(xoldvalue.split())
+                    boldvalue = " ".join(boldvalue.split())
+                    if xoldvalue != boldvalue:
+                        logging.warning("{} has been changed; please edit manually".format(field))
+                        logging.warning("old value in xml: {}".format(xoldvalue))
+                        logging.warning("old value in bib: {}".format(boldvalue))
+                        logging.warning("new value in bib: {}".format(bnewvalue))
+                    else: # success
+                        bnewvalue = html.escape(bnewvalue)
+                        bnewvalue = bnewvalue.replace(r'\begin{fixedcase}', '<fixed-case>')
+                        bnewvalue = bnewvalue.replace(r'\end{fixedcase}', '</fixed-case>')
+                        xnewnode = tex_unicode.convert_node(etree.fromstring('<{}>{}</{}>'.format(xnode.tag, bnewvalue, xnode.tag)))
+                        replace_node(xnode, xnewnode)
+
+    xtree.write(outfilename, encoding="UTF-8", xml_declaration=True)

--- a/bin/tex_unicode.py
+++ b/bin/tex_unicode.py
@@ -18,6 +18,7 @@ table = [Entry('{', '}', None, 'bracket'),
          Entry(r'\textbf', None, 'b', 'unary'),
          Entry(r'\bf', None, 'b', 'setter'),
          Entry(r'\url', None, 'url', 'unary', True),
+         Entry(r'\fixedcase', None, 'fixed-case', 'unary'),
          Entry(r'root', None, 'root', None),
 ]
 openers = {e.open:e for e in table}
@@ -30,7 +31,7 @@ def parse_latex(s):
     """Parse LaTeX into a list of lists."""
     toks = token_re.findall(s)
     toks = collections.deque(toks)
-    stack = [['root']]
+    stack = [[r'root']]
 
     def close_implicit():
         # Implicitly close setters

--- a/bin/tex_unicode.py
+++ b/bin/tex_unicode.py
@@ -1,8 +1,8 @@
-# To do: preserve whitespace
+#!/usr/bin/env python3
 
 import sys
 import latexcodec, codecs, unicodedata
-import lxml.etree as etree
+import lxml.etree as etree, html
 import re
 import collections
 import logging
@@ -95,8 +95,9 @@ def unparse_latex(l, delete_root=False):
 
 trivial_math_re = re.compile(r'@?[\d.,]*(\\%|%)?')
 
-def make_tree(root):
-    """Convert output of parse_latex into an XML string."""
+def xmlify_string(s):
+    """Convert output of parse_latex into an XML string. 
+    It does *not* escape <, >, and &."""
 
     out = []
     
@@ -134,7 +135,7 @@ def make_tree(root):
                 visit(child)
             out.append(close)
 
-    visit(root)
+    visit(parse_latex(s))
     return ''.join(out)
 
 def unicodify_string(s):
@@ -148,38 +149,48 @@ def unicodify_string(s):
     # Use a heuristic to escape some ties (~),
     s = re.sub(r'(?<=[ (])~(?=\d)', r'\\textasciitilde', s)
     # and go ahead and replace the rest because of a bug in latexcodec
-    s = s.replace('~', ' ')
+    s = re.sub(r'(?<!\\)~', ' ', s)
     
     s = s.replace('–', '--') # a bug in our system converts --- to –-; this undoes it
-    s = s.replace(r'\&', '&amp;') # to avoid having an unescaped & in the output
+    s = s.replace(r'\&', '&')
+    
+    # A group with a single char should be equivalent to the bare char.
+    # Also, this avoids a latexcodec bug for \"{\i}, etc.
+    s = re.sub(r'(\\[A-Za-z]+ |\\.)\{([.]|\\i)}', r'\1\2', s)
     
     leading_space = len(s) > 0 and s[0].isspace()
     s = codecs.decode(s, "ulatex+utf8")
     if leading_space: s = " " + s
 
+    # It's easier to deal with control sequences if followed by exactly one space.
+    s = re.sub(r'(\\[A-Za-z]+)\s*', r'\1 ', s)
+
     # Missed due to bugs in latexcodec
-    s = s.replace(r'\^{ı}', 'î')
-    s = s.replace(r'\"{ı}', 'ï')
-    s = s.replace(r'\'{ı}', 'í')
-    s = s.replace(r'\={ı}', 'ī')
     s = s.replace("---", '—')
     s = s.replace("--", '–')
     s = s.replace("``", '“')
     s = s.replace("''", '”')
     # In latest version of latexcodec, but not the one I have
-    s = re.sub(r'\\r\s*{([Aa])}', '{\\1\u030a}', s)
-    s = re.sub(r'\\r\s+([Aa])', '\\1\u030a', s)
+    s = re.sub(r'\\r ([Aa])', '\\1\u030a', s)   # ring
     # Not in latexcodec yet
-    s = s.replace(r'\dh(?![A-Za-z])', 'ð')
-    s = s.replace(r'\DH(?![A-Za-z])', 'Ð')
-    s = s.replace(r'\th(?![A-Za-z])', 'þ')
-    s = s.replace(r'\TH(?![A-Za-z])', 'Þ')
-    s = s.replace(r'\textregistered(?![A-Za-z])', '®')
-    s = s.replace(r'\texttrademark(?![A-Za-z])', '™')
-    s = s.replace(r"\textasciigrave(?![A-Za-z])", "‘")
-    s = s.replace(r"\textquotesingle(?![A-Za-z])", "’")
+    s = re.sub(r'\\cb ([SsTt])', '\\1\u0326', s) # comma-below
+    s = s.replace(r'\dh ', 'ð')
+    s = s.replace(r'\DH ', 'Ð')
+    s = s.replace(r'\th ', 'þ')
+    s = s.replace(r'\TH ', 'Þ')
+    s = s.replace(r'\textregistered ', '®')
+    s = s.replace(r'\texttrademark ', '™')
+    s = s.replace(r'\textasciigrave ', "‘")
+    s = s.replace(r'\textquotesingle ', "’")
 
     s = s.replace('\u00ad', '') # soft hyphen
+    # NFKC normalization would get these, but also others we don't want
+    s = s.replace('ﬁ', 'fi') 
+    s = s.replace('ﬂ', 'fl')
+    s = s.replace('ﬀ', 'ff')
+    s = s.replace('ﬃ', 'ffi')
+    s = s.replace('ﬄ', 'ffl')
+
     s = s.replace(r'\$', '$')
     
     # Straight double quote
@@ -205,14 +216,15 @@ def unicodify_string(s):
     s = re.sub(r'(?<!\\)[{}]', '', s)
     s = re.sub(r'\\([{}])', r'\1', s)
 
-    m = re.search(r'(\\[A-Za-z]+|\\.)', s)
-    if m:
+    def repl(m):
         logging.warning("deleting remaining control sequence {}".format(m.group(1)))
-    s = re.sub(r'(\\[A-Za-z]+|\\.)', '', s)
+        return ""
+    s = re.sub(r'(\\[A-Za-z]+\s*|\\.)', repl, s)
+
     return s
 
 def unicodify_node(t):
-    """Convert all text in XML tree from LaTeX to Unicode."""
+    """Convert all text in XML node from LaTeX to Unicode. Destructive."""
     def visit(node):
         if node.tag in tags and tags[node.tag].verbatim:
             return
@@ -222,20 +234,38 @@ def unicodify_node(t):
             visit(child)
             if child.tail is not None:
                 child.tail = unicodify_string(child.tail)
-
-    # By converting from a tree to a string and back, we pick up any
-    # additional XML tags that the original string might have had.
-    s = etree.tostring(t, with_tail=False, encoding='utf8').decode('utf8')
-    l = parse_latex(s)
-    t = make_tree(l)
-    t = etree.fromstring(t)
     visit(t)
-    return t
+
+def contents(node):
+    out = []
+    if node.text is not None:
+        out.append(html.escape(node.text))
+    for child in node:
+        out.append(etree.tostring(child, encoding=str, with_tail=True))
+    return ''.join(out)
     
+def convert_string(s):
+    s = html.escape(s)
+    s = xmlify_string(s)
+    s = "<root>{}</root>".format(s)
+    t = etree.fromstring(s)
+    unicodify_node(t)
+    return contents(t)
+
+def convert_node(t):
+    """Converts TeX in an XML node to both Unicode and new XML nodes. Nondestructive."""
+    # This roundabout path handles things like \emph{foo <b>bar</b> baz} correctly
+    s = etree.tostring(t, encoding=str, with_tail=False)
+    s = xmlify_string(s)
+    t = etree.fromstring(s)
+    unicodify_node(t)
+    return t
+
 if __name__ == "__main__":
     import fileinput
     for line in fileinput.input():
-        line = line.rstrip()
-        t = etree.fromstring(line)
-        t = unicodify_node(t)
-        print(etree.tostring(t, encoding='utf8').decode('utf8'))
+        """line = convert_string(line)
+        print(line)"""
+        node = etree.fromstring(line)
+        node = convert_node(node)
+        print(etree.tostring(node, encoding=str))

--- a/import/A00.xml
+++ b/import/A00.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="A00">
  <paper id="1000">
  <title>Sixth Applied Natural Language Processing Conference</title>

--- a/import/A83.xml
+++ b/import/A83.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="A83">
  <paper id="1000">
  <title>First Conference on Applied Natural Language Processing</title>

--- a/import/A88.xml
+++ b/import/A88.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="A88">
  <paper id="1000">
  <title>Second Conference on Applied Natural Language Processing</title>

--- a/import/A92.xml
+++ b/import/A92.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="A92">
  <paper id="1000">
  <title>Third Conference on Applied Natural Language Processing</title>

--- a/import/A94.xml
+++ b/import/A94.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="A94">
  <paper id="1000">
  <title>Fourth Conference on Applied Natural Language Processing</title>

--- a/import/A97.xml
+++ b/import/A97.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="A97">
  <paper id="1000">
  <title>Fifth Conference on Applied Natural Language Processing</title>

--- a/import/C04.xml
+++ b/import/C04.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="C04">
 	<paper id="1000">
 		<title>COLING 2004: Proceedings of the 20th International Conference on Computational Linguistics</title>

--- a/import/C08.xml
+++ b/import/C08.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="C08">
    <paper id="1000">
         <title>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</title>
@@ -27,7 +28,7 @@
         <bibkey>abe-inui-matsumoto:2008:PAPERS</bibkey>
    </paper>
    <paper id="1002">
-        <title>A Supervised Algorithm for Verb Disambiguation into VerbNet Classes</title>
+        <title>A Supervised Algorithm for Verb Disambiguation into Verb<fixed-case>Net</fixed-case> Classes</title>
         <author><first>Omri</first><last>Abend</last></author>
         <author><first>Roi</first><last>Reichart</last></author>
         <author><first>Ari</first><last>Rappoport</last></author>
@@ -42,7 +43,7 @@
         <bibkey>abend-reichart-rappoport:2008:PAPERS</bibkey>
    </paper>
    <paper id="1003">
-        <title>On Robustness and Domain Adaptation using SVD for Word Sense Disambiguation</title>
+        <title>On Robustness and Domain Adaptation using <fixed-case>SVD</fixed-case> for Word Sense Disambiguation</title>
         <author><first>Eneko</first><last>Agirre</last></author>
         <author><first>Oier</first><last>Lopez de Lacalle</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -126,7 +127,7 @@
         <bibkey>baldridge:2008:PAPERS</bibkey>
    </paper>
    <paper id="1009">
-        <title>Good Neighbors Make Good Senses: Exploiting Distributional Similarity for Unsupervised WSD</title>
+        <title>Good Neighbors Make Good Senses: Exploiting Distributional Similarity for Unsupervised <fixed-case>WSD</fixed-case></title>
         <author><first>Samuel</first><last>Brody</last></author>
         <author><first>Mirella</first><last>Lapata</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -304,7 +305,7 @@
         <bibkey>crysmann-EtAl:2008:PAPERS</bibkey>
    </paper>
    <paper id="1021">
-        <title>KnowNet: Building a Large Net of Knowledge from the Web</title>
+        <title><fixed-case>KnowNet</fixed-case>: Building a Large Net of Knowledge from the Web</title>
         <author><first>Montse</first><last>Cuadros</last></author>
         <author><first>German</first><last>Rigau</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -363,7 +364,7 @@
         <bibkey>desaeger-torisawa-kazama:2008:PAPERS</bibkey>
    </paper>
    <paper id="1025">
-        <title>Re-estimation of Lexical Parameters for Treebank PCFGs</title>
+        <title>Re-estimation of Lexical Parameters for Treebank <fixed-case>PCFGs</fixed-case></title>
         <author><first>Tejaswini</first><last>Deoskar</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
         <month>August</month>
@@ -389,7 +390,7 @@
         <bibkey>dickinson:2008:PAPERS</bibkey>
    </paper>
    <paper id="1027">
-        <title>Syntactic Reordering Integrated with Phrase-Based SMT</title>
+        <title>Syntactic Reordering Integrated with Phrase-Based <fixed-case>SMT</fixed-case></title>
         <author><first>Jakob</first><last>Elming</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
         <month>August</month>
@@ -677,7 +678,7 @@
         <bibkey>iwatate-asahara-matsumoto:2008:PAPERS</bibkey>
    </paper>
    <paper id="1047">
-        <title>Contents Modelling of Neo-Sumerian Ur III Economic Text Corpus</title>
+        <title>Contents Modelling of Neo-Sumerian Ur <fixed-case>III</fixed-case> Economic Text Corpus</title>
         <author><first>Wojciech</first><last>Jaworski</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
         <month>August</month>
@@ -690,7 +691,7 @@
         <bibkey>jaworski:2008:PAPERS</bibkey>
    </paper>
    <paper id="1048">
-        <title>Generating Chinese Couplets using a Statistical MT Approach</title>
+        <title>Generating Chinese Couplets using a Statistical <fixed-case>MT</fixed-case> Approach</title>
         <author><first>Long</first><last>Jiang</last></author>
         <author><first>Ming</first><last>Zhou</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -761,7 +762,7 @@
         <bibkey>kanayama-nasukawa:2008:PAPERS</bibkey>
    </paper>
    <paper id="1053">
-        <title>A Local Alignment Kernel in the Context of NLP</title>
+        <title>A Local Alignment Kernel in the Context of <fixed-case>NLP</fixed-case></title>
         <author><first>Sophia</first><last>Katrenko</last></author>
         <author><first>Pieter</first><last>Adriaans</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -804,7 +805,7 @@
         <bibkey>khan-vandeemter-ritchie:2008:PAPERS</bibkey>
    </paper>
    <paper id="1056">
-        <title>Normalizing SMS: are Two Metaphors Better than One ?</title>
+        <title>Normalizing <fixed-case>SMS</fixed-case>: are Two Metaphors Better than One ?</title>
         <author><first>Catherine</first><last>Kobus</last></author>
         <author><first>François</first><last>Yvon</last></author>
         <author><first>Géraldine</first><last>Damnati</last></author>
@@ -894,7 +895,7 @@
         <bibkey>li-EtAl:2008:PAPERS1</bibkey>
    </paper>
    <paper id="1062">
-        <title>PNR2: Ranking Sentences with Positive and Negative Reinforcement for Query-Oriented Update Summarization</title>
+        <title><fixed-case>PNR2</fixed-case>: Ranking Sentences with Positive and Negative Reinforcement for Query-Oriented Update Summarization</title>
         <author><first>Wenjie</first><last>Li</last></author>
         <author><first>Furu</first><last>Wei</last></author>
         <author><first>Qin</first><last>Lu</last></author>
@@ -1056,7 +1057,7 @@
         <bibkey>miller-schuler:2008:PAPERS</bibkey>
    </paper>
    <paper id="1073">
-        <title>Applying Discourse Analysis and Data Mining Methods to Spoken OSCE Assessments</title>
+        <title>Applying Discourse Analysis and Data Mining Methods to Spoken <fixed-case>OSCE</fixed-case> Assessments</title>
         <author><first>Meladel</first><last>Mistica</last></author>
         <author><first>Timothy</first><last>Baldwin</last></author>
         <author><first>Marisa</first><last>Cordella</last></author>
@@ -1178,7 +1179,7 @@
         <bibkey>nicolas-EtAl:2008:PAPERS</bibkey>
    </paper>
    <paper id="1081">
-        <title>Parsing the SynTagRus Treebank of Russian</title>
+        <title>Parsing the <fixed-case>SynTagRus</fixed-case> Treebank of Russian</title>
         <author><first>Joakim</first><last>Nivre</last></author>
         <author><first>Igor M.</first><last>Boguslavsky</last></author>
         <author><first>Leonid L.</first><last>Iomdin</last></author>
@@ -1296,7 +1297,7 @@
         <bibkey>qian-EtAl:2008:PAPERS</bibkey>
    </paper>
    <paper id="1089">
-        <title>A Method for Automatic POS Guessing of Chinese Unknown Words</title>
+        <title>A Method for Automatic <fixed-case>POS</fixed-case> Guessing of Chinese Unknown Words</title>
         <author><first>Likun</first><last>Qiu</last></author>
         <author><first>Changjian</first><last>Hu</last></author>
         <author><first>Kai</first><last>Zhao</last></author>
@@ -1341,7 +1342,7 @@
         <bibkey>reichart-rappoport:2008:PAPERS</bibkey>
    </paper>
    <paper id="1092">
-        <title>Anomalies in the WordNet Verb Hierarchy</title>
+        <title>Anomalies in the <fixed-case>WordNet</fixed-case> Verb Hierarchy</title>
         <author><first>Tom</first><last>Richens</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
         <month>August</month>
@@ -1383,7 +1384,7 @@
         <bibkey>roark-hollingshead:2008:PAPERS</bibkey>
    </paper>
    <paper id="1095">
-        <title>Shift-Reduce Dependency DAG Parsing</title>
+        <title>Shift-Reduce Dependency <fixed-case>DAG</fixed-case> Parsing</title>
         <author><first>Kenji</first><last>Sagae</last></author>
         <author><first>Jun’ichi</first><last>Tsujii</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -1429,7 +1430,7 @@
         <bibkey>sasano-kawahara-kurohashi:2008:PAPERS</bibkey>
    </paper>
    <paper id="1098">
-        <title>Estimation of Conditional Probabilities With Decision Trees and an Application to Fine-Grained POS Tagging</title>
+        <title>Estimation of Conditional Probabilities With Decision Trees and an Application to Fine-Grained <fixed-case>POS</fixed-case> Tagging</title>
         <author><first>Helmut</first><last>Schmid</last></author>
         <author><first>Florian</first><last>Laws</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -1594,7 +1595,7 @@
         <bibkey>tatu-srikanth:2008:PAPERS</bibkey>
    </paper>
    <paper id="1109">
-        <title>The Ups and Downs of Preposition Error Detection in ESL Writing</title>
+        <title>The Ups and Downs of Preposition Error Detection in <fixed-case>ESL</fixed-case> Writing</title>
         <author><first>Joel R.</first><last>Tetreault</last></author>
         <author><first>Martin</first><last>Chodorow</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
@@ -1681,7 +1682,7 @@
         <bibkey>turney:2008:PAPERS</bibkey>
    </paper>
    <paper id="1115">
-        <title>Tighter Integration of Rule-Based and Statistical MT in Serial System Combination</title>
+        <title>Tighter Integration of Rule-Based and Statistical <fixed-case>MT</fixed-case> in Serial System Combination</title>
         <author><first>Nicola</first><last>Ueffing</last></author>
         <author><first>Jens</first><last>Stephan</last></author>
         <author><first>Evgeny</first><last>Matusov</last></author>
@@ -1729,7 +1730,7 @@
         <bibkey>vandecruys:2008:PAPERS</bibkey>
    </paper>
    <paper id="1118">
-        <title>Source Language Markers in EUROPARL Translations</title>
+        <title>Source Language Markers in <fixed-case>EUROPARL</fixed-case> Translations</title>
         <author><first>Hans</first><last>van Halteren</last></author>
         <booktitle>Proceedings of the 22nd International Conference on Computational Linguistics (Coling 2008)</booktitle>
         <month>August</month>
@@ -1859,7 +1860,7 @@
         <bibkey>wunsch:2008:PAPERS</bibkey>
    </paper>
    <paper id="1127">
-        <title>Linguistically Annotated BTG for Statistical Machine Translation</title>
+        <title>Linguistically Annotated <fixed-case>BTG</fixed-case> for Statistical Machine Translation</title>
         <author><first>Deyi</first><last>Xiong</last></author>
         <author><first>Min</first><last>Zhang</last></author>
         <author><first>Aiti</first><last>Aw</last></author>
@@ -1950,7 +1951,7 @@
         <bibkey>yu-kawahara-kurohashi:2008:PAPERS</bibkey>
    </paper>
    <paper id="1133">
-        <title>OntoNotes: Corpus Cleanup of Mistaken Agreement Using Word Sense Disambiguation</title>
+        <title><fixed-case>OntoNotes</fixed-case>: Corpus Cleanup of Mistaken Agreement Using Word Sense Disambiguation</title>
         <author><first>Liang-Chih</first><last>Yu</last></author>
         <author><first>Chung-Hsien</first><last>Wu</last></author>
         <author><first>Eduard</first><last>Hovy</last></author>
@@ -2117,7 +2118,7 @@
         <bibkey>zhu-EtAl:2008:PAPERS</bibkey>
    </paper>
    <paper id="1144">
-        <title>A Systematic Comparison of Phrase-Based, Hierarchical and Syntax-Augmented Statistical MT</title>
+        <title>A Systematic Comparison of Phrase-Based, Hierarchical and Syntax-Augmented Statistical <fixed-case>MT</fixed-case></title>
         <author><first>Andreas</first><last>Zollmann</last></author>
         <author><first>Ashish</first><last>Venugopal</last></author>
         <author><first>Franz</first><last>Och</last></author>
@@ -2232,7 +2233,7 @@
         <bibkey>blackwood-degispert-byrne:2008:POSTERS</bibkey>
    </paper>
    <paper id="2006">
-        <title>A Scalable MMR Approach to Sentence Scoring for Multi-Document Update Summarization</title>
+        <title>A Scalable <fixed-case>MMR</fixed-case> Approach to Sentence Scoring for Multi-Document Update Summarization</title>
         <author><first>Florian</first><last>Boudin</last></author>
         <author><first>Marc</first><last>El-Bèze</last></author>
         <author><first>Juan-Manuel</first><last>Torres-Moreno</last></author>
@@ -2293,7 +2294,7 @@
         <bibkey>egg-regneri:2008:POSTERS</bibkey>
    </paper>
    <paper id="2010">
-        <title>The Impact of Reference Quality on Automatic MT Evaluation</title>
+        <title>The Impact of Reference Quality on Automatic <fixed-case>MT</fixed-case> Evaluation</title>
         <author><first>Olivier</first><last>Hamon</last></author>
         <author><first>Djamel</first><last>Mostefa</last></author>
         <booktitle>Coling 2008: Companion volume: Posters</booktitle>
@@ -2322,7 +2323,7 @@
         <bibkey>hatori-miyao-tsujii:2008:POSTERS</bibkey>
    </paper>
    <paper id="2012">
-        <title>ILP-based Conceptual Analysis for Chinese NPs</title>
+        <title><fixed-case>ILP</fixed-case>-based Conceptual Analysis for Chinese <fixed-case>NPs</fixed-case></title>
         <author><first>Paul D.</first><last>Ji</last></author>
         <author><first>Stephen G.</first><last>Pulman</last></author>
         <booktitle>Coling 2008: Companion volume: Posters</booktitle>
@@ -2749,7 +2750,7 @@
         <bibkey>josan-lehal:2008:DEMOS</bibkey>
    </paper>
    <paper id="3005">
-        <title>“Build Your Own” Spoken Dialogue Systems: Automatically Generating ISU Dialogue Systems from Business User Resources</title>
+        <title>“Build Your Own” Spoken Dialogue Systems: Automatically Generating <fixed-case>ISU</fixed-case> Dialogue Systems from Business User Resources</title>
         <author><first>Oliver</first><last>Lemon</last></author>
         <author><first>Xingkun</first><last>Liu</last></author>
         <author><first>Helen</first><last>Hastie</last></author>
@@ -2858,7 +2859,7 @@
         <bibkey>venant:2008:DEMOS</bibkey>
    </paper>
    <paper id="3012">
-        <title>Temporal Processing with the TARSQI Toolkit</title>
+        <title>Temporal Processing with the <fixed-case>TARSQI</fixed-case> Toolkit</title>
         <author><first>Marc</first><last>Verhagen</last></author>
         <author><first>James</first><last>Pustejovsky</last></author>
         <booktitle>Coling 2008: Companion volume: Demonstrations</booktitle>

--- a/import/C08.xml
+++ b/import/C08.xml
@@ -28,7 +28,7 @@
         <bibkey>abe-inui-matsumoto:2008:PAPERS</bibkey>
    </paper>
    <paper id="1002">
-        <title>A Supervised Algorithm for Verb Disambiguation into Verb<fixed-case>Net</fixed-case> Classes</title>
+        <title>A Supervised Algorithm for Verb Disambiguation into <fixed-case>VerbNet</fixed-case> Classes</title>
         <author><first>Omri</first><last>Abend</last></author>
         <author><first>Roi</first><last>Reichart</last></author>
         <author><first>Ari</first><last>Rappoport</last></author>

--- a/import/C10.xml
+++ b/import/C10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="C10">
    <paper id="1000">
         <title>Proceedings of the 23rd International Conference on Computational Linguistics (Coling 2010)</title>

--- a/import/C12.xml
+++ b/import/C12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="C12">
    <paper id="1000">
         <title>Proceedings of COLING 2012</title>
@@ -46,7 +47,7 @@
         <bibkey>akbik-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1003">
-        <title>Automatic Detection of Point of View Differences in Wikipedia</title>
+        <title>Automatic Detection of Point of View Differences in <fixed-case>W</fixed-case>ikipedia</title>
         <author><first>Khalid</first><last>Al Khatib</last></author>
         <author><first>Hinrich</first><last>Schütze</last></author>
         <author><first>Cathleen</first><last>Kantner</last></author>
@@ -61,7 +62,7 @@
         <bibkey>alkhatib-schutze-kantner:2012:PAPERS</bibkey>
    </paper>
    <paper id="1004">
-        <title>SpeedRead: A Fast Named Entity Recognition Pipeline</title>
+        <title><fixed-case>S</fixed-case>peed<fixed-case>R</fixed-case>ead: A Fast Named Entity Recognition Pipeline</title>
         <author><first>Rami</first><last>Al-Rfou’</last></author>
         <author><first>Steven</first><last>Skiena</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -90,7 +91,7 @@
         <bibkey>arcan-federmann-buitelaar:2012:PAPERS</bibkey>
    </paper>
    <paper id="1006">
-        <title>The Floating Arabic Dictionary: An Automatic Method for Updating a Lexical Database through the Detection and Lemmatization of Unknown Words</title>
+        <title>The <fixed-case>F</fixed-case>loating <fixed-case>A</fixed-case>rabic <fixed-case>D</fixed-case>ictionary: An Automatic Method for Updating a Lexical Database through the Detection and Lemmatization of Unknown Words</title>
         <author><first>Mohammed</first><last>Attia</last></author>
         <author><first>Younes</first><last>Samih</last></author>
         <author><first>Khaled</first><last>Shaalan</last></author>
@@ -106,7 +107,7 @@
         <bibkey>attia-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1007">
-        <title>Contribution of Complex Lexical Information to Solve Syntactic Ambiguity in Basque</title>
+        <title>Contribution of Complex Lexical Information to Solve Syntactic Ambiguity in <fixed-case>B</fixed-case>asque</title>
         <author><first>Aitziber</first><last>Atutxa</last></author>
         <author><first>Eneko</first><last>Agirre</last></author>
         <author><first>Kepa</first><last>Sarasola</last></author>
@@ -212,7 +213,7 @@
         <bibkey>barbosa-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1014">
-        <title>An Evaluation of Statistical Post-Editing Systems Applied to RBMT and SMT Systems</title>
+        <title>An Evaluation of Statistical Post-Editing Systems Applied to <fixed-case>RBMT</fixed-case> and <fixed-case>SMT</fixed-case> Systems</title>
         <author><first>Hanna</first><last>Béchara</last></author>
         <author><first>Raphaël</first><last>Rubino</last></author>
         <author><first>Yifan</first><last>He</last></author>
@@ -229,7 +230,7 @@
         <bibkey>bechara-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1015">
-        <title>Prague Dependency Treebank 2.5 – a Revisited Version of PDT 2.0</title>
+        <title><fixed-case>P</fixed-case>rague <fixed-case>D</fixed-case>ependency <fixed-case>T</fixed-case>reebank 2.5 – a Revisited Version of <fixed-case>PDT</fixed-case> 2.0</title>
         <author><first>Eduard</first><last>Bejček</last></author>
         <author><first>Jarmila</first><last>Panevová</last></author>
         <author><first>Jan</first><last>Popelka</last></author>
@@ -248,7 +249,7 @@
         <bibkey>bejek-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1016">
-        <title>Deriving a Lexicon for a Precision Grammar from Language Documentation Resources: A Case Study of Chintang</title>
+        <title>Deriving a Lexicon for a Precision Grammar from Language Documentation Resources: A Case Study of <fixed-case>C</fixed-case>hintang</title>
         <author><first>Emily M.</first><last>Bender</last></author>
         <author><first>Robert</first><last>Schikowski</last></author>
         <author><first>Balthasar</first><last>Bickel</last></author>
@@ -278,7 +279,7 @@
         <bibkey>biemann-roos-weihe:2012:PAPERS</bibkey>
    </paper>
    <paper id="1018">
-        <title>Improvements to Training an RNN parser</title>
+        <title>Improvements to Training an <fixed-case>RNN</fixed-case> parser</title>
         <author><first>Richard</first><last>Billingsley</last></author>
         <author><first>James</first><last>Curran</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -329,7 +330,7 @@
         <bibkey>blake-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1021">
-        <title>Studying the Effect of Input Size for Bayesian Word Segmentation on the Providence Corpus</title>
+        <title>Studying the Effect of Input Size for <fixed-case>B</fixed-case>ayesian Word Segmentation on the <fixed-case>P</fixed-case>rovidence Corpus</title>
         <author><first>Benjamin</first><last>Börschinger</last></author>
         <author><first>Katherine</first><last>Demuth</last></author>
         <author><first>Mark</first><last>Johnson</last></author>
@@ -344,7 +345,7 @@
         <bibkey>brschinger-demuth-johnson:2012:PAPERS</bibkey>
    </paper>
    <paper id="1022">
-        <title>Bayesian Language Modelling of German Compounds</title>
+        <title><fixed-case>B</fixed-case>ayesian Language Modelling of <fixed-case>G</fixed-case>erman Compounds</title>
         <author><first>Jan A.</first><last>Botha</last></author>
         <author><first>Chris</first><last>Dyer</last></author>
         <author><first>Phil</first><last>Blunsom</last></author>
@@ -359,7 +360,7 @@
         <bibkey>botha-dyer-blunsom:2012:PAPERS</bibkey>
    </paper>
    <paper id="1023">
-        <title>Can Spanish Be Simpler? LexSiS: Lexical Simplification for Spanish</title>
+        <title>Can <fixed-case>S</fixed-case>panish Be Simpler? <fixed-case>LexSiS</fixed-case>: Lexical Simplification for <fixed-case>S</fixed-case>panish</title>
         <author><first>Stefan</first><last>Bott</last></author>
         <author><first>Luz</first><last>Rello</last></author>
         <author><first>Biljana</first><last>Drndarevic</last></author>
@@ -404,7 +405,7 @@
         <bibkey>brooke-hirst:2012:PAPERS</bibkey>
    </paper>
    <paper id="1026">
-        <title>Identifying Urdu Complex Predication via Bigram Extraction</title>
+        <title>Identifying <fixed-case>U</fixed-case>rdu Complex Predication via Bigram Extraction</title>
         <author><first>Miriam</first><last>Butt</last></author>
         <author><first>Tina</first><last>Bögel</last></author>
         <author><first>Annette</first><last>Hautli</last></author>
@@ -508,7 +509,7 @@
         <bibkey>chang-clark:2012:PAPERS2</bibkey>
    </paper>
    <paper id="1033">
-        <title>Joint Modeling for Chinese Event Extraction with Rich Linguistic Features</title>
+        <title>Joint Modeling for <fixed-case>C</fixed-case>hinese Event Extraction with Rich Linguistic Features</title>
         <author><first>Chen</first><last>Chen</last></author>
         <author><first>Vincent</first><last>Ng</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -522,7 +523,7 @@
         <bibkey>chen-ng:2012:PAPERS</bibkey>
    </paper>
    <paper id="1034">
-        <title>A Simplification-Translation-Restoration Framework for Cross-Domain SMT Applications</title>
+        <title>A Simplification-Translation-Restoration Framework for Cross-Domain <fixed-case>SMT</fixed-case> Applications</title>
         <author><first>Han-Bin</first><last>Chen</last></author>
         <author><first>Hen-Hsen</first><last>Huang</last></author>
         <author><first>Hsin-Hsi</first><last>Chen</last></author>
@@ -538,7 +539,7 @@
         <bibkey>chen-EtAl:2012:PAPERS1</bibkey>
    </paper>
    <paper id="1035">
-        <title>A Semi-Supervised Bayesian Network Model for Microblog Topic Classification</title>
+        <title>A Semi-Supervised <fixed-case>B</fixed-case>ayesian Network Model for Microblog Topic Classification</title>
         <author><first>Yan</first><last>Chen</last></author>
         <author><first>Zhoujun</first><last>Li</last></author>
         <author><first>Liqiang</first><last>Nie</last></author>
@@ -571,7 +572,7 @@
         <bibkey>cheng-zhulyn:2012:PAPERS</bibkey>
    </paper>
    <paper id="1037">
-        <title>Extraction of Russian Sentiment Lexicon for Product Meta-Domain</title>
+        <title>Extraction of <fixed-case>R</fixed-case>ussian Sentiment Lexicon for Product Meta-Domain</title>
         <author><first>Ilia</first><last>Chetviorkin</last></author>
         <author><first>Natalia</first><last>Loukachevitch</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -665,7 +666,7 @@
         <bibkey>coyne-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1043">
-        <title>Towards Efficient HPSG Generation for German, a Non-Configurational Language</title>
+        <title>Towards Efficient <fixed-case>HPSG</fixed-case> Generation for <fixed-case>G</fixed-case>erman, a Non-Configurational Language</title>
         <author><first>Berthold</first><last>Crysmann</last></author>
         <author><first>Woodley</first><last>Packard</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -679,7 +680,7 @@
         <bibkey>crysmann-packard:2012:PAPERS</bibkey>
    </paper>
    <paper id="1044">
-        <title>A Corpus-Based Study of Edit Categories in Featured and Non-Featured Wikipedia Articles</title>
+        <title>A Corpus-Based Study of Edit Categories in Featured and Non-Featured <fixed-case>W</fixed-case>ikipedia Articles</title>
         <author><first>Johannes</first><last>Daxenberger</last></author>
         <author><first>Iryna</first><last>Gurevych</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -723,7 +724,7 @@
         <bibkey>delpech-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1047">
-        <title>Twitter Topic Summarization by Ranking Tweets using Social Influence and Content Quality</title>
+        <title><fixed-case>T</fixed-case>witter Topic Summarization by Ranking Tweets using Social Influence and Content Quality</title>
         <author><first>Yajuan</first><last>Duan</last></author>
         <author><first>Zhumin</first><last>Chen</last></author>
         <author><first>Furu</first><last>Wei</last></author>
@@ -740,7 +741,7 @@
         <bibkey>duan-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1048">
-        <title>S-Restricted Monotone Alignments: Algorithm, Search Space, and Applications</title>
+        <title><fixed-case>S</fixed-case>-Restricted Monotone Alignments: Algorithm, Search Space, and Applications</title>
         <author><first>Steffen</first><last>Eger</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
         <month>December</month>
@@ -769,7 +770,7 @@
         <bibkey>ehara-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1050">
-        <title>Jointly Disambiguating and Clustering Concepts and Entities with Markov Logic</title>
+        <title>Jointly Disambiguating and Clustering Concepts and Entities with <fixed-case>M</fixed-case>arkov Logic</title>
         <author><first>Angela</first><last>Fahrni</last></author>
         <author><first>Michael</first><last>Strube</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -811,7 +812,7 @@
         <bibkey>farkas-bohnet:2012:PAPERS</bibkey>
    </paper>
    <paper id="1053">
-        <title>Semantic Cohesion Model for Phrase-Based SMT</title>
+        <title>Semantic Cohesion Model for Phrase-Based <fixed-case>SMT</fixed-case></title>
         <author><first>Minwei</first><last>Feng</last></author>
         <author><first>Weiwei</first><last>Sun</last></author>
         <author><first>Hermann</first><last>Ney</last></author>
@@ -946,7 +947,7 @@
         <bibkey>gottipati-jiang:2012:PAPERS</bibkey>
    </paper>
    <paper id="1062">
-        <title>A Distributed Platform for Sanskrit Processing</title>
+        <title>A Distributed Platform for <fixed-case>S</fixed-case>anskrit Processing</title>
         <author><first>Pawan</first><last>Goyal</last></author>
         <author><first>Gérard</first><last>Huet</last></author>
         <author><first>Amba</first><last>Kulkarni</last></author>
@@ -963,7 +964,7 @@
         <bibkey>goyal-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1063">
-        <title>Understanding the Performance of Statistical MT Systems: A Linear Regression Framework</title>
+        <title>Understanding the Performance of Statistical <fixed-case>MT</fixed-case> Systems: A Linear Regression Framework</title>
         <author><first>Francisco</first><last>Guzman</last></author>
         <author><first>Stephan</first><last>Vogel</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -992,7 +993,7 @@
         <bibkey>han-cook-baldwin:2012:PAPERS</bibkey>
    </paper>
    <paper id="1065">
-        <title>Readability Classification for German using Lexical, Syntactic, and Morphological Features</title>
+        <title>Readability Classification for <fixed-case>G</fixed-case>erman using Lexical, Syntactic, and Morphological Features</title>
         <author><first>Julia</first><last>Hancke</last></author>
         <author><first>Sowmya</first><last>Vajjala</last></author>
         <author><first>Detmar</first><last>Meurers</last></author>
@@ -1023,7 +1024,7 @@
         <bibkey>hara-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1067">
-        <title>Flexible Japanese Sentence Compression by Relaxing Unit Constraints</title>
+        <title>Flexible <fixed-case>J</fixed-case>apanese Sentence Compression by Relaxing Unit Constraints</title>
         <author><first>Jun</first><last>Harashima</last></author>
         <author><first>Sadao</first><last>Kurohashi</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -1037,7 +1038,7 @@
         <bibkey>harashima-kurohashi:2012:PAPERS</bibkey>
    </paper>
    <paper id="1068">
-        <title>Approximating Theoretical Linguistics Classification in Real Data: the Case of German “nach” Particle Verbs</title>
+        <title>Approximating Theoretical Linguistics Classification in Real Data: the Case of <fixed-case>G</fixed-case>erman “nach” Particle Verbs</title>
         <author><first>Boris</first><last>Haselbach</last></author>
         <author><first>Kerstin</first><last>Eckart</last></author>
         <author><first>Wolfgang</first><last>Seeker</last></author>
@@ -1083,7 +1084,7 @@
         <bibkey>he-wang:2012:PAPERS</bibkey>
    </paper>
    <paper id="1071">
-        <title>Creating an Extended Named Entity Dictionary from Wikipedia</title>
+        <title>Creating an Extended Named Entity Dictionary from <fixed-case>W</fixed-case>ikipedia</title>
         <author><first>Ryuichiro</first><last>Higashinaka</last></author>
         <author><first>Kugatsu</first><last>Sadamitsu</last></author>
         <author><first>Kuniko</first><last>Saito</last></author>
@@ -1100,7 +1101,7 @@
         <bibkey>higashinaka-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1072">
-        <title>Statistical Method of Building Dialect Language Models for ASR Systems</title>
+        <title>Statistical Method of Building Dialect Language Models for <fixed-case>ASR</fixed-case> Systems</title>
         <author><first>Naoki</first><last>Hirayama</last></author>
         <author><first>Shinsuke</first><last>Mori</last></author>
         <author><first>Hiroshi G.</first><last>Okuno</last></author>
@@ -1115,7 +1116,7 @@
         <bibkey>hirayama-mori-okuno:2012:PAPERS</bibkey>
    </paper>
    <paper id="1073">
-        <title>Tailored Feature Extraction for Lexical Disambiguation of English Verbs Based on Corpus Pattern Analysis</title>
+        <title>Tailored Feature Extraction for Lexical Disambiguation of <fixed-case>E</fixed-case>nglish Verbs Based on Corpus Pattern Analysis</title>
         <author><first>Martin</first><last>Holub</last></author>
         <author><first>Vincent</first><last>Kríž</last></author>
         <author><first>Silvie</first><last>Cinková</last></author>
@@ -1184,7 +1185,7 @@
         <bibkey>huang-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1077">
-        <title>Improved Combinatory Categorial Grammar Induction with Boundary Words and Bayesian Inference</title>
+        <title>Improved Combinatory Categorial Grammar Induction with Boundary Words and <fixed-case>B</fixed-case>ayesian Inference</title>
         <author><first>Yun</first><last>Huang</last></author>
         <author><first>Min</first><last>Zhang</last></author>
         <author><first>Chew-Lim</first><last>Tan</last></author>
@@ -1199,7 +1200,7 @@
         <bibkey>huang-zhang-tan:2012:PAPERS</bibkey>
    </paper>
    <paper id="1078">
-        <title>Mining Rules for Rewriting States in a Transition-based Dependency Parser for English</title>
+        <title>Mining Rules for Rewriting States in a Transition-based Dependency Parser for <fixed-case>E</fixed-case>nglish</title>
         <author><first>Akihiro</first><last>Inokuchi</last></author>
         <author><first>Ayumu</first><last>Yamaoka</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -1213,7 +1214,7 @@
         <bibkey>inokuchi-yamaoka:2012:PAPERS</bibkey>
    </paper>
    <paper id="1079">
-        <title>Coreference Resolution with ILP-based Weighted Abduction</title>
+        <title>Coreference Resolution with <fixed-case>ILP</fixed-case>-based Weighted Abduction</title>
         <author><first>Naoya</first><last>Inoue</last></author>
         <author><first>Ekaterina</first><last>Ovchinnikova</last></author>
         <author><first>Kentaro</first><last>Inui</last></author>
@@ -1320,7 +1321,7 @@
         <bibkey>kapociutedzikiene-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1086">
-        <title>Generating “A for Alpha” When There Are Thousands of Characters</title>
+        <title>Generating “<fixed-case>A</fixed-case> for <fixed-case>A</fixed-case>lpha” When There Are Thousands of Characters</title>
         <author><first>Hiroaki</first><last>Kawasaki</last></author>
         <author><first>Ryohei</first><last>Sasano</last></author>
         <author><first>Hiroya</first><last>Takamura</last></author>
@@ -1396,7 +1397,7 @@
         <bibkey>kong-zhou:2012:PAPERS</bibkey>
    </paper>
    <paper id="1091">
-        <title>Semantic Processing of Compounds in Indian Languages</title>
+        <title>Semantic Processing of Compounds in <fixed-case>I</fixed-case>ndian Languages</title>
         <author><first>Amba</first><last>Kulkarni</last></author>
         <author><first>Soma</first><last>Paul</last></author>
         <author><first>Malhar</first><last>Kulkarni</last></author>
@@ -1413,7 +1414,7 @@
         <bibkey>kulkarni-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1092">
-        <title>Unsupervised Japanese-Chinese Opinion Word Translation using Dependency Distance and Feature-Opinion Association Weight</title>
+        <title>Unsupervised <fixed-case>J</fixed-case>apanese-<fixed-case>C</fixed-case>hinese Opinion Word Translation using Dependency Distance and Feature-Opinion Association Weight</title>
         <author><first>Guo-Hau</first><last>Lai</last></author>
         <author><first>Ying-Mei</first><last>Guo</last></author>
         <author><first>Richard Tzong-Han</first><last>Tsai</last></author>
@@ -1457,7 +1458,7 @@
         <bibkey>le-zuidema:2012:PAPERS</bibkey>
    </paper>
    <paper id="1095">
-        <title>Evaluating Different Methods for Automatically Collecting Large General Corpora for Basque from the Web</title>
+        <title>Evaluating Different Methods for Automatically Collecting Large General Corpora for <fixed-case>B</fixed-case>asque from the Web</title>
         <author><first>Igor</first><last>Leturia</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
         <month>December</month>
@@ -1517,7 +1518,7 @@
         <bibkey>li-EtAl:2012:PAPERS1</bibkey>
    </paper>
    <paper id="1099">
-        <title>Employing Morphological Structures and Sememes for Chinese Event Extraction</title>
+        <title>Employing Morphological Structures and Sememes for <fixed-case>C</fixed-case>hinese Event Extraction</title>
         <author><first>Peifeng</first><last>Li</last></author>
         <author><first>Guodong</first><last>Zhou</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -1531,7 +1532,7 @@
         <bibkey>li-zhou:2012:PAPERS</bibkey>
    </paper>
    <paper id="1100">
-        <title>Joint Modeling of Trigger Identification and Event Type Determination in Chinese Event Extraction</title>
+        <title>Joint Modeling of Trigger Identification and Event Type Determination in <fixed-case>C</fixed-case>hinese Event Extraction</title>
         <author><first>Peifeng</first><last>Li</last></author>
         <author><first>Qiaoming</first><last>Zhu</last></author>
         <author><first>Hongjun</first><last>Diao</last></author>
@@ -1547,7 +1548,7 @@
         <bibkey>li-EtAl:2012:PAPERS2</bibkey>
    </paper>
    <paper id="1101">
-        <title>Integrating Surface and Abstract Features for Robust Cross-Domain Chinese Word Segmentation</title>
+        <title>Integrating Surface and Abstract Features for Robust Cross-Domain <fixed-case>C</fixed-case>hinese Word Segmentation</title>
         <author><first>Xiaoqing</first><last>Li</last></author>
         <author><first>Kun</first><last>Wang</last></author>
         <author><first>Chengqing</first><last>Zong</last></author>
@@ -1577,7 +1578,7 @@
         <bibkey>li-fung:2012:PAPERS</bibkey>
    </paper>
    <paper id="1103">
-        <title>A Separately Passive-Aggressive Training Algorithm for Joint POS Tagging and Dependency Parsing</title>
+        <title>A Separately Passive-Aggressive Training Algorithm for Joint <fixed-case>POS</fixed-case> Tagging and Dependency Parsing</title>
         <author><first>Zhenghua</first><last>Li</last></author>
         <author><first>Min</first><last>Zhang</last></author>
         <author><first>Wanxiang</first><last>Che</last></author>
@@ -1624,7 +1625,7 @@
         <bibkey>liu-liang-sun:2012:PAPERS</bibkey>
    </paper>
    <paper id="1106">
-        <title>Easy-First Chinese POS Tagging and Dependency Parsing</title>
+        <title>Easy-First <fixed-case>C</fixed-case>hinese <fixed-case>POS</fixed-case> Tagging and Dependency Parsing</title>
         <author><first>Ji</first><last>Ma</last></author>
         <author><first>Tong</first><last>Xiao</last></author>
         <author><first>Jingbo</first><last>Zhu</last></author>
@@ -1655,7 +1656,7 @@
         <bibkey>martinezgmez-hara-aizawa:2012:PAPERS</bibkey>
    </paper>
    <paper id="1108">
-        <title>To Exhibit is not to Loiter: A Multilingual, Sense-Disambiguated Wiktionary for Measuring Verb Similarity</title>
+        <title>To Exhibit is not to Loiter: A Multilingual, Sense-Disambiguated <fixed-case>W</fixed-case>iktionary for Measuring Verb Similarity</title>
         <author><first>Christian M.</first><last>Meyer</last></author>
         <author><first>Iryna</first><last>Gurevych</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -1728,7 +1729,7 @@
         <bibkey>mukherjee-liu:2012:PAPERS</bibkey>
    </paper>
    <paper id="1113">
-        <title>Sentiment Analysis in Twitter with Lightweight Discourse Analysis</title>
+        <title>Sentiment Analysis in <fixed-case>T</fixed-case>witter with Lightweight Discourse Analysis</title>
         <author><first>Subhabrata</first><last>Mukherjee</last></author>
         <author><first>Pushpak</first><last>Bhattacharyya</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -1742,7 +1743,7 @@
         <bibkey>mukherjee-bhattacharyya:2012:PAPERS1</bibkey>
    </paper>
    <paper id="1114">
-        <title>YouCat: Weakly Supervised Youtube Video Categorization System from Meta Data &amp; User Comments using WordNet &amp; Wikipedia</title>
+        <title><fixed-case>YouCat</fixed-case>: Weakly Supervised Youtube Video Categorization System from Meta Data &amp; User Comments using <fixed-case>W</fixed-case>ordNet &amp; <fixed-case>W</fixed-case>ikipedia</title>
         <author><first>Subhabrata</first><last>Mukherjee</last></author>
         <author><first>Pushpak</first><last>Bhattacharyya</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -1816,7 +1817,7 @@
         <bibkey>murphy-talukdar-mitchell:2012:PAPERS</bibkey>
    </paper>
    <paper id="1119">
-        <title>Combining Wordnet and Morphosyntactic Information in Terminology Clustering</title>
+        <title>Combining <fixed-case>W</fixed-case>ordnet and Morphosyntactic Information in Terminology Clustering</title>
         <author><first>Agnieszka</first><last>Mykowiecka</last></author>
         <author><first>Malgorzata</first><last>Marciniak</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -1844,7 +1845,7 @@
         <bibkey>nakazawa-kurohashi:2012:PAPERS</bibkey>
    </paper>
    <paper id="1121">
-        <title>Optimizing for Sentence-Level BLEU+1 Yields Short Translations</title>
+        <title>Optimizing for Sentence-Level <fixed-case>BLEU</fixed-case>+1 Yields Short Translations</title>
         <author><first>Preslav</first><last>Nakov</last></author>
         <author><first>Francisco</first><last>Guzman</last></author>
         <author><first>Stephan</first><last>Vogel</last></author>
@@ -1902,7 +1903,7 @@
         <bibkey>narayan-gardent:2012:PAPERS2</bibkey>
    </paper>
    <paper id="1125">
-        <title>A Comparison of Syntactic Reordering Methods for English-German Machine Translation</title>
+        <title>A Comparison of Syntactic Reordering Methods for <fixed-case>E</fixed-case>nglish-<fixed-case>G</fixed-case>erman Machine Translation</title>
         <author><first>Jiri</first><last>Navratil</last></author>
         <author><first>Karthik</first><last>Visweswariah</last></author>
         <author><first>Ananthakrishnan</first><last>Ramanathan</last></author>
@@ -1931,7 +1932,7 @@
         <bibkey>nayak-mukerjee:2012:PAPERS</bibkey>
    </paper>
    <paper id="1127">
-        <title>Bayesian Text Segmentation for Index Term Identification and Keyphrase Extraction</title>
+        <title><fixed-case>B</fixed-case>ayesian Text Segmentation for Index Term Identification and Keyphrase Extraction</title>
         <author><first>David</first><last>Newman</last></author>
         <author><first>Nagendra</first><last>Koilada</last></author>
         <author><first>Jey Han</first><last>Lau</last></author>
@@ -1993,7 +1994,7 @@
         <bibkey>nguyen-vanschijndel-schuler:2012:PAPERS</bibkey>
    </paper>
    <paper id="1131">
-        <title>Tibetan Base Noun Phrase Identification Framework Based on Chinese-Tibetan Sentence Aligned Corpus</title>
+        <title><fixed-case>T</fixed-case>ibetan Base Noun Phrase Identification Framework Based on <fixed-case>C</fixed-case>hinese-<fixed-case>T</fixed-case>ibetan Sentence Aligned Corpus</title>
         <author><first>Ming Hua</first><last>Nuo</last></author>
         <author><first>Hui Dan</first><last>Liu</last></author>
         <author><first>Wei Na</first><last>Zhao</last></author>
@@ -2011,7 +2012,7 @@
         <bibkey>nuo-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1132">
-        <title>A Pipeline Arabic Named Entity Recognition using a Hybrid Approach</title>
+        <title>A Pipeline <fixed-case>A</fixed-case>rabic Named Entity Recognition using a Hybrid Approach</title>
         <author><first>Mai</first><last>Oudah</last></author>
         <author><first>Khaled</first><last>Shaalan</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -2128,7 +2129,7 @@
         <bibkey>qian-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1140">
-        <title>A MWE Acquisition and Lexicon Builder Web Service</title>
+        <title>A <fixed-case>MWE</fixed-case> Acquisition and Lexicon Builder Web Service</title>
         <author><first>Valeria</first><last>Quochi</last></author>
         <author><first>Francesca</first><last>Frontini</last></author>
         <author><first>Francesco</first><last>Rubino</last></author>
@@ -2143,7 +2144,7 @@
         <bibkey>quochi-frontini-rubino:2012:PAPERS</bibkey>
    </paper>
    <paper id="1141">
-        <title>A Diverse Dirichlet Process Ensemble for Unsupervised Induction of Syntactic Categories</title>
+        <title>A Diverse <fixed-case>D</fixed-case>irichlet Process Ensemble for Unsupervised Induction of Syntactic Categories</title>
         <author><first>Roi</first><last>Reichart</last></author>
         <author><first>Gal</first><last>Elidan</last></author>
         <author><first>Ari</first><last>Rappoport</last></author>
@@ -2188,7 +2189,7 @@
         <bibkey>sajjad-pantel-gamon:2012:PAPERS</bibkey>
    </paper>
    <paper id="1144">
-        <title>Joint English Spelling Error Correction and POS Tagging for Language Learners Writing</title>
+        <title>Joint <fixed-case>E</fixed-case>nglish Spelling Error Correction and <fixed-case>POS</fixed-case> Tagging for Language Learners Writing</title>
         <author><first>Keisuke</first><last>Sakaguchi</last></author>
         <author><first>Tomoya</first><last>Mizumoto</last></author>
         <author><first>Mamoru</first><last>Komachi</last></author>
@@ -2271,7 +2272,7 @@
         <bibkey>schwartz-gomez-ungar:2012:PAPERS</bibkey>
    </paper>
    <paper id="1149">
-        <title>The French Social Media Bank: a Treebank of Noisy User Generated Content</title>
+        <title>The <fixed-case>F</fixed-case>rench <fixed-case>S</fixed-case>ocial <fixed-case>M</fixed-case>edia <fixed-case>B</fixed-case>ank: a Treebank of Noisy User Generated Content</title>
         <author><first>Djamé</first><last>Seddah</last></author>
         <author><first>Benoit</first><last>Sagot</last></author>
         <author><first>Marie</first><last>Candito</last></author>
@@ -2288,7 +2289,7 @@
         <bibkey>seddah-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1150">
-        <title>Initial Explorations on using CRFs for Turkish Named Entity Recognition</title>
+        <title>Initial Explorations on using <fixed-case>CRF</fixed-case>s for <fixed-case>T</fixed-case>urkish Named Entity Recognition</title>
         <author><first>Gökhan Akın</first><last>Şeker</last></author>
         <author><first>Gülşen</first><last>Eryiğit</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -2317,7 +2318,7 @@
         <bibkey>sikdar-ekbal-saha:2012:PAPERS</bibkey>
    </paper>
    <paper id="1152">
-        <title>Noun Group and Verb Group Identification for Hindi</title>
+        <title>Noun Group and Verb Group Identification for <fixed-case>H</fixed-case>indi</title>
         <author><first>Smriti</first><last>Singh</last></author>
         <author><first>Om P.</first><last>Damani</last></author>
         <author><first>Vaijayanthi M.</first><last>Sarma</last></author>
@@ -2332,7 +2333,7 @@
         <bibkey>singh-damani-sarma:2012:PAPERS</bibkey>
    </paper>
    <paper id="1153">
-        <title>Named Entity Recognition System for Urdu</title>
+        <title>Named Entity Recognition System for <fixed-case>U</fixed-case>rdu</title>
         <author><first>UmrinderPal</first><last>Singh</last></author>
         <author><first>Vishal</first><last>Goyal</last></author>
         <author><first>Gurpreet Singh</first><last>Lehal</last></author>
@@ -2382,7 +2383,7 @@
         <bibkey>strzalkowski-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1156">
-        <title>NEER: An Unsupervised Method for Named Entity Evolution Recognition</title>
+        <title><fixed-case>NEER</fixed-case>: An Unsupervised Method for Named Entity Evolution Recognition</title>
         <author><first>Nina</first><last>Tahmasebi</last></author>
         <author><first>Gerhard</first><last>Gossen</last></author>
         <author><first>Nattiya</first><last>Kanhabua</last></author>
@@ -2399,7 +2400,7 @@
         <bibkey>tahmasebi-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1157">
-        <title>Evaluating the Translation Accuracy of a Novel Language-Independent MT Methodology</title>
+        <title>Evaluating the Translation Accuracy of a Novel Language-Independent <fixed-case>MT</fixed-case> Methodology</title>
         <author><first>George</first><last>Tambouratzis</last></author>
         <author><first>Sokratis</first><last>Sofianopoulos</last></author>
         <author><first>Marina</first><last>Vassiliou</last></author>
@@ -2474,7 +2475,7 @@
         <bibkey>titov-klementiev:2012:PAPERS</bibkey>
    </paper>
    <paper id="1162">
-        <title>Hunting for Entailing Pairs in the Penn Discourse Treebank</title>
+        <title>Hunting for Entailing Pairs in the <fixed-case>P</fixed-case>enn Discourse Treebank</title>
         <author><first>Sara</first><last>Tonelli</last></author>
         <author><first>Elena</first><last>Cabrio</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -2578,7 +2579,7 @@
         <bibkey>wang-EtAl:2012:PAPERS1</bibkey>
    </paper>
    <paper id="1169">
-        <title>Chinese Evaluative Information Analysis</title>
+        <title><fixed-case>C</fixed-case>hinese Evaluative Information Analysis</title>
         <author><first>Yiou</first><last>Wang</last></author>
         <author><first>Jun’ichi</first><last>Kazama</last></author>
         <author><first>Takuya</first><last>Kawada</last></author>
@@ -2594,7 +2595,7 @@
         <bibkey>wang-EtAl:2012:PAPERS2</bibkey>
    </paper>
    <paper id="1170">
-        <title>Harnessing the CRF Complexity with Domain-Specific Constraints. The Case of Morphosyntactic Tagging of a Highly Inflected Language</title>
+        <title>Harnessing the <fixed-case>CRF</fixed-case> Complexity with Domain-Specific Constraints. The Case of Morphosyntactic Tagging of a Highly Inflected Language</title>
         <author><first>Jakub</first><last>Waszczuk</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
         <month>December</month>
@@ -2721,7 +2722,7 @@
         <bibkey>xu-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1178">
-        <title>Modeling ESL Word Choice Similarities By Representing Word Intensions and Extensions</title>
+        <title>Modeling <fixed-case>ESL</fixed-case> Word Choice Similarities By Representing Word Intensions and Extensions</title>
         <author><first>Huichao</first><last>Xue</last></author>
         <author><first>Rebecca</first><last>Hwa</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -2735,7 +2736,7 @@
         <bibkey>xue-hwa:2012:PAPERS</bibkey>
    </paper>
    <paper id="1179">
-        <title>ISO-TimeML Event Extraction in Persian Text</title>
+        <title><fixed-case>ISO-TimeML</fixed-case> Event Extraction in <fixed-case>P</fixed-case>ersian Text</title>
         <author><first>Yadollah</first><last>Yaghoobzadeh</last></author>
         <author><first>Gholamreza</first><last>Ghassem-Sani</last></author>
         <author><first>Seyed Abolghassem</first><last>Mirroshandel</last></author>
@@ -2751,7 +2752,7 @@
         <bibkey>yaghoobzadeh-EtAl:2012:PAPERS</bibkey>
    </paper>
    <paper id="1180">
-        <title>Measuring the Similarity between TV Programs using Semantic Relations</title>
+        <title>Measuring the Similarity between <fixed-case>TV</fixed-case> Programs using Semantic Relations</title>
         <author><first>Ichiro</first><last>Yamada</last></author>
         <author><first>Masaru</first><last>Miyazaki</last></author>
         <author><first>Hideki</first><last>Sumiyoshi</last></author>
@@ -2785,7 +2786,7 @@
         <bibkey>yin-EtAl:2012:PAPERS1</bibkey>
    </paper>
    <paper id="1182">
-        <title>SentTopic-MultiRank: a Novel Ranking Model for Multi-Document Summarization</title>
+        <title><fixed-case>SentTopic</fixed-case>-<fixed-case>MultiRank</fixed-case>: a Novel Ranking Model for Multi-Document Summarization</title>
         <author><first>Wenpeng</first><last>Yin</last></author>
         <author><first>Yulong</first><last>Pei</last></author>
         <author><first>Fan</first><last>Zhang</last></author>
@@ -2816,7 +2817,7 @@
         <bibkey>yoshino-mori-kawahara:2012:PAPERS</bibkey>
    </paper>
    <paper id="1184">
-        <title>Detecting Word Ordering Errors in Chinese Sentences for Learning Chinese as a Foreign Language</title>
+        <title>Detecting Word Ordering Errors in <fixed-case>C</fixed-case>hinese Sentences for Learning <fixed-case>C</fixed-case>hinese as a Foreign Language</title>
         <author><first>Chi-Hsin</first><last>Yu</last></author>
         <author><first>Hsin-Hsi</first><last>Chen</last></author>
         <booktitle>Proceedings of COLING 2012</booktitle>
@@ -2862,7 +2863,7 @@
         <bibkey>zhai-EtAl:2012:PAPERS2</bibkey>
    </paper>
    <paper id="1187">
-        <title>Constructing Chinese Abbreviation Dictionary: A Stacked Approach</title>
+        <title>Constructing <fixed-case>C</fixed-case>hinese Abbreviation Dictionary: A Stacked Approach</title>
         <author><first>Longkai</first><last>Zhang</last></author>
         <author><first>Sujian</first><last>Li</last></author>
         <author><first>Houfeng</first><last>Wang</last></author>
@@ -2879,7 +2880,7 @@
         <bibkey>zhang-EtAl:2012:PAPERS1</bibkey>
    </paper>
    <paper id="1188">
-        <title>Stacking Heterogeneous Joint Models of Chinese POS Tagging and Dependency Parsing</title>
+        <title>Stacking Heterogeneous Joint Models of <fixed-case>C</fixed-case>hinese <fixed-case>POS</fixed-case> Tagging and Dependency Parsing</title>
         <author><first>Meishan</first><last>Zhang</last></author>
         <author><first>Wanxiang</first><last>Che</last></author>
         <author><first>Ting</first><last>Liu</last></author>
@@ -3001,7 +3002,7 @@
 	 <bibkey>POSTERS:2012</bibkey>
     </paper>
     <paper id="2001">
-	 <title>K-Best Spanning Tree Dependency Parsing With Verb Valency Lexicon Reranking</title>
+	 <title><fixed-case>K</fixed-case>-Best Spanning Tree Dependency Parsing With Verb Valency Lexicon Reranking</title>
 	 <author><first>Zeljko</first><last>Agic</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
 	 <month>December</month>
@@ -3043,7 +3044,7 @@
 	 <bibkey>aker-feng-gaizauskas:2012:POSTERS</bibkey>
     </paper>
     <paper id="2004">
-	 <title>A Formalized Reference Grammar for UNL-Based Machine Translation between English and Arabic</title>
+	 <title>A Formalized Reference Grammar for <fixed-case>UNL</fixed-case>-Based Machine Translation between <fixed-case>E</fixed-case>nglish and <fixed-case>A</fixed-case>rabic</title>
 	 <author><first>Sameh</first><last>Alansary</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
 	 <month>December</month>
@@ -3056,7 +3057,7 @@
 	 <bibkey>alansary:2012:POSTERS</bibkey>
     </paper>
     <paper id="2005">
-	 <title>Mapping Arabic Wikipedia into the Named Entities Taxonomy</title>
+	 <title>Mapping <fixed-case>A</fixed-case>rabic <fixed-case>W</fixed-case>ikipedia into the Named Entities Taxonomy</title>
 	 <author><first>Fahd</first><last>Alotaibi</last></author>
 	 <author><first>Mark</first><last>Lee</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -3098,7 +3099,7 @@
 	 <bibkey>apidianaki:2012:POSTERS</bibkey>
     </paper>
     <paper id="2008">
-	 <title>Cross-Lingual Sentiment Analysis for Indian Languages using Linked WordNets</title>
+	 <title>Cross-Lingual Sentiment Analysis for <fixed-case>I</fixed-case>ndian Languages using Linked WordNets</title>
 	 <author><first>Balamurali</first><last>A.R.</last></author>
 	 <author><first>Aditya</first><last>Joshi</last></author>
 	 <author><first>Pushpak</first><last>Bhattacharyya</last></author>
@@ -3113,7 +3114,7 @@
 	 <bibkey>ar-joshi-bhattacharyya:2012:POSTERS</bibkey>
     </paper>
     <paper id="2009">
-	 <title>The Creation of Large-Scale Annotated Corpora of Minority Languages using UniParser and the EANC platform</title>
+	 <title>The Creation of Large-Scale Annotated Corpora of Minority Languages using <fixed-case>UniParser</fixed-case> and the <fixed-case>EANC</fixed-case> platform</title>
 	 <author><first>Timofey</first><last>Arkhangeskiy</last></author>
 	 <author><first>Oleg</first><last>Belyaev</last></author>
 	 <author><first>Arseniy</first><last>Vydrin</last></author>
@@ -3143,7 +3144,7 @@
 	 <bibkey>asadiatui-faili-assadiatuie:2012:POSTERS</bibkey>
     </paper>
     <paper id="2011">
-	 <title>Improved Spelling Error Detection and Correction for Arabic</title>
+	 <title>Improved Spelling Error Detection and Correction for <fixed-case>A</fixed-case>rabic</title>
 	 <author><first>Mohammed</first><last>Attia</last></author>
 	 <author><first>Pavel</first><last>Pecina</last></author>
 	 <author><first>Younes</first><last>Samih</last></author>
@@ -3260,7 +3261,7 @@
 	 <bibkey>catherine-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2019">
-	 <title>Chinese Noun Phrase Coreference Resolution: Insights into the State of the Art</title>
+	 <title><fixed-case>C</fixed-case>hinese Noun Phrase Coreference Resolution: Insights into the State of the Art</title>
 	 <author><first>Chen</first><last>Chen</last></author>
 	 <author><first>Vincent</first><last>Ng</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -3318,7 +3319,7 @@
 	 <bibkey>chung-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2023">
-	 <title>Morphological Analyzer for Affix Stacking Languages: A Case Study of Marathi</title>
+	 <title>Morphological Analyzer for Affix Stacking Languages: A Case Study of <fixed-case>M</fixed-case>arathi</title>
 	 <author><first>Raj</first><last>Dabre</last></author>
 	 <author><first>Archana</first><last>Amberkar</last></author>
 	 <author><first>Pushpak</first><last>Bhattacharyya</last></author>
@@ -3333,7 +3334,7 @@
 	 <bibkey>dabre-amberkar-bhattacharyya:2012:POSTERS</bibkey>
     </paper>
     <paper id="2024">
-	 <title>Modelling the Organization and Processing of Bangla Polymorphemic Words in the Mental Lexicon: A Computational Approach</title>
+	 <title>Modelling the Organization and Processing of <fixed-case>B</fixed-case>angla Polymorphemic Words in the Mental Lexicon: A Computational Approach</title>
 	 <author><first>Tirthankar</first><last>Dasgupta</last></author>
 	 <author><first>Manjira</first><last>Sinha</last></author>
 	 <author><first>Anupam</first><last>Basu</last></author>
@@ -3480,7 +3481,7 @@
 	 <bibkey>friedrich-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2034">
-	 <title>Leveraging Statistical Transliteration for Dictionary-Based English-Bengali CLIR of OCR’d Text</title>
+	 <title>Leveraging Statistical Transliteration for Dictionary-Based <fixed-case>E</fixed-case>nglish-<fixed-case>B</fixed-case>engali <fixed-case>CLIR</fixed-case> of <fixed-case>OCR</fixed-case>‘d Text</title>
 	 <author><first>Utpal</first><last>Garain</last></author>
 	 <author><first>Arjun</first><last>Das</last></author>
 	 <author><first>David</first><last>Doermann</last></author>
@@ -3496,7 +3497,7 @@
 	 <bibkey>garain-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2035">
-	 <title>RU-EVAL-2012: Evaluating Dependency Parsers for Russian</title>
+	 <title><fixed-case>RU</fixed-case>-<fixed-case>EVAL</fixed-case>-2012: Evaluating Dependency Parsers for <fixed-case>R</fixed-case>ussian</title>
 	 <author><first>Anastasia</first><last>Gareyshina</last></author>
 	 <author><first>Maxim</first><last>Ionov</last></author>
 	 <author><first>Olga</first><last>Lyashevskaya</last></author>
@@ -3571,7 +3572,7 @@
 	 <bibkey>ghosh-muresan:2012:POSTERS</bibkey>
     </paper>
     <paper id="2040">
-	 <title>Translating Questions to SQL Queries with Generative Parsers Discriminatively Reranked</title>
+	 <title>Translating Questions to <fixed-case>SQL</fixed-case> Queries with Generative Parsers Discriminatively Reranked</title>
 	 <author><first>Alessandra</first><last>Giordani</last></author>
 	 <author><first>Alessandro</first><last>Moschitti</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -3585,7 +3586,7 @@
 	 <bibkey>giordani-moschitti:2012:POSTERS</bibkey>
     </paper>
     <paper id="2041">
-	 <title>Classifier-Based Tense Model for SMT</title>
+	 <title>Classifier-Based Tense Model for <fixed-case>SMT</fixed-case></title>
 	 <author><first>Zhengxian</first><last>Gong</last></author>
 	 <author><first>Min</first><last>Zhang</last></author>
 	 <author><first>Chew-lim</first><last>Tan</last></author>
@@ -3629,7 +3630,7 @@
 	 <bibkey>gupta-rosso:2012:POSTERS</bibkey>
     </paper>
     <paper id="2044">
-	 <title>LEPOR: A Robust Evaluation Metric for Machine Translation with Augmented Factors</title>
+	 <title><fixed-case>LEPOR</fixed-case>: A Robust Evaluation Metric for Machine Translation with Augmented Factors</title>
 	 <author><first>Aaron L. F.</first><last>Han</last></author>
 	 <author><first>Derek F.</first><last>Wong</last></author>
 	 <author><first>Lidia S.</first><last>Chao</last></author>
@@ -3658,7 +3659,7 @@
 	 <bibkey>hasan-ng:2012:POSTERS</bibkey>
     </paper>
     <paper id="2046">
-	 <title>FeatureForge: A Novel Tool for Visually Supported Feature Engineering and Corpus Revision</title>
+	 <title><fixed-case>FeatureForge</fixed-case>: A Novel Tool for Visually Supported Feature Engineering and Corpus Revision</title>
 	 <author><first>Florian</first><last>Heimerl</last></author>
 	 <author><first>Charles</first><last>Jochim</last></author>
 	 <author><first>Steffen</first><last>Koch</last></author>
@@ -3674,7 +3675,7 @@
 	 <bibkey>heimerl-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2047">
-	 <title>Verb Temporality Analysis using Reichenbach’s Tense System</title>
+	 <title>Verb Temporality Analysis using <fixed-case>R</fixed-case>eichenbach’s Tense System</title>
 	 <author><first>André</first><last>Horie</last></author>
 	 <author><first>Kumiko</first><last>Tanaka-Ishii</last></author>
 	 <author><first>Mitsuru</first><last>Ishizuka</last></author>
@@ -3703,7 +3704,7 @@
 	 <bibkey>iida-tokunaga:2012:POSTERS</bibkey>
     </paper>
     <paper id="2049">
-	 <title>Comparing Word Relatedness Measures Based on Google <tex-math>n</tex-math>-grams</title>
+	 <title>Comparing Word Relatedness Measures Based on <fixed-case>G</fixed-case>oogle <tex-math>n</tex-math>-grams</title>
 	 <author><first>Aminul</first><last>Islam</last></author>
 	 <author><first>Evangelos</first><last>Milios</last></author>
 	 <author><first>Vlado</first><last>Keselj</last></author>
@@ -3876,7 +3877,7 @@
 	 <bibkey>lee-rim:2012:POSTERS</bibkey>
     </paper>
     <paper id="2061">
-	 <title>Glimpses of Ancient China from Classical Chinese Poems</title>
+	 <title>Glimpses of Ancient <fixed-case>C</fixed-case>hina from Classical Chinese Poems</title>
 	 <author><first>John</first><last>Lee</last></author>
 	 <author><first>Tak-sum</first><last>Wong</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -3890,7 +3891,7 @@
 	 <bibkey>lee-wong:2012:POSTERS</bibkey>
     </paper>
     <paper id="2062">
-	 <title>Conversion between Scripts of Punjabi: Beyond Simple Transliteration</title>
+	 <title>Conversion between Scripts of <fixed-case>P</fixed-case>unjabi: Beyond Simple Transliteration</title>
 	 <author><first>Gurpreet Singh</first><last>Lehal</last></author>
 	 <author><first>Tejinder Singh</first><last>Saini</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -3904,7 +3905,7 @@
 	 <bibkey>lehal-saini:2012:POSTERS1</bibkey>
     </paper>
     <paper id="2063">
-	 <title>Development of a Complete Urdu-Hindi Transliteration System</title>
+	 <title>Development of a Complete <fixed-case>U</fixed-case>rdu-<fixed-case>H</fixed-case>indi Transliteration System</title>
 	 <author><first>Gurpreet Singh</first><last>Lehal</last></author>
 	 <author><first>Tejinder Singh</first><last>Saini</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -3948,7 +3949,7 @@
 	 <bibkey>li-gong-zhou:2012:POSTERS</bibkey>
     </paper>
     <paper id="2066">
-	 <title>A Beam Search Algorithm for ITG Word Alignment</title>
+	 <title>A Beam Search Algorithm for <fixed-case>ITG</fixed-case> Word Alignment</title>
 	 <author><first>Peng</first><last>Li</last></author>
 	 <author><first>Yang</first><last>Liu</last></author>
 	 <author><first>Maosong</first><last>Sun</last></author>
@@ -3963,7 +3964,7 @@
 	 <bibkey>li-liu-sun:2012:POSTERS2</bibkey>
     </paper>
     <paper id="2067">
-	 <title>Active Learning for Chinese Word Segmentation</title>
+	 <title>Active Learning for <fixed-case>C</fixed-case>hinese Word Segmentation</title>
 	 <author><first>Shoushan</first><last>Li</last></author>
 	 <author><first>Guodong</first><last>Zhou</last></author>
 	 <author><first>Chu-Ren</first><last>Huang</last></author>
@@ -4026,7 +4027,7 @@
 	 <bibkey>ling-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2071">
-	 <title>Expected Error Minimization with Ultraconservative Update for SMT</title>
+	 <title>Expected Error Minimization with Ultraconservative Update for <fixed-case>SMT</fixed-case></title>
 	 <author><first>Lemao</first><last>Liu</last></author>
 	 <author><first>Tiejun</first><last>Zhao</last></author>
 	 <author><first>Taro</first><last>Watanabe</last></author>
@@ -4058,7 +4059,7 @@
 	 <bibkey>liu-agam-grossman:2012:POSTERS</bibkey>
     </paper>
     <paper id="2073">
-	 <title>Unsupervised Domain Adaptation for Joint Segmentation and POS-Tagging</title>
+	 <title>Unsupervised Domain Adaptation for Joint Segmentation and <fixed-case>POS</fixed-case>-Tagging</title>
 	 <author><first>Yang</first><last>Liu</last></author>
 	 <author><first>Yue</first><last>Zhang</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -4165,7 +4166,7 @@
 	 <bibkey>mathet-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2080">
-	 <title>Discriminative Boosting from Dictionary and Raw Text – A Novel Approach to Build A Chinese Word Segmenter</title>
+	 <title>Discriminative Boosting from Dictionary and Raw Text – A Novel Approach to Build A <fixed-case>C</fixed-case>hinese Word Segmenter</title>
 	 <author><first>Fandong</first><last>Meng</last></author>
 	 <author><first>Wenbin</first><last>Jiang</last></author>
 	 <author><first>Hao</first><last>Xiong</last></author>
@@ -4231,7 +4232,7 @@
 	 <bibkey>mirovsk-jinova-polakova:2012:POSTERS</bibkey>
     </paper>
     <paper id="2084">
-	 <title>The Effect of Learner Corpus Size in Grammatical Error Correction of ESL Writings</title>
+	 <title>The Effect of Learner Corpus Size in Grammatical Error Correction of <fixed-case>ESL</fixed-case> Writings</title>
 	 <author><first>Tomoya</first><last>Mizumoto</last></author>
 	 <author><first>Yuta</first><last>Hayashibe</last></author>
 	 <author><first>Mamoru</first><last>Komachi</last></author>
@@ -4248,7 +4249,7 @@
 	 <bibkey>mizumoto-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2085">
-	 <title>GRAFIX: Automated Rule-Based Post Editing System to Improve English-Persian SMT Output</title>
+	 <title><fixed-case>GRAFIX</fixed-case>: Automated Rule-Based Post Editing System to Improve <fixed-case>E</fixed-case>nglish-<fixed-case>P</fixed-case>ersian <fixed-case>SMT</fixed-case> Output</title>
 	 <author><first>Mahsa</first><last>Mohaghegh</last></author>
 	 <author><first>Abdolhossein</first><last>Sarrafzadeh</last></author>
 	 <author><first>Mehdi</first><last>Mohammadi</last></author>
@@ -4322,7 +4323,7 @@
 	 <bibkey>palkar-black-parlikar:2012:POSTERS</bibkey>
     </paper>
     <paper id="2090">
-	 <title>Part of Speech (POS) Tagger for Kokborok</title>
+	 <title>Part of Speech (<fixed-case>POS</fixed-case>) Tagger for <fixed-case>K</fixed-case>okborok</title>
 	 <author><first>Braja Gopal</first><last>Patra</last></author>
 	 <author><first>Khumbar</first><last>Debbarma</last></author>
 	 <author><first>Dipankar</first><last>Das</last></author>
@@ -4354,7 +4355,7 @@
 	 <bibkey>peitz-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2092">
-	 <title>On Panini and the Generative Capacity of Contextualized Replacement Systems</title>
+	 <title>On <fixed-case>P</fixed-case>anini and the Generative Capacity of Contextualized Replacement Systems</title>
 	 <author><first>Gerald</first><last>Penn</last></author>
 	 <author><first>Paul</first><last>Kiparsky</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -4456,7 +4457,7 @@
 	 <bibkey>richardson-kuhn:2012:POSTERS</bibkey>
     </paper>
     <paper id="2099">
-	 <title>Korektor – A System for Contextual Spell-Checking and Diacritics Completion</title>
+	 <title><fixed-case>K</fixed-case>orektor – A System for Contextual Spell-Checking and Diacritics Completion</title>
 	 <author><first>Michal</first><last>Richter</last></author>
 	 <author><first>Pavel</first><last>Straňák</last></author>
 	 <author><first>Alexandr</first><last>Rosen</last></author>
@@ -4486,7 +4487,7 @@
 	 <bibkey>romeo-mendes-bel:2012:POSTERS</bibkey>
     </paper>
     <paper id="2101">
-	 <title>A Strategy of Mapping Polish WordNet onto Princeton WordNet</title>
+	 <title>A Strategy of Mapping <fixed-case>P</fixed-case>olish <fixed-case>W</fixed-case>ordNet onto <fixed-case>P</fixed-case>rinceton <fixed-case>W</fixed-case>ordNet</title>
 	 <author><first>Ewa</first><last>Rudnicka</last></author>
 	 <author><first>Marek</first><last>Maziarz</last></author>
 	 <author><first>Maciej</first><last>Piasecki</last></author>
@@ -4521,7 +4522,7 @@
 	 <bibkey>ryu-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2103">
-	 <title>A Fully Coreference-annotated Corpus of Scholarly Papers from the ACL Anthology</title>
+	 <title>A Fully Coreference-annotated Corpus of Scholarly Papers from the <fixed-case>ACL</fixed-case> Anthology</title>
 	 <author><first>Ulrich</first><last>Schäfer</last></author>
 	 <author><first>Christian</first><last>Spurk</last></author>
 	 <author><first>Jörg</first><last>Steffen</last></author>
@@ -4566,7 +4567,7 @@
 	 <bibkey>seeker-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2106">
-	 <title>Extension of TSVM to Multi-Class and Hierarchical Text Classification Problems With General Losses</title>
+	 <title>Extension of <fixed-case>TSVM</fixed-case> to Multi-Class and Hierarchical Text Classification Problems With General Losses</title>
 	 <author><first>Sathiya Keerthi</first><last>Selvaraj</last></author>
 	 <author><first>Sundararajan</first><last>Sellamanickam</last></author>
 	 <author><first>Shirish</first><last>Shevade</last></author>
@@ -4595,7 +4596,7 @@
 	 <bibkey>servan-petitrenaud:2012:POSTERS</bibkey>
     </paper>
     <paper id="2108">
-	 <title>Sense and Reference Disambiguation in Wikipedia</title>
+	 <title>Sense and Reference Disambiguation in <fixed-case>W</fixed-case>ikipedia</title>
 	 <author><first>Hui</first><last>Shen</last></author>
 	 <author><first>Razvan</first><last>Bunescu</last></author>
 	 <author><first>Rada</first><last>Mihalcea</last></author>
@@ -4625,7 +4626,7 @@
 	 <bibkey>shutova-vandecruys-korhonen:2012:POSTERS</bibkey>
     </paper>
     <paper id="2110">
-	 <title>Memory-Efficient Katakana Compound Segmentation using Conditional Random Fields</title>
+	 <title>Memory-Efficient <fixed-case>K</fixed-case>atakana Compound Segmentation using Conditional Random Fields</title>
 	 <author><first>Krauchanka</first><last>Siarhei</last></author>
 	 <author><first>Artsimenya</first><last>Artsiom</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -4639,7 +4640,7 @@
 	 <bibkey>siarhei-artsiom:2012:POSTERS</bibkey>
     </paper>
     <paper id="2111">
-	 <title>New Readability Measures for Bangla and Hindi Texts</title>
+	 <title>New Readability Measures for <fixed-case>B</fixed-case>angla and <fixed-case>H</fixed-case>indi Texts</title>
 	 <author><first>Manjira</first><last>Sinha</last></author>
 	 <author><first>Sakshi</first><last>Sharma</last></author>
 	 <author><first>Tirthankar</first><last>Dasgupta</last></author>
@@ -4686,7 +4687,7 @@
 	 <bibkey>smith-danielsson-jnsson:2012:POSTERS</bibkey>
     </paper>
     <paper id="2114">
-	 <title>Robust Learning in Random Subspaces: Equipping NLP for OOV Effects</title>
+	 <title>Robust Learning in Random Subspaces: Equipping <fixed-case>NLP</fixed-case> for <fixed-case>OOV</fixed-case> Effects</title>
 	 <author><first>Anders</first><last>Søgaard</last></author>
 	 <author><first>Anders</first><last>Johannsen</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -4730,7 +4731,7 @@
 	 <bibkey>song-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2117">
-	 <title>Corpus-based Explorations of Affective Load Differences in Arabic-Hebrew-English</title>
+	 <title>Corpus-based Explorations of Affective Load Differences in <fixed-case>A</fixed-case>rabic-<fixed-case>H</fixed-case>ebrew-<fixed-case>E</fixed-case>nglish</title>
 	 <author><first>Carlo</first><last>Strapparava</last></author>
 	 <author><first>Oliviero</first><last>Stock</last></author>
 	 <author><first>Ilai</first><last>Alon</last></author>
@@ -4968,7 +4969,7 @@
 	 <bibkey>xun-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2133">
-	 <title>HYENA: Hierarchical Type Classification for Entity Names</title>
+	 <title><fixed-case>HYENA</fixed-case>: Hierarchical Type Classification for Entity Names</title>
 	 <author><first>Mohamed Amir</first><last>Yosef</last></author>
 	 <author><first>Sandro</first><last>Bauer</last></author>
 	 <author><first>Johannes</first><last>Hoffart</last></author>
@@ -5028,7 +5029,7 @@
 	 <bibkey>zhang-nivre:2012:POSTERS</bibkey>
     </paper>
     <paper id="2137">
-	 <title>Chinese Word Sense Disambiguation based on Context Expansion</title>
+	 <title><fixed-case>C</fixed-case>hinese Word Sense Disambiguation based on Context Expansion</title>
 	 <author><first>Yang</first><last>Zhizhuo</last></author>
 	 <author><first>Huang</first><last>Heyan</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -5071,7 +5072,7 @@
         <bibkey>DEMOS:2012</bibkey>
    </paper>
    <paper id="3001">
-        <title>Complex Predicates in Telugu: A Computational Perspective</title>
+        <title>Complex Predicates in <fixed-case>T</fixed-case>elugu: A Computational Perspective</title>
         <author><first>Rahul</first><last>Balusu</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
         <month>December</month>
@@ -5113,7 +5114,7 @@
         <bibkey>bhaskar-nongmeikapam-bandyopadhyay:2012:DEMOS</bibkey>
    </paper>
    <paper id="3004">
-        <title>IKAR: An Improved Kit for Anaphora Resolution for Polish</title>
+        <title><fixed-case>IKAR</fixed-case>: An Improved Kit for Anaphora Resolution for <fixed-case>P</fixed-case>olish</title>
         <author><first>Bartosz</first><last>Broda</last></author>
         <author><first>Łukasz</first><last>Burdka</last></author>
         <author><first>Marek</first><last>Maziarz</last></author>
@@ -5155,7 +5156,7 @@
         <bibkey>chakraborty:2012:DEMOS</bibkey>
    </paper>
    <paper id="3007">
-        <title>Word Root Finder: a Morphological Segmentor Based on CRF</title>
+        <title>Word Root Finder: a Morphological Segmentor Based on <fixed-case>CRF</fixed-case></title>
         <author><first>Joseph Z.</first><last>Chang</last></author>
         <author><first>Jason S.</first><last>Chang</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5184,7 +5185,7 @@
         <bibkey>chatterji-chatterjee-sarkar:2012:DEMOS</bibkey>
    </paper>
    <paper id="3009">
-        <title>An Example-Based Japanese Proofreading System for Offshore Development</title>
+        <title>An Example-Based <fixed-case>J</fixed-case>apanese Proofreading System for Offshore Development</title>
         <author><first>Yuchang</first><last>Cheng</last></author>
         <author><first>Tomoki</first><last>Nagase</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5198,7 +5199,7 @@
         <bibkey>cheng-nagase:2012:DEMOS</bibkey>
    </paper>
    <paper id="3010">
-        <title>DomEx: Extraction of Sentiment Lexicons for Domains and Meta-Domains</title>
+        <title><fixed-case>DomEx</fixed-case>: Extraction of Sentiment Lexicons for Domains and Meta-Domains</title>
         <author><first>Ilia</first><last>Chetviorkin</last></author>
         <author><first>Natalia</first><last>Loukachevitch</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5212,7 +5213,7 @@
         <bibkey>chetviorkin-loukachevitch:2012:DEMOS</bibkey>
    </paper>
    <paper id="3011">
-        <title>On the Romanian Rhyme Detection</title>
+        <title>On the <fixed-case>R</fixed-case>omanian Rhyme Detection</title>
         <author><first>Alina</first><last>Ciobanu</last></author>
         <author><first>Liviu P.</first><last>Dinu</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5241,7 +5242,7 @@
         <bibkey>cuayahuitl-kruijffkorbayova-dethlefs:2012:DEMOS</bibkey>
    </paper>
    <paper id="3013">
-        <title>Automated Paradigm Selection for FSA based Konkani Verb Morphological Analyzer</title>
+        <title>Automated Paradigm Selection for <fixed-case>FSA</fixed-case> based <fixed-case>K</fixed-case>onkani Verb Morphological Analyzer</title>
         <author><first>Shilpa</first><last>Desai</last></author>
         <author><first>Jyoti</first><last>Pawar</last></author>
         <author><first>Pushpak</first><last>Bhattacharyya</last></author>
@@ -5256,7 +5257,7 @@
         <bibkey>desai-pawar-bhattacharyya:2012:DEMOS</bibkey>
    </paper>
    <paper id="3014">
-        <title>Hindi and Marathi to English NE Transliteration Tool using Phonology and Stress Analysis</title>
+        <title><fixed-case>H</fixed-case>indi and <fixed-case>M</fixed-case>arathi to <fixed-case>E</fixed-case>nglish <fixed-case>NE</fixed-case> Transliteration Tool using Phonology and Stress Analysis</title>
         <author><first>Manikrao</first><last>Dhore</last></author>
         <author><first>Shantanu</first><last>Dixit</last></author>
         <author><first>Ruchi</first><last>Dhore</last></author>
@@ -5271,7 +5272,7 @@
         <bibkey>dhore-dixit-dhore:2012:DEMOS</bibkey>
    </paper>
    <paper id="3015">
-        <title>Dealing with the Grey Sheep of the Romanian Gender System, the Neuter</title>
+        <title>Dealing with the Grey Sheep of the <fixed-case>R</fixed-case>omanian Gender System, the Neuter</title>
         <author><first>Liviu P.</first><last>Dinu</last></author>
         <author><first>Vlad</first><last>Niculae</last></author>
         <author><first>Maria</first><last>Sulea</last></author>
@@ -5300,7 +5301,7 @@
         <bibkey>dinu-nisioi:2012:DEMOS</bibkey>
    </paper>
    <paper id="3017">
-        <title>ScienQuest: a Treebank Exploitation Tool for non NLP-Specialists</title>
+        <title><fixed-case>ScienQuest</fixed-case>: a Treebank Exploitation Tool for non <fixed-case>NLP</fixed-case>-Specialists</title>
         <author><first>Achille</first><last>Falaise</last></author>
         <author><first>Olivier</first><last>Kraif</last></author>
         <author><first>Agnès</first><last>Tutin</last></author>
@@ -5346,7 +5347,7 @@
         <bibkey>gao-li-zhang:2012:DEMOS1</bibkey>
    </paper>
    <paper id="3020">
-        <title>Beyond Twitter Text: A Preliminary Study on Twitter Hyperlink and its Application</title>
+        <title>Beyond <fixed-case>T</fixed-case>witter Text: A Preliminary Study on <fixed-case>T</fixed-case>witter Hyperlink and its Application</title>
         <author><first>Dehong</first><last>Gao</last></author>
         <author><first>Wenjie</first><last>Li</last></author>
         <author><first>Renxian</first><last>Zhang</last></author>
@@ -5361,7 +5362,7 @@
         <bibkey>gao-li-zhang:2012:DEMOS2</bibkey>
    </paper>
    <paper id="3021">
-        <title>Rule Based Hindi Part of Speech Tagger</title>
+        <title>Rule Based <fixed-case>H</fixed-case>indi Part of Speech Tagger</title>
         <author><first>Navneet</first><last>Garg</last></author>
         <author><first>Vishal</first><last>Goyal</last></author>
         <author><first>Suman</first><last>Preet</last></author>
@@ -5376,7 +5377,7 @@
         <bibkey>garg-goyal-preet:2012:DEMOS</bibkey>
    </paper>
    <paper id="3022">
-        <title>Fangorn: A System for Querying very large Treebanks</title>
+        <title><fixed-case>F</fixed-case>angorn: A System for Querying very large Treebanks</title>
         <author><first>Sumukh</first><last>Ghodke</last></author>
         <author><first>Steven</first><last>Bird</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5390,7 +5391,7 @@
         <bibkey>ghodke-bird:2012:DEMOS</bibkey>
    </paper>
    <paper id="3023">
-        <title>CRAB Reader: A Tool for Analysis and Visualization of Argumentative Zones in Scientific Literature</title>
+        <title><fixed-case>CRAB</fixed-case> Reader: A Tool for Analysis and Visualization of Argumentative Zones in Scientific Literature</title>
         <author><first>Yufan</first><last>Guo</last></author>
         <author><first>Ilona</first><last>Silins</last></author>
         <author><first>Roi</first><last>Reichart</last></author>
@@ -5406,7 +5407,7 @@
         <bibkey>guo-EtAl:2012:DEMOS</bibkey>
    </paper>
    <paper id="3024">
-        <title>Automatic Punjabi Text Extractive Summarization System</title>
+        <title>Automatic <fixed-case>P</fixed-case>unjabi Text Extractive Summarization System</title>
         <author><first>Vishal</first><last>Gupta</last></author>
         <author><first>Gurpreet</first><last>Lehal</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5420,7 +5421,7 @@
         <bibkey>gupta-lehal:2012:DEMOS1</bibkey>
    </paper>
    <paper id="3025">
-        <title>Complete Pre Processing Phase of Punjabi Text Extractive Summarization System</title>
+        <title>Complete Pre Processing Phase of <fixed-case>P</fixed-case>unjabi Text Extractive Summarization System</title>
         <author><first>Vishal</first><last>Gupta</last></author>
         <author><first>Gurpreet</first><last>Lehal</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5434,7 +5435,7 @@
         <bibkey>gupta-lehal:2012:DEMOS2</bibkey>
    </paper>
    <paper id="3026">
-        <title>Revisiting Arabic Semantic Role Labeling using SVM Kernel Methods</title>
+        <title>Revisiting <fixed-case>A</fixed-case>rabic Semantic Role Labeling using <fixed-case>SVM</fixed-case> Kernel Methods</title>
         <author><first>Laurel</first><last>Hart</last></author>
         <author><first>Hassan</first><last>Alam</last></author>
         <author><first>Aman</first><last>Kumar</last></author>
@@ -5449,7 +5450,7 @@
         <bibkey>hart-alam-kumar:2012:DEMOS</bibkey>
    </paper>
    <paper id="3027">
-        <title>fokas: Formerly Known As – A Search Engine Incorporating Named Entity Evolution</title>
+        <title><fixed-case>fokas</fixed-case>: <fixed-case>F</fixed-case>ormerly <fixed-case>K</fixed-case>nown <fixed-case>A</fixed-case>s – A Search Engine Incorporating Named Entity Evolution</title>
         <author><first>Helge</first><last>Holzmann</last></author>
         <author><first>Gerhard</first><last>Gossen</last></author>
         <author><first>Nina</first><last>Tahmasebi</last></author>
@@ -5464,7 +5465,7 @@
         <bibkey>holzmann-gossen-tahmasebi:2012:DEMOS</bibkey>
    </paper>
    <paper id="3028">
-        <title>An Annotation System for Development of Chinese Discourse Corpus</title>
+        <title>An Annotation System for Development of <fixed-case>C</fixed-case>hinese Discourse Corpus</title>
         <author><first>Hen-Hsen</first><last>Huang</last></author>
         <author><first>Hsin-Hsi</first><last>Chen</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5478,7 +5479,7 @@
         <bibkey>huang-chen:2012:DEMOS</bibkey>
    </paper>
    <paper id="3029">
-        <title>Modeling Pollyanna Phenomena in Chinese Sentiment Analysis</title>
+        <title>Modeling <fixed-case>P</fixed-case>ollyanna Phenomena in <fixed-case>C</fixed-case>hinese Sentiment Analysis</title>
         <author><first>Ting-Hao</first><last>Huang</last></author>
         <author><first>Ho-Cheng</first><last>Yu</last></author>
         <author><first>Hsin-Hsi</first><last>Chen</last></author>
@@ -5493,7 +5494,7 @@
         <bibkey>huang-yu-chen:2012:DEMOS</bibkey>
    </paper>
    <paper id="3030">
-        <title>Eating Your Own Cooking: Automatically Linking Wordnet Synsets of Two Languages</title>
+        <title>Eating Your Own Cooking: Automatically Linking <fixed-case>W</fixed-case>ordnet Synsets of Two Languages</title>
         <author><first>Salil</first><last>Joshi</last></author>
         <author><first>Arindam</first><last>Chatterjee</last></author>
         <author><first>Arun Karthikeyan</first><last>Karra</last></author>
@@ -5509,7 +5510,7 @@
         <bibkey>joshi-EtAl:2012:DEMOS</bibkey>
    </paper>
    <paper id="3031">
-        <title>I Can Sense It: a Comprehensive Online System for WSD</title>
+        <title>I Can Sense It: a Comprehensive Online System for <fixed-case>WSD</fixed-case></title>
         <author><first>Salil</first><last>Joshi</last></author>
         <author><first>Mitesh M.</first><last>Khapra</last></author>
         <author><first>Pushpak</first><last>Bhattacharyya</last></author>
@@ -5539,7 +5540,7 @@
         <bibkey>kalitvianski-boitet-bellynck:2012:DEMOS</bibkey>
    </paper>
    <paper id="3033">
-        <title>Discrimination-Net for Hindi</title>
+        <title>Discrimination-Net for <fixed-case>H</fixed-case>indi</title>
         <author><first>Diptesh</first><last>Kanojia</last></author>
         <author><first>Arindam</first><last>Chatterjee</last></author>
         <author><first>Salil</first><last>Joshi</last></author>
@@ -5555,7 +5556,7 @@
         <bibkey>kanojia-EtAl:2012:DEMOS</bibkey>
    </paper>
    <paper id="3034">
-        <title>Rule Based Urdu Stemmer</title>
+        <title>Rule Based <fixed-case>U</fixed-case>rdu Stemmer</title>
         <author><first>Rohit</first><last>Kansal</last></author>
         <author><first>Vishal</first><last>Goyal</last></author>
         <author><first>Gurpreet Singh</first><last>Lehal</last></author>
@@ -5570,7 +5571,7 @@
         <bibkey>kansal-goyal-lehal:2012:DEMOS</bibkey>
    </paper>
    <paper id="3035">
-        <title>JMaxAlign: A Maximum Entropy Parallel Sentence Alignment Tool</title>
+        <title><fixed-case>JMaxAlign</fixed-case>: A Maximum Entropy Parallel Sentence Alignment Tool</title>
         <author><first>Max</first><last>Kaufmann</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
         <month>December</month>
@@ -5583,7 +5584,7 @@
         <bibkey>kaufmann:2012:DEMOS</bibkey>
    </paper>
    <paper id="3036">
-        <title>MIKE: An Interactive Microblogging Keyword Extractor using Contextual Semantic Smoothing</title>
+        <title><fixed-case>MIKE</fixed-case>: An Interactive Microblogging Keyword Extractor using Contextual Semantic Smoothing</title>
         <author><first>Osama</first><last>Khan</last></author>
         <author><first>Asim</first><last>Karim</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5597,7 +5598,7 @@
         <bibkey>khan-karim:2012:DEMOS</bibkey>
    </paper>
    <paper id="3037">
-        <title>Domain Based Classification of Punjabi Text Documents</title>
+        <title>Domain Based Classification of <fixed-case>P</fixed-case>unjabi Text Documents</title>
         <author><first>Nidhi</first><last>Krail</last></author>
         <author><first>Vishal</first><last>Gupta</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5611,7 +5612,7 @@
         <bibkey>krail-gupta:2012:DEMOS</bibkey>
    </paper>
    <paper id="3038">
-        <title>Open Information Extraction for SOV Language Based on Entity-Predicate Pair Detection</title>
+        <title>Open Information Extraction for <fixed-case>SOV</fixed-case> Language Based on Entity-Predicate Pair Detection</title>
         <author><first>Woong-Ki</first><last>Lee</last></author>
         <author><first>Yeon-Su</first><last>Lee</last></author>
         <author><first>Hyoung-Gyu</first><last>Lee</last></author>
@@ -5628,7 +5629,7 @@
         <bibkey>lee-EtAl:2012:DEMOS</bibkey>
    </paper>
    <paper id="3039">
-        <title>An Omni-Font Gurmukhi to Shahmukhi Transliteration System</title>
+        <title>An Omni-Font <fixed-case>G</fixed-case>urmukhi to <fixed-case>S</fixed-case>hahmukhi Transliteration System</title>
         <author><first>Gurpreet Singh</first><last>Lehal</last></author>
         <author><first>Tejinder Singh</first><last>Saini</last></author>
         <author><first>Savleen Kaur</first><last>Chowdhary</last></author>
@@ -5643,7 +5644,7 @@
         <bibkey>lehal-saini-chowdhary:2012:DEMOS</bibkey>
    </paper>
    <paper id="3040">
-        <title>THUTR: A Translation Retrieval System</title>
+        <title><fixed-case>THUTR</fixed-case>: A Translation Retrieval System</title>
         <author><first>Chunyang</first><last>Liu</last></author>
         <author><first>Qi</first><last>Liu</last></author>
         <author><first>Yang</first><last>Liu</last></author>
@@ -5691,7 +5692,7 @@
         <bibkey>nguyen-vogel:2012:DEMOS</bibkey>
    </paper>
    <paper id="3043">
-        <title>Stemming Tigrinya Words for Information Retrieval</title>
+        <title>Stemming <fixed-case>T</fixed-case>igrinya Words for Information Retrieval</title>
         <author><first>Omer</first><last>Osman</last></author>
         <author><first>Yoshiki</first><last>Mikami</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5705,7 +5706,7 @@
         <bibkey>osman-mikami:2012:DEMOS</bibkey>
    </paper>
    <paper id="3044">
-        <title>OpenWordNet-PT: An Open Brazilian Wordnet for Reasoning</title>
+        <title><fixed-case>OpenWordNet</fixed-case>-<fixed-case>PT</fixed-case>: An Open <fixed-case>B</fixed-case>razilian <fixed-case>W</fixed-case>ordnet for Reasoning</title>
         <author><first>Valeria</first><last>de Paiva</last></author>
         <author><first>Alexandre</first><last>Rademaker</last></author>
         <author><first>Gerard</first><last>de Melo</last></author>
@@ -5720,7 +5721,7 @@
         <bibkey>depaiva-rademaker-demelo:2012:DEMOS</bibkey>
    </paper>
    <paper id="3045">
-        <title>WordNet Website Development And Deployment using Content Management Approach</title>
+        <title><fixed-case>W</fixed-case>ordNet Website Development And Deployment using Content Management Approach</title>
         <author><first>Neha</first><last>Prabhugaonkar</last></author>
         <author><first>Apurva</first><last>Nagvenkar</last></author>
         <author><first>Venkatesh</first><last>Prabhu</last></author>
@@ -5749,7 +5750,7 @@
         <bibkey>ren:2012:DEMOS1</bibkey>
    </paper>
    <paper id="3047">
-        <title>A Practical Chinese-English ON Translation Method Based on ON’s Distribution Characteristics on the Web</title>
+        <title>A Practical <fixed-case>C</fixed-case>hinese-<fixed-case>E</fixed-case>nglish <fixed-case>ON</fixed-case> Translation Method Based on <fixed-case>ON</fixed-case>‘s Distribution Characteristics on the Web</title>
         <author><first>Feiliang</first><last>Ren</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
         <month>December</month>
@@ -5762,7 +5763,7 @@
         <bibkey>ren:2012:DEMOS2</bibkey>
    </paper>
    <paper id="3048">
-        <title>Elissa: A Dialectal to Standard Arabic Machine Translation System</title>
+        <title><fixed-case>E</fixed-case>lissa: A Dialectal to Standard <fixed-case>A</fixed-case>rabic Machine Translation System</title>
         <author><first>Wael</first><last>Salloum</last></author>
         <author><first>Nizar</first><last>Habash</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5776,7 +5777,7 @@
         <bibkey>salloum-habash:2012:DEMOS</bibkey>
    </paper>
    <paper id="3049">
-        <title>Domain Based Punjabi Text Document Clustering</title>
+        <title>Domain Based <fixed-case>P</fixed-case>unjabi Text Document Clustering</title>
         <author><first>Saurabh</first><last>Sharma</last></author>
         <author><first>Vishal</first><last>Gupta</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5790,7 +5791,7 @@
         <bibkey>sharma-gupta:2012:DEMOS</bibkey>
    </paper>
    <paper id="3050">
-        <title>Open source multi-platform NooJ for NLP</title>
+        <title>Open source multi-platform <fixed-case>NooJ</fixed-case> for <fixed-case>NLP</fixed-case></title>
         <author><first>Max</first><last>Silberztein</last></author>
         <author><first>Tamás</first><last>Váradi</last></author>
         <author><first>Marko</first><last>Tadić</last></author>
@@ -5805,7 +5806,7 @@
         <bibkey>silberztein-varadi-tadi:2012:DEMOS</bibkey>
    </paper>
    <paper id="3051">
-        <title>Punjabi Text-To-Speech Synthesis System</title>
+        <title><fixed-case>P</fixed-case>unjabi Text-To-Speech Synthesis System</title>
         <author><first>Parminder</first><last>Singh</last></author>
         <author><first>Gurpreet Singh</first><last>Lehal</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5819,7 +5820,7 @@
         <bibkey>singh-lehal:2012:DEMOS</bibkey>
    </paper>
    <paper id="3052">
-        <title>EXCOTATE: An Add-on to MMAX2 for Inspection and Exchange of Annotated Data</title>
+        <title><fixed-case>EXCOTATE</fixed-case>: An Add-on to <fixed-case>MMAX2</fixed-case> for Inspection and Exchange of Annotated Data</title>
         <author><first>Tobias</first><last>Stadtfeld</last></author>
         <author><first>Tibor</first><last>Kiss</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5833,7 +5834,7 @@
         <bibkey>stadtfeld-kiss:2012:DEMOS</bibkey>
    </paper>
    <paper id="3053">
-        <title>Bulgarian Inflectional Morphology in Universal Networking Language</title>
+        <title><fixed-case>B</fixed-case>ulgarian Inflectional Morphology in Universal Networking Language</title>
         <author><first>Velislava</first><last>Stoykova</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
         <month>December</month>
@@ -5846,7 +5847,7 @@
         <bibkey>stoykova:2012:DEMOS</bibkey>
    </paper>
    <paper id="3054">
-        <title>Central and South-East European Resources in META-SHARE</title>
+        <title><fixed-case>C</fixed-case>entral and <fixed-case>S</fixed-case>outh-<fixed-case>E</fixed-case>ast <fixed-case>E</fixed-case>uropean Resources in <fixed-case>META</fixed-case>-<fixed-case>SHARE</fixed-case></title>
         <author><first>Marko</first><last>Tadić</last></author>
         <author><first>Tamás</first><last>Váradi</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5860,7 +5861,7 @@
         <bibkey>tadi-varadi:2012:DEMOS</bibkey>
    </paper>
    <paper id="3055">
-        <title>Markov Chains for Robust Graph-Based Commonsense Information Extraction</title>
+        <title><fixed-case>M</fixed-case>arkov Chains for Robust Graph-Based Commonsense Information Extraction</title>
         <author><first>Niket</first><last>Tandon</last></author>
         <author><first>Dheeraj</first><last>Rajagopal</last></author>
         <author><first>Gerard</first><last>de Melo</last></author>
@@ -5889,7 +5890,7 @@
         <bibkey>tsai-wang:2012:DEMOS</bibkey>
    </paper>
    <paper id="3057">
-        <title>UNL Explorer</title>
+        <title><fixed-case>UNL</fixed-case> Explorer</title>
         <author><first>Hiroshi</first><last>Uchida</last></author>
         <author><first>Meiying</first><last>Zhu</last></author>
         <author><first>Md. Anwarus Salam</first><last>Khan</last></author>
@@ -5904,7 +5905,7 @@
         <bibkey>uchida-zhu-khan:2012:DEMOS</bibkey>
    </paper>
    <paper id="3058">
-        <title>An SMT-driven Authoring Tool</title>
+        <title>An <fixed-case>SMT</fixed-case>-driven Authoring Tool</title>
         <author><first>Sriram</first><last>Venkatapathy</last></author>
         <author><first>Shachar</first><last>Mirkin</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5935,7 +5936,7 @@
         <bibkey>wang-EtAl:2012:DEMOS1</bibkey>
    </paper>
    <paper id="3060">
-        <title>Demo of iMAG Possibilities: MT-postediting, Translation Quality Evaluation, Parallel Corpus Production</title>
+        <title>Demo of <fixed-case>iMAG</fixed-case> Possibilities: <fixed-case>MT</fixed-case>-postediting, Translation Quality Evaluation, Parallel Corpus Production</title>
         <author><first>Ling Xiao</first><last>Wang</last></author>
         <author><first>Ying</first><last>Zhang</last></author>
         <author><first>Christian</first><last>Boitet</last></author>
@@ -5951,7 +5952,7 @@
         <bibkey>wang-EtAl:2012:DEMOS2</bibkey>
    </paper>
    <paper id="3061">
-        <title>Jane 2: Open Source Phrase-based and Hierarchical Statistical Machine Translation</title>
+        <title><fixed-case>J</fixed-case>ane 2: Open Source Phrase-based and Hierarchical Statistical Machine Translation</title>
         <author><first>Joern</first><last>Wuebker</last></author>
         <author><first>Matthias</first><last>Huck</last></author>
         <author><first>Stephan</first><last>Peitz</last></author>
@@ -5971,7 +5972,7 @@
         <bibkey>wuebker-EtAl:2012:DEMOS</bibkey>
    </paper>
    <paper id="3062">
-        <title>Automatic Extraction of Turkish Hypernym-Hyponym Pairs From Large Corpus</title>
+        <title>Automatic Extraction of <fixed-case>T</fixed-case>urkish Hypernym-Hyponym Pairs From Large Corpus</title>
         <author><first>Savas</first><last>Yildirim</last></author>
         <author><first>Tugba</first><last>Yildiz</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -5985,7 +5986,7 @@
         <bibkey>yildirim-yildiz:2012:DEMOS</bibkey>
    </paper>
    <paper id="3063">
-        <title>Chinese Web Scale Linguistic Datasets and Toolkit</title>
+        <title><fixed-case>C</fixed-case>hinese Web Scale Linguistic Datasets and Toolkit</title>
         <author><first>Chi-Hsin</first><last>Yu</last></author>
         <author><first>Hsin-Hsi</first><last>Chen</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -6013,7 +6014,7 @@
         <bibkey>yu-hsu:2012:DEMOS</bibkey>
    </paper>
    <paper id="3065">
-        <title>Arabic Morphological Analyzer with Agglutinative Affix Morphemes and Fusional Concatenation Rules</title>
+        <title><fixed-case>A</fixed-case>rabic Morphological Analyzer with Agglutinative Affix Morphemes and Fusional Concatenation Rules</title>
         <author><first>Fadi</first><last>Zaraket</last></author>
         <author><first>Jad</first><last>Makhlouta</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>
@@ -6027,7 +6028,7 @@
         <bibkey>zaraket-makhlouta:2012:DEMOS</bibkey>
    </paper>
    <paper id="3066">
-        <title>SMR-Cmp: Square-Mean-Root Approach to Comparison of Monolingual Contrastive Corpora</title>
+        <title><fixed-case>SMR</fixed-case>-<fixed-case>Cmp</fixed-case>: Square-Mean-Root Approach to Comparison of Monolingual Contrastive Corpora</title>
         <author><first>HuaRui</first><last>Zhang</last></author>
         <author><first>Chu-Ren</first><last>Huang</last></author>
         <author><first>Francesca</first><last>Quattri</last></author>
@@ -6042,7 +6043,7 @@
         <bibkey>zhang-huang-quattri:2012:DEMOS</bibkey>
    </paper>
    <paper id="3067">
-        <title>A Machine Learning Approach to Convert CCGbank to Penn Treebank</title>
+        <title>A Machine Learning Approach to Convert <fixed-case>CCGbank</fixed-case> to <fixed-case>P</fixed-case>enn Treebank</title>
         <author><first>Xiaotian</first><last>Zhang</last></author>
         <author><first>Hai</first><last>Zhao</last></author>
         <author><first>Cong</first><last>Hui</last></author>

--- a/import/C12.xml
+++ b/import/C12.xml
@@ -3161,7 +3161,7 @@
 	 <bibkey>attia-EtAl:2012:POSTERS</bibkey>
     </paper>
     <paper id="2012">
-	 <title>Heloise — A Reengineering of Ariane-G5 SLLPs for Application to π-languages</title>
+	 <title><fixed-case>H</fixed-case>eloise — A Reengineering of <fixed-case>A</fixed-case>riane-<fixed-case>G</fixed-case>5 <fixed-case>SLLP</fixed-case>s for Application to π-languages</title>
 	 <author><first>Vincent</first><last>Berment</last></author>
 	 <author><first>Christian</first><last>Boitet</last></author>
 	 <booktitle>Proceedings of COLING 2012: Posters</booktitle>
@@ -5085,7 +5085,7 @@
         <bibkey>balusu:2012:DEMOS</bibkey>
    </paper>
    <paper id="3002">
-        <title>Heloise — An Ariane-G5 Compatible Rnvironment for Developing Expert MT Systems Online</title>
+        <title><fixed-case>H</fixed-case>eloise — An <fixed-case>A</fixed-case>riane-<fixed-case>G</fixed-case>5 Compatible Rnvironment for Developing Expert <fixed-case>MT</fixed-case> Systems Online</title>
         <author><first>Vincent</first><last>Berment</last></author>
         <author><first>Christian</first><last>Boitet</last></author>
         <booktitle>Proceedings of COLING 2012: Demonstration Papers</booktitle>

--- a/import/C14.xml
+++ b/import/C14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="C14">
   <paper id="1000">
     <title>Proceedings of COLING 2014, the 25th International Conference on Computational Linguistics: Technical Papers</title>

--- a/import/C16.xml
+++ b/import/C16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="C16">
   <paper id="1000">
     <title>Proceedings of COLING 2016, the 26th International Conference on Computational Linguistics: Technical Papers</title>

--- a/import/C18.xml
+++ b/import/C18.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="C18">
    <paper id="1000">
         <title>Proceedings of the 27th International Conference on Computational Linguistics</title>

--- a/import/D07.xml
+++ b/import/D07.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D07">
    <paper id="1000">
         <title>Proceedings of the 2007 Joint Conference on Empirical Methods in Natural Language Processing and Computational Natural Language Learning (EMNLP-CoNLL)</title>
@@ -16,14 +17,14 @@
    </paper>
 
    <paper id="1003">
-        <title>What is the Jeopardy Model? A Quasi-Synchronous Grammar for QA</title>
+        <title>What is the <fixed-case>J</fixed-case>eopardy Model? A Quasi-Synchronous Grammar for <fixed-case>QA</fixed-case></title>
         <author><first>Mengqiu</first><last>Wang</last></author>
         <author><first>Noah A.</first><last>Smith</last></author>
         <author><first>Teruko</first><last>Mitamura</last></author>
    </paper>
 
    <paper id="1004">
-        <title>Learning Unsupervised SVM Classifier for Answer Selection in Web Question Answering</title>
+        <title>Learning Unsupervised <fixed-case>SVM</fixed-case> Classifier for Answer Selection in Web Question Answering</title>
         <author><first>Youzheng</first><last>Wu</last></author>
         <author><first>Ruiqiang</first><last>Zhang</last></author>
         <author><first>Xinhui</first><last>Hu</last></author>
@@ -38,7 +39,7 @@
    </paper>
 
    <paper id="1006">
-        <title>Getting the Structure Right for Word Alignment: LEAF</title>
+        <title>Getting the Structure Right for Word Alignment: <fixed-case>LEAF</fixed-case></title>
         <author><first>Alexander</first><last>Fraser</last></author>
         <author><first>Daniel</first><last>Marcu</last></author>
    </paper>
@@ -109,7 +110,7 @@
    </paper>
 
    <paper id="1017">
-        <title>LEDIR: An Unsupervised Algorithm for Learning Directionality of Inference Rules</title>
+        <title><fixed-case>LEDIR</fixed-case>: An Unsupervised Algorithm for Learning Directionality of Inference Rules</title>
         <author><first>Rahul</first><last>Bhagat</last></author>
         <author><first>Patrick</first><last>Pantel</last></author>
         <author><first>Eduard</first><last>Hovy</last></author>
@@ -136,7 +137,7 @@
    </paper>
 
    <paper id="1021">
-        <title>Compressing Trigram Language Models With Golomb Coding</title>
+        <title>Compressing Trigram Language Models With <fixed-case>Golomb</fixed-case> Coding</title>
         <author><first>Kenneth</first><last>Church</last></author>
         <author><first>Ted</first><last>Hart</last></author>
         <author><first>Jianfeng</first><last>Gao</last></author>
@@ -174,7 +175,7 @@
    </paper>
 
    <paper id="1027">
-        <title>Recovering Non-Local Dependencies for Chinese</title>
+        <title>Recovering Non-Local Dependencies for <fixed-case>C</fixed-case>hinese</title>
         <author><first>Yuqing</first><last>Guo</last></author>
         <author><first>Haifeng</first><last>Wang</last></author>
         <author><first>Josef</first><last>van Genabith</last></author>
@@ -195,19 +196,19 @@
    </paper>
 
    <paper id="1030">
-        <title>Using RBMT Systems to Produce Bilingual Corpus for SMT</title>
+        <title>Using <fixed-case>RBMT</fixed-case> Systems to Produce Bilingual Corpus for <fixed-case>SMT</fixed-case></title>
         <author><first>Xiaoguang</first><last>Hu</last></author>
         <author><first>Haifeng</first><last>Wang</last></author>
         <author><first>Hua</first><last>Wu</last></author>
    </paper>
 
    <paper id="1031">
-        <title>Why Doesn’t EM Find Good HMM POS-Taggers?</title>
+        <title>Why Doesn’t <fixed-case>EM</fixed-case> Find Good <fixed-case>HMM</fixed-case> <fixed-case>POS</fixed-case>-Taggers?</title>
         <author><first>Mark</first><last>Johnson</last></author>
    </paper>
 
    <paper id="1032">
-        <title>Probabilistic Coordination Disambiguation in a Fully-Lexicalized Japanese Parser</title>
+        <title>Probabilistic Coordination Disambiguation in a Fully-Lexicalized <fixed-case>J</fixed-case>apanese Parser</title>
         <author><first>Daisuke</first><last>Kawahara</last></author>
         <author><first>Sadao</first><last>Kurohashi</last></author>
    </paper>
@@ -219,7 +220,7 @@
    </paper>
 
    <paper id="1034">
-        <title>Extending a Thesaurus in the Pan-Chinese Context</title>
+        <title>Extending a Thesaurus in the Pan-<fixed-case>C</fixed-case>hinese Context</title>
         <author><first>Oi Yee</first><last>Kwong</last></author>
         <author><first>Benjamin K.</first><last>Tsou</last></author>
    </paper>
@@ -266,7 +267,7 @@
    </paper>
 
    <paper id="1041">
-        <title>Part-of-Speech Tagging for Middle English through Alignment and Projection of Parallel Diachronic Texts</title>
+        <title>Part-of-Speech Tagging for Middle <fixed-case>E</fixed-case>nglish through Alignment and Projection of Parallel Diachronic Texts</title>
         <author><first>Taesun</first><last>Moon</last></author>
         <author><first>Jason</first><last>Baldridge</last></author>
    </paper>
@@ -279,13 +280,13 @@
    </paper>
 
    <paper id="1043">
-        <title>V-Measure: A Conditional Entropy-Based External Cluster Evaluation Measure</title>
+        <title><fixed-case>V</fixed-case>-Measure: A Conditional Entropy-Based External Cluster Evaluation Measure</title>
         <author><first>Andrew</first><last>Rosenberg</last></author>
         <author><first>Julia</first><last>Hirschberg</last></author>
    </paper>
 
    <paper id="1044">
-        <title>Bayesian Document Generative Model with Explicit Multiple Topics</title>
+        <title><fixed-case>Bayesian</fixed-case> Document Generative Model with Explicit Multiple Topics</title>
         <author><first>Issei</first><last>Sato</last></author>
         <author><first>Hiroshi</first><last>Nakagawa</last></author>
    </paper>
@@ -298,13 +299,13 @@
    </paper>
 
    <paper id="1046">
-        <title>Morphological Disambiguation of Hebrew: A Case Study in Classifier Combination</title>
+        <title>Morphological Disambiguation of <fixed-case>H</fixed-case>ebrew: A Case Study in Classifier Combination</title>
         <author><first>Danny</first><last>Shacham</last></author>
         <author><first>Shuly</first><last>Wintner</last></author>
    </paper>
 
    <paper id="1047">
-        <title>Enhancing Single-Document Summarization by Combining RankNet and Third-Party Sources</title>
+        <title>Enhancing Single-Document Summarization by Combining <fixed-case>R</fixed-case>ank<fixed-case>N</fixed-case>et and Third-Party Sources</title>
         <author><first>Krysta</first><last>Svore</last></author>
         <author><first>Lucy</first><last>Vanderwende</last></author>
         <author><first>Christopher</first><last>Burges</last></author>
@@ -319,7 +320,7 @@
    </paper>
 
    <paper id="1049">
-        <title>Smoothed Bloom Filter Language Models: Tera-Scale LMs on the Cheap</title>
+        <title>Smoothed <fixed-case>Bloom</fixed-case> Filter Language Models: Tera-Scale <fixed-case>LMs</fixed-case> on the Cheap</title>
         <author><first>David</first><last>Talbot</last></author>
         <author><first>Miles</first><last>Osborne</last></author>
    </paper>
@@ -365,7 +366,7 @@
    </paper>
 
    <paper id="1056">
-        <title>Phrase Reordering Model Integrating Syntactic Knowledge for SMT</title>
+        <title>Phrase Reordering Model Integrating Syntactic Knowledge for <fixed-case>SMT</fixed-case></title>
         <author><first>Dongdong</first><last>Zhang</last></author>
         <author><first>Mu</first><last>Li</last></author>
         <author><first>Chi-Ho</first><last>Li</last></author>
@@ -373,7 +374,7 @@
    </paper>
 
    <paper id="1057">
-        <title>Identification and Resolution of Chinese Zero Pronouns: A Machine Learning Approach</title>
+        <title>Identification and Resolution of <fixed-case>C</fixed-case>hinese Zero Pronouns: A Machine Learning Approach</title>
         <author><first>Shanheng</first><last>Zhao</last></author>
         <author><first>Hwee Tou</first><last>Ng</last></author>
    </paper>
@@ -405,13 +406,13 @@
    </paper>
 
    <paper id="1062">
-        <title>Experimental Evaluation of LTAG-Based Features for Semantic Role Labeling</title>
+        <title>Experimental Evaluation of <fixed-case>LTAG</fixed-case>-Based Features for Semantic Role Labeling</title>
         <author><first>Yudong</first><last>Liu</last></author>
         <author><first>Anoop</first><last>Sarkar</last></author>
    </paper>
 
    <paper id="1063">
-        <title>Japanese Dependency Analysis Using the Ancestor-Descendant Relation</title>
+        <title><fixed-case>J</fixed-case>apanese Dependency Analysis Using the Ancestor-Descendant Relation</title>
         <author><first>Akihiro</first><last>Tamura</last></author>
         <author><first>Hiroya</first><last>Takamura</last></author>
         <author><first>Manabu</first><last>Okumura</last></author>
@@ -430,13 +431,13 @@
    </paper>
 
    <paper id="1066">
-        <title>Treebank Annotation Schemes and Parser Evaluation for German</title>
+        <title>Treebank Annotation Schemes and Parser Evaluation for <fixed-case>G</fixed-case>erman</title>
         <author><first>Ines</first><last>Rehbein</last></author>
         <author><first>Josef</first><last>van Genabith</last></author>
    </paper>
 
    <paper id="1067">
-        <title>Semi-Markov Models for Sequence Segmentation</title>
+        <title>Semi-<fixed-case>M</fixed-case>arkov Models for Sequence Segmentation</title>
         <author><first>Qinfeng</first><last>Shi</last></author>
         <author><first>Yasemin</first><last>Altun</last></author>
         <author><first>Alex</first><last>Smola</last></author>
@@ -444,14 +445,14 @@
    </paper>
 
    <paper id="1068">
-        <title>A Graph-Based Approach to Named Entity Categorization in Wikipedia Using Conditional Random Fields</title>
+        <title>A Graph-Based Approach to Named Entity Categorization in <fixed-case>Wikipedia</fixed-case> Using Conditional Random Fields</title>
         <author><first>Yotaro</first><last>Watanabe</last></author>
         <author><first>Masayuki</first><last>Asahara</last></author>
         <author><first>Yuji</first><last>Matsumoto</last></author>
    </paper>
 
    <paper id="1069">
-        <title>MavenRank: Identifying Influential Members of the US Senate Using Lexical Centrality</title>
+        <title><fixed-case>M</fixed-case>aven<fixed-case>R</fixed-case>ank: Identifying Influential Members of the <fixed-case>US</fixed-case> Senate Using Lexical Centrality</title>
         <author><first>Anthony</first><last>Fader</last></author>
         <author><first>Dragomir R.</first><last>Radev</last></author>
         <author><first>Michael H.</first><last>Crespin</last></author>
@@ -467,13 +468,13 @@
    </paper>
 
    <paper id="1071">
-        <title>Online Learning of Relaxed CCG Grammars for Parsing to Logical Form</title>
+        <title>Online Learning of Relaxed <fixed-case>CCG</fixed-case> Grammars for Parsing to Logical Form</title>
         <author><first>Luke</first><last>Zettlemoyer</last></author>
         <author><first>Michael</first><last>Collins</last></author>
    </paper>
 
    <paper id="1072">
-        <title>The Infinite PCFG Using Hierarchical Dirichlet Processes</title>
+        <title>The Infinite <fixed-case>PCFG</fixed-case> Using Hierarchical <fixed-case>Dirichlet</fixed-case> Processes</title>
         <author><first>Percy</first><last>Liang</last></author>
         <author><first>Slav</first><last>Petrov</last></author>
         <author><first>Michael</first><last>Jordan</last></author>
@@ -481,13 +482,13 @@
    </paper>
 
    <paper id="1073">
-        <title>Exploiting Wikipedia as External Knowledge for Named Entity Recognition</title>
+        <title>Exploiting <fixed-case>Wikipedia</fixed-case> as External Knowledge for Named Entity Recognition</title>
         <author><first>Jun’ichi</first><last>Kazama</last></author>
         <author><first>Kentaro</first><last>Torisawa</last></author>
    </paper>
 
    <paper id="1074">
-        <title>Large-Scale Named Entity Disambiguation Based on Wikipedia Data</title>
+        <title>Large-Scale Named Entity Disambiguation Based on <fixed-case>Wikipedia</fixed-case> Data</title>
         <author><first>Silviu</first><last>Cucerzan</last></author>
    </paper>
 
@@ -506,7 +507,7 @@
    </paper>
 
    <paper id="1077">
-        <title>Chinese Syntactic Reordering for Statistical Machine Translation</title>
+        <title><fixed-case>C</fixed-case>hinese Syntactic Reordering for Statistical Machine Translation</title>
         <author><first>Chao</first><last>Wang</last></author>
         <author><first>Michael</first><last>Collins</last></author>
         <author><first>Philipp</first><last>Koehn</last></author>
@@ -520,7 +521,7 @@
    </paper>
 
    <paper id="1079">
-        <title>What Can Syntax-Based MT Learn from Phrase-Based MT?</title>
+        <title>What Can Syntax-Based <fixed-case>MT</fixed-case> Learn from Phrase-Based <fixed-case>MT</fixed-case>?</title>
         <author><first>Steve</first><last>DeNeefe</last></author>
         <author><first>Kevin</first><last>Knight</last></author>
         <author><first>Wei</first><last>Wang</last></author>
@@ -634,7 +635,7 @@
    </paper>
 
    <paper id="1096">
-        <title>The CoNLL 2007 Shared Task on Dependency Parsing</title>
+        <title>The <fixed-case>CoNLL</fixed-case> 2007 Shared Task on Dependency Parsing</title>
         <author><first>Joakim</first><last>Nivre</last></author>
         <author><first>Johan</first><last>Hall</last></author>
         <author><first>Sandra</first><last>Kübler</last></author>
@@ -679,7 +680,7 @@
    </paper>
 
    <paper id="1102">
-        <title>Log-Linear Models of Non-Projective Trees, <tex-math>k</tex-math>-best MST Parsing and Tree-Ranking</title>
+        <title>Log-Linear Models of Non-Projective Trees, <tex-math>k</tex-math>-best <fixed-case>MST</fixed-case> Parsing and Tree-Ranking</title>
         <author><first>Keith</first><last>Hall</last></author>
         <author><first>Jiri</first><last>Havelka</last></author>
         <author><first>David A.</first><last>Smith</last></author>
@@ -705,7 +706,7 @@
    </paper>
 
    <paper id="1106">
-        <title>Learning to Find English to Chinese Transliterations on the Web</title>
+        <title>Learning to Find <fixed-case>E</fixed-case>nglish to <fixed-case>C</fixed-case>hinese Transliterations on the Web</title>
         <author><first>Jian-Cheng</first><last>Wu</last></author>
         <author><first>Jason S.</first><last>Chang</last></author>
    </paper>
@@ -742,7 +743,7 @@
    </paper>
 
    <paper id="1111">
-        <title>Dependency Parsing and Domain Adaptation with LR Models and Parser Ensembles</title>
+        <title>Dependency Parsing and Domain Adaptation with <fixed-case>LR</fixed-case> Models and Parser Ensembles</title>
         <author><first>Kenji</first><last>Sagae</last></author>
         <author><first>Jun’ichi</first><last>Tsujii</last></author>
    </paper>
@@ -758,7 +759,7 @@
    </paper>
 
    <paper id="1113">
-        <title>Crystal: Analyzing Predictive Opinions on the Web</title>
+        <title><fixed-case>Crystal</fixed-case>: Analyzing Predictive Opinions on the Web</title>
         <author><first>Soo-Min</first><last>Kim</last></author>
         <author><first>Eduard</first><last>Hovy</last></author>
    </paper>
@@ -771,13 +772,13 @@
    </paper>
 
    <paper id="1115">
-        <title>Building Lexicon for Sentiment Analysis from Massive Collection of HTML Documents</title>
+        <title>Building Lexicon for Sentiment Analysis from Massive Collection of <fixed-case>HTML</fixed-case> Documents</title>
         <author><first>Nobuhiro</first><last>Kaji</last></author>
         <author><first>Masaru</first><last>Kitsuregawa</last></author>
    </paper>
 
    <paper id="1116">
-        <title>Determining Case in Arabic: Learning Complex Linguistic Behavior Requires Complex Linguistic Features</title>
+        <title>Determining Case in <fixed-case>A</fixed-case>rabic: Learning Complex Linguistic Behavior Requires Complex Linguistic Features</title>
         <author><first>Nizar</first><last>Habash</last></author>
         <author><first>Ryan</first><last>Gabbard</last></author>
         <author><first>Owen</first><last>Rambow</last></author>
@@ -786,7 +787,7 @@
    </paper>
 
    <paper id="1117">
-        <title>Mandarin Part-of-Speech Tagging and Discriminative Reranking</title>
+        <title><fixed-case>Mandarin</fixed-case> Part-of-Speech Tagging and Discriminative Reranking</title>
         <author><first>Zhongqiang</first><last>Huang</last></author>
         <author><first>Mary</first><last>Harper</last></author>
         <author><first>Wen</first><last>Wang</last></author>
@@ -800,7 +801,7 @@
    </paper>
 
    <paper id="1119">
-        <title>Multilingual Dependency Parsing and Domain Adaptation using DeSR</title>
+        <title>Multilingual Dependency Parsing and Domain Adaptation using <fixed-case>DeSR</fixed-case></title>
         <author><first>Giuseppe</first><last>Attardi</last></author>
         <author><first>Felice</first><last>Dell’Orletta</last></author>
         <author><first>Maria</first><last>Simi</last></author>
@@ -809,7 +810,7 @@
    </paper>
 
    <paper id="1120">
-        <title>Hybrid Ways to Improve Domain Independence in an ML Dependency Parser</title>
+        <title>Hybrid Ways to Improve Domain Independence in an <fixed-case>ML</fixed-case> Dependency Parser</title>
         <author><first>Eckhard</first><last>Bick</last></author>
    </paper>
 
@@ -838,7 +839,7 @@
    </paper>
 
    <paper id="1125">
-        <title>Covington Variations</title>
+        <title><fixed-case>Covington</fixed-case> Variations</title>
         <author><first>Svetoslav</first><last>Marinov</last></author>
    </paper>
 
@@ -857,7 +858,7 @@
    </paper>
 
    <paper id="1128">
-        <title>Pro3Gres Parser in the CoNLL Domain Adaptation Shared Task</title>
+        <title><fixed-case>Pro3Gres</fixed-case> Parser in the <fixed-case>CoNLL</fixed-case> Domain Adaptation Shared Task</title>
         <author><first>Gerold</first><last>Schneider</last></author>
         <author><first>Kaarel</first><last>Kaljurand</last></author>
         <author><first>Fabio</first><last>Rinaldi</last></author>
@@ -871,13 +872,13 @@
    </paper>
 
    <paper id="1130">
-        <title>Adapting the RASP System for the CoNLL07 Domain-Adaptation Task</title>
+        <title>Adapting the <fixed-case>RASP</fixed-case> System for the <fixed-case>CoNLL07</fixed-case> Domain-Adaptation Task</title>
         <author><first>Rebecca</first><last>Watson</last></author>
         <author><first>Ted</first><last>Briscoe</last></author>
    </paper>
 
    <paper id="1131">
-        <title>Multilingual Deterministic Dependency Parsing Framework using Modified Finite Newton Method Support Vector Machines</title>
+        <title>Multilingual Deterministic Dependency Parsing Framework using Modified Finite <fixed-case>N</fixed-case>ewton Method Support Vector Machines</title>
         <author><first>Yu-Chieh</first><last>Wu</last></author>
         <author><first>Jie-Chi</first><last>Yang</last></author>
         <author><first>Yue-Shi</first><last>Lee</last></author>

--- a/import/D08.xml
+++ b/import/D08.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D08">
    <paper id="1000">
         <title>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</title>
@@ -27,7 +28,7 @@
         <bibkey>jancsary-matiasek-trost:2008:EMNLP</bibkey>
    </paper>
    <paper id="1002">
-        <title>It’s a Contradiction – no, it’s not: A Case Study using Functional Relations</title>
+        <title>It’s a Contradiction – no, it’s not: <fixed-case>A</fixed-case> Case Study using Functional Relations</title>
         <author><first>Alan</first><last>Ritter</last></author>
         <author><first>Stephen</first><last>Soderland</last></author>
         <author><first>Doug</first><last>Downey</last></author>
@@ -60,7 +61,7 @@
         <bibkey>li-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1004">
-        <title>Modeling Annotators: A Generative Approach to Learning from Annotator Rationales</title>
+        <title>Modeling Annotators: <fixed-case>A</fixed-case> Generative Approach to Learning from Annotator Rationales</title>
         <author><first>Omar</first><last>Zaidan</last></author>
         <author><first>Jason</first><last>Eisner</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -116,7 +117,7 @@
         <bibkey>bergsma-lin-goebel:2008:EMNLP</bibkey>
    </paper>
    <paper id="1008">
-        <title>Dependency-based Semantic Role Labeling of PropBank</title>
+        <title>Dependency-based Semantic Role Labeling of <fixed-case>PropBank</fixed-case></title>
         <author><first>Richard</first><last>Johansson</last></author>
         <author><first>Pierre</first><last>Nugues</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -161,7 +162,7 @@
         <bibkey>liu-EtAl:2008:EMNLP1</bibkey>
    </paper>
    <paper id="1011">
-        <title>Indirect-HMM-based Hypothesis Alignment for Combining Outputs from Machine Translation Systems</title>
+        <title>Indirect-<fixed-case>HMM</fixed-case>-based Hypothesis Alignment for Combining Outputs from Machine Translation Systems</title>
         <author><first>Xiaodong</first><last>He</last></author>
         <author><first>Mei</first><last>Yang</last></author>
         <author><first>Jianfeng</first><last>Gao</last></author>
@@ -193,7 +194,7 @@
         <bibkey>petrov-haghighi-klein:2008:EMNLP</bibkey>
    </paper>
    <paper id="1013">
-        <title>Adding Redundant Features for CRFs-based Sentence Sentiment Classification</title>
+        <title>Adding Redundant Features for <fixed-case>CRFs</fixed-case>-based Sentence Sentiment Classification</title>
         <author><first>Jun</first><last>Zhao</last></author>
         <author><first>Kang</first><last>Liu</last></author>
         <author><first>Gen</first><last>Wang</last></author>
@@ -268,7 +269,7 @@
         <bibkey>torresmartins-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1018">
-        <title>Better Binarization for the CKY Parsing</title>
+        <title>Better Binarization for the <fixed-case>CKY</fixed-case> Parsing</title>
         <author><first>Xinying</first><last>Song</last></author>
         <author><first>Shilin</first><last>Ding</last></author>
         <author><first>Chin-Yew</first><last>Lin</last></author>
@@ -297,7 +298,7 @@
         <bibkey>filippova-strube:2008:EMNLP</bibkey>
    </paper>
    <paper id="1020">
-        <title>Revisiting Readability: A Unified Framework for Predicting Text Quality</title>
+        <title>Revisiting Readability: <fixed-case>A</fixed-case> Unified Framework for Predicting Text Quality</title>
         <author><first>Emily</first><last>Pitler</last></author>
         <author><first>Ani</first><last>Nenkova</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -410,7 +411,7 @@
         <bibkey>snow-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1028">
-        <title>HotSpots: Visualizing Edits to a Text</title>
+        <title><fixed-case>HotSpots</fixed-case>: <fixed-case>V</fixed-case>isualizing Edits to a Text</title>
         <author><first>Srinivas</first><last>Bangalore</last></author>
         <author><first>David</first><last>Smith</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -424,7 +425,7 @@
         <bibkey>bangalore-smith:2008:EMNLP</bibkey>
    </paper>
    <paper id="1029">
-        <title>Who is Who and What is What: Experiments in Cross-Document Co-Reference</title>
+        <title><fixed-case>W</fixed-case>ho is <fixed-case>W</fixed-case>ho and <fixed-case>W</fixed-case>hat is <fixed-case>W</fixed-case>hat: <fixed-case>E</fixed-case>xperiments in Cross-Document Co-Reference</title>
         <author><first>Alex</first><last>Baron</last></author>
         <author><first>Marjorie</first><last>Freedman</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -438,7 +439,7 @@
         <bibkey>baron-freedman:2008:EMNLP</bibkey>
    </paper>
    <paper id="1030">
-        <title>Arabic Named Entity Recognition using Optimized Feature Sets</title>
+        <title><fixed-case>A</fixed-case>rabic Named Entity Recognition using Optimized Feature Sets</title>
         <author><first>Yassine</first><last>Benajiba</last></author>
         <author><first>Mona</first><last>Diab</last></author>
         <author><first>Paolo</first><last>Rosso</last></author>
@@ -481,7 +482,7 @@
         <bibkey>chali-joty:2008:EMNLP</bibkey>
    </paper>
    <paper id="1033">
-        <title>Sampling Alignment Structure under a Bayesian Translation Model</title>
+        <title>Sampling Alignment Structure under a <fixed-case>B</fixed-case>ayesian Translation Model</title>
         <author><first>John</first><last>DeNero</last></author>
         <author><first>Alexandre</first><last>Bouchard-Côté</last></author>
         <author><first>Dan</first><last>Klein</last></author>
@@ -510,7 +511,7 @@
         <bibkey>ding-chang:2008:EMNLP</bibkey>
    </paper>
    <paper id="1035">
-        <title>Bayesian Unsupervised Topic Segmentation</title>
+        <title><fixed-case>B</fixed-case>ayesian Unsupervised Topic Segmentation</title>
         <author><first>Jacob</first><last>Eisenstein</last></author>
         <author><first>Regina</first><last>Barzilay</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -524,7 +525,7 @@
         <bibkey>eisenstein-barzilay:2008:EMNLP</bibkey>
    </paper>
    <paper id="1036">
-        <title>A comparison of Bayesian estimators for unsupervised Hidden Markov Model POS taggers</title>
+        <title>A comparison of <fixed-case>B</fixed-case>ayesian estimators for unsupervised <fixed-case>H</fixed-case>idden <fixed-case>M</fixed-case>arkov <fixed-case>M</fixed-case>odel <fixed-case>POS</fixed-case> taggers</title>
         <author><first>Jianfeng</first><last>Gao</last></author>
         <author><first>Mark</first><last>Johnson</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -598,7 +599,7 @@
         <bibkey>higuchi-rzepka-araki:2008:EMNLP</bibkey>
    </paper>
    <paper id="1041">
-        <title>When Harry Met Harri: Cross-lingual Name Spelling Normalization</title>
+        <title>When Harry Met Harri: <fixed-case>C</fixed-case>ross-lingual Name Spelling Normalization</title>
         <author><first>Fei</first><last>Huang</last></author>
         <author><first>Ahmad</first><last>Emami</last></author>
         <author><first>Imed</first><last>Zitouni</last></author>
@@ -642,7 +643,7 @@
         <bibkey>lee-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1044">
-        <title>Scalable Language Processing Algorithms for the Masses: A Case Study in Computing Word Co-occurrence Matrices with MapReduce</title>
+        <title>Scalable Language Processing Algorithms for the Masses: <fixed-case>A</fixed-case> Case Study in Computing Word Co-occurrence Matrices with <fixed-case>MapReduce</fixed-case></title>
         <author><first>Jimmy</first><last>Lin</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
         <month>October</month>
@@ -655,7 +656,7 @@
         <bibkey>lin:2008:EMNLP</bibkey>
    </paper>
    <paper id="1045">
-        <title>Online Acquisition of Japanese Unknown Morphemes using Morphological Constraints</title>
+        <title>Online Acquisition of <fixed-case>J</fixed-case>apanese Unknown Morphemes using Morphological Constraints</title>
         <author><first>Yugo</first><last>Murawaki</last></author>
         <author><first>Sadao</first><last>Kurohashi</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -669,7 +670,7 @@
         <bibkey>murawaki-kurohashi:2008:EMNLP</bibkey>
    </paper>
    <paper id="1046">
-        <title>Legal Docket Classification: Where Machine Learning Stumbles</title>
+        <title>Legal Docket Classification: <fixed-case>W</fixed-case>here Machine Learning Stumbles</title>
         <author><first>Ramesh</first><last>Nallapati</last></author>
         <author><first>Christopher D.</first><last>Manning</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -699,7 +700,7 @@
         <bibkey>okazaki-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1048">
-        <title>Automatic induction of FrameNet lexical units</title>
+        <title>Automatic induction of <fixed-case>FrameNet</fixed-case> lexical units</title>
         <author><first>Marco</first><last>Pennacchiotti</last></author>
         <author><first>Diego</first><last>De Cao</last></author>
         <author><first>Roberto</first><last>Basili</last></author>
@@ -763,7 +764,7 @@
         <bibkey>sanchistrilles-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1052">
-        <title>LTAG Dependency Parsing with Bidirectional Incremental Construction</title>
+        <title><fixed-case>LTAG</fixed-case> Dependency Parsing with Bidirectional Incremental Construction</title>
         <author><first>Libin</first><last>Shen</last></author>
         <author><first>Aravind</first><last>Joshi</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -791,7 +792,7 @@
         <bibkey>shi-zhou:2008:EMNLP</bibkey>
    </paper>
    <paper id="1054">
-        <title>HTM: A Topic Model for Hypertexts</title>
+        <title><fixed-case>HTM</fixed-case>: <fixed-case>A</fixed-case> Topic Model for Hypertexts</title>
         <author><first>Congkai</first><last>Sun</last></author>
         <author><first>Bin</first><last>Gao</last></author>
         <author><first>Zhenfu</first><last>Cao</last></author>
@@ -841,7 +842,7 @@
         <bibkey>vickrey-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1057">
-        <title>Seed and Grow: Augmenting Statistically Generated Summary Sentences using Schematic Word Patterns</title>
+        <title>Seed and Grow: <fixed-case>A</fixed-case>ugmenting Statistically Generated Summary Sentences using Schematic Word Patterns</title>
         <author><first>Stephen</first><last>Wan</last></author>
         <author><first>Robert</first><last>Dale</last></author>
         <author><first>Mark</first><last>Dras</last></author>
@@ -857,7 +858,7 @@
         <bibkey>wan-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1058">
-        <title>Using Bilingual Knowledge and Ensemble Techniques for Unsupervised Chinese Sentiment Analysis</title>
+        <title>Using Bilingual Knowledge and Ensemble Techniques for Unsupervised <fixed-case>C</fixed-case>hinese Sentiment Analysis</title>
         <author><first>Xiaojun</first><last>Wan</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
         <month>October</month>
@@ -870,7 +871,7 @@
         <bibkey>wan:2008:EMNLP1</bibkey>
    </paper>
    <paper id="1059">
-        <title>A Tale of Two Parsers: Investigating and Combining Graph-based and Transition-based Dependency Parsing</title>
+        <title>A Tale of Two Parsers: <fixed-case>I</fixed-case>nvestigating and Combining Graph-based and Transition-based Dependency Parsing</title>
         <author><first>Yue</first><last>Zhang</last></author>
         <author><first>Stephen</first><last>Clark</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -960,7 +961,7 @@
         <bibkey>chiang-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1065">
-        <title>Lattice Minimum Bayes-Risk Decoding for Statistical Machine Translation</title>
+        <title>Lattice <fixed-case>Minimum Bayes-Risk</fixed-case> Decoding for Statistical Machine Translation</title>
         <author><first>Roy</first><last>Tromble</last></author>
         <author><first>Shankar</first><last>Kumar</last></author>
         <author><first>Franz</first><last>Och</last></author>
@@ -976,7 +977,7 @@
         <bibkey>tromble-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1066">
-        <title>Phrase Translation Probabilities with ITG Priors and Smoothing as Learning Objective</title>
+        <title>Phrase Translation Probabilities with <fixed-case>ITG</fixed-case> Priors and Smoothing as Learning Objective</title>
         <author><first>Markos</first><last>Mylonakis</last></author>
         <author><first>Khalil</first><last>Sima’an</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1003,7 +1004,7 @@
         <bibkey>ng:2008:EMNLP</bibkey>
    </paper>
    <paper id="1068">
-        <title>Joint Unsupervised Coreference Resolution with Markov Logic</title>
+        <title>Joint Unsupervised Coreference Resolution with <fixed-case>Markov Logic</fixed-case></title>
         <author><first>Hoifung</first><last>Poon</last></author>
         <author><first>Pedro</first><last>Domingos</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1085,7 +1086,7 @@
         <bibkey>chambers-jurafsky:2008:EMNLP</bibkey>
    </paper>
    <paper id="1074">
-        <title>Automatic Inference of the Temporal Location of Situations in Chinese Text</title>
+        <title>Automatic Inference of the Temporal Location of Situations in <fixed-case>C</fixed-case>hinese Text</title>
         <author><first>Nianwen</first><last>Xue</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
         <month>October</month>
@@ -1243,7 +1244,7 @@
         <bibkey>maccartney-galley-manning:2008:EMNLP</bibkey>
    </paper>
    <paper id="1085">
-        <title>Attacking Decipherment Problems Optimally with Low-Order N-gram Models</title>
+        <title>Attacking Decipherment Problems Optimally with Low-Order <fixed-case>N-gram</fixed-case> Models</title>
         <author><first>Sujith</first><last>Ravi</last></author>
         <author><first>Kevin</first><last>Knight</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1257,7 +1258,7 @@
         <bibkey>ravi-knight:2008:EMNLP</bibkey>
    </paper>
    <paper id="1086">
-        <title>Integrating Multi-level Linguistic Knowledge with a Unified Framework for Mandarin Speech Recognition</title>
+        <title>Integrating Multi-level Linguistic Knowledge with a Unified Framework for <fixed-case>M</fixed-case>andarin Speech Recognition</title>
         <author><first>Xinhao</first><last>Wang</last></author>
         <author><first>Jiazhong</first><last>Nie</last></author>
         <author><first>Dingsheng</first><last>Luo</last></author>
@@ -1273,7 +1274,7 @@
         <bibkey>wang-EtAl:2008:EMNLP1</bibkey>
    </paper>
    <paper id="1087">
-        <title>N-gram Weighting: Reducing Training Data Mismatch in Cross-Domain Language Model Estimation</title>
+        <title><fixed-case>N-gram</fixed-case> Weighting: <fixed-case>R</fixed-case>educing Training Data Mismatch in Cross-Domain Language Model Estimation</title>
         <author><first>Bo-June (Paul)</first><last>Hsu</last></author>
         <author><first>James</first><last>Glass</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1287,7 +1288,7 @@
         <bibkey>hsu-glass:2008:EMNLP</bibkey>
    </paper>
    <paper id="1088">
-        <title>Complexity of Finding the BLEU-optimal Hypothesis in a Confusion Network</title>
+        <title>Complexity of Finding the <fixed-case>BLEU</fixed-case>-optimal Hypothesis in a Confusion Network</title>
         <author><first>Gregor</first><last>Leusch</last></author>
         <author><first>Evgeny</first><last>Matusov</last></author>
         <author><first>Hermann</first><last>Ney</last></author>
@@ -1431,7 +1432,7 @@
         <bibkey>huang-thint-qin:2008:EMNLP</bibkey>
    </paper>
    <paper id="1098">
-        <title>CoCQA: Co-Training over Questions and Answers with an Application to Predicting Question Subjectivity Orientation</title>
+        <title><fixed-case>CoCQA</fixed-case>: <fixed-case>Co-Training</fixed-case> over Questions and Answers with an Application to Predicting Question Subjectivity Orientation</title>
         <author><first>Baoli</first><last>Li</last></author>
         <author><first>Yandong</first><last>Liu</last></author>
         <author><first>Eugene</first><last>Agichtein</last></author>
@@ -1518,7 +1519,7 @@
         <bibkey>mohammad-dorr-hirst:2008:EMNLP</bibkey>
    </paper>
    <paper id="1104">
-        <title>Construction of an Idiom Corpus and its Application to Idiom Identification based on WSD Incorporating Idiom-Specific Features</title>
+        <title>Construction of an Idiom Corpus and its Application to Idiom Identification based on <fixed-case>WSD</fixed-case> Incorporating Idiom-Specific Features</title>
         <author><first>Chikara</first><last>Hashimoto</last></author>
         <author><first>Daisuke</first><last>Kawahara</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1532,7 +1533,7 @@
         <bibkey>hashimoto-kawahara:2008:EMNLP</bibkey>
    </paper>
    <paper id="1105">
-        <title>Word Sense Disambiguation Using OntoNotes: An Empirical Study</title>
+        <title>Word Sense Disambiguation Using <fixed-case>OntoNotes</fixed-case>: <fixed-case>A</fixed-case>n Empirical Study</title>
         <author><first>Zhi</first><last>Zhong</last></author>
         <author><first>Hwee Tou</first><last>Ng</last></author>
         <author><first>Yee Seng</first><last>Chan</last></author>
@@ -1547,7 +1548,7 @@
         <bibkey>zhong-ng-chan:2008:EMNLP</bibkey>
    </paper>
    <paper id="1106">
-        <title>Graph-based Analysis of Semantic Drift in Espresso-like Bootstrapping Algorithms</title>
+        <title>Graph-based Analysis of Semantic Drift in <fixed-case>Espresso</fixed-case>-like Bootstrapping Algorithms</title>
         <author><first>Mamoru</first><last>Komachi</last></author>
         <author><first>Taku</first><last>Kudo</last></author>
         <author><first>Masashi</first><last>Shimbo</last></author>
@@ -1563,7 +1564,7 @@
         <bibkey>komachi-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1107">
-        <title>The Linguistic Structure of English Web-Search Queries</title>
+        <title>The Linguistic Structure of <fixed-case>E</fixed-case>nglish Web-Search Queries</title>
         <author><first>Cory</first><last>Barr</last></author>
         <author><first>Rosie</first><last>Jones</last></author>
         <author><first>Moira</first><last>Regelson</last></author>
@@ -1578,7 +1579,7 @@
         <bibkey>barr-jones-regelson:2008:EMNLP</bibkey>
    </paper>
    <paper id="1108">
-        <title>Mining and Modeling Relations between Formal and Informal Chinese Phrases from Web Corpora</title>
+        <title>Mining and Modeling Relations between Formal and Informal <fixed-case>C</fixed-case>hinese Phrases from Web Corpora</title>
         <author><first>Zhifei</first><last>Li</last></author>
         <author><first>David</first><last>Yarowsky</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1592,7 +1593,7 @@
         <bibkey>li-yarowsky:2008:EMNLP</bibkey>
    </paper>
    <paper id="1109">
-        <title>Unsupervised Multilingual Learning for POS Tagging</title>
+        <title>Unsupervised Multilingual Learning for <fixed-case>POS</fixed-case> Tagging</title>
         <author><first>Benjamin</first><last>Snyder</last></author>
         <author><first>Tahira</first><last>Naseem</last></author>
         <author><first>Jacob</first><last>Eisenstein</last></author>
@@ -1608,7 +1609,7 @@
         <bibkey>snyder-EtAl:2008:EMNLP</bibkey>
    </paper>
    <paper id="1110">
-        <title>Part-of-Speech Tagging for English-Spanish Code-Switched Text</title>
+        <title><fixed-case>Part-of-Speech</fixed-case> Tagging for <fixed-case>E</fixed-case>nglish-<fixed-case>S</fixed-case>panish Code-Switched Text</title>
         <author><first>Thamar</first><last>Solorio</last></author>
         <author><first>Yang</first><last>Liu</last></author>
         <booktitle>Proceedings of the 2008 Conference on Empirical Methods in Natural Language Processing</booktitle>

--- a/import/D09.xml
+++ b/import/D09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D09">
    <paper id="1000">
         <title>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</title>
@@ -40,7 +41,7 @@
         <bibkey>furstenau-lapata:2009:EMNLP</bibkey>
    </paper>
    <paper id="1003">
-        <title>Semi-supervised Semantic Role Labeling Using the Latent Words Language Model</title>
+        <title>Semi-supervised Semantic Role Labeling Using the <fixed-case>Latent Words Language Model</fixed-case></title>
         <author><first>Koen</first><last>Deschacht</last></author>
         <author><first>Marie-Francine</first><last>Moens</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -54,7 +55,7 @@
         <bibkey>deschacht-moens:2009:EMNLP</bibkey>
    </paper>
    <paper id="1004">
-        <title>Semantic Dependency Parsing of NomBank and PropBank: An Efficient Integrated Approach via a Large-scale Feature Selection</title>
+        <title>Semantic Dependency Parsing of <fixed-case>NomBank</fixed-case> and <fixed-case>PropBank</fixed-case>: An Efficient Integrated Approach via a Large-scale Feature Selection</title>
         <author><first>Hai</first><last>Zhao</last></author>
         <author><first>Wenliang</first><last>Chen</last></author>
         <author><first>Chunyu</first><last>Kit</last></author>
@@ -373,7 +374,7 @@
         <bibkey>pennacchiotti-pantel:2009:EMNLP</bibkey>
    </paper>
    <paper id="1026">
-        <title>Labeled LDA: A supervised topic model for credit attribution in multi-labeled corpora</title>
+        <title><fixed-case>Labeled LDA</fixed-case>: A supervised topic model for credit attribution in multi-labeled corpora</title>
         <author><first>Daniel</first><last>Ramage</last></author>
         <author><first>David</first><last>Hall</last></author>
         <author><first>Ramesh</first><last>Nallapati</last></author>
@@ -419,7 +420,7 @@
         <bibkey>davidov-rappoport:2009:EMNLP1</bibkey>
    </paper>
    <paper id="1029">
-        <title>Wikipedia as Frame Information Repository</title>
+        <title><fixed-case>Wikipedia</fixed-case> as Frame Information Repository</title>
         <author><first>Sara</first><last>Tonelli</last></author>
         <author><first>Claudio</first><last>Giuliano</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -433,7 +434,7 @@
         <bibkey>tonelli-giuliano:2009:EMNLP</bibkey>
    </paper>
    <paper id="1030">
-        <title>Fast, Cheap, and Creative: Evaluating Translation Quality Using Amazon’s Mechanical Turk</title>
+        <title>Fast, Cheap, and Creative: Evaluating Translation Quality Using <fixed-case>Amazon’s</fixed-case> <fixed-case>Mechanical Turk</fixed-case></title>
         <author><first>Chris</first><last>Callison-Burch</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
         <month>August</month>
@@ -519,7 +520,7 @@
         <bibkey>ranganath-jurafsky-mcfarland:2009:EMNLP</bibkey>
    </paper>
    <paper id="1036">
-        <title>Recognizing Implicit Discourse Relations in the Penn Discourse Treebank</title>
+        <title>Recognizing Implicit Discourse Relations in the <fixed-case>Penn Discourse Treebank</fixed-case></title>
         <author><first>Ziheng</first><last>Lin</last></author>
         <author><first>Min-Yen</first><last>Kan</last></author>
         <author><first>Hwee Tou</first><last>Ng</last></author>
@@ -534,7 +535,7 @@
         <bibkey>lin-kan-ng:2009:EMNLP</bibkey>
    </paper>
    <paper id="1037">
-        <title>A Bayesian Model of Syntax-Directed Tree to String Grammar Induction</title>
+        <title>A <fixed-case>Bayesian</fixed-case> Model of Syntax-Directed Tree to String Grammar Induction</title>
         <author><first>Trevor</first><last>Cohn</last></author>
         <author><first>Phil</first><last>Blunsom</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -565,7 +566,7 @@
         <bibkey>xiao-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1039">
-        <title>Accuracy-Based Scoring for DOT: Towards Direct Error Minimization for Data-Oriented Translation</title>
+        <title>Accuracy-Based Scoring for <fixed-case>DOT</fixed-case>: Towards Direct Error Minimization for <fixed-case>Data-Oriented Translation</fixed-case></title>
         <author><first>Daniel</first><last>Galron</last></author>
         <author><first>Sergio</first><last>Penkale</last></author>
         <author><first>Andy</first><last>Way</last></author>
@@ -624,7 +625,7 @@
         <bibkey>lu-ng-lee:2009:EMNLP</bibkey>
    </paper>
    <paper id="1043">
-        <title>Perceptron Reranking for CCG Realization</title>
+        <title>Perceptron Reranking for <fixed-case>CCG</fixed-case> Realization</title>
         <author><first>Michael</first><last>White</last></author>
         <author><first>Rajakrishnan</first><last>Rajkumar</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -771,7 +772,7 @@
         <bibkey>crammer-dredze-kulesza:2009:EMNLP</bibkey>
    </paper>
    <paper id="1053">
-        <title>Model Adaptation via Model Interpolation and Boosting for Web Search Ranking</title>
+        <title>Model Adaptation via Model Interpolation and Boosting for <fixed-case>Web</fixed-case> Search Ranking</title>
         <author><first>Jianfeng</first><last>Gao</last></author>
         <author><first>Qiang</first><last>Wu</last></author>
         <author><first>Chris</first><last>Burges</last></author>
@@ -824,7 +825,7 @@
         <bibkey>tseng-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1056">
-        <title>The role of named entities in Web People Search</title>
+        <title>The role of named entities in <fixed-case>Web</fixed-case> <fixed-case>People Search</fixed-case></title>
         <author><first>Javier</first><last>Artiles</last></author>
         <author><first>Enrique</first><last>Amigó</last></author>
         <author><first>Julio</first><last>Gonzalo</last></author>
@@ -899,7 +900,7 @@
         <bibkey>chen-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1061">
-        <title>Topic-wise, Sentiment-wise, or Otherwise? Identifying the Hidden Dimension for Unsupervised Text Classification</title>
+        <title>Topic-wise, Sentiment-wise, or Otherwise? <fixed-case>Identifying</fixed-case> the Hidden Dimension for Unsupervised Text Classification</title>
         <author><first>Sajib</first><last>Dasgupta</last></author>
         <author><first>Vincent</first><last>Ng</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -958,7 +959,7 @@
         <bibkey>dalvi-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1065">
-        <title>EEG responds to conceptual stimuli and corpus semantics</title>
+        <title><fixed-case>EEG</fixed-case> responds to conceptual stimuli and corpus semantics</title>
         <author><first>Brian</first><last>Murphy</last></author>
         <author><first>Marco</first><last>Baroni</last></author>
         <author><first>Massimo</first><last>Poesio</last></author>
@@ -1001,7 +1002,7 @@
         <bibkey>sun-korhonen:2009:EMNLP</bibkey>
    </paper>
    <paper id="1068">
-        <title>Improving Web Search Relevance with Semantic Features</title>
+        <title>Improving <fixed-case>Web</fixed-case> Search Relevance with Semantic Features</title>
         <author><first>Yumao</first><last>Lu</last></author>
         <author><first>Fuchun</first><last>Peng</last></author>
         <author><first>Gilad</first><last>Mishne</last></author>
@@ -1018,7 +1019,7 @@
         <bibkey>lu-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1069">
-        <title>Can Chinese Phonemes Improve Machine Transliteration?: A Comparative Study of English-to-Chinese Transliteration Models</title>
+        <title>Can <fixed-case>Chinese</fixed-case> Phonemes Improve Machine Transliteration?: A Comparative Study of <fixed-case>English-to-Chinese</fixed-case> Transliteration Models</title>
         <author><first>Jong-Hoon</first><last>Oh</last></author>
         <author><first>Kiyotaka</first><last>Uchimoto</last></author>
         <author><first>Kentaro</first><last>Torisawa</last></author>
@@ -1048,7 +1049,7 @@
         <bibkey>moon-erk-baldridge:2009:EMNLP</bibkey>
    </paper>
    <paper id="1071">
-        <title>The infinite HMM for unsupervised PoS tagging</title>
+        <title>The infinite <fixed-case>HMM</fixed-case> for unsupervised <fixed-case>PoS</fixed-case> tagging</title>
         <author><first>Jurgen</first><last>Van Gael</last></author>
         <author><first>Andreas</first><last>Vlachos</last></author>
         <author><first>Zoubin</first><last>Ghahramani</last></author>
@@ -1063,7 +1064,7 @@
         <bibkey>vangael-vlachos-ghahramani:2009:EMNLP</bibkey>
    </paper>
    <paper id="1072">
-        <title>A Simple Unsupervised Learner for POS Disambiguation Rules Given Only a Minimal Lexicon</title>
+        <title>A Simple Unsupervised Learner for <fixed-case>POS</fixed-case> Disambiguation Rules Given Only a Minimal Lexicon</title>
         <author><first>Qiuye</first><last>Zhao</last></author>
         <author><first>Mitch</first><last>Marcus</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1077,7 +1078,7 @@
         <bibkey>zhao-marcus:2009:EMNLP</bibkey>
    </paper>
    <paper id="1073">
-        <title>Tree Kernel-based SVM with Structured Syntactic Knowledge for BTG-based Phrase Reordering</title>
+        <title>Tree Kernel-based <fixed-case>SVM</fixed-case> with Structured Syntactic Knowledge for <fixed-case>BTG</fixed-case>-based Phrase Reordering</title>
         <author><first>Min</first><last>Zhang</last></author>
         <author><first>Haizhou</first><last>Li</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1147,7 +1148,7 @@
         <bibkey>miller:2009:EMNLP</bibkey>
    </paper>
    <paper id="1078">
-        <title>Less is More: Significance-Based N-gram Selection for Smaller, Better Language Models</title>
+        <title>Less is More: Significance-Based <fixed-case>N-gram</fixed-case> Selection for Smaller, Better Language Models</title>
         <author><first>Robert C.</first><last>Moore</last></author>
         <author><first>Chris</first><last>Quirk</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1161,7 +1162,7 @@
         <bibkey>moore-quirk:2009:EMNLP</bibkey>
    </paper>
    <paper id="1079">
-        <title>Stream-based Randomised Language Models for SMT</title>
+        <title>Stream-based Randomised Language Models for <fixed-case>SMT</fixed-case></title>
         <author><first>Abby</first><last>Levenberg</last></author>
         <author><first>Miles</first><last>Osborne</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1232,7 +1233,7 @@
         <bibkey>yih:2009:EMNLP</bibkey>
    </paper>
    <paper id="1084">
-        <title>A Relational Model of Semantic Similarity between Words using Automatically Extracted Lexical Pattern Clusters from the Web</title>
+        <title>A Relational Model of Semantic Similarity between Words using Automatically Extracted Lexical Pattern Clusters from the <fixed-case>Web</fixed-case></title>
         <author><first>Danushka</first><last>Bollegala</last></author>
         <author><first>Yutaka</first><last>Matsuo</last></author>
         <author><first>Mitsuru</first><last>Ishizuka</last></author>
@@ -1276,7 +1277,7 @@
         <bibkey>smith-eisner:2009:EMNLP</bibkey>
    </paper>
    <paper id="1087">
-        <title>Self-Training PCFG Grammars with Latent Annotations Across Languages</title>
+        <title>Self-Training <fixed-case>PCFG</fixed-case> Grammars with Latent Annotations Across Languages</title>
         <author><first>Zhongqiang</first><last>Huang</last></author>
         <author><first>Mary</first><last>Harper</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1364,7 +1365,7 @@
         <bibkey>mimno-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1093">
-        <title>Using the Web for Language Independent Spellchecking and Autocorrection</title>
+        <title>Using the <fixed-case>Web</fixed-case> for Language Independent Spellchecking and Autocorrection</title>
         <author><first>Casey</first><last>Whitelaw</last></author>
         <author><first>Ben</first><last>Hutchinson</last></author>
         <author><first>Grace Y</first><last>Chung</last></author>
@@ -1444,7 +1445,7 @@
         <bibkey>yamada-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1098">
-        <title>Web-Scale Distributional Similarity and Entity Set Expansion</title>
+        <title><fixed-case>Web</fixed-case>-Scale Distributional Similarity and Entity Set Expansion</title>
         <author><first>Patrick</first><last>Pantel</last></author>
         <author><first>Eric</first><last>Crestan</last></author>
         <author><first>Arkady</first><last>Borkovsky</last></author>
@@ -1578,7 +1579,7 @@
         <bibkey>liu-EtAl:2009:EMNLP3</bibkey>
    </paper>
    <paper id="1107">
-        <title>Sinuhe – Statistical Machine Translation using a Globally Trained Conditional Exponential Family Translation Model</title>
+        <title><fixed-case>Sinuhe</fixed-case> – Statistical Machine Translation using a Globally Trained Conditional Exponential Family Translation Model</title>
         <author><first>Matti</first><last>Kääriäinen</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
         <month>August</month>
@@ -1607,7 +1608,7 @@
         <bibkey>zhang-EtAl:2009:EMNLP1</bibkey>
    </paper>
    <paper id="1109">
-        <title>Gazpacho and summer rash: lexical relationships from temporal patterns of web search queries</title>
+        <title><fixed-case>Gazpacho</fixed-case> and summer rash: lexical relationships from temporal patterns of web search queries</title>
         <author><first>Enrique</first><last>Alfonseca</last></author>
         <author><first>Massimiliano</first><last>Ciaramita</last></author>
         <author><first>Keith</first><last>Hall</last></author>
@@ -1684,7 +1685,7 @@
         <bibkey>dong-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1114">
-        <title>The Feature Subspace Method for SMT System Combination</title>
+        <title>The <fixed-case>Feature</fixed-case> <fixed-case>Subspace</fixed-case> Method for <fixed-case>SMT</fixed-case> System Combination</title>
         <author><first>Nan</first><last>Duan</last></author>
         <author><first>Mu</first><last>Li</last></author>
         <author><first>Tong</first><last>Xiao</last></author>
@@ -1804,7 +1805,7 @@
         <bibkey>hara-miyao-tsujii:2009:EMNLP</bibkey>
    </paper>
    <paper id="1122">
-        <title>Large-Scale Verb Entailment Acquisition from the Web</title>
+        <title>Large-Scale Verb Entailment Acquisition from the <fixed-case>Web</fixed-case></title>
         <author><first>Chikara</first><last>Hashimoto</last></author>
         <author><first>Kentaro</first><last>Torisawa</last></author>
         <author><first>Kow</first><last>Kuroda</last></author>
@@ -1865,7 +1866,7 @@
         <bibkey>he-toutanova:2009:EMNLP</bibkey>
    </paper>
    <paper id="1126">
-        <title>Fully Lexicalising CCGbank with Hat Categories</title>
+        <title>Fully Lexicalising <fixed-case>CCGbank</fixed-case> with Hat Categories</title>
         <author><first>Matthew</first><last>Honnibal</last></author>
         <author><first>James R.</first><last>Curran</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1910,7 +1911,7 @@
         <bibkey>huang-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1129">
-        <title>Real-Word Spelling Correction using Google Web 1T 3-grams</title>
+        <title>Real-Word Spelling Correction using <fixed-case>Google</fixed-case> <fixed-case>Web</fixed-case> <fixed-case>1T</fixed-case> 3-grams</title>
         <author><first>Aminul</first><last>Islam</last></author>
         <author><first>Diana</first><last>Inkpen</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1939,7 +1940,7 @@
         <bibkey>jeong-lin-lee:2009:EMNLP</bibkey>
    </paper>
    <paper id="1131">
-        <title>Using Morphological and Syntactic Structures for Chinese Opinion Analysis</title>
+        <title>Using Morphological and Syntactic Structures for <fixed-case>Chinese</fixed-case> Opinion Analysis</title>
         <author><first>Lun-Wei</first><last>Ku</last></author>
         <author><first>Ting-Hao</first><last>Huang</last></author>
         <author><first>Hsin-Hsi</first><last>Chen</last></author>
@@ -1954,7 +1955,7 @@
         <bibkey>ku-huang-chen:2009:EMNLP</bibkey>
    </paper>
    <paper id="1132">
-        <title>Finding Short Definitions of Terms on Web Pages</title>
+        <title>Finding Short Definitions of Terms on <fixed-case>Web</fixed-case> Pages</title>
         <author><first>Gerasimos</first><last>Lampouras</last></author>
         <author><first>Ion</first><last>Androutsopoulos</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1968,7 +1969,7 @@
         <bibkey>lampouras-androutsopoulos:2009:EMNLP</bibkey>
    </paper>
    <paper id="1133">
-        <title>Improving Nominal SRL in Chinese Language with Verbal SRL Information and Automatic Predicate Recognition</title>
+        <title>Improving Nominal <fixed-case>SRL</fixed-case> in <fixed-case>Chinese</fixed-case> Language with Verbal <fixed-case>SRL</fixed-case> Information and Automatic Predicate Recognition</title>
         <author><first>Junhui</first><last>Li</last></author>
         <author><first>Guodong</first><last>Zhou</last></author>
         <author><first>Hai</first><last>Zhao</last></author>
@@ -2100,7 +2101,7 @@
         <bibkey>nakov-ng:2009:EMNLP</bibkey>
    </paper>
    <paper id="1142">
-        <title>What’s in a name? In some languages, grammatical gender</title>
+        <title>What’s in a name? <fixed-case>In</fixed-case> some languages, grammatical gender</title>
         <author><first>Vivi</first><last>Nastase</last></author>
         <author><first>Marius</first><last>Popescu</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -2217,7 +2218,7 @@
         <bibkey>qian-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1150">
-        <title>Construction of a Blog Emotion Corpus for Chinese Emotional Expression Analysis</title>
+        <title>Construction of a Blog Emotion Corpus for <fixed-case>Chinese</fixed-case> Emotional Expression Analysis</title>
         <author><first>Changqin</first><last>Quan</last></author>
         <author><first>Fuji</first><last>Ren</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -2259,7 +2260,7 @@
         <bibkey>srinivasan-yates:2009:EMNLP</bibkey>
    </paper>
    <paper id="1153">
-        <title>Chinese Semantic Role Labeling with Shallow Parsing</title>
+        <title><fixed-case>Chinese</fixed-case> Semantic Role Labeling with Shallow Parsing</title>
         <author><first>Weiwei</first><last>Sun</last></author>
         <author><first>Zhifang</first><last>Sui</last></author>
         <author><first>Meng</first><last>Wang</last></author>
@@ -2275,7 +2276,7 @@
         <bibkey>sun-EtAl:2009:EMNLP</bibkey>
    </paper>
    <paper id="1154">
-        <title>Discovery of Term Variation in Japanese Web Search Queries</title>
+        <title>Discovery of Term Variation in <fixed-case>Japanese</fixed-case> Web Search Queries</title>
         <author><first>Hisami</first><last>Suzuki</last></author>
         <author><first>Xiao</first><last>Li</last></author>
         <author><first>Jianfeng</first><last>Gao</last></author>
@@ -2396,7 +2397,7 @@
         <bibkey>zhang-EtAl:2009:EMNLP2</bibkey>
    </paper>
    <paper id="1162">
-        <title>Chinese Novelty Mining</title>
+        <title><fixed-case>Chinese</fixed-case> Novelty Mining</title>
         <author><first>Yi</first><last>Zhang</last></author>
         <author><first>Flora S.</first><last>Tsai</last></author>
         <booktitle>Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing</booktitle>

--- a/import/D10.xml
+++ b/import/D10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D10">
    <paper id="1000">
         <title>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</title>
@@ -88,7 +89,7 @@
         <bibkey>boydgraber-resnik:2010:EMNLP</bibkey>
    </paper>
    <paper id="1006">
-        <title>Jointly Modeling Aspects and Opinions with a MaxEnt-LDA Hybrid</title>
+        <title>Jointly Modeling Aspects and Opinions with a <fixed-case>MaxEnt</fixed-case>-<fixed-case>LDA</fixed-case> Hybrid</title>
         <author><first>Xin</first><last>Zhao</last></author>
         <author><first>Jing</first><last>Jiang</last></author>
         <author><first>Hongfei</first><last>Yan</last></author>
@@ -134,7 +135,7 @@
         <bibkey>goyal-riloff-daumeiii:2010:EMNLP</bibkey>
    </paper>
    <paper id="1009">
-        <title>Handling Noisy Queries in Cross Language FAQ Retrieval</title>
+        <title>Handling Noisy Queries in Cross Language <fixed-case>FAQ</fixed-case> Retrieval</title>
         <author><first>Danish</first><last>Contractor</last></author>
         <author><first>Govind</first><last>Kothari</last></author>
         <author><first>Tanveer</first><last>Faruquie</last></author>
@@ -151,7 +152,7 @@
         <bibkey>contractor-EtAl:2010:EMNLP</bibkey>
    </paper>
    <paper id="1010">
-        <title>Learning the Relative Usefulness of Questions in Community QA</title>
+        <title>Learning the Relative Usefulness of Questions in Community <fixed-case>QA</fixed-case></title>
         <author><first>Razvan</first><last>Bunescu</last></author>
         <author><first>Yunfeng</first><last>Huang</last></author>
         <booktitle>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -303,7 +304,7 @@
         <bibkey>qian-EtAl:2010:EMNLP</bibkey>
    </paper>
    <paper id="1020">
-        <title>Crouching Dirichlet, Hidden Markov Model: Unsupervised POS Tagging with Context Local Tag Generation</title>
+        <title>Crouching Dirichlet, Hidden Markov Model: Unsupervised <fixed-case>POS</fixed-case> Tagging with Context Local Tag Generation</title>
         <author><first>Taesun</first><last>Moon</last></author>
         <author><first>Katrin</first><last>Erk</last></author>
         <author><first>Jason</first><last>Baldridge</last></author>
@@ -362,7 +363,7 @@
         <bibkey>persing-davis-ng:2010:EMNLP</bibkey>
    </paper>
    <paper id="1024">
-        <title>Evaluating Models of Latent Document Semantics in the Presence of OCR Errors</title>
+        <title>Evaluating Models of Latent Document Semantics in the Presence of <fixed-case>OCR</fixed-case> Errors</title>
         <author><first>Daniel</first><last>Walker</last></author>
         <author><first>William B.</first><last>Lund</last></author>
         <author><first>Eric K.</first><last>Ringger</last></author>
@@ -676,7 +677,7 @@
         <bibkey>foster-goutte-kuhn:2010:EMNLP</bibkey>
    </paper>
    <paper id="1045">
-        <title>NLP on Spoken Documents Without ASR</title>
+        <title><fixed-case>NLP</fixed-case> on Spoken Documents Without <fixed-case>ASR</fixed-case></title>
         <author><first>Mark</first><last>Dredze</last></author>
         <author><first>Aren</first><last>Jansen</last></author>
         <author><first>Glen</first><last>Coppersmith</last></author>
@@ -846,7 +847,7 @@
         <bibkey>espinosa-EtAl:2010:EMNLP</bibkey>
    </paper>
    <paper id="1056">
-        <title>Two Decades of Unsupervised POS Induction: How Far Have We Come?</title>
+        <title>Two Decades of Unsupervised <fixed-case>POS</fixed-case> Induction: How Far Have We Come?</title>
         <author><first>Christos</first><last>Christodoulopoulos</last></author>
         <author><first>Sharon</first><last>Goldwater</last></author>
         <author><first>Mark</first><last>Steedman</last></author>
@@ -876,7 +877,7 @@
         <bibkey>dredze-oates-piatko:2010:EMNLP</bibkey>
    </paper>
    <paper id="1058">
-        <title>A Fast Fertility Hidden Markov Model for Word Alignment Using MCMC</title>
+        <title>A Fast Fertility Hidden Markov Model for Word Alignment Using <fixed-case>MCMC</fixed-case></title>
         <author><first>Shaojun</first><last>Zhao</last></author>
         <author><first>Daniel</first><last>Gildea</last></author>
         <booktitle>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -951,7 +952,7 @@
         <bibkey>chung-gildea:2010:EMNLP</bibkey>
    </paper>
    <paper id="1063">
-        <title>SCFG Decoding Without Binarization</title>
+        <title><fixed-case>SCFG</fixed-case> Decoding Without Binarization</title>
         <author><first>Mark</first><last>Hopkins</last></author>
         <author><first>Greg</first><last>Langmead</last></author>
         <booktitle>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -978,7 +979,7 @@
         <bibkey>max:2010:EMNLP</bibkey>
    </paper>
    <paper id="1065">
-        <title>Combining Unsupervised and Supervised Alignments for MT: An Empirical Study</title>
+        <title>Combining Unsupervised and Supervised Alignments for <fixed-case>MT</fixed-case>: An Empirical Study</title>
         <author><first>Jinxi</first><last>Xu</last></author>
         <author><first>Antti-Veikko</first><last>Rosti</last></author>
         <booktitle>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1019,7 +1020,7 @@
         <bibkey>reichart-rappoport:2010:EMNLP2</bibkey>
    </paper>
    <paper id="1068">
-        <title>Unsupervised Parse Selection for HPSG</title>
+        <title>Unsupervised Parse Selection for <fixed-case>HPSG</fixed-case></title>
         <author><first>Rebecca</first><last>Dridan</last></author>
         <author><first>Timothy</first><last>Baldwin</last></author>
         <booktitle>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1171,7 +1172,7 @@
         <bibkey>chang-han:2010:EMNLP</bibkey>
    </paper>
    <paper id="1078">
-        <title>Latent-Descriptor Clustering for Unsupervised POS Induction</title>
+        <title>Latent-Descriptor Clustering for Unsupervised <fixed-case>POS</fixed-case> Induction</title>
         <author><first>Michael</first><last>Lamar</last></author>
         <author><first>Yariv</first><last>Maron</last></author>
         <author><first>Elie</first><last>Bienenstock</last></author>
@@ -1220,7 +1221,7 @@
         <bibkey>eidelman-huang-harper:2010:EMNLP</bibkey>
    </paper>
    <paper id="1081">
-        <title>An Efficient Algorithm for Unsupervised Word Segmentation with Branching Entropy and MDL</title>
+        <title>An Efficient Algorithm for Unsupervised Word Segmentation with Branching Entropy and <fixed-case>MDL</fixed-case></title>
         <author><first>Valentin</first><last>Zhikov</last></author>
         <author><first>Hiroya</first><last>Takamura</last></author>
         <author><first>Manabu</first><last>Okumura</last></author>
@@ -1235,7 +1236,7 @@
         <bibkey>zhikov-takamura-okumura:2010:EMNLP</bibkey>
    </paper>
    <paper id="1082">
-        <title>A Fast Decoder for Joint Word Segmentation and POS-Tagging Using a Single Discriminative Model</title>
+        <title>A Fast Decoder for Joint Word Segmentation and <fixed-case>POS</fixed-case>-Tagging Using a Single Discriminative Model</title>
         <author><first>Yue</first><last>Zhang</last></author>
         <author><first>Stephen</first><last>Clark</last></author>
         <booktitle>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1249,7 +1250,7 @@
         <bibkey>zhang-clark:2010:EMNLP</bibkey>
    </paper>
    <paper id="1083">
-        <title>Simple Type-Level Unsupervised POS Tagging</title>
+        <title>Simple Type-Level Unsupervised <fixed-case>POS</fixed-case> Tagging</title>
         <author><first>Yoong Keok</first><last>Lee</last></author>
         <author><first>Aria</first><last>Haghighi</last></author>
         <author><first>Regina</first><last>Barzilay</last></author>
@@ -1337,7 +1338,7 @@
         <bibkey>cholakov-vannoord:2010:EMNLP</bibkey>
    </paper>
    <paper id="1089">
-        <title>WikiWars: A New Corpus for Research on Temporal Expressions</title>
+        <title><fixed-case>WikiWars</fixed-case>: A New Corpus for Research on Temporal Expressions</title>
         <author><first>Pawel</first><last>Mazur</last></author>
         <author><first>Robert</first><last>Dale</last></author>
         <booktitle>Proceedings of the 2010 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1351,7 +1352,7 @@
         <bibkey>mazur-dale:2010:EMNLP</bibkey>
    </paper>
    <paper id="1090">
-        <title>PEM: A Paraphrase Evaluation Metric Exploiting Parallel Texts</title>
+        <title><fixed-case>PEM</fixed-case>: A Paraphrase Evaluation Metric Exploiting Parallel Texts</title>
         <author><first>Chang</first><last>Liu</last></author>
         <author><first>Daniel</first><last>Dahlmeier</last></author>
         <author><first>Hwee Tou</first><last>Ng</last></author>
@@ -1559,7 +1560,7 @@
         <bibkey>shi-mihalcea-tian:2010:EMNLP</bibkey>
    </paper>
    <paper id="1104">
-        <title>SRL-Based Verb Selection for ESL</title>
+        <title><fixed-case>SRL</fixed-case>-Based Verb Selection for <fixed-case>ESL</fixed-case></title>
         <author><first>Xiaohua</first><last>Liu</last></author>
         <author><first>Bo</first><last>Han</last></author>
         <author><first>Kuan</first><last>Li</last></author>
@@ -1635,7 +1636,7 @@
         <bibkey>kozareva-hovy:2010:EMNLP</bibkey>
    </paper>
    <paper id="1109">
-        <title>Function-Based Question Classification for General QA</title>
+        <title>Function-Based Question Classification for General <fixed-case>QA</fixed-case></title>
         <author><first>Fan</first><last>Bu</last></author>
         <author><first>Xingwei</first><last>Zhu</last></author>
         <author><first>Yu</first><last>Hao</last></author>
@@ -1780,7 +1781,7 @@
         <bibkey>brody:2010:EMNLP</bibkey>
    </paper>
    <paper id="1119">
-        <title>Inducing Probabilistic CCG Grammars from Logical Form with Higher-Order Unification</title>
+        <title>Inducing Probabilistic <fixed-case>CCG</fixed-case> Grammars from Logical Form with Higher-Order Unification</title>
         <author><first>Tom</first><last>Kwiatkowksi</last></author>
         <author><first>Luke</first><last>Zettlemoyer</last></author>
         <author><first>Sharon</first><last>Goldwater</last></author>

--- a/import/D11.xml
+++ b/import/D11.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D11">
    <paper id="1000">
         <title>Proceedings of the 2011 Conference on Empirical Methods in Natural Language Processing</title>

--- a/import/D12.xml
+++ b/import/D12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D12">
   <paper id="1000">
     <title>Proceedings of the 2012 Joint Conference on Empirical Methods in Natural Language Processing and Computational Natural Language Learning</title>

--- a/import/D13.xml
+++ b/import/D13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D13">
   <paper id="1000">
     <title>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</title>
@@ -280,7 +281,7 @@
   </paper>
 
   <paper id="1017">
-    <title>Appropriately Incorporating Statistical Significance in PMI</title>
+    <title>Appropriately Incorporating Statistical Significance in <fixed-case>PMI</fixed-case></title>
     <author><first>Om P.</first><last>Damani</last></author>
     <author><first>Shweta</first><last>Ghonge</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -310,7 +311,7 @@
   </paper>
 
   <paper id="1019">
-    <title>Joint Learning of Phonetic Units and Word Pronunciations for ASR</title>
+    <title>Joint Learning of Phonetic Units and Word Pronunciations for <fixed-case>ASR</fixed-case></title>
     <author><first>Chia-ying</first><last>Lee</last></author>
     <author><first>Yu</first><last>Zhang</last></author>
     <author><first>James</first><last>Glass</last></author>
@@ -326,7 +327,7 @@
   </paper>
 
   <paper id="1020">
-    <title>MCTest: A Challenge Dataset for the Open-Domain Machine Comprehension of Text</title>
+    <title><fixed-case>MCTest</fixed-case>: A Challenge Dataset for the Open-Domain Machine Comprehension of Text</title>
     <author><first>Matthew</first><last>Richardson</last></author>
     <author><first>Christopher J.C.</first><last>Burges</last></author>
     <author><first>Erin</first><last>Renshaw</last></author>
@@ -456,7 +457,7 @@
   </paper>
 
   <paper id="1028">
-    <title>Exploiting Zero Pronouns to Improve Chinese Coreference Resolution</title>
+    <title>Exploiting Zero Pronouns to Improve <fixed-case>Chinese</fixed-case> Coreference Resolution</title>
     <author><first>Fang</first><last>Kong</last></author>
     <author><first>Hwee Tou</first><last>Ng</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -504,7 +505,7 @@
   </paper>
 
   <paper id="1031">
-    <title>Exploring Representations from Unlabeled Data with Co-training for Chinese Word Segmentation</title>
+    <title>Exploring Representations from Unlabeled Data with Co-training for <fixed-case>Chinese</fixed-case> Word Segmentation</title>
     <author><first>Longkai</first><last>Zhang</last></author>
     <author><first>Houfeng</first><last>Wang</last></author>
     <author><first>Xu</first><last>Sun</last></author>
@@ -521,7 +522,7 @@
   </paper>
 
   <paper id="1032">
-    <title>Efficient Higher-Order CRFs for Morphological Tagging</title>
+    <title>Efficient Higher-Order <fixed-case>CRFs</fixed-case> for Morphological Tagging</title>
     <author><first>Thomas</first><last>Mueller</last></author>
     <author><first>Helmut</first><last>Schmid</last></author>
     <author><first>Hinrich</first><last>Schütze</last></author>
@@ -883,7 +884,7 @@
   </paper>
 
   <paper id="1054">
-    <title>Recursive Autoencoders for ITG-Based Translation</title>
+    <title>Recursive Autoencoders for <fixed-case>ITG</fixed-case>-Based Translation</title>
     <author><first>Peng</first><last>Li</last></author>
     <author><first>Yang</first><last>Liu</last></author>
     <author><first>Maosong</first><last>Sun</last></author>
@@ -899,7 +900,7 @@
   </paper>
 
   <paper id="1055">
-    <title>Automatically Classifying Edit Categories in Wikipedia Revisions</title>
+    <title>Automatically Classifying Edit Categories in <fixed-case>Wikipedia</fixed-case> Revisions</title>
     <author><first>Johannes</first><last>Daxenberger</last></author>
     <author><first>Iryna</first><last>Gurevych</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -965,7 +966,7 @@
   </paper>
 
   <paper id="1059">
-    <title>Unsupervised Spectral Learning of WCFG as Low-rank Matrix Completion</title>
+    <title>Unsupervised Spectral Learning of <fixed-case>WCFG</fixed-case> as Low-rank Matrix Completion</title>
     <author><first>Raphaël</first><last>Bailly</last></author>
     <author><first>Xavier</first><last>Carreras</last></author>
     <author><first>Franco M.</first><last>Luque</last></author>
@@ -997,7 +998,7 @@
   </paper>
 
   <paper id="1061">
-    <title>Deep Learning for Chinese Word Segmentation and POS Tagging</title>
+    <title>Deep Learning for <fixed-case>Chinese</fixed-case> Word Segmentation and <fixed-case>POS</fixed-case> Tagging</title>
     <author><first>Xiaoqing</first><last>Zheng</last></author>
     <author><first>Hanyang</first><last>Chen</last></author>
     <author><first>Tianyu</first><last>Xu</last></author>
@@ -1013,7 +1014,7 @@
   </paper>
 
   <paper id="1062">
-    <title>Joint Chinese Word Segmentation and POS Tagging on Heterogeneous Annotated Corpora with Multiple Task Learning</title>
+    <title>Joint <fixed-case>Chinese</fixed-case> Word Segmentation and <fixed-case>POS</fixed-case> Tagging on Heterogeneous Annotated Corpora with Multiple Task Learning</title>
     <author><first>Xipeng</first><last>Qiu</last></author>
     <author><first>Jiayi</first><last>Zhao</last></author>
     <author><first>Xuanjing</first><last>Huang</last></author>
@@ -1132,7 +1133,7 @@
   </paper>
 
   <paper id="1069">
-    <title>Automatically Determining a Proper Length for Multi-Document Summarization: A Bayesian Nonparametric Approach</title>
+    <title>Automatically Determining a Proper Length for Multi-Document Summarization: A <fixed-case>Bayesian</fixed-case> Nonparametric Approach</title>
     <author><first>Tengfei</first><last>Ma</last></author>
     <author><first>Hiroshi</first><last>Nakagawa</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1197,7 +1198,7 @@
   </paper>
 
   <paper id="1073">
-    <title>Mining Scientific Terms and their Definitions: A Study of the ACL Anthology</title>
+    <title>Mining Scientific Terms and their Definitions: A Study of the <fixed-case>ACL</fixed-case> Anthology</title>
     <author><first>Yiping</first><last>Jin</last></author>
     <author><first>Min-Yen</first><last>Kan</last></author>
     <author><first>Jun-Ping</first><last>Ng</last></author>
@@ -1356,7 +1357,7 @@
   </paper>
 
   <paper id="1083">
-    <title>A Corpus Level MIRA Tuning Strategy for Machine Translation</title>
+    <title>A Corpus Level <fixed-case>MIRA</fixed-case> Tuning Strategy for Machine Translation</title>
     <author><first>Ming</first><last>Tan</last></author>
     <author><first>Tian</first><last>Xia</last></author>
     <author><first>Shaojun</first><last>Wang</last></author>
@@ -1436,7 +1437,7 @@
   </paper>
 
   <paper id="1088">
-    <title>Russian Stress Prediction using Maximum Entropy Ranking</title>
+    <title><fixed-case>Russian</fixed-case> Stress Prediction using Maximum Entropy Ranking</title>
     <author><first>Keith</first><last>Hall</last></author>
     <author><first>Richard</first><last>Sproat</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1481,7 +1482,7 @@
   </paper>
 
   <paper id="1091">
-    <title>Is Twitter A Better Corpus for Measuring Sentiment Similarity?</title>
+    <title>Is <fixed-case>Twitter</fixed-case> A Better Corpus for Measuring Sentiment Similarity?</title>
     <author><first>Shi</first><last>Feng</last></author>
     <author><first>Le</first><last>Zhang</last></author>
     <author><first>Binyang</first><last>Li</last></author>
@@ -1500,7 +1501,7 @@
   </paper>
 
   <paper id="1092">
-    <title>Implicit Feature Detection via a Constrained Topic Model and SVM</title>
+    <title>Implicit Feature Detection via a Constrained Topic Model and <fixed-case>SVM</fixed-case></title>
     <author><first>Wei</first><last>Wang</last></author>
     <author><first>Hua</first><last>Xu</last></author>
     <author><first>Xiaoqiu</first><last>Huang</last></author>
@@ -1548,7 +1549,7 @@
   </paper>
 
   <paper id="1095">
-    <title>Japanese Zero Reference Resolution Considering Exophora and Author/Reader Mentions</title>
+    <title><fixed-case>Japanese</fixed-case> Zero Reference Resolution Considering Exophora and Author/Reader Mentions</title>
     <author><first>Masatsugu</first><last>Hangyo</last></author>
     <author><first>Daisuke</first><last>Kawahara</last></author>
     <author><first>Sadao</first><last>Kurohashi</last></author>
@@ -1745,7 +1746,7 @@
   </paper>
 
   <paper id="1107">
-    <title>Multi-Domain Adaptation for SMT Using Multi-Task Learning</title>
+    <title>Multi-Domain Adaptation for <fixed-case>SMT</fixed-case> Using Multi-Task Learning</title>
     <author><first>Lei</first><last>Cui</last></author>
     <author><first>Xilun</first><last>Chen</last></author>
     <author><first>Dongdong</first><last>Zhang</last></author>
@@ -1831,7 +1832,7 @@
   </paper>
 
   <paper id="1112">
-    <title>Max-Violation Perceptron and Forced Decoding for Scalable MT Training</title>
+    <title>Max-Violation Perceptron and Forced Decoding for Scalable <fixed-case>MT</fixed-case> Training</title>
     <author><first>Heng</first><last>Yu</last></author>
     <author><first>Liang</first><last>Huang</last></author>
     <author><first>Haitao</first><last>Mi</last></author>
@@ -1863,7 +1864,7 @@
   </paper>
 
   <paper id="1114">
-    <title>Gender Inference of Twitter Users in Non-English Contexts</title>
+    <title>Gender Inference of <fixed-case>Twitter</fixed-case> Users in Non-<fixed-case>English</fixed-case> Contexts</title>
     <author><first>Morgane</first><last>Ciot</last></author>
     <author><first>Morgan</first><last>Sonderegger</last></author>
     <author><first>Derek</first><last>Ruths</last></author>
@@ -1879,7 +1880,7 @@
   </paper>
 
   <paper id="1115">
-    <title>A Multimodal LDA Model integrating Textual, Cognitive and Visual Modalities</title>
+    <title>A Multimodal <fixed-case>LDA</fixed-case> Model integrating Textual, Cognitive and Visual Modalities</title>
     <author><first>Stephen</first><last>Roller</last></author>
     <author><first>Sabine</first><last>Schulte im Walde</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1894,7 +1895,7 @@
   </paper>
 
   <paper id="1116">
-    <title>Combining PCFG-LA Models with Dual Decomposition: A Case Study with Function Labels and Binarization</title>
+    <title>Combining <fixed-case>PCFG</fixed-case>-<fixed-case>LA</fixed-case> Models with Dual Decomposition: A Case Study with Function Labels and Binarization</title>
     <author><first>Joseph</first><last>Le Roux</last></author>
     <author><first>Antoine</first><last>Rozenknop</last></author>
     <author><first>Jennifer</first><last>Foster</last></author>
@@ -1928,7 +1929,7 @@
   </paper>
 
   <paper id="1118">
-    <title>Improvements to the Bayesian Topic N-Gram Models</title>
+    <title>Improvements to the <fixed-case>Bayesian</fixed-case> Topic N-Gram Models</title>
     <author><first>Hiroshi</first><last>Noji</last></author>
     <author><first>Daichi</first><last>Mochihashi</last></author>
     <author><first>Yusuke</first><last>Miyao</last></author>
@@ -1944,7 +1945,7 @@
   </paper>
 
   <paper id="1119">
-    <title>An Empirical Study Of Semi-Supervised Chinese Word Segmentation Using Co-Training</title>
+    <title>An Empirical Study Of Semi-Supervised <fixed-case>Chinese</fixed-case> Word Segmentation Using Co-Training</title>
     <author><first>Fan</first><last>Yang</last></author>
     <author><first>Paul</first><last>Vozila</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -1959,7 +1960,7 @@
   </paper>
 
   <paper id="1120">
-    <title>Ubertagging: Joint Segmentation and Supertagging for English</title>
+    <title>Ubertagging: Joint Segmentation and Supertagging for <fixed-case>English</fixed-case></title>
     <author><first>Rebecca</first><last>Dridan</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
     <month>October</month>
@@ -1973,7 +1974,7 @@
   </paper>
 
   <paper id="1121">
-    <title>Automatic Knowledge Acquisition for Case Alternation between the Passive and Active Voices in Japanese</title>
+    <title>Automatic Knowledge Acquisition for Case Alternation between the Passive and Active Voices in <fixed-case>Japanese</fixed-case></title>
     <author><first>Ryohei</first><last>Sasano</last></author>
     <author><first>Daisuke</first><last>Kawahara</last></author>
     <author><first>Sadao</first><last>Kurohashi</last></author>
@@ -2037,7 +2038,7 @@
   </paper>
 
   <paper id="1125">
-    <title>Sentiment Analysis: How to Derive Prior Polarities from SentiWordNet</title>
+    <title>Sentiment Analysis: How to Derive Prior Polarities from <fixed-case>SentiWordNet</fixed-case></title>
     <author><first>Marco</first><last>Guerini</last></author>
     <author><first>Lorenzo</first><last>Gatti</last></author>
     <author><first>Marco</first><last>Turchi</last></author>
@@ -2133,7 +2134,7 @@
   </paper>
 
   <paper id="1131">
-    <title>This Text Has the Scent of Starbucks: A Laplacian Structured Sparsity Model for Computational Branding Analytics</title>
+    <title>This Text Has the Scent of <fixed-case>Starbucks</fixed-case>: A Laplacian Structured Sparsity Model for Computational Branding Analytics</title>
     <author><first>William Yang</first><last>Wang</last></author>
     <author><first>Edward</first><last>Lin</last></author>
     <author><first>John</first><last>Kominek</last></author>
@@ -2200,7 +2201,7 @@
   </paper>
 
   <paper id="1135">
-    <title>Chinese Zero Pronoun Resolution: Some Recent Advances</title>
+    <title><fixed-case>Chinese</fixed-case> Zero Pronoun Resolution: Some Recent Advances</title>
     <author><first>Chen</first><last>Chen</last></author>
     <author><first>Vincent</first><last>Ng</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -2364,7 +2365,7 @@
   </paper>
 
   <paper id="1145">
-    <title>Automatic Idiom Identification in Wiktionary</title>
+    <title>Automatic Idiom Identification in <fixed-case>Wiktionary</fixed-case></title>
     <author><first>Grace</first><last>Muzny</last></author>
     <author><first>Luke</first><last>Zettlemoyer</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -2379,7 +2380,7 @@
   </paper>
 
   <paper id="1146">
-    <title>Elephant: Sequence Labeling for Word and Sentence Segmentation</title>
+    <title><fixed-case>Elephant</fixed-case>: Sequence Labeling for Word and Sentence Segmentation</title>
     <author><first>Kilian</first><last>Evang</last></author>
     <author><first>Valerio</first><last>Basile</last></author>
     <author><first>Grzegorz</first><last>Chrupała</last></author>
@@ -2411,7 +2412,7 @@
   </paper>
 
   <paper id="1148">
-    <title>Naive Bayes Word Sense Induction</title>
+    <title>Naive <fixed-case>Bayes</fixed-case> Word Sense Induction</title>
     <author><first>Do Kook</first><last>Choe</last></author>
     <author><first>Eugene</first><last>Charniak</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -2426,7 +2427,7 @@
   </paper>
 
   <paper id="1149">
-    <title>The VerbCorner Project: Toward an Empirically-Based Semantic Decomposition of Verbs</title>
+    <title>The <fixed-case>VerbCorner</fixed-case> Project: Toward an Empirically-Based Semantic Decomposition of Verbs</title>
     <author><first>Joshua K.</first><last>Hartshorne</last></author>
     <author><first>Claire</first><last>Bonial</last></author>
     <author><first>Martha</first><last>Palmer</last></author>
@@ -2585,7 +2586,7 @@
   </paper>
 
   <paper id="1159">
-    <title>A Hierarchical Entity-Based Approach to Structuralize User Generated Content in Social Media: A Case of Yahoo! Answers</title>
+    <title>A Hierarchical Entity-Based Approach to Structuralize User Generated Content in Social Media: A Case of <fixed-case>Yahoo</fixed-case>! Answers</title>
     <author><first>Baichuan</first><last>Li</last></author>
     <author><first>Jing</first><last>Liu</last></author>
     <author><first>Chin-Yew</first><last>Lin</last></author>
@@ -2603,7 +2604,7 @@
   </paper>
 
   <paper id="1160">
-    <title>Semantic Parsing on Freebase from Question-Answer Pairs</title>
+    <title>Semantic Parsing on <fixed-case>Freebase</fixed-case> from Question-Answer Pairs</title>
     <author><first>Jonathan</first><last>Berant</last></author>
     <author><first>Andrew</first><last>Chou</last></author>
     <author><first>Roy</first><last>Frostig</last></author>
@@ -2669,7 +2670,7 @@
   </paper>
 
   <paper id="1164">
-    <title>A Convex Alternative to IBM Model 2</title>
+    <title>A Convex Alternative to <fixed-case>IBM</fixed-case> Model 2</title>
     <author><first>Andrei</first><last>Simion</last></author>
     <author><first>Michael</first><last>Collins</last></author>
     <author><first>Cliff</first><last>Stein</last></author>
@@ -3073,7 +3074,7 @@
   </paper>
 
   <paper id="1189">
-    <title>Collective Opinion Target Extraction in Chinese Microblogs</title>
+    <title>Collective Opinion Target Extraction in <fixed-case>Chinese</fixed-case> Microblogs</title>
     <author><first>Xinjie</first><last>Zhou</last></author>
     <author><first>Xiaojun</first><last>Wan</last></author>
     <author><first>Jianguo</first><last>Xiao</last></author>
@@ -3089,7 +3090,7 @@
   </paper>
 
   <paper id="1190">
-    <title>Detecting Promotional Content in Wikipedia</title>
+    <title>Detecting Promotional Content in <fixed-case>Wikipedia</fixed-case></title>
     <author><first>Shruti</first><last>Bhosale</last></author>
     <author><first>Heath</first><last>Vinicombe</last></author>
     <author><first>Raymond</first><last>Mooney</last></author>
@@ -3105,7 +3106,7 @@
   </paper>
 
   <paper id="1191">
-    <title>Learning Topics and Positions from Debatepedia</title>
+    <title>Learning Topics and Positions from <fixed-case>Debatepedia</fixed-case></title>
     <author><first>Swapna</first><last>Gottipati</last></author>
     <author><first>Minghui</first><last>Qiu</last></author>
     <author><first>Yanchuan</first><last>Sim</last></author>
@@ -3123,7 +3124,7 @@
   </paper>
 
   <paper id="1192">
-    <title>A Unified Model for Topics, Events and Users on Twitter</title>
+    <title>A Unified Model for Topics, Events and Users on <fixed-case>Twitter</fixed-case></title>
     <author><first>Qiming</first><last>Diao</last></author>
     <author><first>Jing</first><last>Jiang</last></author>
     <booktitle>Proceedings of the 2013 Conference on Empirical Methods in Natural Language Processing</booktitle>
@@ -3170,7 +3171,7 @@
   </paper>
 
   <paper id="1195">
-    <title>A Multi-Teraflop Constituency Parser using GPUs</title>
+    <title>A Multi-Teraflop Constituency Parser using <fixed-case>GPUs</fixed-case></title>
     <author><first>John</first><last>Canny</last></author>
     <author><first>David</first><last>Hall</last></author>
     <author><first>Dan</first><last>Klein</last></author>
@@ -3186,7 +3187,7 @@
   </paper>
 
   <paper id="1196">
-    <title>Fish Transporters and Miracle Homes: How Compositional Distributional Semantics can Help NP Parsing</title>
+    <title>Fish Transporters and Miracle Homes: How Compositional Distributional Semantics can Help <fixed-case>NP</fixed-case> Parsing</title>
     <author><first>Angeliki</first><last>Lazaridou</last></author>
     <author><first>Eva Maria</first><last>Vecchi</last></author>
     <author><first>Marco</first><last>Baroni</last></author>

--- a/import/D14.xml
+++ b/import/D14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D14">
   <paper id="1000">
     <title>

--- a/import/D15.xml
+++ b/import/D15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D15">
   <paper id="1000">
     <title>

--- a/import/D16.xml
+++ b/import/D16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D16">
   <paper id="1000">
     <title>

--- a/import/D17.xml
+++ b/import/D17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D17">
   <paper id="1000">
     <title>

--- a/import/D18.xml
+++ b/import/D18.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="D18">
   <paper id="1000">
     <title>Proceedings of the 2018 Conference on Empirical Methods in Natural Language Processing</title>

--- a/import/E09.xml
+++ b/import/E09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="E09">
    <paper id="1000">
         <title>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</title>
@@ -39,7 +40,7 @@
         <bibkey>dejong:2009:EACL</bibkey>
    </paper>
    <paper id="1003">
-        <title>On the Use of Comparable Corpora to Improve SMT performance</title>
+        <title>On the Use of Comparable Corpora to Improve <fixed-case>SMT</fixed-case> performance</title>
         <author><first>Sadaf</first><last>Abdul-Rauf</last></author>
         <author><first>Holger</first><last>Schwenk</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
@@ -53,7 +54,7 @@
         <bibkey>abdulrauf-schwenk:2009:EACL</bibkey>
    </paper>
    <paper id="1004">
-        <title>Contextual Phrase-Level Polarity Analysis Using Lexical Affect Scoring and Syntactic N-Grams</title>
+        <title>Contextual Phrase-Level Polarity Analysis Using Lexical Affect Scoring and Syntactic <fixed-case>N</fixed-case>-Grams</title>
         <author><first>Apoorv</first><last>Agarwal</last></author>
         <author><first>Fadi</first><last>Biadsy</last></author>
         <author><first>Kathleen</first><last>Mckeown</last></author>
@@ -68,7 +69,7 @@
         <bibkey>agarwal-biadsy-mckeown:2009:EACL</bibkey>
    </paper>
    <paper id="1005">
-        <title>Personalizing PageRank for Word Sense Disambiguation</title>
+        <title>Personalizing <fixed-case>P</fixed-case>age<fixed-case>R</fixed-case>ank for Word Sense Disambiguation</title>
         <author><first>Eneko</first><last>Agirre</last></author>
         <author><first>Aitor</first><last>Soroa</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
@@ -82,7 +83,7 @@
         <bibkey>agirre-soroa:2009:EACL</bibkey>
    </paper>
    <paper id="1006">
-        <title>Supervised Domain Adaption for WSD</title>
+        <title>Supervised Domain Adaption for <fixed-case>WSD</fixed-case></title>
         <author><first>Eneko</first><last>Agirre</last></author>
         <author><first>Oier</first><last>Lopez de Lacalle</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
@@ -110,7 +111,7 @@
         <bibkey>ahpine-jacquet:2009:EACL</bibkey>
    </paper>
    <paper id="1008">
-        <title>Correcting Automatic Translations through Collaborations between MT and Monolingual Target-Language Users</title>
+        <title>Correcting Automatic Translations through Collaborations between <fixed-case>MT</fixed-case> and Monolingual Target-Language Users</title>
         <author><first>Joshua</first><last>Albrecht</last></author>
         <author><first>Rebecca</first><last>Hwa</last></author>
         <author><first>G. Elisabeta</first><last>Marai</last></author>
@@ -138,7 +139,7 @@
         <bibkey>angelov:2009:EACL</bibkey>
    </paper>
    <paper id="1010">
-        <title>Data-Driven Semantic Analysis for Multilingual WSD and Lexical Selection in Translation</title>
+        <title>Data-Driven Semantic Analysis for Multilingual <fixed-case>WSD</fixed-case> and Lexical Selection in Translation</title>
         <author><first>Marianna</first><last>Apidianaki</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
         <month>March</month>
@@ -151,7 +152,7 @@
         <bibkey>apidianaki:2009:EACL</bibkey>
    </paper>
    <paper id="1011">
-        <title>Syntactic Phrase Reordering for English-to-Arabic Statistical Machine Translation</title>
+        <title>Syntactic Phrase Reordering for <fixed-case>E</fixed-case>nglish-to-<fixed-case>A</fixed-case>rabic Statistical Machine Translation</title>
         <author><first>Ibrahim</first><last>Badr</last></author>
         <author><first>Rabih</first><last>Zbib</last></author>
         <author><first>James</first><last>Glass</last></author>
@@ -208,7 +209,7 @@
         <bibkey>cahill-forst:2009:EACL</bibkey>
    </paper>
    <paper id="1015">
-        <title>Large-Coverage Root Lexicon Extraction for Hindi</title>
+        <title>Large-Coverage Root Lexicon Extraction for <fixed-case>H</fixed-case>indi</title>
         <author><first>Cohan Sujay</first><last>Carlos</last></author>
         <author><first>Monojit</first><last>Choudhury</last></author>
         <author><first>Sandipan</first><last>Dandapat</last></author>
@@ -250,7 +251,7 @@
         <bibkey>chae-nenkova:2009:EACL</bibkey>
    </paper>
    <paper id="1018">
-        <title>EM Works for Pronoun Anaphora Resolution</title>
+        <title><fixed-case>EM</fixed-case> Works for Pronoun Anaphora Resolution</title>
         <author><first>Eugene</first><last>Charniak</last></author>
         <author><first>Micha</first><last>Elsner</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
@@ -264,7 +265,7 @@
         <bibkey>charniak-elsner:2009:EACL</bibkey>
    </paper>
    <paper id="1019">
-        <title>Web Augmentation of Language Models for Continuous Speech Recognition of SMS Text Messages</title>
+        <title>Web Augmentation of Language Models for Continuous Speech Recognition of <fixed-case>SMS</fixed-case> Text Messages</title>
         <author><first>Mathias</first><last>Creutz</last></author>
         <author><first>Sami</first><last>Virpioja</last></author>
         <author><first>Anna</first><last>Kovaleva</last></author>
@@ -437,7 +438,7 @@
         <bibkey>fitzgerald-hall-jelinek:2009:EACL</bibkey>
    </paper>
    <paper id="1031">
-        <title>TBL-Improved Non-Deterministic Segmentation and POS Tagging for a Chinese Parser</title>
+        <title><fixed-case>TBL</fixed-case>-Improved Non-Deterministic Segmentation and <fixed-case>POS</fixed-case> Tagging for a <fixed-case>C</fixed-case>hinese Parser</title>
         <author><first>Martin</first><last>Forst</last></author>
         <author><first>Ji</first><last>Fang</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
@@ -540,7 +541,7 @@
         <bibkey>gimpel-smith:2009:EACL</bibkey>
    </paper>
    <paper id="1038">
-        <title>Enhancing Unlexicalized Parsing Performance Using a Wide Coverage Lexicon, Fuzzy Tag-Set Mapping, and EM-HMM-Based Lexical Probabilities</title>
+        <title>Enhancing Unlexicalized Parsing Performance Using a Wide Coverage Lexicon, Fuzzy Tag-Set Mapping, and <fixed-case>EM-HMM</fixed-case>-Based Lexical Probabilities</title>
         <author><first>Yoav</first><last>Goldberg</last></author>
         <author><first>Reut</first><last>Tsarfaty</last></author>
         <author><first>Meni</first><last>Adler</last></author>
@@ -708,7 +709,7 @@
         <bibkey>kastner-monz:2009:EACL</bibkey>
    </paper>
    <paper id="1049">
-        <title>N-Gram-Based Statistical Machine Translation versus Syntax Augmented Machine Translation: Comparison and System Combination</title>
+        <title><fixed-case>N</fixed-case>-Gram-Based Statistical Machine Translation versus Syntax Augmented Machine Translation: Comparison and System Combination</title>
         <author><first>Maxim</first><last>Khalilov</last></author>
         <author><first>José A. R.</first><last>Fonollosa</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
@@ -764,7 +765,7 @@
         <bibkey>koller-lascarides:2009:EACL</bibkey>
    </paper>
    <paper id="1053">
-        <title>Dependency Trees and the Strong Generative Capacity of CCG</title>
+        <title>Dependency Trees and the Strong Generative Capacity of <fixed-case>CCG</fixed-case></title>
         <author><first>Alexander</first><last>Koller</last></author>
         <author><first>Marco</first><last>Kuhlmann</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
@@ -865,7 +866,7 @@
         <bibkey>lerman-blairgoldensohn-mcdonald:2009:EACL</bibkey>
    </paper>
    <paper id="1060">
-        <title>Correcting a POS-Tagged Corpus Using Three Complementary Methods</title>
+        <title>Correcting a <fixed-case>POS</fixed-case>-Tagged Corpus Using Three Complementary Methods</title>
         <author><first>Hrafn</first><last>Loftsson</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
         <month>March</month>
@@ -1006,7 +1007,7 @@
         <bibkey>ninomiya-EtAl:2009:EACL</bibkey>
    </paper>
    <paper id="1070">
-        <title>Analysing Wikipedia and Gold-Standard Corpora for NER Training</title>
+        <title>Analysing <fixed-case>W</fixed-case>ikipedia and Gold-Standard Corpora for <fixed-case>NER</fixed-case> Training</title>
         <author><first>Joel</first><last>Nothman</last></author>
         <author><first>Tara</first><last>Murphy</last></author>
         <author><first>James R.</first><last>Curran</last></author>
@@ -1048,7 +1049,7 @@
         <bibkey>ovrelid:2009:EACL</bibkey>
    </paper>
    <paper id="1073">
-        <title>Outclassing Wikipedia in Open-Domain Information Extraction: Weakly-Supervised Acquisition of Attributes over Conceptual Hierarchies</title>
+        <title>Outclassing <fixed-case>W</fixed-case>ikipedia in Open-Domain Information Extraction: Weakly-Supervised Acquisition of Attributes over Conceptual Hierarchies</title>
         <author><first>Marius</first><last>Paşca</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
         <month>March</month>
@@ -1252,7 +1253,7 @@
         <bibkey>sporleder-li:2009:EACL</bibkey>
    </paper>
    <paper id="1087">
-        <title>Semi-Supervised Training for the Averaged Perceptron POS Tagger</title>
+        <title>Semi-Supervised Training for the Averaged Perceptron <fixed-case>POS</fixed-case> Tagger</title>
         <author><first>Drahomíra “johanka”</first><last>Spoustová</last></author>
         <author><first>Jan</first><last>Hajič</last></author>
         <author><first>Jan</first><last>Raab</last></author>
@@ -1311,7 +1312,7 @@
         <bibkey>tsuruoka-tsujii-ananiadou:2009:EACL</bibkey>
    </paper>
    <paper id="1091">
-        <title>MINT: A Method for Effective and Scalable Mining of Named Entity Transliterations from Large Comparable Corpora</title>
+        <title><fixed-case>MINT</fixed-case>: A Method for Effective and Scalable Mining of Named Entity Transliterations from Large Comparable Corpora</title>
         <author><first>Raghavendra</first><last>Udupa</last></author>
         <author><first>K</first><last>Saravanan</last></author>
         <author><first>A</first><last>Kumaran</last></author>
@@ -1327,7 +1328,7 @@
         <bibkey>udupa-EtAl:2009:EACL</bibkey>
    </paper>
    <paper id="1092">
-        <title>Deriving Generalized Knowledge from Corpora Using WordNet Abstraction</title>
+        <title>Deriving Generalized Knowledge from Corpora Using <fixed-case>WordNet</fixed-case> Abstraction</title>
         <author><first>Benjamin</first><last>Van Durme</last></author>
         <author><first>Phillip</first><last>Michalak</last></author>
         <author><first>Lenhart</first><last>Schubert</last></author>
@@ -1429,7 +1430,7 @@
         <bibkey>washtell:2009:EACL</bibkey>
    </paper>
    <paper id="1099">
-        <title>Language ID in the Context of Harvesting Language Data off the Web</title>
+        <title>Language <fixed-case>ID</fixed-case> in the Context of Harvesting Language Data off the Web</title>
         <author><first>Fei</first><last>Xia</last></author>
         <author><first>William</first><last>Lewis</last></author>
         <author><first>Hoifung</first><last>Poon</last></author>
@@ -1468,7 +1469,7 @@
         <bibkey>EACL-DEMOS:2009</bibkey>
    </paper>
    <paper id="2001">
-        <title>Frolog: an Accommodating Text-Adventure Game</title>
+        <title><fixed-case>Frolog</fixed-case>: an Accommodating Text-Adventure Game</title>
         <author><first>Luciana</first><last>Benotti</last></author>
         <booktitle>Proceedings of the Demonstrations Session at EACL 2009</booktitle>
         <month>April</month>
@@ -1481,7 +1482,7 @@
         <bibkey>benotti:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2002">
-        <title>CBSEAS, a Summarization System – Integration of Opinion Mining Techniques to Summarize Blogs</title>
+        <title><fixed-case>CBSEAS</fixed-case>, a Summarization System – Integration of Opinion Mining Techniques to Summarize Blogs</title>
         <author><first>Aurélien</first><last>Bossard</last></author>
         <author><first>Michel</first><last>Généreux</last></author>
         <author><first>Thierry</first><last>Poibeau</last></author>
@@ -1528,7 +1529,7 @@
         <bibkey>cheng-EtAl:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2005">
-        <title>An Open-Source Natural Language Generator for OWL Ontologies and its Use in Protege and Second Life</title>
+        <title>An Open-Source Natural Language Generator for <fixed-case>OWL</fixed-case> Ontologies and its Use in Protege and Second Life</title>
         <author><first>Dimitrios</first><last>Galanis</last></author>
         <author><first>George</first><last>Karakatsiotis</last></author>
         <author><first>Gerasimos</first><last>Lampouras</last></author>
@@ -1544,7 +1545,7 @@
         <bibkey>galanis-EtAl:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2006">
-        <title>eHumanities Desktop - An Online System for Corpus Management and Analysis in Support of Computing in the Humanities</title>
+        <title><fixed-case>eHumanities Desktop</fixed-case> - An Online System for Corpus Management and Analysis in Support of Computing in the Humanities</title>
         <author><first>Rüdiger</first><last>Gleim</last></author>
         <author><first>Ulli</first><last>Waltinger</last></author>
         <author><first>Alexandra</first><last>Ernst</last></author>
@@ -1562,7 +1563,7 @@
         <bibkey>gleim-EtAl:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2007">
-        <title>A Comparison of Clausal Coordinate Ellipsis in Estonian and German: Remarkably Similar Elision Rules Allow a Language-Independent Ellipsis-Generation Module</title>
+        <title>A Comparison of Clausal Coordinate Ellipsis in <fixed-case>E</fixed-case>stonian and <fixed-case>G</fixed-case>erman: Remarkably Similar Elision Rules Allow a Language-Independent Ellipsis-Generation Module</title>
         <author><first>Karin</first><last>Harbusch</last></author>
         <author><first>Mare</first><last>Koit</last></author>
         <author><first>Haldur</first><last>Õim</last></author>
@@ -1577,7 +1578,7 @@
         <bibkey>harbusch-koit-oim:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2008">
-        <title>Foma: a Finite-State Compiler and Library</title>
+        <title><fixed-case>Foma</fixed-case>: a Finite-State Compiler and Library</title>
         <author><first>Mans</first><last>Hulden</last></author>
         <booktitle>Proceedings of the Demonstrations Session at EACL 2009</booktitle>
         <month>April</month>
@@ -1643,7 +1644,7 @@
         <bibkey>lewis-xia:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2012">
-        <title>A Tool for Multi-Word Expression Extraction in Modern Greek Using Syntactic Parsing</title>
+        <title>A Tool for Multi-Word Expression Extraction in Modern <fixed-case>G</fixed-case>reek Using Syntactic Parsing</title>
         <author><first>Athina</first><last>Michou</last></author>
         <author><first>Violeta</first><last>Seretan</last></author>
         <booktitle>Proceedings of the Demonstrations Session at EACL 2009</booktitle>
@@ -1684,7 +1685,7 @@
         <bibkey>pastra-balta:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2015">
-        <title>Grammar Development in GF</title>
+        <title>Grammar Development in <fixed-case>GF</fixed-case></title>
         <author><first>Aarne</first><last>Ranta</last></author>
         <author><first>Krasimir</first><last>Angelov</last></author>
         <author><first>Björn</first><last>Bringert</last></author>
@@ -1699,7 +1700,7 @@
         <bibkey>ranta-angelov-bringert:2009:EACL-DEMOS</bibkey>
    </paper>
    <paper id="2016">
-        <title>Three BioNLP Tools Powered by a Biological Lexicon</title>
+        <title>Three <fixed-case>BioNLP</fixed-case> Tools Powered by a Biological Lexicon</title>
         <author><first>Yutaka</first><last>Sasaki</last></author>
         <author><first>Paul</first><last>Thompson</last></author>
         <author><first>John</first><last>McNaught</last></author>
@@ -1757,7 +1758,7 @@
         <bibkey>aimetti:2009:EACL-SRWS</bibkey>
    </paper>
    <paper id="3002">
-        <title>A Memory-Based Approach to the Treatment of Serial Verb Construction in Combinatory Categorial Grammar</title>
+        <title>A Memory-Based Approach to the Treatment of Serial Verb Construction in <fixed-case>C</fixed-case>ombinatory <fixed-case>C</fixed-case>ategorial <fixed-case>G</fixed-case>rammar</title>
         <author><first>Prachya</first><last>Boonkwan</last></author>
         <booktitle>Proceedings of the Student Research Workshop at EACL 2009</booktitle>
         <month>April</month>
@@ -1770,7 +1771,7 @@
         <bibkey>boonkwan:2009:EACL-SRWS</bibkey>
    </paper>
    <paper id="3003">
-        <title>Combining a Statistical Language Model with Logistic Regression to Predict the Lexical and Syntactic Difficulty of Texts for FFL</title>
+        <title>Combining a Statistical Language Model with Logistic Regression to Predict the Lexical and Syntactic Difficulty of Texts for <fixed-case>FFL</fixed-case></title>
         <author><first>Thomas</first><last>François</last></author>
         <booktitle>Proceedings of the Student Research Workshop at EACL 2009</booktitle>
         <month>April</month>
@@ -1809,7 +1810,7 @@
         <bibkey>plank:2009:EACL-SRWS</bibkey>
    </paper>
    <paper id="3006">
-        <title>A Chain-starting Classifier of Definite NPs in Spanish</title>
+        <title>A Chain-starting Classifier of Definite <fixed-case>NPs</fixed-case> in Spanish</title>
         <author><first>Marta</first><last>Recasens</last></author>
         <booktitle>Proceedings of the Student Research Workshop at EACL 2009</booktitle>
         <month>April</month>
@@ -1822,7 +1823,7 @@
         <bibkey>recasens:2009:EACL-SRWS</bibkey>
    </paper>
    <paper id="3007">
-        <title>Speech Emotion Recognition With TGI+.2 Classifier</title>
+        <title>Speech Emotion Recognition With <fixed-case>TGI+.2</fixed-case> Classifier</title>
         <author><first>Julia</first><last>Sidorova</last></author>
         <booktitle>Proceedings of the Student Research Workshop at EACL 2009</booktitle>
         <month>April</month>
@@ -1835,7 +1836,7 @@
         <bibkey>sidorova:2009:EACL-SRWS</bibkey>
    </paper>
    <paper id="3008">
-        <title>A Comparison of Merging Strategies for Translation of German Compounds</title>
+        <title>A Comparison of Merging Strategies for Translation of <fixed-case>G</fixed-case>erman Compounds</title>
         <author><first>Sara</first><last>Stymne</last></author>
         <booktitle>Proceedings of the Student Research Workshop at EACL 2009</booktitle>
         <month>April</month>

--- a/import/E09.xml
+++ b/import/E09.xml
@@ -27,7 +27,7 @@
         <bibkey>copestake:2009:EACL</bibkey>
    </paper>
    <paper id="1002">
-        <title><b>Invited Talk:</b> NLP and the Humanities: The Revival of an Old Liaison</title>
+        <title><b>Invited Talk:</b> <fixed-case>NLP</fixed-case> and the Humanities: The Revival of an Old Liaison</title>
         <author><first>Francisca</first><last>de Jong</last></author>
         <booktitle>Proceedings of the 12th Conference of the European Chapter of the ACL (EACL 2009)</booktitle>
         <month>March</month>

--- a/import/E12.xml
+++ b/import/E12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="E12">
    <paper id="1000">
         <title>Proceedings of the 13th Conference of the European Chapter of the Association for Computational Linguistics</title>

--- a/import/E14.xml
+++ b/import/E14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="E14">
   <paper id="1000">
     <title>

--- a/import/E17.xml
+++ b/import/E17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="E17">
   <paper id="1000">
     <title>Proceedings of the 15th Conference of the European Chapter of the Association for Computational Linguistics: Volume 1, Long Papers</title>

--- a/import/F12.xml
+++ b/import/F12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="F12">
   <paper id="1000">
     <title>Proceedings of the Joint Conference JEP-TALN-RECITAL 2012, volume 1: JEP</title>

--- a/import/F13.xml
+++ b/import/F13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="F13">
 	<paper id="1000">
 		<title>Proceedings of TALN 2013 (Volume 1: Long Papers)</title>

--- a/import/F14.xml
+++ b/import/F14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="F14">
 	<paper id="1000">
 		<title>Proceedings of TALN 2014 (Volume 1: Long Papers)</title>

--- a/import/H05.xml
+++ b/import/H05.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="H05">
    <paper id="1000">
         <title>Proceedings of Human Language Technology Conference and Conference on Empirical Methods in Natural Language Processing</title>
@@ -881,7 +882,7 @@
    </paper>
 
    <paper id="2006">
-        <title>NooJ: a Linguistic Annotation System for Corpus Processing</title>
+        <title>Noo<fixed-case>J</fixed-case>: a Linguistic Annotation System for Corpus Processing</title>
         <author><first>Max</first><last>Silberztein</last></author>
    </paper>
 
@@ -959,7 +960,7 @@
    </paper>
 
    <paper id="2015">
-        <title>The MIT Spoken Lecture Processing Project</title>
+        <title>The <fixed-case>M</fixed-case><fixed-case>I</fixed-case><fixed-case>T</fixed-case> Spoken Lecture Processing Project</title>
         <author><first>James R.</first><last>Glass</last></author>
         <author><first>Timothy J.</first><last>Hazen</last></author>
         <author><first>D. Scott</first><last>Cyphers</last></author>
@@ -968,14 +969,14 @@
    </paper>
 
    <paper id="2016">
-        <title>MBOI: Discovery of Business Opportunities on the Internet</title>
+        <title><fixed-case>M</fixed-case><fixed-case>B</fixed-case><fixed-case>O</fixed-case><fixed-case>I</fixed-case>: Discovery of Business Opportunities on the Internet</title>
         <author><first>Arman</first><last>Tajarobi</last></author>
         <author><first>Jean-François</first><last>Garneau</last></author>
         <author><first>François</first><last>Paradis</last></author>
    </paper>
 
    <paper id="2017">
-        <title>OPINE: Extracting Product Features and Opinions from Reviews</title>
+        <title><fixed-case>O</fixed-case><fixed-case>P</fixed-case><fixed-case>I</fixed-case><fixed-case>N</fixed-case><fixed-case>E</fixed-case>: Extracting Product Features and Opinions from Reviews</title>
         <author><first>Ana-Maria</first><last>Popescu</last></author>
         <author><first>Bao</first><last>Nguyen</last></author>
         <author><first>Oren</first><last>Etzioni</last></author>
@@ -995,7 +996,7 @@
    </paper>
 
    <paper id="2019">
-        <title>POSBIOTM/W: A Development Workbench for Machine Learning Oriented Biomedical Text Mining System</title>
+        <title><fixed-case>P</fixed-case><fixed-case>O</fixed-case><fixed-case>S</fixed-case><fixed-case>B</fixed-case><fixed-case>I</fixed-case><fixed-case>O</fixed-case><fixed-case>T</fixed-case><fixed-case>M</fixed-case>/<fixed-case>W</fixed-case>: A Development Workbench for Machine Learning Oriented Biomedical Text Mining System</title>
         <author><first>Kyungduk</first><last>Kim</last></author>
         <author><first>Yu</first><last>Song</last></author>
         <author><first>Gary Geunbae</first><last>Lee</last></author>

--- a/import/I08.xml
+++ b/import/I08.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="I08">
 
 <paper id="1000">

--- a/import/I11.xml
+++ b/import/I11.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="I11">
   <paper id="1000">
     <title>Proceedings of 5th International Joint Conference on Natural Language Processing</title>

--- a/import/I13.xml
+++ b/import/I13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="I13">
   <paper id="1000">
     <title>Proceedings of the Sixth International Joint Conference on Natural Language Processing</title>

--- a/import/I17.xml
+++ b/import/I17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="I17">
   <paper id="1000">
     <title>Proceedings of the Eighth International Joint Conference on Natural Language Processing (Volume 1: Long Papers)</title>

--- a/import/K15.xml
+++ b/import/K15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="K15">
   <paper id="1000">
     <title>

--- a/import/K16.xml
+++ b/import/K16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="K16">
   <paper id="1000">
     <title>

--- a/import/K17.xml
+++ b/import/K17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="K17">
   <paper id="1000">
     <title>

--- a/import/K18.xml
+++ b/import/K18.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="K18">
   <paper id="1000">
     <title>Proceedings of the 22nd Conference on Computational Natural Language Learning</title>
@@ -82,7 +83,7 @@
   </paper>
 
   <paper id="1005">
-    <title>A Unified Neural Network Model for Geolocating Twitter Users</title>
+    <title>A Unified Neural Network Model for Geolocating <fixed-case>Twitter</fixed-case> Users</title>
     <author><first>Mohammad</first><last>Ebrahimi</last></author>
     <author><first>Elaheh</first><last>ShafieiBavani</last></author>
     <author><first>Raymond</first><last>Wong</last></author>
@@ -116,7 +117,7 @@
   </paper>
 
   <paper id="1007">
-    <title>Adversarially Regularising Neural NLI Models to Integrate Logical Background Knowledge</title>
+    <title>Adversarially Regularising Neural <fixed-case>NLI</fixed-case> Models to Integrate Logical Background Knowledge</title>
     <author><first>Pasquale</first><last>Minervini</last></author>
     <author><first>Sebastian</first><last>Riedel</last></author>
     <booktitle>Proceedings of the 22nd Conference on Computational Natural Language Learning</booktitle>
@@ -362,7 +363,7 @@
   </paper>
 
   <paper id="1021">
-    <title>Generalizing Procrustes Analysis for Better Bilingual Dictionary Induction</title>
+    <title>Generalizing <fixed-case>Procrustes</fixed-case> Analysis for Better Bilingual Dictionary Induction</title>
     <author><first>Yova</first><last>Kementchedjhieva</last></author>
     <author><first>Sebastian</first><last>Ruder</last></author>
     <author><first>Ryan</first><last>Cotterell</last></author>
@@ -593,7 +594,7 @@
   </paper>
 
   <paper id="1034">
-    <title>Upcycle Your OCR: Reusing OCRs for Post-OCR Text Correction in Romanised Sanskrit</title>
+    <title>Upcycle Your <fixed-case>OCR</fixed-case>: Reusing <fixed-case>OCRs</fixed-case> for Post-<fixed-case>OCR</fixed-case> Text Correction in Romanised Sanskrit</title>
     <author><first>Amrith</first><last>Krishna</last></author>
     <author><first>Bodhisattwa P.</first><last>Majumder</last></author>
     <author><first>Rajesh</first><last>Bhat</last></author>
@@ -744,7 +745,7 @@
   </paper>
 
   <paper id="1043">
-    <title>DIMSIM: An Accurate Chinese Phonetic Similarity Algorithm Based on Learned High Dimensional Encoding</title>
+    <title><fixed-case>DIMSIM</fixed-case>: An Accurate Chinese Phonetic Similarity Algorithm Based on Learned High Dimensional Encoding</title>
     <author><first>Min</first><last>Li</last></author>
     <author><first>Marina</first><last>Danilevsky</last></author>
     <author><first>Sara</first><last>Noeman</last></author>
@@ -780,7 +781,7 @@
   </paper>
 
   <paper id="1045">
-    <title>Bringing Order to Neural Word Embeddings with Embeddings Augmented by Random Permutations (EARP)</title>
+    <title>Bringing Order to Neural Word Embeddings with Embeddings Augmented by Random Permutations (<fixed-case>EARP</fixed-case>)</title>
     <author><first>Trevor</first><last>Cohen</last></author>
     <author><first>Dominic</first><last>Widdows</last></author>
     <booktitle>Proceedings of the 22nd Conference on Computational Natural Language Learning</booktitle>
@@ -989,7 +990,7 @@
   </paper>
 
   <paper id="2000">
-    <title>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</title>
+    <title>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</title>
     <editor><first>Daniel</first><last>Zeman</last></editor>
     <editor><first>Jan</first><last>Hajič</last></editor>
     <month>October</month>
@@ -1002,7 +1003,7 @@
   </paper>
 
   <paper id="2001">
-    <title>CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</title>
+    <title><fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</title>
     <author><first>Daniel</first><last>Zeman</last></author>
     <author><first>Jan</first><last>Hajič</last></author>
     <author><first>Martin</first><last>Popel</last></author>
@@ -1011,7 +1012,7 @@
     <author><first>Filip</first><last>Ginter</last></author>
     <author><first>Joakim</first><last>Nivre</last></author>
     <author><first>Slav</first><last>Petrov</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1024,13 +1025,13 @@
   </paper>
 
   <paper id="2002">
-    <title>The 2018 Shared Task on Extrinsic Parser Evaluation: On the Downstream Utility of English Universal Dependency Parsers</title>
+    <title>The 2018 Shared Task on Extrinsic Parser Evaluation: On the Downstream Utility of <fixed-case>English</fixed-case> Universal Dependency Parsers</title>
     <author><first>Murhaf</first><last>Fares</last></author>
     <author><first>Stephan</first><last>Oepen</last></author>
     <author><first>Lilja</first><last>Øvrelid</last></author>
     <author><first>Jari</first><last>Björne</last></author>
     <author><first>Richard</first><last>Johansson</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1043,10 +1044,10 @@
   </paper>
 
   <paper id="2003">
-    <title>CEA LIST: Processing Low-Resource Languages for CoNLL 2018</title>
+    <title><fixed-case>CEA</fixed-case> <fixed-case>LIST</fixed-case>: Processing Low-Resource Languages for <fixed-case>CoNLL</fixed-case> 2018</title>
     <author><first>Elie</first><last>Duthoo</last></author>
     <author><first>Olivier</first><last>Mesnard</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1062,7 +1063,7 @@
     <title>Semi-Supervised Neural System for Tagging, Parsing and Lematization</title>
     <author><first>Piotr</first><last>Rybak</last></author>
     <author><first>Alina</first><last>Wróblewska</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1075,13 +1076,13 @@
   </paper>
 
   <paper id="2005">
-    <title>Towards Better UD Parsing: Deep Contextualized Word Embeddings, Ensemble, and Treebank Concatenation</title>
+    <title>Towards Better <fixed-case>UD</fixed-case> Parsing: Deep Contextualized Word Embeddings, Ensemble, and Treebank Concatenation</title>
     <author><first>Wanxiang</first><last>Che</last></author>
     <author><first>Yijia</first><last>Liu</last></author>
     <author><first>Yuxuan</first><last>Wang</last></author>
     <author><first>Bo</first><last>Zheng</last></author>
     <author><first>Ting</first><last>Liu</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1094,12 +1095,12 @@
   </paper>
 
   <paper id="2006">
-    <title>Joint Learning of POS and Dependencies for Multilingual Universal Dependency Parsing</title>
+    <title>Joint Learning of <fixed-case>POS</fixed-case> and Dependencies for Multilingual Universal Dependency Parsing</title>
     <author><first>Zuchao</first><last>Li</last></author>
     <author><first>Shexia</first><last>He</last></author>
     <author><first>Zhuosheng</first><last>Zhang</last></author>
     <author><first>Hai</first><last>Zhao</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1116,7 +1117,7 @@
     <author><first>Yingting</first><last>Wu</last></author>
     <author><first>Hai</first><last>Zhao</last></author>
     <author><first>Jia-Jun</first><last>Tong</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1129,10 +1130,10 @@
   </paper>
 
   <paper id="2008">
-    <title>An Improved Neural Network Model for Joint POS Tagging and Dependency Parsing</title>
+    <title>An Improved Neural Network Model for Joint <fixed-case>POS</fixed-case> Tagging and Dependency Parsing</title>
     <author><first>Dat Quoc</first><last>Nguyen</last></author>
     <author><first>Karin</first><last>Verspoor</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1145,13 +1146,13 @@
   </paper>
 
   <paper id="2009">
-    <title>IBM Research at the CoNLL 2018 Shared Task on Multilingual Parsing</title>
+    <title><fixed-case>IBM</fixed-case> Research at the <fixed-case>CoNLL</fixed-case> 2018 Shared Task on Multilingual Parsing</title>
     <author><first>Hui</first><last>Wan</last></author>
     <author><first>Tahira</first><last>Naseem</last></author>
     <author><first>Young-Suk</first><last>Lee</last></author>
     <author><first>Vittorio</first><last>Castelli</last></author>
     <author><first>Miguel</first><last>Ballesteros</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1164,11 +1165,11 @@
   </paper>
 
   <paper id="2010">
-    <title>Universal Dependency Parsing with a General Transition-Based DAG Parser</title>
+    <title>Universal Dependency Parsing with a General Transition-Based <fixed-case>DAG</fixed-case> Parser</title>
     <author><first>Daniel</first><last>Hershcovich</last></author>
     <author><first>Omri</first><last>Abend</last></author>
     <author><first>Ari</first><last>Rappoport</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1188,7 +1189,7 @@
     <author><first>Joakim</first><last>Nivre</last></author>
     <author><first>Yan</first><last>Shao</last></author>
     <author><first>Sara</first><last>Stymne</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1201,11 +1202,11 @@
   </paper>
 
   <paper id="2012">
-    <title>Tree-Stack LSTM in Transition Based Dependency Parsing</title>
+    <title>Tree-Stack <fixed-case>LSTM</fixed-case> in Transition Based Dependency Parsing</title>
     <author><first>Ömer</first><last>Kırnap</last></author>
     <author><first>Erenay</first><last>Dayanık</last></author>
     <author><first>Deniz</first><last>Yuret</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1218,13 +1219,13 @@
   </paper>
 
   <paper id="2013">
-    <title>Turku Neural Parser Pipeline: An End-to-End System for the CoNLL 2018 Shared Task</title>
+    <title>Turku Neural Parser Pipeline: An End-to-End System for the <fixed-case>CoNLL</fixed-case> 2018 Shared Task</title>
     <author><first>Jenna</first><last>Kanerva</last></author>
     <author><first>Filip</first><last>Ginter</last></author>
     <author><first>Niko</first><last>Miekka</last></author>
     <author><first>Akseli</first><last>Leino</last></author>
     <author><first>Tapio</first><last>Salakoski</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1237,12 +1238,12 @@
   </paper>
 
   <paper id="2014">
-    <title>SEx BiST: A Multi-Source Trainable Parser with Deep Contextualized Lexical Representations</title>
+    <title><fixed-case>SEx</fixed-case> <fixed-case>BiST</fixed-case>: A Multi-Source Trainable Parser with Deep Contextualized Lexical Representations</title>
     <author><first>KyungTae</first><last>Lim</last></author>
     <author><first>Cheoneum</first><last>Park</last></author>
     <author><first>Changki</first><last>Lee</last></author>
     <author><first>Thierry</first><last>Poibeau</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1255,11 +1256,11 @@
   </paper>
 
   <paper id="2015">
-    <title>The SLT-Interactions Parsing System at the CoNLL 2018 Shared Task</title>
+    <title>The <fixed-case>SLT</fixed-case>-Interactions Parsing System at the <fixed-case>CoNLL</fixed-case> 2018 Shared Task</title>
     <author><first>Riyaz A.</first><last>Bhat</last></author>
     <author><first>Irshad</first><last>Bhat</last></author>
     <author><first>Srinivas</first><last>Bangalore</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1277,7 +1278,7 @@
     <author><first>Timothy</first><last>Dozat</last></author>
     <author><first>Yuhao</first><last>Zhang</last></author>
     <author><first>Christopher D.</first><last>Manning</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1290,11 +1291,11 @@
   </paper>
 
   <paper id="2017">
-    <title>NLP-Cube: End-to-End Raw Text Processing With Neural Networks</title>
+    <title><fixed-case>NLP</fixed-case>-Cube: End-to-End Raw Text Processing With Neural Networks</title>
     <author><first>Tiberiu</first><last>Boroș</last></author>
     <author><first>Stefan Daniel</first><last>Dumitrescu</last></author>
     <author><first>Ruxandra</first><last>Burtica</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1307,11 +1308,11 @@
   </paper>
 
   <paper id="2018">
-    <title>Towards JointUD: Part-of-speech Tagging and Lemmatization using Recurrent Neural Networks</title>
+    <title>Towards <fixed-case>JointUD</fixed-case>: Part-of-speech Tagging and Lemmatization using Recurrent Neural Networks</title>
     <author><first>Gor</first><last>Arakelyan</last></author>
     <author><first>Karen</first><last>Hambardzumyan</last></author>
     <author><first>Hrant</first><last>Khachatrian</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1324,10 +1325,10 @@
   </paper>
 
   <paper id="2019">
-    <title>CUNI x-ling: Parsing Under-Resourced Languages in CoNLL 2018 UD Shared Task</title>
+    <title><fixed-case>CUNI</fixed-case> x-ling: Parsing Under-Resourced Languages in <fixed-case>CoNLL</fixed-case> 2018 <fixed-case>UD</fixed-case> Shared Task</title>
     <author><first>Rudolf</first><last>Rosa</last></author>
     <author><first>David</first><last>Mareček</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1340,9 +1341,9 @@
   </paper>
 
   <paper id="2020">
-    <title>UDPipe 2.0 Prototype at CoNLL 2018 UD Shared Task</title>
+    <title><fixed-case>UDPipe</fixed-case> 2.0 Prototype at <fixed-case>CoNLL</fixed-case> 2018 <fixed-case>UD</fixed-case> Shared Task</title>
     <author><first>Milan</first><last>Straka</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1355,11 +1356,11 @@
   </paper>
 
   <paper id="2021">
-    <title>Universal Morpho-Syntactic Parsing and the Contribution of Lexica: Analyzing the ONLP Lab Submission to the CoNLL 2018 Shared Task</title>
+    <title>Universal Morpho-Syntactic Parsing and the Contribution of Lexica: Analyzing the <fixed-case>ONLP</fixed-case> Lab Submission to the <fixed-case>CoNLL</fixed-case> 2018 Shared Task</title>
     <author><first>Amit</first><last>Seker</last></author>
     <author><first>Amir</first><last>More</last></author>
     <author><first>Reut</first><last>Tsarfaty</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1372,11 +1373,11 @@
   </paper>
 
   <paper id="2022">
-    <title>SParse: Koç University Graph-Based Parsing System for the CoNLL 2018 Shared Task</title>
+    <title><fixed-case>SParse</fixed-case>: Koç University Graph-Based Parsing System for the CoNLL 2018 Shared Task</title>
     <author><first>Berkay</first><last>Önder</last></author>
     <author><first>Can</first><last>Gümeli</last></author>
     <author><first>Deniz</first><last>Yuret</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1389,7 +1390,7 @@
   </paper>
 
   <paper id="2023">
-    <title>ELMoLex: Connecting ELMo and Lexicon Features for Dependency Parsing</title>
+    <title><fixed-case>ELMoLex</fixed-case>: Connecting <fixed-case>ELMo</fixed-case> and Lexicon Features for Dependency Parsing</title>
     <author><first>Ganesh</first><last>Jawahar</last></author>
     <author><first>Benjamin</first><last>Muller</last></author>
     <author><first>Amal</first><last>Fethi</last></author>
@@ -1397,7 +1398,7 @@
     <author><first>Eric</first><last>Villemonte de la Clergerie</last></author>
     <author><first>Benoît</first><last>Sagot</last></author>
     <author><first>Djamé</first><last>Seddah</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1410,12 +1411,12 @@
   </paper>
 
   <paper id="2024">
-    <title>A Morphology-Based Representation Model for LSTM-Based Dependency Parsing of Agglutinative Languages</title>
+    <title>A Morphology-Based Representation Model for <fixed-case>LSTM</fixed-case>-Based Dependency Parsing of Agglutinative Languages</title>
     <author><first>Şaziye Betül</first><last>Özateş</last></author>
     <author><first>Arzucan</first><last>Özgür</last></author>
     <author><first>Tunga</first><last>Gungor</last></author>
     <author><first>Balkız</first><last>Öztürk</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1428,13 +1429,13 @@
   </paper>
 
   <paper id="2025">
-    <title>AntNLP at CoNLL 2018 Shared Task: A Graph-Based Parser for Universal Dependency Parsing</title>
+    <title><fixed-case>AntNLP</fixed-case> at <fixed-case>CoNLL</fixed-case> 2018 Shared Task: A Graph-Based Parser for Universal Dependency Parsing</title>
     <author><first>Tao</first><last>Ji</last></author>
     <author><first>Yufang</first><last>Liu</last></author>
     <author><first>Yijun</first><last>Wang</last></author>
     <author><first>Yuanbin</first><last>Wu</last></author>
     <author><first>Man</first><last>Lan</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>
@@ -1452,7 +1453,7 @@
     <author><first>Mengxiao</first><last>Lin</last></author>
     <author><first>Zhifeng</first><last>Hu</last></author>
     <author><first>Xipeng</first><last>Qiu</last></author>
-    <booktitle>Proceedings of the CoNLL 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
+    <booktitle>Proceedings of the <fixed-case>CoNLL</fixed-case> 2018 Shared Task: Multilingual Parsing from Raw Text to Universal Dependencies</booktitle>
     <month>October</month>
     <year>2018</year>
     <address>Brussels, Belgium</address>

--- a/import/L10.xml
+++ b/import/L10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="L10">
   <paper id="1000">
     <title>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</title>

--- a/import/L12.xml
+++ b/import/L12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="L12">
 <paper id="1000">
 <title>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</title>

--- a/import/L14.xml
+++ b/import/L14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="L14">
 <paper id="1000">
 <title>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC-2014)</title>

--- a/import/N03.xml
+++ b/import/N03.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N03">
    <paper id="1000">
         <title>Proceedings of the 2003 Human Language Technology Conference of the North American Chapter of the Association for Computational Linguistics</title>

--- a/import/N04.xml
+++ b/import/N04.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N04">
 
 	<paper id="1000">

--- a/import/N06.xml
+++ b/import/N06.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N06">
    <paper id="1000">
         <title>Proceedings of the Human Language Technology Conference of the NAACL, Main Conference</title>

--- a/import/N07.xml
+++ b/import/N07.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N07">
    <paper id="1000">
         <title>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Proceedings of the Main Conference</title>
@@ -263,7 +264,7 @@
         <bibkey>gliozzo-pennacchiotti-pantel:2007:main</bibkey>
    </paper>
    <paper id="1018">
-        <title>Bayesian Inference for PCFGs via Markov Chain Monte Carlo</title>
+        <title><fixed-case>Bayesian</fixed-case> Inference for <fixed-case>PCFG</fixed-case>s via <fixed-case>Markov</fixed-case> Chain <fixed-case>Monte</fixed-case> <fixed-case>Carlo</fixed-case></title>
         <author><first>Mark</first><last>Johnson</last></author>
         <author><first>Thomas</first><last>Griffiths</last></author>
         <author><first>Sharon</first><last>Goldwater</last></author>
@@ -333,7 +334,7 @@
         <bibkey>wong-mooney:2007:main</bibkey>
    </paper>
    <paper id="1023">
-        <title>Lexicalized Markov Grammars for Sentence Compression</title>
+        <title>Lexicalized <fixed-case>Markov</fixed-case> Grammars for Sentence Compression</title>
         <author><first>Michel</first><last>Galley</last></author>
         <author><first>Kathleen</first><last>McKeown</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Proceedings of the Main Conference</booktitle>
@@ -347,7 +348,7 @@
         <bibkey>galley-mckeown:2007:main</bibkey>
    </paper>
    <paper id="1024">
-        <title>Hybrid Models for Semantic Classification of Chinese Unknown Words</title>
+        <title>Hybrid Models for Semantic Classification of <fixed-case>Chinese</fixed-case> Unknown Words</title>
         <author><first>Xiaofei</first><last>Lu</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Proceedings of the Main Conference</booktitle>
         <month>April</month>
@@ -360,7 +361,7 @@
         <bibkey>lu:2007:main</bibkey>
    </paper>
    <paper id="1025">
-        <title>Using Wikipedia for Automatic Word Sense Disambiguation</title>
+        <title>Using <fixed-case>Wikipedia</fixed-case> for Automatic Word Sense Disambiguation</title>
         <author><first>Rada</first><last>Mihalcea</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Proceedings of the Main Conference</booktitle>
         <month>April</month>
@@ -373,7 +374,7 @@
         <bibkey>mihalcea:2007:main</bibkey>
    </paper>
    <paper id="1026">
-        <title>Data-Driven Graph Construction for Semi-Supervised Graph-Based Learning in NLP</title>
+        <title>Data-Driven Graph Construction for Semi-Supervised Graph-Based Learning in <fixed-case>NLP</fixed-case></title>
         <author><first>Andrei</first><last>Alexandrescu</last></author>
         <author><first>Katrin</first><last>Kirchhoff</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Proceedings of the Main Conference</booktitle>
@@ -505,7 +506,7 @@
         <bibkey>heeman:2007:main</bibkey>
    </paper>
    <paper id="1035">
-        <title>Estimating the Reliability of MDP Policies: a Confidence Interval Approach</title>
+        <title>Estimating the Reliability of <fixed-case>MDP</fixed-case> Policies: a Confidence Interval Approach</title>
         <author><first>Joel</first><last>Tetreault</last></author>
         <author><first>Dan</first><last>Bohus</last></author>
         <author><first>Diane</first><last>Litman</last></author>
@@ -661,7 +662,7 @@
         <bibkey>inkpen:2007:main</bibkey>
    </paper>
    <paper id="1046">
-        <title>A Log-Linear Block Transliteration Model based on Bi-Stream HMMs</title>
+        <title>A Log-Linear Block Transliteration Model based on Bi-Stream <fixed-case>HMM</fixed-case>s</title>
         <author><first>Bing</first><last>Zhao</last></author>
         <author><first>Nguyen</first><last>Bach</last></author>
         <author><first>Ian</first><last>Lane</last></author>
@@ -902,7 +903,7 @@
         <bibkey>utiyama-isahara:2007:main</bibkey>
    </paper>
    <paper id="1062">
-        <title>Efficient Phrase-Table Representation for Machine Translation with Applications to Online MT and Speech Translation</title>
+        <title>Efficient Phrase-Table Representation for Machine Translation with Applications to Online <fixed-case>MT</fixed-case> and Speech Translation</title>
         <author><first>Richard</first><last>Zens</last></author>
         <author><first>Hermann</first><last>Ney</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Proceedings of the Main Conference</booktitle>
@@ -916,7 +917,7 @@
         <bibkey>zens-ney:2007:main</bibkey>
    </paper>
    <paper id="1063">
-        <title>An Efficient Two-Pass Approach to Synchronous-CFG Driven Statistical MT</title>
+        <title>An Efficient Two-Pass Approach to Synchronous-<fixed-case>CFG</fixed-case> Driven Statistical <fixed-case>MT</fixed-case></title>
         <author><first>Ashish</first><last>Venugopal</last></author>
         <author><first>Andreas</first><last>Zollmann</last></author>
         <author><first>Vogel</first><last>Stephan</last></author>
@@ -1035,7 +1036,7 @@
         <bibkey>pradhan-ward-martin:2007:main</bibkey>
    </paper>
    <paper id="1071">
-        <title>ISP: Learning Inferential Selectional Preferences</title>
+        <title><fixed-case>ISP</fixed-case>: Learning Inferential Selectional Preferences</title>
         <author><first>Patrick</first><last>Pantel</last></author>
         <author><first>Rahul</first><last>Bhagat</last></author>
         <author><first>Bonaventura</first><last>Coppola</last></author>
@@ -1130,7 +1131,7 @@
         <bibkey>bohus-EtAl:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2004">
-        <title>Joint Versus Independent Phonological Feature Models within CRF Phone Recognition</title>
+        <title>Joint Versus Independent Phonological Feature Models within <fixed-case>CRF</fixed-case> Phone Recognition</title>
         <author><first>Ilana</first><last>Bromberg</last></author>
         <author><first>Jeremy</first><last>Morris</last></author>
         <author><first>Eric</first><last>Fosler-Lussier</last></author>
@@ -1145,7 +1146,7 @@
         <bibkey>bromberg-morris-foslerlussier:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2005">
-        <title>K-Best Suffix Arrays</title>
+        <title><fixed-case>K</fixed-case>-Best Suffix Arrays</title>
         <author><first>Kenneth</first><last>Church</last></author>
         <author><first>Bo</first><last>Thiesson</last></author>
         <author><first>Robert</first><last>Ragno</last></author>
@@ -1276,7 +1277,7 @@
         <bibkey>gurevich-deane:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2014">
-        <title>Arabic Diacritization through Full Morphological Tagging</title>
+        <title><fixed-case>Arabic</fixed-case> Diacritization through Full Morphological Tagging</title>
         <author><first>Nizar</first><last>Habash</last></author>
         <author><first>Owen</first><last>Rambow</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Companion Volume, Short Papers</booktitle>
@@ -1290,7 +1291,7 @@
         <bibkey>habash-rambow:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2015">
-        <title>Are Very Large N-Best Lists Useful for SMT?</title>
+        <title>Are Very Large <fixed-case>N</fixed-case>-Best Lists Useful for <fixed-case>SMT</fixed-case>?</title>
         <author><first>Saša</first><last>Hasan</last></author>
         <author><first>Richard</first><last>Zens</last></author>
         <author><first>Hermann</first><last>Ney</last></author>
@@ -1318,7 +1319,7 @@
         <bibkey>havelka:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2017">
-        <title>iROVER: Improving System Combination with Classification</title>
+        <title><fixed-case>iROVER</fixed-case>: Improving System Combination with Classification</title>
         <author><first>Dustin</first><last>Hillard</last></author>
         <author><first>Bjoern</first><last>Hoffmeister</last></author>
         <author><first>Mari</first><last>Ostendorf</last></author>
@@ -1363,7 +1364,7 @@
         <bibkey>hugginsdaines-rudnicky:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2020">
-        <title>ILR-Based MT Comprehension Test with Multi-Level Questions</title>
+        <title><fixed-case>ILR</fixed-case>-Based <fixed-case>MT</fixed-case> Comprehension Test with Multi-Level Questions</title>
         <author><first>Douglas</first><last>Jones</last></author>
         <author><first>Martha</first><last>Herzog</last></author>
         <author><first>Hussny</first><last>Ibrahim</last></author>
@@ -1523,7 +1524,7 @@
         <bibkey>metze:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2031">
-        <title>RH: A Retro-Hybrid Parser</title>
+        <title><fixed-case>RH</fixed-case>: A Retro-Hybrid Parser</title>
         <author><first>Paula</first><last>Newman</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Companion Volume, Short Papers</booktitle>
         <month>April</month>
@@ -1536,7 +1537,7 @@
         <bibkey>newman:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2032">
-        <title>Subtree Mining for Relation Extraction from Wikipedia</title>
+        <title>Subtree Mining for Relation Extraction from <fixed-case>Wikipedia</fixed-case></title>
         <author><first>Dat P.T.</first><last>Nguyen</last></author>
         <author><first>Yutaka</first><last>Matsuo</last></author>
         <author><first>Mitsuru</first><last>Ishizuka</last></author>
@@ -1551,7 +1552,7 @@
         <bibkey>nguyen-matsuo-ishizuka:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2033">
-        <title>Advances in the CMU/Interact Arabic GALE Transcription System</title>
+        <title>Advances in the <fixed-case>CMU/Interact</fixed-case> <fixed-case>Arabic</fixed-case> <fixed-case>GALE</fixed-case> Transcription System</title>
         <author><first>Mohamed</first><last>Noamany</last></author>
         <author><first>Thomas</first><last>Schaaf</last></author>
         <author><first>Tanja</first><last>Schultz</last></author>
@@ -1582,7 +1583,7 @@
         <bibkey>perez-EtAl:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2035">
-        <title>Analysis and System Combination of Phrase- and N-Gram-Based Statistical Machine Translation Systems</title>
+        <title>Analysis and System Combination of Phrase- and <fixed-case>N</fixed-case>-Gram-Based Statistical Machine Translation Systems</title>
         <author><first>Marta</first><last>R. Costa-jussà</last></author>
         <author><first>Josep M.</first><last>Crego</last></author>
         <author><first>David</first><last>Vilar</last></author>
@@ -1627,7 +1628,7 @@
         <bibkey>sarikaya-deng:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2038">
-        <title>Agenda-Based User Simulation for Bootstrapping a POMDP Dialogue System</title>
+        <title>Agenda-Based User Simulation for Bootstrapping a <fixed-case>POMDP</fixed-case> Dialogue System</title>
         <author><first>Jost</first><last>Schatzmann</last></author>
         <author><first>Blaise</first><last>Thomson</last></author>
         <author><first>Karl</first><last>Weilhammer</last></author>
@@ -1714,7 +1715,7 @@
         <bibkey>tratz-sanfilippo:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2044">
-        <title>The Effects of Word Prediction on Communication Rate for AAC</title>
+        <title>The Effects of Word Prediction on Communication Rate for <fixed-case>AAC</fixed-case></title>
         <author><first>Keith</first><last>Trnka</last></author>
         <author><first>Debra</first><last>Yarrington</last></author>
         <author><first>John</first><last>McCaw</last></author>
@@ -1775,7 +1776,7 @@
         <bibkey>wang-shawetaylor-szedmak:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2048">
-        <title>Modifying SO-PMI for Japanese Weblog Opinion Mining by Using a Balancing Factor and Detecting Neutral Expressions</title>
+        <title>Modifying <fixed-case>SO-PMI</fixed-case> for <fixed-case>Japanese</fixed-case> Weblog Opinion Mining by Using a Balancing Factor and Detecting Neutral Expressions</title>
         <author><first>Guangwei</first><last>Wang</last></author>
         <author><first>Kenji</first><last>Araki</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Companion Volume, Short Papers</booktitle>
@@ -1789,7 +1790,7 @@
         <bibkey>wang-araki:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2049">
-        <title>Combined Use of Speaker- and Tone-Normalized Pitch Reset with Pause Duration for Automatic Story Segmentation in Mandarin Broadcast News</title>
+        <title>Combined Use of Speaker- and Tone-Normalized Pitch Reset with Pause Duration for Automatic Story Segmentation in <fixed-case>Mandarin</fixed-case> Broadcast News</title>
         <author><first>Lei</first><last>Xie</last></author>
         <author><first>Chuan</first><last>Liu</last></author>
         <author><first>Helen</first><last>Meng</last></author>
@@ -1804,7 +1805,7 @@
         <bibkey>xie-liu-meng:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2050">
-        <title>Chinese Named Entity Recognition with Cascaded Hybrid Model</title>
+        <title><fixed-case>Chinese</fixed-case> Named Entity Recognition with Cascaded Hybrid Model</title>
         <author><first>Xiaofeng</first><last>Yu</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Companion Volume, Short Papers</booktitle>
         <month>April</month>
@@ -1817,7 +1818,7 @@
         <bibkey>yu:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2051">
-        <title>A Three-Step Deterministic Parser for Chinese Dependency Parsing</title>
+        <title>A Three-Step Deterministic Parser for <fixed-case>Chinese</fixed-case> Dependency Parsing</title>
         <author><first>Kun</first><last>Yu</last></author>
         <author><first>Sadao</first><last>Kurohashi</last></author>
         <author><first>Hao</first><last>Liu</last></author>
@@ -1832,7 +1833,7 @@
         <bibkey>yu-kurohashi-liu:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2052">
-        <title>Comparing Wikipedia and German Wordnet by Evaluating Semantic Relatedness on Multiple Datasets</title>
+        <title>Comparing <fixed-case>Wikipedia</fixed-case> and <fixed-case>German</fixed-case> <fixed-case>Wordnet</fixed-case> by Evaluating Semantic Relatedness on Multiple Datasets</title>
         <author><first>Torsten</first><last>Zesch</last></author>
         <author><first>Iryna</first><last>Gurevych</last></author>
         <author><first>Max</first><last>Mühlhäuser</last></author>
@@ -1861,7 +1862,7 @@
         <bibkey>zettlemoyer-moore:2007:ShortPapers</bibkey>
    </paper>
    <paper id="2054">
-        <title>Speech Summarization Without Lexical Features for Mandarin Broadcast News</title>
+        <title>Speech Summarization Without Lexical Features for <fixed-case>Mandarin</fixed-case> Broadcast News</title>
         <author><first>Jian</first><last>Zhang</last></author>
         <author><first>Pascale</first><last>Fung</last></author>
         <booktitle>Human Language Technologies 2007: The Conference of the North American Chapter of the Association for Computational Linguistics; Companion Volume, Short Papers</booktitle>
@@ -2045,7 +2046,7 @@
         <bibkey>NAACLHLTDemos:2007</bibkey>
    </paper>
    <paper id="4001">
-        <title>Demonstration of PLOW: A Dialogue System for One-Shot Task Learning</title>
+        <title>Demonstration of <fixed-case>PLOW</fixed-case>: A Dialogue System for One-Shot Task Learning</title>
         <author><first>James</first><last>Allen</last></author>
         <author><first>Nathanael</first><last>Chambers</last></author>
         <author><first>George</first><last>Ferguson</last></author>
@@ -2081,7 +2082,7 @@
         <bibkey>burstein-EtAl:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4003">
-        <title>Adaptive Tutorial Dialogue Systems Using Deep NLP Techniques</title>
+        <title>Adaptive Tutorial Dialogue Systems Using Deep <fixed-case>NLP</fixed-case> Techniques</title>
         <author><first>Myroslava O.</first><last>Dzikovska</last></author>
         <author><first>Charles B.</first><last>Callaway</last></author>
         <author><first>Elaine</first><last>Farrow</last></author>
@@ -2099,7 +2100,7 @@
         <bibkey>dzikovska-EtAl:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4004">
-        <title>POSSLT: A Korean to English Spoken Language Translation System</title>
+        <title><fixed-case>POSSLT</fixed-case>: A <fixed-case>K</fixed-case>orean to <fixed-case>E</fixed-case>nglish Spoken Language Translation System</title>
         <author><first>Donghyeon</first><last>Lee</last></author>
         <author><first>Jonghoon</first><last>Lee</last></author>
         <author><first>Gary Geunbae</first><last>Lee</last></author>
@@ -2133,7 +2134,7 @@
         <bibkey>murray-EtAl:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4006">
-        <title>Cedit – Semantic Networks Manual Annotation Tool</title>
+        <title><fixed-case>Cedit</fixed-case> – Semantic Networks Manual Annotation Tool</title>
         <author><first>Václav</first><last>Novák</last></author>
         <booktitle>Proceedings of Human Language Technologies: The Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL-HLT)</booktitle>
         <month>April</month>
@@ -2161,7 +2162,7 @@
         <bibkey>seneff-wang-chao:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4008">
-        <title>RavenCalendar: A Multimodal Dialog System for Managing a Personal Calendar</title>
+        <title><fixed-case>RavenCalendar</fixed-case>: A Multimodal Dialog System for Managing a Personal Calendar</title>
         <author><first>Svetlana</first><last>Stenchikova</last></author>
         <author><first>Basia</first><last>Mucha</last></author>
         <author><first>Sarah</first><last>Hoffman</last></author>
@@ -2177,7 +2178,7 @@
         <bibkey>stenchikova-EtAl:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4009">
-        <title>The CALO Meeting Assistant</title>
+        <title>The <fixed-case>CALO</fixed-case> Meeting Assistant</title>
         <author><first>L. Lynn</first><last>Voss</last></author>
         <author><first>Patrick</first><last>Ehlen</last></author>
         <booktitle>Proceedings of Human Language Technologies: The Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL-HLT)</booktitle>
@@ -2191,7 +2192,7 @@
         <bibkey>voss-ehlen:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4010">
-        <title>OMS-J: An Opinion Mining System for Japanese Weblog Reviews Using a Combination of Supervised and Unsupervised Approaches</title>
+        <title><fixed-case>OMS-J</fixed-case>: An Opinion Mining System for <fixed-case>J</fixed-case>apanese Weblog Reviews Using a Combination of Supervised and Unsupervised Approaches</title>
         <author><first>Guangwei</first><last>Wang</last></author>
         <author><first>Kenji</first><last>Araki</last></author>
         <booktitle>Proceedings of Human Language Technologies: The Annual Conference of the North American Chapter of the Association for Computational Linguistics (NAACL-HLT)</booktitle>
@@ -2248,7 +2249,7 @@
         <bibkey>yan-EtAl:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4013">
-        <title>TextRunner: Open Information Extraction on the Web</title>
+        <title><fixed-case>TextRunner</fixed-case>: Open Information Extraction on the Web</title>
         <author><first>Alexander</first><last>Yates</last></author>
         <author><first>Michele</first><last>Banko</last></author>
         <author><first>Matthew</first><last>Broadhead</last></author>
@@ -2266,7 +2267,7 @@
         <bibkey>yates-EtAl:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4014">
-        <title>The Hidden Information State Dialogue Manager: A Real-World POMDP-Based System</title>
+        <title>The Hidden Information State Dialogue Manager: A Real-World <fixed-case>POMDP</fixed-case>-Based System</title>
         <author><first>Steve</first><last>Young</last></author>
         <author><first>Jost</first><last>Schatzmann</last></author>
         <author><first>Blaise</first><last>Thomson</last></author>
@@ -2296,7 +2297,7 @@
         <bibkey>zhou:2007:NAACLHLTDemos</bibkey>
    </paper>
    <paper id="4016">
-        <title>Voice-Rate: A Dialog System for Consumer Ratings</title>
+        <title><fixed-case>Voice-Rate</fixed-case>: A Dialog System for Consumer Ratings</title>
         <author><first>Geoffrey</first><last>Zweig</last></author>
         <author><first>Y.C.</first><last>Ju</last></author>
         <author><first>Patrick</first><last>Nguyen</last></author>

--- a/import/N09.xml
+++ b/import/N09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N09">
    <paper id="1000">
         <title>Proceedings of Human Language Technologies: The 2009 Annual Conference of the North American Chapter of the Association for Computational Linguistics</title>
@@ -2231,7 +2232,7 @@
         <bibkey>vemulapalli-EtAl:2009:SRWS</bibkey>
    </paper>
    <paper id="3002">
-        <title>Solving the “Who’s Mark Johnson Puzzle”: Information Extraction Based Cross Document Coreference</title>
+        <title>Solving the “<fixed-case>W</fixed-case>ho’s <fixed-case>M</fixed-case>ark <fixed-case>J</fixed-case>ohnson <fixed-case>P</fixed-case>uzzle”: <fixed-case>I</fixed-case>nformation Extraction Based Cross Document Coreference</title>
         <author><first>Jian</first><last>Huang</last></author>
         <author><first>Sarah M.</first><last>Taylor</last></author>
         <author><first>Jonathan L.</first><last>Smith</last></author>
@@ -2290,7 +2291,7 @@
         <bibkey>dligach-palmer:2009:SRWS</bibkey>
    </paper>
    <paper id="3006">
-        <title>Pronunciation Modeling in Spelling Correction for Writers of English as a Foreign Language</title>
+        <title>Pronunciation Modeling in Spelling Correction for Writers of <fixed-case>E</fixed-case>nglish as a <fixed-case>F</fixed-case>oreign <fixed-case>L</fixed-case>anguage</title>
         <author><first>Adriane</first><last>Boyd</last></author>
         <booktitle>Proceedings of Human Language Technologies: The 2009 Annual Conference of the North American Chapter of the Association for Computational Linguistics, Companion Volume: Student Research Workshop and Doctoral Consortium</booktitle>
         <month>June</month>
@@ -2303,7 +2304,7 @@
         <bibkey>boyd:2009:SRWS</bibkey>
    </paper>
    <paper id="3007">
-        <title>Building a Semantic Lexicon of English Nouns via Bootstrapping</title>
+        <title>Building a Semantic Lexicon of <fixed-case>E</fixed-case>nglish Nouns via Bootstrapping</title>
         <author><first>Ting</first><last>Qian</last></author>
         <author><first>Benjamin</first><last>Van Durme</last></author>
         <author><first>Lenhart</first><last>Schubert</last></author>
@@ -2318,7 +2319,7 @@
         <bibkey>qian-vandurme-schubert:2009:SRWS</bibkey>
    </paper>
    <paper id="3008">
-        <title>Multiple Word Alignment with Profile Hidden Markov Models</title>
+        <title>Multiple Word Alignment with <fixed-case>P</fixed-case>rofile <fixed-case>H</fixed-case>idden <fixed-case>M</fixed-case>arkov <fixed-case>M</fixed-case>odels</title>
         <author><first>Aditya</first><last>Bhargava</last></author>
         <author><first>Grzegorz</first><last>Kondrak</last></author>
         <booktitle>Proceedings of Human Language Technologies: The 2009 Annual Conference of the North American Chapter of the Association for Computational Linguistics, Companion Volume: Student Research Workshop and Doctoral Consortium</booktitle>
@@ -2374,7 +2375,7 @@
         <bibkey>bellare-crammer-freitag:2009:SRWS</bibkey>
    </paper>
    <paper id="3012">
-        <title>Syntactic Tree-based Relation Extraction Using a Generalization of Collins and Duffy Convolution Tree Kernel</title>
+        <title>Syntactic Tree-based Relation Extraction Using a Generalization of <fixed-case>C</fixed-case>ollins and <fixed-case>D</fixed-case>uffy Convolution Tree Kernel</title>
         <author><first>Mahdy</first><last>Khayyamian</last></author>
         <author><first>Seyed Abolghasem</first><last>Mirroshandel</last></author>
         <author><first>Hassan</first><last>Abolhassani</last></author>
@@ -2389,7 +2390,7 @@
         <bibkey>khayyamian-mirroshandel-abolhassani:2009:SRWS</bibkey>
    </paper>
    <paper id="3013">
-        <title>Towards Building a Competitive Opinion Summarization System: Challenges and Keys</title>
+        <title>Towards Building a Competitive Opinion Summarization System: <fixed-case>C</fixed-case>hallenges and Keys</title>
         <author><first>Elena</first><last>Lloret</last></author>
         <author><first>Alexandra</first><last>Balahur</last></author>
         <author><first>Manuel</first><last>Palomar</last></author>
@@ -2432,7 +2433,7 @@
         <bibkey>novielli-strapparava:2009:SRWS</bibkey>
    </paper>
    <paper id="3016">
-        <title>Modeling Letter-to-Phoneme Conversion as a Phrase Based Statistical Machine Translation Problem with Minimum Error Rate Training</title>
+        <title>Modeling Letter-to-Phoneme Conversion as a Phrase Based Statistical Machine Translation Problem with <fixed-case>M</fixed-case>inimum <fixed-case>E</fixed-case>rror <fixed-case>R</fixed-case>ate Training</title>
         <author><first>Taraka</first><last>Rama</last></author>
         <author><first>Anil Kumar</first><last>Singh</last></author>
         <author><first>Sudheer</first><last>Kolachina</last></author>
@@ -2628,7 +2629,7 @@
         <bibkey>kumar-rose-witbrock:2009:Demonstrations</bibkey>
    </paper>
    <paper id="5003">
-        <title>STAT: Speech Transcription Analysis Tool</title>
+        <title><fixed-case>STAT</fixed-case>: Speech Transcription Analysis Tool</title>
         <author><first>Stephen A.</first><last>Kunath</last></author>
         <author><first>Steven H.</first><last>Weinberger</last></author>
         <booktitle>Proceedings of Human Language Technologies: The 2009 Annual Conference of the North American Chapter of the Association for Computational Linguistics, Companion Volume: Demonstration Session</booktitle>
@@ -2658,7 +2659,7 @@
         <bibkey>kurimo-EtAl:2009:Demonstrations</bibkey>
    </paper>
    <paper id="5005">
-        <title>WordNet::SenseRelate::AllWords - A Broad Coverage Word Sense Tagger that Maximizes Semantic Relatedness</title>
+        <title><fixed-case>WordNet::SenseRelate::AllWords</fixed-case> - A Broad Coverage Word Sense Tagger that Maximizes Semantic Relatedness</title>
         <author><first>Ted</first><last>Pedersen</last></author>
         <author><first>Varada</first><last>Kolhatkar</last></author>
         <booktitle>Proceedings of Human Language Technologies: The 2009 Annual Conference of the North American Chapter of the Association for Computational Linguistics, Companion Volume: Demonstration Session</booktitle>

--- a/import/N10.xml
+++ b/import/N10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N10">
    <paper id="1000">
         <title>Human Language Technologies: The 2010 Annual Conference of the North American Chapter of the Association for Computational Linguistics</title>

--- a/import/N12.xml
+++ b/import/N12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N12">
   <paper id="1000">
     <title>Proceedings of the 2012 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies</title>

--- a/import/N13.xml
+++ b/import/N13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N13">
   <paper id="1000">
     <title>Proceedings of the 2013 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies</title>

--- a/import/N15.xml
+++ b/import/N15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N15">
   <paper id="1000">
     <title>

--- a/import/N16.xml
+++ b/import/N16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N16">
   <paper id="1000">
     <title>
@@ -2543,7 +2544,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>714–719</pages>
     <url>http://www.aclweb.org/anthology/N16-1085</url>
-    <revision id='2'>N16-1085v2</revision>
+    <revision id="2">N16-1085v2</revision>
     <doi>10.18653/v1/N16-1085</doi>
     <attachment type="presentation">N16-1085.Presentation.pdf</attachment>
     <bibtype>inproceedings</bibtype>

--- a/import/N18.xml
+++ b/import/N18.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="N18">
   <paper id="1000">
     <title>

--- a/import/P00.xml
+++ b/import/P00.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P00">
 <paper id="1000">
  <title>Proceedings of the 38th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P01.xml
+++ b/import/P01.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P01">
 <paper id="1000">
  <title>Proceedings of the 39th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P02.xml
+++ b/import/P02.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P02">
 <paper id="1000">
  <title>Proceedings of the 40th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P03.xml
+++ b/import/P03.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P03">
    <paper id="1000">
         <title>Proceedings of the 41st Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P04.xml
+++ b/import/P04.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P04">
   <paper id="1000">
     <title>Proceedings of the 42nd Annual Meeting of the Association for Computational Linguistics (ACL-04)</title>

--- a/import/P05.xml
+++ b/import/P05.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P05">
    <paper id="1000">
         <title>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</title>
@@ -143,7 +144,7 @@
         <bibkey>soricut-marcu:2005:ACL</bibkey>
    </paper>
    <paper id="1010">
-        <title>Probabilistic CFG with Latent Annotations</title>
+        <title>Probabilistic <fixed-case>CFG</fixed-case> with Latent Annotations</title>
         <author><first>Takuya</first><last>Matsuzaki</last></author>
         <author><first>Yusuke</first><last>Miyao</last></author>
         <author><first>Jun’ichi</first><last>Tsujii</last></author>
@@ -158,7 +159,7 @@
         <bibkey>matsuzaki-miyao-tsujii:2005:ACL</bibkey>
    </paper>
    <paper id="1011">
-        <title>Probabilistic Disambiguation Models for Wide-Coverage HPSG Parsing</title>
+        <title>Probabilistic Disambiguation Models for Wide-Coverage <fixed-case>HPSG</fixed-case> Parsing</title>
         <author><first>Yusuke</first><last>Miyao</last></author>
         <author><first>Jun’ichi</first><last>Tsujii</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
@@ -386,7 +387,7 @@
         <bibkey>harabagiu-EtAl:2005:ACL</bibkey>
    </paper>
    <paper id="1027">
-        <title>Question Answering as Question-Biased Term Extraction: A New Approach toward Multilingual QA</title>
+        <title>Question Answering as Question-Biased Term Extraction: A New Approach toward Multilingual <fixed-case>QA</fixed-case></title>
         <author><first>Yutaka</first><last>Sasaki</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
         <month>June</month>
@@ -446,7 +447,7 @@
         <bibkey>rieser-moore:2005:ACL</bibkey>
    </paper>
    <paper id="1031">
-        <title>Towards Finding and Fixing Fragments—Using ML to Identify Non-Sentential Utterances and their Antecedents in Multi-Party Dialogue</title>
+        <title>Towards Finding and Fixing Fragments—Using <fixed-case>ML</fixed-case> to Identify Non-Sentential Utterances and their Antecedents in Multi-Party Dialogue</title>
         <author><first>David</first><last>Schlangen</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
         <month>June</month>
@@ -487,7 +488,7 @@
         <bibkey>chiang:2005:ACL</bibkey>
    </paper>
    <paper id="1034">
-        <title>Dependency Treelet Translation: Syntactically Informed Phrasal SMT</title>
+        <title>Dependency Treelet Translation: Syntactically Informed Phrasal <fixed-case>SMT</fixed-case></title>
         <author><first>Chris</first><last>Quirk</last></author>
         <author><first>Arul</first><last>Menezes</last></author>
         <author><first>Colin</first><last>Cherry</last></author>
@@ -502,7 +503,7 @@
         <bibkey>quirk-menezes-cherry:2005:ACL</bibkey>
    </paper>
    <paper id="1035">
-        <title>QARLA: A Framework for the Evaluation of Text Summarization Systems</title>
+        <title><fixed-case>QARLA</fixed-case>: A Framework for the Evaluation of Text Summarization Systems</title>
         <author><first>Enrique</first><last>Amigó</last></author>
         <author><first>Julio</first><last>Gonzalo</last></author>
         <author><first>Anselmo</first><last>Peñas</last></author>
@@ -546,7 +547,7 @@
         <bibkey>zhou-hovy:2005:ACL</bibkey>
    </paper>
    <paper id="1038">
-        <title>Lexicalization in Crosslinguistic Probabilistic Parsing: The Case of French</title>
+        <title>Lexicalization in Crosslinguistic Probabilistic Parsing: The Case of <fixed-case>F</fixed-case>rench</title>
         <author><first>Abhishek</first><last>Arun</last></author>
         <author><first>Frank</first><last>Keller</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
@@ -560,7 +561,7 @@
         <bibkey>arun-keller:2005:ACL</bibkey>
    </paper>
    <paper id="1039">
-        <title>What to Do When Lexicalization Fails: Parsing German with Suffix Analysis and Smoothing</title>
+        <title>What to Do When Lexicalization Fails: Parsing <fixed-case>G</fixed-case>erman with Suffix Analysis and Smoothing</title>
         <author><first>Amit</first><last>Dubey</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
         <month>June</month>
@@ -587,7 +588,7 @@
         <bibkey>dickinson-meurers:2005:ACL</bibkey>
    </paper>
    <paper id="1041">
-        <title>High Precision Treebanking—Blazing Useful Trees Using POS Information</title>
+        <title>High Precision Treebanking—Blazing Useful Trees Using <fixed-case>POS</fixed-case> Information</title>
         <author><first>Takaaki</first><last>Tanaka</last></author>
         <author><first>Francis</first><last>Bond</last></author>
         <author><first>Stephan</first><last>Oepen</last></author>
@@ -603,7 +604,7 @@
         <bibkey>tanaka-EtAl:2005:ACL</bibkey>
    </paper>
    <paper id="1042">
-        <title>A Dynamic Bayesian Framework to Model Context and Memory in Edit Distance Learning: An Application to Pronunciation Classification</title>
+        <title>A Dynamic <fixed-case>B</fixed-case>ayesian Framework to Model Context and Memory in Edit Distance Learning: An Application to Pronunciation Classification</title>
         <author><first>Karim</first><last>Filali</last></author>
         <author><first>Jeff</first><last>Bilmes</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
@@ -617,7 +618,7 @@
         <bibkey>filali-bilmes:2005:ACL</bibkey>
    </paper>
    <paper id="1043">
-        <title>Learning Stochastic OT Grammars: A Bayesian Approach using Data Augmentation and Gibbs Sampling</title>
+        <title>Learning Stochastic <fixed-case>OT</fixed-case> Grammars: A <fixed-case>B</fixed-case>ayesian Approach using Data Augmentation and <fixed-case>G</fixed-case>ibbs Sampling</title>
         <author><first>Ying</first><last>Lin</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
         <month>June</month>
@@ -674,7 +675,7 @@
         <bibkey>grenager-klein-manning:2005:ACL</bibkey>
    </paper>
    <paper id="1047">
-        <title>A Semantic Approach to IE Pattern Induction</title>
+        <title>A Semantic Approach to <fixed-case>IE</fixed-case> Pattern Induction</title>
         <author><first>Mark</first><last>Stevenson</last></author>
         <author><first>Mark</first><last>Greenwood</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
@@ -878,7 +879,7 @@
         <bibkey>mann-yarowsky:2005:ACL</bibkey>
    </paper>
    <paper id="1061">
-        <title>Simple Algorithms for Complex Relation Extraction with Applications to Biomedical IE</title>
+        <title>Simple Algorithms for Complex Relation Extraction with Applications to Biomedical <fixed-case>IE</fixed-case></title>
         <author><first>Ryan</first><last>McDonald</last></author>
         <author><first>Fernando</first><last>Pereira</last></author>
         <author><first>Seth</first><last>Kulick</last></author>
@@ -983,7 +984,7 @@
         <bibkey>ding-palmer:2005:ACL</bibkey>
    </paper>
    <paper id="1068">
-        <title>Context-Dependent SMT Model using Bilingual Verb-Noun Collocation</title>
+        <title>Context-Dependent <fixed-case>SMT</fixed-case> Model using Bilingual Verb-Noun Collocation</title>
         <author><first>Young-Sook</first><last>Hwang</last></author>
         <author><first>Yutaka</first><last>Sasaki</last></author>
         <booktitle>Proceedings of the 43rd Annual Meeting of the Association for Computational Linguistics (ACL’05)</booktitle>
@@ -1113,7 +1114,7 @@
         <bibkey>yallop-korhonen-briscoe:2005:ACL</bibkey>
    </paper>
    <paper id="1077">
-        <title>Randomized Algorithms and NLP: Using Locality Sensitive Hash Functions for High Speed Noun Clustering</title>
+        <title>Randomized Algorithms and <fixed-case>NLP</fixed-case>: Using Locality Sensitive Hash Functions for High Speed Noun Clustering</title>
         <author><first>Deepak</first><last>Ravichandran</last></author>
         <author><first>Patrick</first><last>Pantel</last></author>
         <author><first>Eduard</first><last>Hovy</last></author>
@@ -1140,7 +1141,7 @@
         <bibkey>Student:2005</bibkey>
    </paper>
    <paper id="2001">
-        <title>Hybrid Methods for POS Guessing of Chinese Unknown Words</title>
+        <title>Hybrid Methods for <fixed-case>POS</fixed-case> Guessing of <fixed-case>C</fixed-case>hinese Unknown Words</title>
         <author><first>Xiaofei</first><last>Lu</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1153,7 +1154,7 @@
         <bibkey>lu:2005:Student</bibkey>
    </paper>
    <paper id="2002">
-        <title>Understanding the Thematic Structure of the Qur’an: An Exploratory Multivariate Approach</title>
+        <title>Understanding the Thematic Structure of the <fixed-case>Q</fixed-case>ur’an: An Exploratory Multivariate Approach</title>
         <author><first>Naglaa</first><last>Thabet</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1179,7 +1180,7 @@
         <bibkey>pecina:2005:Student</bibkey>
    </paper>
    <paper id="2004">
-        <title>Jointly Labeling Multiple Sequences: A Factorial HMM Approach</title>
+        <title>Jointly Labeling Multiple Sequences: A Factorial <fixed-case>HMM</fixed-case> Approach</title>
         <author><first>Kevin</first><last>Duh</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1218,7 +1219,7 @@
         <bibkey>tatu:2005:Student</bibkey>
    </paper>
    <paper id="2007">
-        <title>American Sign Language Generation: Multimodal NLG with Multiple Linguistic Channels</title>
+        <title>American Sign Language Generation: Multimodal <fixed-case>NLG</fixed-case> with Multiple Linguistic Channels</title>
         <author><first>Matt</first><last>Huenerfauth</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1296,7 +1297,7 @@
         <bibkey>degispert:2005:Student</bibkey>
    </paper>
    <paper id="2013">
-        <title>Automatic Induction of a CCG Grammar for Turkish</title>
+        <title>Automatic Induction of a <fixed-case>CCG</fixed-case> Grammar for <fixed-case>T</fixed-case>urkish</title>
         <author><first>Ruken</first><last>Cakici</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1374,7 +1375,7 @@
         <bibkey>xie:2005:Student</bibkey>
    </paper>
    <paper id="2019">
-        <title>A Corpus-Based Approach to Topic in Danish dialog</title>
+        <title>A Corpus-Based Approach to Topic in <fixed-case>D</fixed-case>anish dialog</title>
         <author><first>Philip</first><last>Diderichsen</last></author>
         <author><first>Jakob</first><last>Elming</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
@@ -1388,7 +1389,7 @@
         <bibkey>diderichsen-elming:2005:Student</bibkey>
    </paper>
    <paper id="2020">
-        <title>Learning Information Structure in the Prague Treebank</title>
+        <title>Learning Information Structure in the <fixed-case>P</fixed-case>rague <fixed-case>T</fixed-case>reebank</title>
         <author><first>Oana</first><last>Postolache</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1401,7 +1402,7 @@
         <bibkey>postolache:2005:Student</bibkey>
    </paper>
    <paper id="2021">
-        <title>Speech Recognition of Czech—Inclusion of Rare Words Helps</title>
+        <title>Speech Recognition of <fixed-case>C</fixed-case>zech—Inclusion of Rare Words Helps</title>
         <author><first>Petr</first><last>Podvesky</last></author>
         <author><first>Pavel</first><last>Machek</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
@@ -1415,7 +1416,7 @@
         <bibkey>podvesky-machek:2005:Student</bibkey>
    </paper>
    <paper id="2022">
-        <title>Using Bilingual Dependencies to Align Words in English/French Parallel Corpora</title>
+        <title>Using Bilingual Dependencies to Align Words in <fixed-case>E</fixed-case>nglish/<fixed-case>F</fixed-case>rench Parallel Corpora</title>
         <author><first>Sylwia</first><last>Ozdowska</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1428,7 +1429,7 @@
         <bibkey>ozdowska:2005:Student</bibkey>
    </paper>
    <paper id="2023">
-        <title>An Unsupervised System for Identifying English Inclusions in German Text</title>
+        <title>An Unsupervised System for Identifying <fixed-case>E</fixed-case>nglish Inclusions in <fixed-case>G</fixed-case>erman Text</title>
         <author><first>Beatrice</first><last>Alex</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1441,7 +1442,7 @@
         <bibkey>alex:2005:Student</bibkey>
    </paper>
    <paper id="2024">
-        <title>Corpus-Oriented Development of Japanese HPSG Parsers</title>
+        <title>Corpus-Oriented Development of <fixed-case>J</fixed-case>apanese <fixed-case>HPSG</fixed-case> Parsers</title>
         <author><first>Kazuhiro</first><last>Yoshida</last></author>
         <booktitle>Proceedings of the ACL Student Research Workshop</booktitle>
         <month>June</month>
@@ -1509,7 +1510,7 @@
         <bibkey>devault-EtAl:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3002">
-        <title>Accessing GermaNet Data and Computing Semantic Relatedness</title>
+        <title>Accessing <fixed-case>GermaNet</fixed-case> Data and Computing Semantic Relatedness</title>
         <author><first>Iryna</first><last>Gurevych</last></author>
         <author><first>Hendrik</first><last>Niederlich</last></author>
         <booktitle>Proceedings of the ACL Interactive Poster and Demonstration Sessions</booktitle>
@@ -1537,7 +1538,7 @@
         <bibkey>koller-thater:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3004">
-        <title>CL Research’s Knowledge Management System</title>
+        <title><fixed-case>CL</fixed-case> Research’s Knowledge Management System</title>
         <author><first>Kenneth C.</first><last>Litkowski</last></author>
         <booktitle>Proceedings of the ACL Interactive Poster and Demonstration Sessions</booktitle>
         <month>June</month>
@@ -1580,7 +1581,7 @@
         <bibkey>lee-kim-jang:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3007">
-        <title>High Throughput Modularized NLP System for Clinical Text</title>
+        <title>High Throughput Modularized <fixed-case>NLP</fixed-case> System for Clinical Text</title>
         <author><first>Serguei</first><last>Pakhomov</last></author>
         <author><first>James</first><last>Buntrock</last></author>
         <author><first>Patrick</first><last>Duffy</last></author>
@@ -1612,7 +1613,7 @@
         <bibkey>rayner-EtAl:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3009">
-        <title>The Linguist’s Search Engine: An Overview</title>
+        <title>The <fixed-case>L</fixed-case>inguist’s <fixed-case>S</fixed-case>earch <fixed-case>E</fixed-case>ngine: An Overview</title>
         <author><first>Philip</first><last>Resnik</last></author>
         <author><first>Aaron</first><last>Elkiss</last></author>
         <booktitle>Proceedings of the ACL Interactive Poster and Demonstration Sessions</booktitle>
@@ -1641,7 +1642,7 @@
         <bibkey>wu-lin-chang:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3011">
-        <title>SPEECH OGLE: Indexing Uncertainty for Spoken Document Search</title>
+        <title><fixed-case>SPEECH</fixed-case> <fixed-case>OGLE</fixed-case>: Indexing Uncertainty for Spoken Document Search</title>
         <author><first>Ciprian</first><last>Chelba</last></author>
         <author><first>Alex</first><last>Acero</last></author>
         <booktitle>Proceedings of the ACL Interactive Poster and Demonstration Sessions</booktitle>
@@ -1655,7 +1656,7 @@
         <bibkey>chelba-acero:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3012">
-        <title>Multimodal Generation in the COMIC Dialogue System</title>
+        <title>Multimodal Generation in the <fixed-case>COMIC</fixed-case> Dialogue System</title>
         <author><first>Mary E.</first><last>Foster</last></author>
         <author><first>Michael</first><last>White</last></author>
         <author><first>Andrea</first><last>Setzer</last></author>
@@ -1684,7 +1685,7 @@
         <bibkey>mihalcea:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3014">
-        <title>SenseLearner: Word Sense Disambiguation for All Words in Unrestricted Text</title>
+        <title><fixed-case>SenseLearner</fixed-case>: Word Sense Disambiguation for All Words in Unrestricted Text</title>
         <author><first>Rada</first><last>Mihalcea</last></author>
         <author><first>Andras</first><last>Csomai</last></author>
         <booktitle>Proceedings of the ACL Interactive Poster and Demonstration Sessions</booktitle>
@@ -1758,7 +1759,7 @@
         <bibkey>nichols-hwa:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3019">
-        <title>SenseRelate::TargetWord—A Generalized Framework for Word Sense Disambiguation</title>
+        <title><fixed-case>SenseRelate::TargetWord</fixed-case>—A Generalized Framework for Word Sense Disambiguation</title>
         <author><first>Siddharth</first><last>Patwardhan</last></author>
         <author><first>Satanjeev</first><last>Banerjee</last></author>
         <author><first>Ted</first><last>Pedersen</last></author>
@@ -1786,7 +1787,7 @@
         <bibkey>rapp:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3021">
-        <title>Automating Temporal Annotation with TARSQI</title>
+        <title>Automating Temporal Annotation with <fixed-case>TARSQI</fixed-case></title>
         <author><first>Marc</first><last>Verhagen</last></author>
         <author><first>Inderjeet</first><last>Mani</last></author>
         <author><first>Roser</first><last>Sauri</last></author>
@@ -1807,7 +1808,7 @@
         <bibkey>verhagen-EtAl:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3022">
-        <title>Two Diverse Systems Built using Generic Components for Spoken Dialogue (Recent Progress on TRIPS)</title>
+        <title>Two Diverse Systems Built using Generic Components for Spoken Dialogue (Recent Progress on <fixed-case>TRIPS</fixed-case>)</title>
         <author><first>James</first><last>Allen</last></author>
         <author><first>George</first><last>Ferguson</last></author>
         <author><first>Amanda</first><last>Stent</last></author>
@@ -1828,7 +1829,7 @@
         <bibkey>allen-EtAl:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3023">
-        <title>Transonics: A Practical Speech-to-Speech Translator for English-Farsi Medical Dialogs</title>
+        <title>Transonics: A Practical Speech-to-Speech Translator for <fixed-case>E</fixed-case>nglish-<fixed-case>F</fixed-case>arsi Medical Dialogs</title>
         <author><first>Robert</first><last>Belvin</last></author>
         <author><first>Emil</first><last>Ettelaie</last></author>
         <author><first>Sudeep</first><last>Gandhe</last></author>
@@ -1893,7 +1894,7 @@
         <bibkey>jayaraman-lavie:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3027">
-        <title>SenseClusters: Unsupervised Clustering and Labeling of Similar Contexts</title>
+        <title><fixed-case>SenseClusters</fixed-case>: Unsupervised Clustering and Labeling of Similar Contexts</title>
         <author><first>Anagha</first><last>Kulkarni</last></author>
         <author><first>Ted</first><last>Pedersen</last></author>
         <booktitle>Proceedings of the ACL Interactive Poster and Demonstration Sessions</booktitle>
@@ -1920,7 +1921,7 @@
         <bibkey>mueller:2005:PosterDemo</bibkey>
    </paper>
    <paper id="3029">
-        <title>HAHAcronym: A Computational Humor System</title>
+        <title><fixed-case>HAHAcronym</fixed-case>: A Computational Humor System</title>
         <author><first>Oliviero</first><last>Stock</last></author>
         <author><first>Carlo</first><last>Strapparava</last></author>
         <booktitle>Proceedings of the ACL Interactive Poster and Demonstration Sessions</booktitle>

--- a/import/P06.xml
+++ b/import/P06.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P06">
    <paper id="1000">
         <title>Proceedings of the 21st International Conference on Computational Linguistics and 44th Annual Meeting of the Association for Computational Linguistics</title>
@@ -4157,7 +4158,7 @@
         <bibkey>tsarfaty:2006:SRW</bibkey>
    </paper>
    <paper id="3010">
-        <title>A Hybrid Relational Approach for WSD – First Results</title>
+        <title>A Hybrid Relational Approach for <fixed-case>WSD</fixed-case> – First Results</title>
         <author><first>Lucia</first><last>Specia</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Student Research Workshop</booktitle>
         <month>July</month>
@@ -4170,7 +4171,7 @@
         <bibkey>specia:2006:SRW</bibkey>
    </paper>
    <paper id="3011">
-        <title>On2L – A Framework for Incremental Ontology Learning in Spoken Dialog Systems</title>
+        <title><fixed-case>On2L</fixed-case> – A Framework for Incremental Ontology Learning in Spoken Dialog Systems</title>
         <author><first>Berenike</first><last>Loos</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Student Research Workshop</booktitle>
         <month>July</month>
@@ -4246,7 +4247,7 @@
         <bibkey>IP:2006</bibkey>
    </paper>
    <paper id="4001">
-        <title>FAST – An Automatic Generation System for Grammar Tests</title>
+        <title><fixed-case>FAST</fixed-case> – An Automatic Generation System for Grammar Tests</title>
         <author><first>Chia-Yin</first><last>Chen</last></author>
         <author><first>Hsien-Chin</first><last>Liou</last></author>
         <author><first>Jason S.</first><last>Chang</last></author>
@@ -4275,7 +4276,7 @@
         <bibkey>montero-araki:2006:IP</bibkey>
    </paper>
    <paper id="4003">
-        <title>LeXFlow: A System for Cross-Fertilization of Computational Lexicons</title>
+        <title><fixed-case>LeXFlow</fixed-case>: A System for Cross-Fertilization of Computational Lexicons</title>
         <author><first>Maurizio</first><last>Tesconi</last></author>
         <author><first>Andrea</first><last>Marchetti</last></author>
         <author><first>Francesca</first><last>Bertagna</last></author>
@@ -4293,7 +4294,7 @@
         <bibkey>tesconi-EtAl:2006:IP</bibkey>
    </paper>
    <paper id="4004">
-        <title>Valido: A Visual Tool for Validating Sense Annotations</title>
+        <title><fixed-case>Valido</fixed-case>: A Visual Tool for Validating Sense Annotations</title>
         <author><first>Roberto</first><last>Navigli</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Interactive Presentation Sessions</booktitle>
         <month>July</month>
@@ -4306,7 +4307,7 @@
         <bibkey>navigli:2006:IP</bibkey>
    </paper>
    <paper id="4005">
-        <title>An Intelligent Search Engine and GUI-based Efficient MEDLINE Search Tool Based on Deep Syntactic Parsing</title>
+        <title>An Intelligent Search Engine and <fixed-case>GUI</fixed-case>-based Efficient <fixed-case>MEDLINE</fixed-case> Search Tool Based on Deep Syntactic Parsing</title>
         <author><first>Tomoko</first><last>Ohta</last></author>
         <author><first>Yusuke</first><last>Miyao</last></author>
         <author><first>Takashi</first><last>Ninomiya</last></author>
@@ -4330,7 +4331,7 @@
         <bibkey>ohta-EtAl:2006:IP</bibkey>
    </paper>
    <paper id="4006">
-        <title>MIMA Search: A Structuring Knowledge System towards Innovation for Engineering Education</title>
+        <title><fixed-case>MIMA</fixed-case> Search: A Structuring Knowledge System towards Innovation for Engineering Education</title>
         <author><first>Hideki</first><last>Mima</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Interactive Presentation Sessions</booktitle>
         <month>July</month>
@@ -4343,7 +4344,7 @@
         <bibkey>mima:2006:IP</bibkey>
    </paper>
    <paper id="4007">
-        <title>FERRET: Interactive Question-Answering for Real-World Environments</title>
+        <title><fixed-case>FERRET</fixed-case>: Interactive Question-Answering for Real-World Environments</title>
         <author><first>Andrew</first><last>Hickl</last></author>
         <author><first>Patrick</first><last>Wang</last></author>
         <author><first>John</first><last>Lehmann</last></author>
@@ -4359,7 +4360,7 @@
         <bibkey>hickl-EtAl:2006:IP</bibkey>
    </paper>
    <paper id="4008">
-        <title>K-QARD: A Practical Korean Question Answering Framework for Restricted Domain</title>
+        <title><fixed-case>K-QARD</fixed-case>: A Practical Korean Question Answering Framework for Restricted Domain</title>
         <author><first>Young-In</first><last>Song</last></author>
         <author><first>HooJung</first><last>Chung</last></author>
         <author><first>Kyoung-Soo</first><last>Han</last></author>
@@ -4391,7 +4392,7 @@
         <bibkey>mazur-dale:2006:IP</bibkey>
    </paper>
    <paper id="4010">
-        <title>Chinese Named Entity and Relation Identification System</title>
+        <title><fixed-case>Chinese</fixed-case> Named Entity and Relation Identification System</title>
         <author><first>Tianfang</first><last>Yao</last></author>
         <author><first>Hans</first><last>Uszkoreit</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Interactive Presentation Sessions</booktitle>
@@ -4421,7 +4422,7 @@
         <bibkey>wu-EtAl:2006:IP</bibkey>
    </paper>
    <paper id="4012">
-        <title>LexNet: A Graphical Environment for Graph-Based NLP</title>
+        <title><fixed-case>LexNet</fixed-case>: A Graphical Environment for Graph-Based <fixed-case>NLP</fixed-case></title>
         <author><first>Dragomir R.</first><last>Radev</last></author>
         <author><first>Güneş</first><last>Erkan</last></author>
         <author><first>Anthony</first><last>Fader</last></author>
@@ -4439,7 +4440,7 @@
         <bibkey>radev-EtAl:2006:IP</bibkey>
    </paper>
    <paper id="4013">
-        <title>Archivus: A Multimodal System for Multimedia Meeting Browsing and Retrieval</title>
+        <title><fixed-case>Archivus</fixed-case>: A Multimodal System for Multimedia Meeting Browsing and Retrieval</title>
         <author><first>Marita</first><last>Ailomaa</last></author>
         <author><first>Miroslav</first><last>Melichar</last></author>
         <author><first>Agnes</first><last>Lisowska</last></author>
@@ -4470,7 +4471,7 @@
         <bibkey>lonning-oepen:2006:IP</bibkey>
    </paper>
    <paper id="4015">
-        <title>The SAMMIE System: Multimodal In-Car Dialogue</title>
+        <title>The <fixed-case>SAMMIE</fixed-case> System: Multimodal In-Car Dialogue</title>
         <author><first>Tilman</first><last>Becker</last></author>
         <author><first>Peter</first><last>Poller</last></author>
         <author><first>Jan</first><last>Schehl</last></author>
@@ -4488,7 +4489,7 @@
         <bibkey>becker-EtAl:2006:IP</bibkey>
    </paper>
    <paper id="4016">
-        <title>TwicPen: Hand-held Scanner and Translation Software for non-Native Readers</title>
+        <title><fixed-case>TwicPen</fixed-case>: Hand-held Scanner and Translation Software for non-Native Readers</title>
         <author><first>Eric</first><last>Wehrli</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Interactive Presentation Sessions</booktitle>
         <month>July</month>
@@ -4501,7 +4502,7 @@
         <bibkey>wehrli:2006:IP</bibkey>
    </paper>
    <paper id="4017">
-        <title>An Implemented Description of Japanese: The Lexeed Dictionary and the Hinoki Treebank</title>
+        <title>An Implemented Description of <fixed-case>Japanese</fixed-case>: The <fixed-case>Lexeed</fixed-case> Dictionary and the <fixed-case>Hinoki</fixed-case> Treebank</title>
         <author><first>Sanae</first><last>Fujita</last></author>
         <author><first>Takaaki</first><last>Tanaka</last></author>
         <author><first>Francis</first><last>Bond</last></author>
@@ -4517,7 +4518,7 @@
         <bibkey>fujita-EtAl:2006:IP</bibkey>
    </paper>
    <paper id="4018">
-        <title>NLTK: The Natural Language Toolkit</title>
+        <title><fixed-case>NLTK</fixed-case>: The <fixed-case>Natural</fixed-case> <fixed-case>Language</fixed-case> <fixed-case>Toolkit</fixed-case></title>
         <author><first>Steven</first><last>Bird</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Interactive Presentation Sessions</booktitle>
         <month>July</month>
@@ -4530,7 +4531,7 @@
         <bibkey>bird:2006:IP</bibkey>
    </paper>
    <paper id="4019">
-        <title>Outilex, a Linguistic Platform for Text Processing</title>
+        <title><fixed-case>Outilex</fixed-case>, a Linguistic Platform for Text Processing</title>
         <author><first>Olivier</first><last>Blanc</last></author>
         <author><first>Matthieu</first><last>Constant</last></author>
         <booktitle>Proceedings of the COLING/ACL 2006 Interactive Presentation Sessions</booktitle>
@@ -4544,7 +4545,7 @@
         <bibkey>blanc-constant:2006:IP</bibkey>
    </paper>
    <paper id="4020">
-        <title>The Second Release of the RASP System</title>
+        <title>The Second Release of the <fixed-case>RASP</fixed-case> System</title>
         <author><first>Ted</first><last>Briscoe</last></author>
         <author><first>John</first><last>Carroll</last></author>
         <author><first>Rebecca</first><last>Watson</last></author>

--- a/import/P07.xml
+++ b/import/P07.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P07">
    <paper id="1000">
         <title>Proceedings of the 45th Annual Meeting of the Association of Computational Linguistics</title>

--- a/import/P08.xml
+++ b/import/P08.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P08">
    <paper id="1000">
         <title>Proceedings of ACL-08: HLT</title>
@@ -71,7 +72,7 @@
         <bibkey>banko-etzioni:2008:ACLMain</bibkey>
    </paper>
    <paper id="1005">
-        <title>PDT 2.0 Requirements on a Query Language</title>
+        <title><fixed-case>PDT</fixed-case> 2.0 Requirements on a Query Language</title>
         <author><first>Jiří</first><last>Mírovský</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
         <month>June</month>
@@ -101,7 +102,7 @@
         <bibkey>miyao-EtAl:2008:ACLMain</bibkey>
    </paper>
    <paper id="1007">
-        <title>MAXSIM: A Maximum Similarity Metric for Machine Translation Evaluation</title>
+        <title><fixed-case>MAXSIM</fixed-case>: A Maximum Similarity Metric for Machine Translation Evaluation</title>
         <author><first>Yee Seng</first><last>Chan</last></author>
         <author><first>Hwee Tou</first><last>Ng</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
@@ -156,7 +157,7 @@
         <bibkey>deng-xu-gao:2008:ACLMain</bibkey>
    </paper>
    <paper id="1011">
-        <title>Measure Word Generation for English-Chinese SMT Systems</title>
+        <title>Measure Word Generation for <fixed-case>English</fixed-case>-<fixed-case>Chinese</fixed-case> <fixed-case>SMT</fixed-case> Systems</title>
         <author><first>Dongdong</first><last>Zhang</last></author>
         <author><first>Mu</first><last>Li</last></author>
         <author><first>Nan</first><last>Duan</last></author>
@@ -173,7 +174,7 @@
         <bibkey>zhang-EtAl:2008:ACLMain1</bibkey>
    </paper>
    <paper id="1012">
-        <title>Bayesian Learning of Non-Compositional Phrases with Synchronous Parsing</title>
+        <title><fixed-case>Bayesian</fixed-case> Learning of Non-Compositional Phrases with Synchronous Parsing</title>
         <author><first>Hao</first><last>Zhang</last></author>
         <author><first>Chris</first><last>Quirk</last></author>
         <author><first>Robert C.</first><last>Moore</last></author>
@@ -318,7 +319,7 @@
         <bibkey>lee-seneff:2008:ACLMain</bibkey>
    </paper>
    <paper id="1022">
-        <title>Hypertagging: Supertagging for Surface Realization with CCG</title>
+        <title>Hypertagging: Supertagging for Surface Realization with <fixed-case>CCG</fixed-case></title>
         <author><first>Dominic</first><last>Espinosa</last></author>
         <author><first>Michael</first><last>White</last></author>
         <author><first>Dennis</first><last>Mehay</last></author>
@@ -506,7 +507,7 @@
         <bibkey>andreevskaia-bergler:2008:ACLMain</bibkey>
    </paper>
    <paper id="1035">
-        <title>A Generic Sentence Trimmer with CRFs</title>
+        <title>A Generic Sentence Trimmer with <fixed-case>CRF</fixed-case>s</title>
         <author><first>Tadashi</first><last>Nomoto</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
         <month>June</month>
@@ -533,7 +534,7 @@
         <bibkey>titov-mcdonald:2008:ACLMain</bibkey>
    </paper>
    <paper id="1037">
-        <title>Improving Parsing and PP Attachment Performance with Sense Information</title>
+        <title>Improving Parsing and <fixed-case>PP</fixed-case> Attachment Performance with Sense Information</title>
         <author><first>Eneko</first><last>Agirre</last></author>
         <author><first>Timothy</first><last>Baldwin</last></author>
         <author><first>David</first><last>Martinez</last></author>
@@ -548,7 +549,7 @@
         <bibkey>agirre-baldwin-martinez:2008:ACLMain</bibkey>
    </paper>
    <paper id="1038">
-        <title>A Logical Basis for the D Combinator and Normal Form in CCG</title>
+        <title>A Logical Basis for the <fixed-case>D</fixed-case> Combinator and Normal Form in <fixed-case>CCG</fixed-case></title>
         <author><first>Frederick</first><last>Hoyt</last></author>
         <author><first>Jason</first><last>Baldridge</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
@@ -562,7 +563,7 @@
         <bibkey>hoyt-baldridge:2008:ACLMain</bibkey>
    </paper>
    <paper id="1039">
-        <title>Parsing Noun Phrase Structure with CCG</title>
+        <title>Parsing Noun Phrase Structure with <fixed-case>CCG</fixed-case></title>
         <author><first>David</first><last>Vadas</last></author>
         <author><first>James R.</first><last>Curran</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
@@ -632,7 +633,7 @@
         <bibkey>goldberg-tsarfaty:2008:ACLMain</bibkey>
    </paper>
    <paper id="1044">
-        <title>Which Words Are Hard to Recognize? Prosodic, Lexical, and Disfluency Factors that Increase ASR Error Rates</title>
+        <title>Which Words Are Hard to Recognize? Prosodic, Lexical, and Disfluency Factors that Increase <fixed-case>ASR</fixed-case> Error Rates</title>
         <author><first>Sharon</first><last>Goldwater</last></author>
         <author><first>Dan</first><last>Jurafsky</last></author>
         <author><first>Christopher D.</first><last>Manning</last></author>
@@ -689,7 +690,7 @@
         <bibkey>kazama-torisawa:2008:ACLMain</bibkey>
    </paper>
    <paper id="1048">
-        <title>Evaluating Roget’s Thesauri</title>
+        <title>Evaluating <fixed-case>Roget</fixed-case>‘s Thesauri</title>
         <author><first>Alistair</first><last>Kennedy</last></author>
         <author><first>Stan</first><last>Szpakowicz</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
@@ -731,7 +732,7 @@
         <bibkey>li-brew:2008:ACLMain</bibkey>
    </paper>
    <paper id="1051">
-        <title>Collecting a Why-Question Corpus for Development and Evaluation of an Automatic QA-System</title>
+        <title>Collecting a Why-Question Corpus for Development and Evaluation of an Automatic <fixed-case>QA</fixed-case>-System</title>
         <author><first>Joanna</first><last>Mrozinski</last></author>
         <author><first>Edward</first><last>Whittaker</last></author>
         <author><first>Sadaoki</first><last>Furui</last></author>
@@ -802,7 +803,7 @@
         <bibkey>polifroni-walker:2008:ACLMain</bibkey>
    </paper>
    <paper id="1056">
-        <title>Word Clustering and Word Selection Based Feature Reduction for MaxEnt Based Hindi NER</title>
+        <title>Word Clustering and Word Selection Based Feature Reduction for MaxEnt Based Hindi <fixed-case>NER</fixed-case></title>
         <author><first>Sujan Kumar</first><last>Saha</last></author>
         <author><first>Pabitra</first><last>Mitra</last></author>
         <author><first>Sudeshna</first><last>Sarkar</last></author>
@@ -817,7 +818,7 @@
         <bibkey>saha-mitra-sarkar:2008:ACLMain</bibkey>
    </paper>
    <paper id="1057">
-        <title>Combining EM Training and the MDL Principle for an Automatic Verb Classification Incorporating Selectional Preferences</title>
+        <title>Combining <fixed-case>EM</fixed-case> Training and the <fixed-case>MDL</fixed-case> Principle for an Automatic Verb Classification Incorporating Selectional Preferences</title>
         <author><first>Sabine</first><last>Schulte im Walde</last></author>
         <author><first>Christian</first><last>Hying</last></author>
         <author><first>Christian</first><last>Scheible</last></author>
@@ -892,7 +893,7 @@
         <bibkey>wang-schuurmans-lin:2008:ACLMain</bibkey>
    </paper>
    <paper id="1062">
-        <title>Chinese-English Backward Transliteration Assisted with Mining Monolingual Web Pages</title>
+        <title><fixed-case>Chinese</fixed-case>-<fixed-case>English</fixed-case> Backward Transliteration Assisted with Mining Monolingual Web Pages</title>
         <author><first>Fan</first><last>Yang</last></author>
         <author><first>Jun</first><last>Zhao</last></author>
         <author><first>Bo</first><last>Zou</last></author>
@@ -909,7 +910,7 @@
         <bibkey>yang-EtAl:2008:ACLMain1</bibkey>
    </paper>
    <paper id="1063">
-        <title>Robustness and Generalization of Role Sets: PropBank vs. VerbNet</title>
+        <title>Robustness and Generalization of Role Sets: <fixed-case>PropBank</fixed-case> vs. <fixed-case>VerbNet</fixed-case></title>
         <author><first>Beñat</first><last>Zapirain</last></author>
         <author><first>Eneko</first><last>Agirre</last></author>
         <author><first>Lluís</first><last>Màrquez</last></author>
@@ -942,7 +943,7 @@
         <bibkey>zhang-EtAl:2008:ACLMain3</bibkey>
    </paper>
    <paper id="1065">
-        <title>Automatic Syllabification with Structured SVMs for Letter-to-Phoneme Conversion</title>
+        <title>Automatic Syllabification with Structured <fixed-case>SVM</fixed-case>s for Letter-to-Phoneme Conversion</title>
         <author><first>Susan</first><last>Bartlett</last></author>
         <author><first>Grzegorz</first><last>Kondrak</last></author>
         <author><first>Colin</first><last>Cherry</last></author>
@@ -1059,7 +1060,7 @@
         <bibkey>lee-jung-lee:2008:ACLMain</bibkey>
    </paper>
    <paper id="1073">
-        <title>Learning Effective Multimodal Dialogue Strategies from Wizard-of-Oz Data: Bootstrapping and Evaluation</title>
+        <title>Learning Effective Multimodal Dialogue Strategies from <fixed-case>Wizard-of-Oz</fixed-case> Data: Bootstrapping and Evaluation</title>
         <author><first>Verena</first><last>Rieser</last></author>
         <author><first>Oliver</first><last>Lemon</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
@@ -1148,7 +1149,7 @@
         <bibkey>szpektor-EtAl:2008:ACLMain</bibkey>
    </paper>
    <paper id="1079">
-        <title>Unsupervised Discovery of Generic Relationships Using Pattern Clusters and its Evaluation by Automatically Generated SAT Analogy Questions</title>
+        <title>Unsupervised Discovery of Generic Relationships Using Pattern Clusters and its Evaluation by Automatically Generated <fixed-case>SAT</fixed-case> Analogy Questions</title>
         <author><first>Dmitry</first><last>Davidov</last></author>
         <author><first>Ari</first><last>Rappoport</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
@@ -1193,7 +1194,7 @@
         <bibkey>ding-EtAl:2008:ACLMain</bibkey>
    </paper>
    <paper id="1082">
-        <title>Learning to Rank Answers on Large Online QA Collections</title>
+        <title>Learning to Rank Answers on Large Online <fixed-case>QA</fixed-case> Collections</title>
         <author><first>Mihai</first><last>Surdeanu</last></author>
         <author><first>Massimiliano</first><last>Ciaramita</last></author>
         <author><first>Hugo</first><last>Zaragoza</last></author>
@@ -1238,7 +1239,7 @@
         <bibkey>snyder-barzilay:2008:ACLMain</bibkey>
    </paper>
    <paper id="1085">
-        <title>EM Can Find Pretty Good HMM POS-Taggers (When Given a Good Start)</title>
+        <title><fixed-case>EM</fixed-case> Can Find Pretty Good <fixed-case>HMM</fixed-case> <fixed-case>POS</fixed-case>-Taggers (When Given a Good Start)</title>
         <author><first>Yoav</first><last>Goldberg</last></author>
         <author><first>Meni</first><last>Adler</last></author>
         <author><first>Michael</first><last>Elhadad</last></author>
@@ -1327,7 +1328,7 @@
         <bibkey>chambers-jurafsky:2008:ACLMain</bibkey>
    </paper>
    <paper id="1091">
-        <title>Semantic Role Labeling Systems for Arabic using Kernel Methods</title>
+        <title>Semantic Role Labeling Systems for <fixed-case>A</fixed-case>rabic using Kernel Methods</title>
         <author><first>Mona</first><last>Diab</last></author>
         <author><first>Alessandro</first><last>Moschitti</last></author>
         <author><first>Daniele</first><last>Pighin</last></author>
@@ -1476,7 +1477,7 @@
         <bibkey>liang-klein:2008:ACLMain</bibkey>
    </paper>
    <paper id="1101">
-        <title>Joint Word Segmentation and POS Tagging Using a Single Perceptron</title>
+        <title>Joint Word Segmentation and <fixed-case>POS</fixed-case> Tagging Using a Single Perceptron</title>
         <author><first>Yue</first><last>Zhang</last></author>
         <author><first>Stephen</first><last>Clark</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
@@ -1626,7 +1627,7 @@
         <bibkey>gomezrodriguez-carroll-weir:2008:ACLMain</bibkey>
    </paper>
    <paper id="1111">
-        <title>Evaluating a Crosslinguistic Grammar Resource: A Case Study of Wambaya</title>
+        <title>Evaluating a Crosslinguistic Grammar Resource: A Case Study of <fixed-case>W</fixed-case>ambaya</title>
         <author><first>Emily M.</first><last>Bender</last></author>
         <booktitle>Proceedings of ACL-08: HLT</booktitle>
         <month>June</month>
@@ -1699,7 +1700,7 @@
         <bibkey>dyer-muresan-resnik:2008:ACLMain</bibkey>
    </paper>
    <paper id="1116">
-        <title>Combining Multiple Resources to Improve SMT-based Paraphrasing Model</title>
+        <title>Combining Multiple Resources to Improve <fixed-case>SMT</fixed-case>-based Paraphrasing Model</title>
         <author><first>Shiqi</first><last>Zhao</last></author>
         <author><first>Cheng</first><last>Niu</last></author>
         <author><first>Ming</first><last>Zhou</last></author>
@@ -2840,7 +2841,7 @@
         <bibkey>liao:2008:SRW</bibkey>
    </paper>
    <paper id="3005">
-        <title>A Re-examination on Features in Regression Based Approach to Automatic MT Evaluation</title>
+        <title>A Re-examination on Features in Regression Based Approach to Automatic <fixed-case>MT</fixed-case> Evaluation</title>
         <author><first>Shuqi</first><last>Sun</last></author>
         <author><first>Yin</first><last>Chen</last></author>
         <author><first>Jufeng</first><last>Li</last></author>
@@ -2855,7 +2856,7 @@
         <bibkey>sun-chen-li:2008:SRW</bibkey>
    </paper>
    <paper id="3006">
-        <title>The Role of Positive Feedback in Intelligent Tutoring Systems</title>
+        <title>The Role of Positive Feedback in <fixed-case>I</fixed-case>ntelligent <fixed-case>T</fixed-case>utoring <fixed-case>S</fixed-case>ystems</title>
         <author><first>Davide</first><last>Fossati</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Student Research Workshop</booktitle>
         <month>June</month>
@@ -2894,7 +2895,7 @@
         <bibkey>kersey:2008:SRW</bibkey>
    </paper>
    <paper id="3009">
-        <title>An Unsupervised Vector Approach to Biomedical Term Disambiguation: Integrating UMLS and Medline</title>
+        <title>An Unsupervised Vector Approach to Biomedical Term Disambiguation: Integrating <fixed-case>UMLS</fixed-case> and <fixed-case>M</fixed-case>edline</title>
         <author><first>Bridget</first><last>McInnes</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Student Research Workshop</booktitle>
         <month>June</month>
@@ -2907,7 +2908,7 @@
         <bibkey>mcinnes:2008:SRW</bibkey>
    </paper>
    <paper id="3010">
-        <title>A Subcategorization Acquisition System for French Verbs</title>
+        <title>A Subcategorization Acquisition System for <fixed-case>F</fixed-case>rench Verbs</title>
         <author><first>Cédric</first><last>Messiant</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Student Research Workshop</booktitle>
         <month>June</month>
@@ -2957,7 +2958,7 @@
         <bibkey>ACLDemos:2008</bibkey>
    </paper>
    <paper id="4001">
-        <title>Demonstration of a POMDP Voice Dialer</title>
+        <title>Demonstration of a <fixed-case>POMDP</fixed-case> Voice Dialer</title>
         <author><first>Jason</first><last>Williams</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Demo Session</booktitle>
         <month>June</month>
@@ -3004,7 +3005,7 @@
         <bibkey>versley-EtAl:2008:ACLDemos</bibkey>
    </paper>
    <paper id="4004">
-        <title>Demonstration of the UAM CorpusTool for Text and Image Annotation</title>
+        <title>Demonstration of the <fixed-case>UAM</fixed-case> <fixed-case>CorpusTool</fixed-case> for Text and Image Annotation</title>
         <author><first>Mick</first><last>O’Donnell</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Demo Session</booktitle>
         <month>June</month>
@@ -3017,7 +3018,7 @@
         <bibkey>odonnell:2008:ACLDemos</bibkey>
    </paper>
    <paper id="4005">
-        <title>Interactive ASR Error Correction for Touchscreen Devices</title>
+        <title>Interactive <fixed-case>ASR</fixed-case> Error Correction for Touchscreen Devices</title>
         <author><first>David</first><last>Huggins-Daines</last></author>
         <author><first>Alexander I.</first><last>Rudnicky</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Demo Session</booktitle>
@@ -3031,7 +3032,7 @@
         <bibkey>hugginsdaines-rudnicky:2008:ACLDemos</bibkey>
    </paper>
    <paper id="4006">
-        <title>Yawat: Yet Another Word Alignment Tool</title>
+        <title><fixed-case>Yawat:</fixed-case> <fixed-case>Yet</fixed-case> <fixed-case>Another</fixed-case> <fixed-case>Word</fixed-case> <fixed-case>Alignment</fixed-case> <fixed-case>Tool</fixed-case></title>
         <author><first>Ulrich</first><last>Germann</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Demo Session</booktitle>
         <month>June</month>
@@ -3044,7 +3045,7 @@
         <bibkey>germann:2008:ACLDemos</bibkey>
    </paper>
    <paper id="4007">
-        <title>SIDE: The Summarization Integrated Development Environment</title>
+        <title><fixed-case>SIDE:</fixed-case> The <fixed-case>Summarization</fixed-case> <fixed-case>Integrated</fixed-case> <fixed-case>Development</fixed-case> <fixed-case>Environment</fixed-case></title>
         <author><first>Moonyoung</first><last>Kang</last></author>
         <author><first>Sourish</first><last>Chaudhuri</last></author>
         <author><first>Mahesh</first><last>Joshi</last></author>
@@ -3060,7 +3061,7 @@
         <bibkey>kang-EtAl:2008:ACLDemos</bibkey>
    </paper>
    <paper id="4008">
-        <title>ModelTalker Voice Recorder—An Interface System for Recording a Corpus of Speech for Synthesis</title>
+        <title><fixed-case>ModelTalker</fixed-case> <fixed-case>Voice</fixed-case> <fixed-case>Recorder</fixed-case>—An Interface System for Recording a Corpus of Speech for Synthesis</title>
         <author><first>Debra</first><last>Yarrington</last></author>
         <author><first>John</first><last>Gray</last></author>
         <author><first>Chris</first><last>Pennington</last></author>
@@ -3080,7 +3081,7 @@
         <bibkey>yarrington-EtAl:2008:ACLDemos</bibkey>
    </paper>
    <paper id="4009">
-        <title>The QuALiM Question Answering Demo: Supplementing Answers with Paragraphs drawn from Wikipedia</title>
+        <title>The <fixed-case>QuALiM</fixed-case> Question Answering Demo: Supplementing Answers with Paragraphs drawn from <fixed-case>Wikipedia</fixed-case></title>
         <author><first>Michael</first><last>Kaisser</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Demo Session</booktitle>
         <month>June</month>

--- a/import/P09.xml
+++ b/import/P09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P09">
    <paper id="1000">
         <title>Proceedings of the Joint Conference of the 47th Annual Meeting of the ACL and the 4th International Joint Conference on Natural Language Processing of the AFNLP</title>

--- a/import/P10.xml
+++ b/import/P10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P10">
    <paper id="1000">
         <title>Proceedings of the 48th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P11.xml
+++ b/import/P11.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P11">
   <paper id="1000">
     <title>Proceedings of the 49th Annual Meeting of the Association for Computational Linguistics: Human Language Technologies</title>

--- a/import/P12.xml
+++ b/import/P12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P12">
   <paper id="1000">
     <title>Proceedings of the 50th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)</title>

--- a/import/P13.xml
+++ b/import/P13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P13">
    <paper id="1000">
         <title>Proceedings of the 51st Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)</title>

--- a/import/P14.xml
+++ b/import/P14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P14">
   <paper id="1000">
     <title>

--- a/import/P15.xml
+++ b/import/P15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P15">
   <paper id="1000">
     <title>Proceedings of the 53rd Annual Meeting of the Association for Computational Linguistics and the 7th International Joint Conference on Natural Language Processing (Volume 1: Long Papers)</title>

--- a/import/P16.xml
+++ b/import/P16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P16">
   <paper id="1000">
     <title>

--- a/import/P17.xml
+++ b/import/P17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P17">
   <paper id="1000">
     <title>

--- a/import/P18.xml
+++ b/import/P18.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P18">
    <paper id="1000">
         <title>Proceedings of the 56th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)</title>

--- a/import/P79.xml
+++ b/import/P79.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P79">
  <paper id="1000">
  <title>17th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P80.xml
+++ b/import/P80.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P80">
  <paper id="1000">
  <title>18th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P81.xml
+++ b/import/P81.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P81">
  <paper id="1000">
  <title>19th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P82.xml
+++ b/import/P82.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P82">
  <paper id="1000">
  <title>20th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P83.xml
+++ b/import/P83.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P83">
  <paper id="1000">
  <title>21st Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P84.xml
+++ b/import/P84.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P84">
  <paper id="1000">
  <title>10th International Conference on Computational Linguistics and 22nd Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P85.xml
+++ b/import/P85.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P85">
  <paper id="1000">
  <title>23rd Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P86.xml
+++ b/import/P86.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P86">
  <paper id="1000">
  <title>24th Annual Meeting of the Association for Computational Linguistics </title>

--- a/import/P87.xml
+++ b/import/P87.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P87">
  <paper id="1000">
  <title>25th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P88.xml
+++ b/import/P88.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P88">
  <paper id="1000">
  <title>26th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P89.xml
+++ b/import/P89.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P89">
  <paper id="1000">
  <title>27th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P90.xml
+++ b/import/P90.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P90">
  <paper id="1000">
  <title>28th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P91.xml
+++ b/import/P91.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P91">
  <paper id="1000">
  <title>29th Annual Meeting of the Association for ational Linguistics</title>

--- a/import/P92.xml
+++ b/import/P92.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P92">
  <paper id="1000">
  <title>30th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P93.xml
+++ b/import/P93.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P93">
  <paper id="1000">
  <title>31st Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P94.xml
+++ b/import/P94.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P94">
  <paper id="1000">
  <title>32nd Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P95.xml
+++ b/import/P95.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P95">
  <paper id="1000">
  <title>33rd Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P96.xml
+++ b/import/P96.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P96">
  <paper id="1000">
  <title>34th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P97.xml
+++ b/import/P97.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P97">
 <paper id="1000">
 <title>35th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/P98.xml
+++ b/import/P98.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P98">
  <paper id="1000">
  <title>36th Annual Meeting of the Association for Computational Linguistics and 17th International Conference on Computational Linguistics, Volume 1</title>

--- a/import/P99.xml
+++ b/import/P99.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="P99">
  <paper id="1000">
  <title>Proceedings of the 37th Annual Meeting of the Association for Computational Linguistics</title>

--- a/import/Q15.xml
+++ b/import/Q15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Q15">
   <paper id="1000">
     <title>Transactions of the Association for Computational Linguistics – Volume 3, Issue 1</title>
@@ -76,7 +77,7 @@
     </paper>
 
   <paper id="1007">
-    <title>Gappy Pattern Matching on GPUs for On-Demand Extraction of Hierarchical Translation Grammars</title>
+    <title>Gappy Pattern Matching on <fixed-case>GPUs</fixed-case> for On-Demand Extraction of Hierarchical Translation Grammars</title>
     <author><first>Hua</first><last>He</last></author>
     <author><first>Jimmy</first><last>Lin</last></author>
     <author><first>Adam</first><last>Lopez</last></author>

--- a/import/Q16.xml
+++ b/import/Q16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Q16">
   <paper id="1000">
     <title>Transactions of the Association for Computational Linguistics – Volume 4, Issue 1</title>

--- a/import/Q17.xml
+++ b/import/Q17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Q17">
   <paper id="1000">
     <title>Transactions of the Association for Computational Linguistics – Volume 5, Issue 1</title>

--- a/import/Q18.xml
+++ b/import/Q18.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Q18">
 
   <paper id="1000">

--- a/import/R09.xml
+++ b/import/R09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="R09">
    <paper id="1000">
         <title>Proceedings of the International Conference RANLP-2009</title>

--- a/import/R11.xml
+++ b/import/R11.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="R11">
   <paper id="1000">
     <title>Proceedings of the International Conference Recent Advances in Natural Language Processing 2011</title>

--- a/import/R13.xml
+++ b/import/R13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="R13">
   <paper id="1000">
     <title>Proceedings of the International Conference Recent Advances in Natural Language Processing RANLP 2013</title>

--- a/import/R15.xml
+++ b/import/R15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="R15">
   <paper id="1000">
     <title>Proceedings of the International Conference Recent Advances in Natural Language Processing</title>

--- a/import/R17.xml
+++ b/import/R17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="R17">
   <paper id="1000" href="https://doi.org/10.26615/978-954-452-049-6_">
     <title>Proceedings of the International Conference Recent Advances in Natural Language Processing, RANLP 2017</title>

--- a/import/S01.xml
+++ b/import/S01.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S01">
   <paper id="1000">
     <title>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</title>
@@ -13,7 +14,7 @@
   </paper>
 
   <paper id="1001">
-    <title>SENSEVAL-2: Overview</title>
+    <title><fixed-case>SENSEVAL</fixed-case>-2: Overview</title>
     <author><first>Philip</first><last>Edmonds</last></author>
     <author><first>Scott</first><last>Cotton</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
@@ -28,7 +29,7 @@
   </paper>
 
   <paper id="1002">
-    <title>The Basque Task: Did Systems Perform in the Upperbound?</title>
+    <title>The <fixed-case>B</fixed-case>asque Task: Did Systems Perform in the Upperbound?</title>
     <author><first>Eneko</first><last>Agirre</last></author>
     <author><first>Elena</first><last>Garcia</last></author>
     <author><first>Mikel</first><last>Lersundi</last></author>
@@ -93,7 +94,7 @@
   </paper>
 
   <paper id="1006">
-    <title>Sensiting Inflectionality: Estonian Task for SENSEVAL-2</title>
+    <title>Sensiting Inflectionality: Estonian Task for <fixed-case>SENSEVAL</fixed-case>-2</title>
     <author><first>Neeme</first><last>Kahusk</last></author>
     <author><first>Heili</first><last>Orav</last></author>
     <author><first>Haldur</first><last>Õim</last></author>
@@ -125,7 +126,7 @@
   </paper>
 
   <paper id="1008">
-    <title>SENSEVAL-2 Japanese Dictionary Task</title>
+    <title><fixed-case>SENSEVAL</fixed-case>-2 Japanese Dictionary Task</title>
     <author><first>Kiyoaki</first><last>Shirai</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
     <month>July</month>
@@ -139,7 +140,7 @@
   </paper>
 
   <paper id="1009">
-    <title>SENSEVAL-2 Japanese Translation Task</title>
+    <title><fixed-case>SENSEVAL</fixed-case>-2 Japanese Translation Task</title>
     <author><first>Sadao</first><last>Kurohashi</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
     <month>July</month>
@@ -153,7 +154,7 @@
   </paper>
 
   <paper id="1010">
-    <title>Framework and Results for the Spanish SENSEVAL</title>
+    <title>Framework and Results for the Spanish <fixed-case>SENSEVAL</fixed-case></title>
     <author><first>German</first><last>Rigau</last></author>
     <author><first>Mariona</first><last>Taulé</last></author>
     <author><first>Ana</first><last>Fernandez</last></author>
@@ -170,7 +171,7 @@
   </paper>
 
   <paper id="1011">
-    <title>SENSEVAL-2 The Swedish Framework</title>
+    <title><fixed-case>SENSEVAL</fixed-case>-2 The Swedish Framework</title>
     <author><first>Dimitrios</first><last>Kokkinakis</last></author>
     <author><first>Jerker</first><last>Järborg</last></author>
     <author><first>Yvonne</first><last>Cederholm</last></author>
@@ -186,7 +187,7 @@
   </paper>
 
   <paper id="1012">
-    <title>The SENSEVAL-2 Panel on Domains, Topics and Senses</title>
+    <title>The <fixed-case>SENSEVAL</fixed-case>-2 Panel on Domains, Topics and Senses</title>
     <author><first>Paul</first><last>Buitelaar</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
     <month>July</month>
@@ -248,7 +249,7 @@
   </paper>
 
   <paper id="1016">
-    <title>Improving WSD with Multi-Level View of Context Monitored by Similarity Measure</title>
+    <title>Improving <fixed-case>WSD</fixed-case> with Multi-Level View of Context Monitored by Similarity Measure</title>
     <author><first>Eric</first><last>Crestan</last></author>
     <author><first>Marc</first><last>El-Bèze</last></author>
     <author><first>Claude</first><last>de Loupy</last></author>
@@ -264,7 +265,7 @@
   </paper>
 
   <paper id="1017">
-    <title>Using LazyBoosting for Word Sense Disambiguation</title>
+    <title>Using <fixed-case>L</fixed-case>azy<fixed-case>B</fixed-case>oosting for Word Sense Disambiguation</title>
     <author><first>Gerard</first><last>Escudero</last></author>
     <author><first>Lluís</first><last>Màrquez</last></author>
     <author><first>German</first><last>Rigau</last></author>
@@ -280,7 +281,7 @@
   </paper>
 
   <paper id="1018">
-    <title>The UNED Systems at SENSEVAL-2</title>
+    <title>The <fixed-case>UNED</fixed-case> Systems at <fixed-case>SENSEVAL</fixed-case>-2</title>
     <author><first>David</first><last>Fernández-Amorós</last></author>
     <author><first>Julio</first><last>Gonzalo</last></author>
     <author><first>Felisa</first><last>Verdejo</last></author>
@@ -296,7 +297,7 @@
   </paper>
 
   <paper id="1019">
-    <title>Semantic Tagging Using WordNet Examples</title>
+    <title>Semantic Tagging Using <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Examples</title>
     <author><first>Sherwood</first><last>Haynes</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
     <month>July</month>
@@ -358,7 +359,7 @@
   </paper>
 
   <paper id="1023">
-    <title>ATR-SLT System for SENSEVAL-2 Japanese Translation Task</title>
+    <title><fixed-case>ATR-SLT</fixed-case> System for <fixed-case>SENSEVAL</fixed-case>-2 Japanese Translation Task</title>
     <author><first>Tadashi</first><last>Kumano</last></author>
     <author><first>Hideki</first><last>Kashioka</last></author>
     <author><first>Hideki</first><last>Tanaka</last></author>
@@ -374,7 +375,7 @@
   </paper>
 
   <paper id="1024">
-    <title>Sense and Deduction: The Power of Peewees Applied to the SENSEVAL-2 Swedish Lexical Sample Task</title>
+    <title>Sense and Deduction: The Power of Peewees Applied to the <fixed-case>SENSEVAL</fixed-case>-2 Swedish Lexical Sample Task</title>
     <author><first>Torbjörn</first><last>Lager</last></author>
     <author><first>Natalia</first><last>Zinovjeva</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
@@ -389,7 +390,7 @@
   </paper>
 
   <paper id="1025">
-    <title>Primitive-Based Word Sense Disambiguation for SENSEVAL-2</title>
+    <title>Primitive-Based Word Sense Disambiguation for <fixed-case>SENSEVAL</fixed-case>-2</title>
     <author><first>Lim Beng</first><last>Tat</last></author>
     <author><first>Zaharin</first><last>Yusoff</last></author>
     <author><first>Tang Enya</first><last>Kong</last></author>
@@ -406,7 +407,7 @@
   </paper>
 
   <paper id="1026">
-    <title>Use of Machine Readable Dictionaries for Word-Sense Disambiguation in SENSEVAL-2</title>
+    <title>Use of Machine Readable Dictionaries for Word-Sense Disambiguation in <fixed-case>SENSEVAL</fixed-case>-2</title>
     <author><first>Kenneth C.</first><last>Litkowski</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
     <month>July</month>
@@ -468,7 +469,7 @@
   </paper>
 
   <paper id="1030">
-    <title>Combination of Contextual Features for Word Sense Disambiguation: LIU-WSD</title>
+    <title>Combination of Contextual Features for Word Sense Disambiguation: <fixed-case>LIU-WSD</fixed-case></title>
     <author><first>Magnus</first><last>Merkel</last></author>
     <author><first>Mikael</first><last>Andersson</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
@@ -498,7 +499,7 @@
   </paper>
 
   <paper id="1032">
-    <title>The University of Alicante Word Sense Disambiguation System</title>
+    <title><fixed-case>T</fixed-case>he <fixed-case>U</fixed-case>niversity of <fixed-case>A</fixed-case>licante Word Sense Disambiguation System</title>
     <author><first>Andrés</first><last>Montoyo</last></author>
     <author><first>Armando</first><last>Suárez</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
@@ -531,7 +532,7 @@
   </paper>
 
   <paper id="1034">
-    <title>Machine Learning with Lexical Features: The Duluth Approach to SENSEVAL-2</title>
+    <title>Machine Learning with Lexical Features: <fixed-case>T</fixed-case>he <fixed-case>D</fixed-case>uluth Approach to <fixed-case>SENSEVAL</fixed-case>-2</title>
     <author><first>Ted</first><last>Pedersen</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
     <month>July</month>
@@ -559,7 +560,7 @@
   </paper>
 
   <paper id="1036">
-    <title>KUNLP system using Classification Information Model at SENSEVAL-2</title>
+    <title><fixed-case>KUNLP</fixed-case> system using Classification Information Model at <fixed-case>SENSEVAL</fixed-case>-2</title>
     <author><first>Hee-Cheol</first><last>Seo</last></author>
     <author><first>Sang-Zoo</first><last>Lee</last></author>
     <author><first>Hae-Chang</first><last>Rim</last></author>
@@ -576,7 +577,7 @@
   </paper>
 
   <paper id="1037">
-    <title>WASP-Bench: a Lexicographic Tool Supporting Word Sense Disambiguation</title>
+    <title><fixed-case>WASP</fixed-case>-<fixed-case>B</fixed-case>ench: a Lexicographic Tool Supporting Word Sense Disambiguation</title>
     <author><first>David</first><last>Tugwell</last></author>
     <author><first>Adam</first><last>Kilgarriff</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
@@ -608,7 +609,7 @@
   </paper>
 
   <paper id="1039">
-    <title>Automatic WSD: Does it Make Sense of Estonian?</title>
+    <title>Automatic <fixed-case>WSD</fixed-case>: Does it Make Sense of Estonian?</title>
     <author><first>Kadri</first><last>Vider</last></author>
     <author><first>Kaarel</first><last>Kaljurand</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
@@ -623,7 +624,7 @@
   </paper>
 
   <paper id="1040">
-    <title>The John Hopkins SENSEVAL-2 System Descriptions</title>
+    <title><fixed-case>T</fixed-case>he <fixed-case>J</fixed-case>ohn <fixed-case>H</fixed-case>opkins <fixed-case>SENSEVAL</fixed-case>-2 System Descriptions</title>
     <author><first>David</first><last>Yarowsky</last></author>
     <author><first>Silviu</first><last>Cucerzan</last></author>
     <author><first>Radu</first><last>Florian</last></author>

--- a/import/S01.xml
+++ b/import/S01.xml
@@ -345,7 +345,7 @@
   </paper>
 
   <paper id="1022">
-    <title>The Språkdata-ML System as Used for SENSEVAL-2</title>
+    <title>The <fixed-case>S</fixed-case>pråkdata-<fixed-case>ML</fixed-case> System as Used for <fixed-case>SENSEVAL</fixed-case>-2</title>
     <author><first>Dimitrios</first><last>Kokkinakis</last></author>
     <booktitle>Proceedings of SENSEVAL-2 Second International Workshop on Evaluating Word Sense Disambiguation Systems</booktitle>
     <month>July</month>

--- a/import/S07.xml
+++ b/import/S07.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S07">
    <paper id="1000">
         <title>Proceedings of the Fourth International Workshop on Semantic Evaluations (SemEval-2007)</title>

--- a/import/S10.xml
+++ b/import/S10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S10">
    <paper id="1000">
         <title>Proceedings of the 5th International Workshop on Semantic Evaluation</title>
@@ -1358,7 +1359,7 @@
         <bibkey>izquierdo-suarez-rigau:2010:SemEval</bibkey>
    </paper>
    <paper id="1091">
-        <title>HIT-CIR: An Unsupervised WSD System Based on Domain Most Frequent Sense Estimation</title>
+        <title>HIT-CIR: An Unsupervised <fixed-case>WSD</fixed-case> System Based on Domain Most Frequent Sense Estimation</title>
         <author><first>Yuhang</first><last>Guo</last></author>
         <author><first>Wanxiang</first><last>Che</last></author>
         <author><first>Wei</first><last>He</last></author>

--- a/import/S12.xml
+++ b/import/S12.xml
@@ -1,6 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S12">
   <paper id="1000">
-    <title>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</title>
+    <title><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></title>
     <editor><first>Eneko</first><last>Agirre</last></editor>
     <editor><first>Johan</first><last>Bos</last></editor>
     <editor><first>Mona</first><last>iab</last></editor>
@@ -20,7 +21,7 @@
     <title>Casting Implicit Role Linking as an Anaphora Resolution Task</title>
     <author><first>Carina</first><last>Silberer</last></author>
     <author><first>Anette</first><last>Frank</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -34,7 +35,7 @@
   <paper id="1002">
     <title>Adaptive Clustering for Coreference Resolution with Deterministic Rules and Web-Based Language Models</title>
     <author><first>Razvan</first><last>Bunescu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -50,7 +51,7 @@
     <author><first>Samer</first><last>Hassan</last></author>
     <author><first>Carmen</first><last>Banea</last></author>
     <author><first>Rada</first><last>Mihalcea</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -66,7 +67,7 @@
     <author><first>Bharath</first><last>Dandala</last></author>
     <author><first>Rada</first><last>Mihalcea</last></author>
     <author><first>Razvan</first><last>Bunescu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -83,7 +84,7 @@
     <author><first>Ido</first><last>Dagan</last></author>
     <author><first>Maya</first><last>Gorodetsky</last></author>
     <author><first>Ezra</first><last>Daya</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -98,7 +99,7 @@
     <title>The Use of Granularity in Rhetorical Relation Prediction</title>
     <author><first>Blake</first><last>Howald</last></author>
     <author><first>Martha</first><last>Abramson</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -112,7 +113,7 @@
   <paper id="1007">
     <title>“Could you make me a favour and do coffee, please?”: Implications for Automatic Error Correction in English and Dutch</title>
     <author><first>Sophia</first><last>Katrenko</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -128,7 +129,7 @@
     <author><first>Rao Muhammad Adeel</first><last>Nawab</last></author>
     <author><first>Mark</first><last>Stevenson</last></author>
     <author><first>Paul</first><last>Clough</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -144,7 +145,7 @@
     <author><first>Chaya</first><last>Liebeskind</last></author>
     <author><first>Ido</first><last>Dagan</last></author>
     <author><first>Jonathan</first><last>Schler</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -159,7 +160,7 @@
     <title>Sorting out the Most Confusing English Phrasal Verbs</title>
     <author><first>Yuancheng</first><last>Tu</last></author>
     <author><first>Dan</first><last>Roth</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -176,7 +177,7 @@
     <author><first>Chris</first><last>Dyer</last></author>
     <author><first>Phil</first><last>Blunsom</last></author>
     <author><first>Stephen</first><last>Pulman</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -191,7 +192,7 @@
     <title>Identifying hypernyms in distributional semantic spaces</title>
     <author><first>Alessandro</first><last>Lenci</last></author>
     <author><first>Giulia</first><last>Benotto</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -207,7 +208,7 @@
     <author><first>Bert</first><last>Baumgaertner</last></author>
     <author><first>Raquel</first><last>Fernandez</last></author>
     <author><first>Matthew</first><last>Stone</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -225,7 +226,7 @@
     <author><first>Afsaneh</first><last>Fazly</last></author>
     <author><first>Sven</first><last>Dickinson</last></author>
     <author><first>Suzanne</first><last>Stevenson</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -239,7 +240,7 @@
   <paper id="1015">
     <title>Lexical semantic typologies from bilingual corpora — A framework</title>
     <author><first>Steffen</first><last>Eger</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -253,7 +254,7 @@
   <paper id="1016">
     <title>Non-atomic Classification to Improve a Semantic Role Labeler for a Low-resource Language</title>
     <author><first>Richard</first><last>Johansson</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -268,7 +269,7 @@
     <title>Combining resources for MWE-token classification</title>
     <author><first>Richard</first><last>Fothergill</last></author>
     <author><first>Timothy</first><last>Baldwin</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -284,7 +285,7 @@
     <author><first>Anais</first><last>Cadilhac</last></author>
     <author><first>Nicholas</first><last>Asher</last></author>
     <author><first>Farah</first><last>Benamara</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -300,7 +301,7 @@
     <author><first>Brian</first><last>Murphy</last></author>
     <author><first>Partha</first><last>Talukdar</last></author>
     <author><first>Tom</first><last>Mitchell</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -314,7 +315,7 @@
   <paper id="1020">
     <title>Simple and Phrasal Implicatives</title>
     <author><first>Lauri</first><last>Karttunen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -330,7 +331,7 @@
     <author><first>Karl Moritz</first><last>Hermann</last></author>
     <author><first>Phil</first><last>Blunsom</last></author>
     <author><first>Stephen</first><last>Pulman</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -345,7 +346,7 @@
     <title>Expanding the Range of Tractable Scope-Underspecified Semantic Representations</title>
     <author><first>Mehdi</first><last>Manshadi</last></author>
     <author><first>James</first><last>Allen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -361,7 +362,7 @@
     <author><first>Gemma</first><last>Boleda</last></author>
     <author><first>Sebastian</first><last>Padó</last></author>
     <author><first>Jason</first><last>Utt</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -377,7 +378,7 @@
     <author><first>Selja</first><last>Seppälä</last></author>
     <author><first>Lucie</first><last>Barque</last></author>
     <author><first>Alexis</first><last>Nasr</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -392,7 +393,7 @@
     <title>Modelling selectional preferences in a lexical hierarchy</title>
     <author><first>Diarmuid</first><last>Ó Séaghdha</last></author>
     <author><first>Anna</first><last>Korhonen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -407,7 +408,7 @@
     <title>Unsupervised Induction of a Syntax-Semantics Lexicon Using Iterative Refinement</title>
     <author><first>Hagen</first><last>Fürstenau</last></author>
     <author><first>Owen</first><last>Rambow</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -421,7 +422,7 @@
   <paper id="1027">
     <title>An Evaluation of Graded Sense Disambiguation using Word Sense Induction</title>
     <author><first>David</first><last>Jurgens</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -436,7 +437,7 @@
     <title>Ensemble-based Semantic Lexicon Induction for Semantic Tagging</title>
     <author><first>Ashequl</first><last>Qadir</last></author>
     <author><first>Ellen</first><last>Riloff</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -452,7 +453,7 @@
     <author><first>Dipanjan</first><last>Das</last></author>
     <author><first>André F. T.</first><last>Martins</last></author>
     <author><first>Noah A.</first><last>Smith</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -467,7 +468,7 @@
     <title>Aligning Predicate Argument Structures in Monolingual Comparable Texts: A New Corpus for a New Task</title>
     <author><first>Michael</first><last>Roth</last></author>
     <author><first>Anette</first><last>Frank</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -484,7 +485,7 @@
     <author><first>Rebecca</first><last>Dridan</last></author>
     <author><first>Diana</first><last>McCarthy</last></author>
     <author><first>Timothy</first><last>Baldwin</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -500,7 +501,7 @@
     <author><first>Eyal</first><last>Shnarch</last></author>
     <author><first>Ido</first><last>Dagan</last></author>
     <author><first>Jacob</first><last>Goldberger</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -514,7 +515,7 @@
   <paper id="1033">
     <title>#Emotional Tweets</title>
     <author><first>Saif</first><last>Mohammad</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -530,7 +531,7 @@
     <author><first>Juri</first><last>Ganitkevitch</last></author>
     <author><first>Benjamin</first><last>Van Durme</last></author>
     <author><first>Chris</first><last>Callison-Burch</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -545,7 +546,7 @@
     <title>*SEM 2012 Shared Task: Resolving the Scope and Focus of Negation</title>
     <author><first>Roser</first><last>Morante</last></author>
     <author><first>Eduardo</first><last>Blanco</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -560,7 +561,7 @@
     <title>UABCoRAL: A Preliminary study for Resolving the Scope of Negation</title>
     <author><first>Binod</first><last>Gyawali</last></author>
     <author><first>Thamar</first><last>Solorio</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -577,7 +578,7 @@
     <author><first>Laura</first><last>Plaza</last></author>
     <author><first>Alberto</first><last>Díaz</last></author>
     <author><first>Miguel</first><last>Ballesteros</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -596,7 +597,7 @@
     <author><first>Pablo</first><last>Gervás</last></author>
     <author><first>Jorge</first><last>Carrillo de Albornoz</last></author>
     <author><first>Laura</first><last>Plaza</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -611,7 +612,7 @@
     <title>UConcordia: CLaC Negation Focus Detection at *Sem 2012</title>
     <author><first>Sabine</first><last>Rosenberg</last></author>
     <author><first>Sabine</first><last>Bergler</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -628,7 +629,7 @@
     <author><first>Johan</first><last>Bos</last></author>
     <author><first>Kilian</first><last>Evang</last></author>
     <author><first>Noortje</first><last>Venhuizen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -645,7 +646,7 @@
     <author><first>Erik</first><last>Velldal</last></author>
     <author><first>Lilja</first><last>Øvrelid</last></author>
     <author><first>Stephan</first><last>Oepen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -662,7 +663,7 @@
     <author><first>Erik</first><last>Velldal</last></author>
     <author><first>Lilja</first><last>Øvrelid</last></author>
     <author><first>Jonathon</first><last>Read</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -677,7 +678,7 @@
     <title>UMichigan: A Conditional Random Field Model for Resolving the Scope of Negation</title>
     <author><first>Amjad</first><last>Abu Jbara</last></author>
     <author><first>Dragomir</first><last>Radev</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -691,7 +692,7 @@
   <paper id="1044">
     <title>UWashington: Negation Resolution using Machine Learning Methods</title>
     <author><first>James Paul</first><last>White</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -705,7 +706,7 @@
   <paper id="1045">
     <title>FBK: Exploiting Phrasal and Contextual Clues for Negation Scope Detection</title>
     <author><first>Md. Faisal Mahbub</first><last>Chowdhury</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -721,7 +722,7 @@
     <author><first>Lucia</first><last>Specia</last></author>
     <author><first>Sujay Kumar</first><last>Jauhar</last></author>
     <author><first>Rada</first><last>Mihalcea</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -738,7 +739,7 @@
     <author><first>Saif</first><last>Mohammad</last></author>
     <author><first>Peter</first><last>Turney</last></author>
     <author><first>Keith</first><last>Holyoak</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -754,7 +755,7 @@
     <author><first>parisa</first><last>kordjamshidi</last></author>
     <author><first>steven</first><last>bethard</last></author>
     <author><first>Marie-Francine</first><last>Moens</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -769,7 +770,7 @@
     <title>SemEval-2012 Task 4: Evaluating Chinese Word Similarity</title>
     <author><first>Peng</first><last>Jin</last></author>
     <author><first>Yunfang</first><last>Wu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -786,7 +787,7 @@
     <author><first>Meishan</first><last>Zhang</last></author>
     <author><first>Yanqiu</first><last>Shao</last></author>
     <author><first>Ting</first><last>Liu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -803,7 +804,7 @@
     <author><first>Daniel</first><last>Cer</last></author>
     <author><first>Mona</first><last>Diab</last></author>
     <author><first>Aitor</first><last>Gonzalez-Agirre</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -819,7 +820,7 @@
     <author><first>Andrew</first><last>Gordon</last></author>
     <author><first>Zornitsa</first><last>Kozareva</last></author>
     <author><first>Melissa</first><last>Roemmele</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -837,7 +838,7 @@
     <author><first>Yashar</first><last>Mehdad</last></author>
     <author><first>Luisa</first><last>Bentivogli</last></author>
     <author><first>Danilo</first><last>Giampiccolo</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -854,7 +855,7 @@
     <author><first>Héctor</first><last>Martínez</last></author>
     <author><first>Sigrid</first><last>Klerke</last></author>
     <author><first>Anders</first><last>Søgaard</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -869,7 +870,7 @@
     <title>UTD: Determining Relational Similarity Using Lexical Patterns</title>
     <author><first>Bryan</first><last>Rink</last></author>
     <author><first>Sanda</first><last>Harabagiu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -884,7 +885,7 @@
     <title>UTD-SpRL: A Joint Approach to Spatial Role Labeling</title>
     <author><first>Kirk</first><last>Roberts</last></author>
     <author><first>Sanda</first><last>Harabagiu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -901,7 +902,7 @@
     <author><first>Bin</first><last>Li</last></author>
     <author><first>Xinyu</first><last>Dai</last></author>
     <author><first>Jiajun</first><last>Chen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -917,7 +918,7 @@
     <author><first>Zhijun</first><last>Wu</last></author>
     <author><first>Xuan</first><last>Wang</last></author>
     <author><first>Xinxin</first><last>Li</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -934,7 +935,7 @@
     <author><first>Chris</first><last>Biemann</last></author>
     <author><first>Iryna</first><last>Gurevych</last></author>
     <author><first>Torsten</first><last>Zesch</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -952,7 +953,7 @@
     <author><first>Mladen</first><last>Karan</last></author>
     <author><first>Jan</first><last>Šnajder</last></author>
     <author><first>Bojana</first><last>Dalbelo Bašić</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -968,7 +969,7 @@
     <author><first>Sergio</first><last>Jimenez</last></author>
     <author><first>Claudia</first><last>Becerra</last></author>
     <author><first>Alexander</first><last>Gelbukh</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -985,7 +986,7 @@
     <author><first>Jesus</first><last>Gimenez</last></author>
     <author><first>Julio</first><last>Gonzalo</last></author>
     <author><first>Felisa</first><last>Verdejo</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1002,7 +1003,7 @@
     <author><first>Bryan</first><last>Rink</last></author>
     <author><first>Kirk</first><last>Roberts</last></author>
     <author><first>Sanda</first><last>Harabagiu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1017,7 +1018,7 @@
     <title>HDU: Cross-lingual Textual Entailment with SMT Features</title>
     <author><first>Katharina</first><last>Wäschle</last></author>
     <author><first>Sascha</first><last>Fendrich</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1033,7 +1034,7 @@
     <author><first>Miquel</first><last>Esplà-Gomis</last></author>
     <author><first>Felipe</first><last>Sánchez-Martínez</last></author>
     <author><first>Mikel L.</first><last>Forcada</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1048,7 +1049,7 @@
     <title>UOW-SHEF: SimpLex – Lexical Simplicity Ranking based on Contextual and Psycholinguistic Features</title>
     <author><first>Sujay Kumar</first><last>Jauhar</last></author>
     <author><first>Lucia</first><last>Specia</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1063,7 +1064,7 @@
     <title>SB: mmSystem - Using Decompositional Semantics for Lexical Simplification</title>
     <author><first>Marilisa</first><last>Amoia</last></author>
     <author><first>Massimo</first><last>Romanelli</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1080,7 +1081,7 @@
     <author><first>Cyril</first><last>Grouin</last></author>
     <author><first>Anne</first><last>Garcia-Fernandez</last></author>
     <author><first>Delphine</first><last>Bernhard</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1094,7 +1095,7 @@
   <paper id="1069">
     <title>UNT-SimpRank: Systems for Lexical Simplification Ranking</title>
     <author><first>Ravi</first><last>Sinha</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1108,7 +1109,7 @@
   <paper id="1070">
     <title>Duluth : Measuring Degrees of Relational Similarity with the Gloss Vector Measure of Semantic Relatedness</title>
     <author><first>Ted</first><last>Pedersen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1127,7 +1128,7 @@
     <author><first>Darnes</first><last>Vilariño</last></author>
     <author><first>David</first><last>Pinto</last></author>
     <author><first>Saul</first><last>León</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1145,7 +1146,7 @@
     <author><first>liu</first><last>fei</last></author>
     <author><first>cai</first><last>dongfeng</last></author>
     <author><first>zhang</first><last>guiping</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1160,7 +1161,7 @@
     <title>ICT:A System Combination for Chinese Semantic Dependency Parsing</title>
     <author><first>Hao</first><last>Xiong</last></author>
     <author><first>Qun</first><last>Liu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1178,7 +1179,7 @@
     <author><first>Shuaishuai</first><last>Xu</last></author>
     <author><first>Xinyu</first><last>Dai</last></author>
     <author><first>Jiajun</first><last>Chen</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1194,7 +1195,7 @@
     <author><first>Jian</first><last>Xu</last></author>
     <author><first>Qin</first><last>Lu</last></author>
     <author><first>Zhengzhong</first><last>Liu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1209,7 +1210,7 @@
     <title>ETS: Discriminative Edit Models for Paraphrase Scoring</title>
     <author><first>Michael</first><last>Heilman</last></author>
     <author><first>Nitin</first><last>Madnani</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1224,7 +1225,7 @@
     <title>Sbdlrhmn: A Rule-based Human Interpretation System for Semantic Textual Similarity Task</title>
     <author><first>Samir</first><last>AbdelRahman</last></author>
     <author><first>Catherine</first><last>Blake</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1238,7 +1239,7 @@
   <paper id="1078">
     <title>LIMSI: Learning Semantic Similarity by Selecting Random Word Subsets</title>
     <author><first>Artem</first><last>Sokolov</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1252,7 +1253,7 @@
   <paper id="1079">
     <title>ATA-Sem: Chunk-based Determination of Semantic Text Similarity</title>
     <author><first>Demetrios</first><last>Glinos</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1269,7 +1270,7 @@
     <author><first>Ronan</first><last>Tournier</last></author>
     <author><first>Nathalie</first><last>Aussenac-Gilles</last></author>
     <author><first>Josiane</first><last>Mothe</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1285,7 +1286,7 @@
     <author><first>Diana</first><last>McCarthy</last></author>
     <author><first>Spandana</first><last>Gella</last></author>
     <author><first>Siva</first><last>Reddy</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1302,7 +1303,7 @@
     <author><first>NIkos</first><last>Malandrakis</last></author>
     <author><first>Elias</first><last>Iosif</last></author>
     <author><first>Alexandros</first><last>Potamianos</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1319,7 +1320,7 @@
     <author><first>Partha</first><last>Pakray</last></author>
     <author><first>Sivaji</first><last>Bandyopadhyay</last></author>
     <author><first>Alexander</first><last>Gelbukh</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1334,7 +1335,7 @@
     <title>Tiantianzhu7:System Description of Semantic Textual Similarity (STS) in the SemEval-2012 (Task 6)</title>
     <author><first>Zhu</first><last>Tiantian</last></author>
     <author><first>Lan</first><last>Man</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1350,7 +1351,7 @@
     <author><first>Sumit</first><last>Bhagwani</last></author>
     <author><first>Shrutiranjan</first><last>Satapathy</last></author>
     <author><first>Harish</first><last>Karnick</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1365,7 +1366,7 @@
     <title>Weiwei: A Simple Unsupervised Latent Semantics based Approach for Sentence Similarity</title>
     <author><first>Weiwei</first><last>Guo</last></author>
     <author><first>Mona</first><last>Diab</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1381,7 +1382,7 @@
     <author><first>Annalina</first><last>Caputo</last></author>
     <author><first>Pierpaolo</first><last>Basile</last></author>
     <author><first>Giovanni</first><last>Semeraro</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1398,7 +1399,7 @@
     <author><first>Paolo</first><last>Annesi</last></author>
     <author><first>Valerio</first><last>Storch</last></author>
     <author><first>Roberto</first><last>Basili</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1413,7 +1414,7 @@
     <title>Saarland: Vector-based models of semantic textual similarity</title>
     <author><first>Georgiana</first><last>Dinu</last></author>
     <author><first>Stefan</first><last>Thater</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1436,7 +1437,7 @@
     <author><first>Sonia</first><last>Vázquez</last></author>
     <author><first>Andrés</first><last>Montoyo</last></author>
     <author><first>Rafael</first><last>Muñoz</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1451,7 +1452,7 @@
     <title>SRIUBC: Simple Similarity Features for Semantic Textual Similarity</title>
     <author><first>Eric</first><last>Yeh</last></author>
     <author><first>Eneko</first><last>Agirre</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1467,7 +1468,7 @@
     <author><first>José Guilherme</first><last>Camargo de Souza</last></author>
     <author><first>Matteo</first><last>Negri</last></author>
     <author><first>Yashar</first><last>Mehdad</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1486,7 +1487,7 @@
     <author><first>Mireya</first><last>Tovar</last></author>
     <author><first>Saul</first><last>León</last></author>
     <author><first>Esteban</first><last>Castillo</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1503,7 +1504,7 @@
     <author><first>Samer</first><last>Hassan</last></author>
     <author><first>Michael</first><last>Mohler</last></author>
     <author><first>Rada</first><last>Mihalcea</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1519,7 +1520,7 @@
     <author><first>Nitish</first><last>Aggarwal</last></author>
     <author><first>Kartik</first><last>Asooja</last></author>
     <author><first>Paul</first><last>Buitelaar</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1534,7 +1535,7 @@
     <title>Stanford: Probabilistic Edit Distance Metrics for STS</title>
     <author><first>Mengqiu</first><last>Wang</last></author>
     <author><first>Daniel</first><last>Cer</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1553,7 +1554,7 @@
     <author><first>Luke</first><last>Stringer</last></author>
     <author><first>Mark</first><last>Stevenson</last></author>
     <author><first>Judita</first><last>Preiss</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1569,7 +1570,7 @@
     <author><first>Janardhan</first><last>Singh</last></author>
     <author><first>Arindam</first><last>Bhattacharya</last></author>
     <author><first>Pushpak</first><last>Bhattacharyya</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1584,7 +1585,7 @@
     <title>SAGAN: An approach to Semantic Textual Similarity based on Textual Entailment</title>
     <author><first>Julio</first><last>Castillo</last></author>
     <author><first>Paula</first><last>Estrella</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1600,7 +1601,7 @@
     <author><first>Miguel</first><last>Rios</last></author>
     <author><first>Wilker</first><last>Aziz</last></author>
     <author><first>Lucia</first><last>Specia</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1616,7 +1617,7 @@
     <author><first>Sneha</first><last>Jha</last></author>
     <author><first>Hansen</first><last>A. Schwartz</last></author>
     <author><first>Lyle</first><last>Ungar</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1632,7 +1633,7 @@
     <author><first>Sergio</first><last>Jimenez</last></author>
     <author><first>Claudia</first><last>Becerra</last></author>
     <author><first>Alexander</first><last>Gelbukh</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1649,7 +1650,7 @@
     <author><first>Partha</first><last>Pakray</last></author>
     <author><first>Sivaji</first><last>Bandyopadhyay</last></author>
     <author><first>Alexander</first><last>Gelbukh</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1666,7 +1667,7 @@
     <author><first>Luca</first><last>Dini</last></author>
     <author><first>Alessio</first><last>Bosca</last></author>
     <author><first>Marco</first><last>Trevisan</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1682,7 +1683,7 @@
     <author><first>Yashar</first><last>Mehdad</last></author>
     <author><first>Matteo</first><last>Negri</last></author>
     <author><first>Jose Guilherme</first><last>C. de Souza</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1700,7 +1701,7 @@
     <author><first>Mireya</first><last>Tovar</last></author>
     <author><first>Saul</first><last>León</last></author>
     <author><first>Esteban</first><last>Castillo</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1714,7 +1715,7 @@
   <paper id="1107">
     <title>DirRelCond3: Detecting Textual Entailment Across Languages With Conditions On Directional Text Relatedness Scores</title>
     <author><first>Alpar</first><last>Perini</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1730,7 +1731,7 @@
     <author><first>Fandong</first><last>Meng</last></author>
     <author><first>Hao</first><last>Xiong</last></author>
     <author><first>Qun</first><last>Liu</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -1745,7 +1746,7 @@
     <title>SAGAN: A Machine Translation Approach for Cross-Lingual Textual Entailment</title>
     <author><first>Julio</first><last>Castillo</last></author>
     <author><first>Marina</first><last>Cardenas</last></author>
-    <booktitle>*SEM 2012: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation (SemEval 2012)</booktitle>
+    <booktitle><fixed-case>*SEM 2012</fixed-case>: The First Joint Conference on Lexical and Computational Semantics – Volume 1: Proceedings of the main conference and the shared task, and Volume 2: Proceedings of the Sixth International Workshop on Semantic Evaluation <fixed-case>(SemEval 2012)</fixed-case></booktitle>
     <month>7-8 June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>

--- a/import/S13.xml
+++ b/import/S13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S13">
   <paper id="1000">
     <title>Second Joint Conference on Lexical and Computational Semantics (*SEM), Volume 1: Proceedings of the Main Conference and the Shared Task: Semantic Textual Similarity</title>

--- a/import/S14.xml
+++ b/import/S14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S14">
   <paper id="1000">
     <title>

--- a/import/S15.xml
+++ b/import/S15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S15">
   <paper id="1000">
     <title>

--- a/import/S16.xml
+++ b/import/S16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S16">
   <paper id="1000">
     <title>

--- a/import/S17.xml
+++ b/import/S17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S17">
   <paper id="1000">
     <title>

--- a/import/S18.xml
+++ b/import/S18.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S18">
   <paper id="1000">
     <title>Proceedings of The 12th International Workshop on Semantic Evaluation</title>

--- a/import/S98.xml
+++ b/import/S98.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="S98">
   <paper id="1000">
     <title>Proceedings of the Pilot SENSEVAL</title>

--- a/import/U03.xml
+++ b/import/U03.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U03">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Workshop 2003</title>

--- a/import/U04.xml
+++ b/import/U04.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U04">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Workshop 2004</title>

--- a/import/U05.xml
+++ b/import/U05.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U05">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Workshop 2005</title>

--- a/import/U06.xml
+++ b/import/U06.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U06">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Workshop 2006</title>

--- a/import/U07.xml
+++ b/import/U07.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U07">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Workshop 2007</title>

--- a/import/U08.xml
+++ b/import/U08.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U08">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Association Workshop 2008</title>

--- a/import/U09.xml
+++ b/import/U09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U09">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Association Workshop 2009</title>

--- a/import/U10.xml
+++ b/import/U10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U10">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Association Workshop 2010</title>

--- a/import/U11.xml
+++ b/import/U11.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U11">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Association Workshop 2011</title>

--- a/import/U12.xml
+++ b/import/U12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U12">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Association Workshop 2012</title>

--- a/import/U13.xml
+++ b/import/U13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U13">
    <paper id="1000">
         <title>Proceedings of the Australasian Language Technology Association Workshop 2013 (ALTA 2013)</title>

--- a/import/U14.xml
+++ b/import/U14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U14">
   <paper id="1000">
     <title>Proceedings of the Australasian Language Technology Association Workshop 2014</title>

--- a/import/U15.xml
+++ b/import/U15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U15">
   <paper id="1000">
     <title>Proceedings of the Australasian Language Technology Association Workshop 2015</title>

--- a/import/U16.xml
+++ b/import/U16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U16">
   <paper id="1000">
     <title>Proceedings of the Australasian Language Technology Association Workshop 2016</title>

--- a/import/U17.xml
+++ b/import/U17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="U17">
   <paper id="1000">
     <title>Proceedings of the Australasian Language Technology Association Workshop 2017</title>

--- a/import/W00.xml
+++ b/import/W00.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W00">
  <paper id="0100">
  <title>NAACL-ANLP 2000 Workshop: Syntactic and Semantic Complexity in Natural Language Processing Systems</title>
@@ -1545,7 +1546,7 @@
   </paper>
 
   <paper id="1501">
-    <title>Experience using GATE for NLP R&amp;D</title>
+    <title>Experience using <fixed-case>GATE</fixed-case> for <fixed-case>NLP</fixed-case> <fixed-case>R&amp;D</fixed-case></title>
     <author><first>Hamish</first><last>Cunningham</last></author>
     <author><first>Diana</first><last>Maynard</last></author>
     <author><first>Kalina</first><last>Bontcheva</last></author>
@@ -1625,7 +1626,7 @@
   </paper>
 
   <paper id="1506">
-    <title>The XML Framework and Its Implications for the Development of Natural Language Processing Tools</title>
+    <title>The <fixed-case>XML</fixed-case> Framework and Its Implications for the Development of Natural Language Processing Tools</title>
     <author><first>Nancy</first><last>Ide</last></author>
     <booktitle>Proceedings of the COLING-2000 Workshop on Using Toolsets and Architectures To Build NLP Systems</booktitle>
     <month>August</month>
@@ -1725,7 +1726,7 @@
   </paper>
 
   <paper id="1602">
-    <title>Precompilation of HPSG in ALE into a CFG for Fast Parsing</title>
+    <title>Precompilation of <fixed-case>HPSG</fixed-case> in <fixed-case>ALE</fixed-case> into a <fixed-case>CFG</fixed-case> for Fast Parsing</title>
     <author><first>John C.</first><last>Brown</last></author>
     <author><first>Suresh</first><last>Manandhar</last></author>
     <booktitle>Proceedings of the COLING-2000 Workshop on Efficiency In Large-Scale Parsing Systems</booktitle>
@@ -1953,7 +1954,7 @@
   </paper>
 
   <paper id="1708">
-    <title>Alignment of Sound Track with Text in a TV Drama</title>
+    <title>Alignment of Sound Track with Text in a <fixed-case>TV</fixed-case> Drama</title>
     <author><first>Seigo</first><last>Tanimura</last></author>
     <author><first>Hiroshi</first><last>Nakagawa</last></author>
     <booktitle>Proceedings of the COLING-2000 Workshop on Semantic Annotation and Intelligent Content</booktitle>
@@ -1968,7 +1969,7 @@
   </paper>
 
   <paper id="1709">
-    <title>Semantic Transcoding: Making the WWW More Understandable and Usable with External Annotations</title>
+    <title>Semantic Transcoding: Making the <fixed-case>WWW</fixed-case> More Understandable and Usable with External Annotations</title>
     <author><first>Katashi</first><last>Nagao</last></author>
     <author><first>Shingo</first><last>Hosoya</last></author>
     <author><first>Yoshinari</first><last>Shirai</last></author>
@@ -2045,7 +2046,7 @@
   </paper>
 
   <paper id="1803">
-    <title>Easy and Hard Constraint Ranking in OT: Algorithms and Complexity</title>
+    <title>Easy and Hard Constraint Ranking in <fixed-case>OT</fixed-case>: Algorithms and Complexity</title>
     <author><first>Jason</first><last>Eisner</last></author>
     <booktitle>Proceedings of the Fifth Workshop of the ACL Special Interest Group in Computational Phonology</booktitle>
     <month>August</month>

--- a/import/W01.xml
+++ b/import/W01.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W01">
 
 <paper id="0100">

--- a/import/W02.xml
+++ b/import/W02.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W02">
 
 <paper id="0100">

--- a/import/W04.xml
+++ b/import/W04.xml
@@ -2365,7 +2365,7 @@
 	</paper>
 
 	<paper id="2112">
-		<title>R<fixed-case>j</fixed-case>ecnik.com : English - Serbo-Croatian Electronic Dictionary</title>
+		<title>R{j}ecnik.com : English - Serbo-Croatian Electronic Dictionary</title>
 		<author><first>Vlado</first><last>Kešelj</last></author>
 		<author><first>Tanja</first><last>Kešelj</last></author>
 		<author><first>Larisa</first><last>Zlatić</last></author>

--- a/import/W04.xml
+++ b/import/W04.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W04">
 
 	<paper id="0100">
@@ -2364,7 +2365,7 @@
 	</paper>
 
 	<paper id="2112">
-		<title>Rjecnik.com : English - Serbo-Croatian Electronic Dictionary</title>
+		<title>R<fixed-case>j</fixed-case>ecnik.com : English - Serbo-Croatian Electronic Dictionary</title>
 		<author><first>Vlado</first><last>Kešelj</last></author>
 		<author><first>Tanja</first><last>Kešelj</last></author>
 		<author><first>Larisa</first><last>Zlatić</last></author>

--- a/import/W05.xml
+++ b/import/W05.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W05">
    <paper id="0100">
         <title>Proceedings of the Second ACL Workshop on Effective Tools and Methodologies for Teaching NLP and CL</title>
@@ -39,7 +40,7 @@
         <bibkey>cassell-stone:2005:TNLP</bibkey>
    </paper>
    <paper id="0103">
-        <title>“Language and Computers”: Creating an Introduction for a General Undergraduate Audience</title>
+        <title>“Language and <fixed-case>C</fixed-case>omputers”: Creating an Introduction for a General Undergraduate Audience</title>
         <author><first>Chris</first><last>Brew</last></author>
         <author><first>Markus</first><last>Dickinson</last></author>
         <author><first>W. Detmar</first><last>Meurers</last></author>
@@ -54,7 +55,7 @@
         <bibkey>brew-dickinson-meurers:2005:TNLP</bibkey>
    </paper>
    <paper id="0104">
-        <title>A Core-Tools Statistical NLP Course</title>
+        <title>A Core-Tools Statistical <fixed-case>NLP</fixed-case> Course</title>
         <author><first>Dan</first><last>Klein</last></author>
         <booktitle>Proceedings of the Second ACL Workshop on Effective Tools and Methodologies for Teaching NLP and CL</booktitle>
         <month>June</month>
@@ -82,7 +83,7 @@
         <bibkey>light-arens-lu:2005:TNLP</bibkey>
    </paper>
    <paper id="0106">
-        <title>Making Hidden Markov Models More Transparent</title>
+        <title>Making Hidden <fixed-case>M</fixed-case>arkov Models More Transparent</title>
         <author><first>Nashira</first><last>Lincoln</last></author>
         <author><first>Marc</first><last>Light</last></author>
         <booktitle>Proceedings of the Second ACL Workshop on Effective Tools and Methodologies for Teaching NLP and CL</booktitle>
@@ -96,7 +97,7 @@
         <bibkey>lincoln-light:2005:TNLP</bibkey>
    </paper>
    <paper id="0107">
-        <title>Concrete Assignments for Teaching NLP in an M.S. Program</title>
+        <title>Concrete Assignments for Teaching <fixed-case>NLP</fixed-case> in an <fixed-case>M.S.</fixed-case> Program</title>
         <author><first>Reva</first><last>Freedman</last></author>
         <booktitle>Proceedings of the Second ACL Workshop on Effective Tools and Methodologies for Teaching NLP and CL</booktitle>
         <month>June</month>
@@ -109,7 +110,7 @@
         <bibkey>freedman:2005:TNLP</bibkey>
    </paper>
    <paper id="0108">
-        <title>Language Technology from a European Perspective</title>
+        <title>Language Technology from a <fixed-case>E</fixed-case>uropean Perspective</title>
         <author><first>Hans</first><last>Uszkoreit</last></author>
         <author><first>Valia</first><last>Kordoni</last></author>
         <author><first>Vladislav</first><last>Kubon</last></author>
@@ -126,7 +127,7 @@
         <bibkey>uszkoreit-EtAl:2005:TNLP</bibkey>
    </paper>
    <paper id="0109">
-        <title>Natural Language Processing at the School of Information Studies for Africa</title>
+        <title>Natural Language Processing at the <fixed-case>S</fixed-case>chool of <fixed-case>I</fixed-case>nformation <fixed-case>S</fixed-case>tudies for <fixed-case>A</fixed-case>frica</title>
         <author><first>Björn</first><last>Gambäck</last></author>
         <author><first>Gunnar</first><last>Eriksson</last></author>
         <author><first>Athanassia</first><last>Fourla</last></author>
@@ -141,7 +142,7 @@
         <bibkey>gamback-eriksson-fourla:2005:TNLP</bibkey>
    </paper>
    <paper id="0110">
-        <title>Teaching Language Technology at the North-West University</title>
+        <title>Teaching Language Technology at the <fixed-case>N</fixed-case>orth-<fixed-case>W</fixed-case>est <fixed-case>U</fixed-case>niversity</title>
         <author><first>Suléne</first><last>Pilon</last></author>
         <author><first>Gerhard B</first><last>Van Huyssteen</last></author>
         <author><first>Bertus</first><last>Van Rooy</last></author>
@@ -156,7 +157,7 @@
         <bibkey>pilon-vanhuyssteen-vanrooy:2005:TNLP</bibkey>
    </paper>
    <paper id="0111">
-        <title>Hands-On NLP for an Interdisciplinary Audience</title>
+        <title>Hands-On <fixed-case>NLP</fixed-case> for an Interdisciplinary Audience</title>
         <author><first>Elizabeth</first><last>Liddy</last></author>
         <author><first>Nancy</first><last>McCracken</last></author>
         <booktitle>Proceedings of the Second ACL Workshop on Effective Tools and Methodologies for Teaching NLP and CL</booktitle>
@@ -303,7 +304,7 @@
         <bibkey>gweon-EtAl:2005:EduApp</bibkey>
    </paper>
    <paper id="0209">
-        <title>Direkt Profil: A System for Evaluating Texts of Second Language Learners of French Based on Developmental Sequences</title>
+        <title><fixed-case>D</fixed-case>irekt <fixed-case>P</fixed-case>rofil: A System for Evaluating Texts of Second Language Learners of <fixed-case>F</fixed-case>rench Based on Developmental Sequences</title>
         <author><first>Jonas</first><last>Granfeldt</last></author>
         <author><first>Pierre</first><last>Nugues</last></author>
         <author><first>Emil</first><last>Persson</last></author>
@@ -322,7 +323,7 @@
         <bibkey>granfeldt-EtAl:2005:EduApp</bibkey>
    </paper>
    <paper id="0210">
-        <title>Measuring Non-native Speakers’ Proficiency of English by Using a Test with Automatically-Generated Fill-in-the-Blank Questions</title>
+        <title>Measuring Non-native Speakers’ Proficiency of <fixed-case>E</fixed-case>nglish by Using a Test with Automatically-Generated Fill-in-the-Blank Questions</title>
         <author><first>Eiichiro</first><last>Sumita</last></author>
         <author><first>Fumiaki</first><last>Sugaya</last></author>
         <author><first>Seiichi</first><last>Yamamoto</last></author>
@@ -337,7 +338,7 @@
         <bibkey>sumita-sugaya-yamamoto:2005:EduApp</bibkey>
    </paper>
    <paper id="0211">
-        <title>Evaluating State-of-the-Art Treebank-style Parsers for Coh-Metrix and Other Learning Technology Environments</title>
+        <title>Evaluating State-of-the-Art <fixed-case>T</fixed-case>reebank-style Parsers for <fixed-case>Coh-Metrix</fixed-case> and Other Learning Technology Environments</title>
         <author><first>Christian F.</first><last>Hempelmann</last></author>
         <author><first>Vasile</first><last>Rus</last></author>
         <author><first>Arthur C.</first><last>Graesser</last></author>
@@ -395,7 +396,7 @@
         <bibkey>CorpAnn:2005</bibkey>
    </paper>
    <paper id="0301">
-        <title>Introduction to Frontiers in Corpus Annotation II: Pie in the Sky</title>
+        <title>Introduction to <fixed-case>F</fixed-case>rontiers in <fixed-case>C</fixed-case>orpus <fixed-case>A</fixed-case>nnotation <fixed-case>II</fixed-case>: <fixed-case>P</fixed-case>ie in the <fixed-case>S</fixed-case>ky</title>
         <author><first>Adam</first><last>Meyers</last></author>
         <booktitle>Proceedings of the Workshop on Frontiers in Corpus Annotations II: Pie in the Sky</booktitle>
         <month>June</month>
@@ -408,7 +409,7 @@
         <bibkey>meyers:2005:CorpAnn</bibkey>
    </paper>
    <paper id="0302">
-        <title>Merging PropBank, NomBank, TimeBank, Penn Discourse Treebank and Coreference</title>
+        <title>Merging <fixed-case>PropBank</fixed-case>, <fixed-case>NomBank</fixed-case>, <fixed-case>TimeBank</fixed-case>, <fixed-case>Penn</fixed-case> <fixed-case>Discourse</fixed-case> <fixed-case>Treebank</fixed-case> and Coreference</title>
         <author><first>James</first><last>Pustejovsky</last></author>
         <author><first>Adam</first><last>Meyers</last></author>
         <author><first>Martha</first><last>Palmer</last></author>
@@ -472,7 +473,7 @@
         <bibkey>dinesh-EtAl:2005:CorpAnn</bibkey>
    </paper>
    <paper id="0306">
-        <title>Investigating the Characteristics of Causal Relations in Japanese Text</title>
+        <title>Investigating the Characteristics of Causal Relations in <fixed-case>J</fixed-case>apanese Text</title>
         <author><first>Takashi</first><last>Inui</last></author>
         <author><first>Manabu</first><last>Okumura</last></author>
         <booktitle>Proceedings of the Workshop on Frontiers in Corpus Annotations II: Pie in the Sky</booktitle>
@@ -516,7 +517,7 @@
         <bibkey>wilson-wiebe:2005:CorpAnn</bibkey>
    </paper>
    <paper id="0309">
-        <title>A Parallel Proposition Bank II for Chinese and English</title>
+        <title>A Parallel <fixed-case>P</fixed-case>roposition <fixed-case>B</fixed-case>ank <fixed-case>II</fixed-case> for <fixed-case>C</fixed-case>hinese and <fixed-case>E</fixed-case>nglish</title>
         <author><first>Martha</first><last>Palmer</last></author>
         <author><first>Nianwen</first><last>Xue</last></author>
         <author><first>Olga</first><last>Babko-Malaya</last></author>
@@ -563,7 +564,7 @@
         <bibkey>poesio-artstein:2005:CorpAnn</bibkey>
    </paper>
    <paper id="0312">
-        <title>Annotating Discourse Connectives in the Chinese Treebank</title>
+        <title>Annotating Discourse Connectives in the <fixed-case>C</fixed-case>hinese Treebank</title>
         <author><first>Nianwen</first><last>Xue</last></author>
         <booktitle>Proceedings of the Workshop on Frontiers in Corpus Annotations II: Pie in the Sky</booktitle>
         <month>June</month>
@@ -775,7 +776,7 @@
         <bibkey>hu-EtAl:2005:Psychocomp1</bibkey>
    </paper>
    <paper id="0504">
-        <title>Refining the SED Heuristic for Morpheme Discovery: Another Look at Swahili</title>
+        <title>Refining the <fixed-case>SED</fixed-case> Heuristic for Morpheme Discovery: Another Look at <fixed-case>S</fixed-case>wahili</title>
         <author><first>Yu</first><last>Hu</last></author>
         <author><first>Irina</first><last>Matveeva</last></author>
         <author><first>John</first><last>Goldsmith</last></author>
@@ -833,7 +834,7 @@
         <bibkey>macwhinney:2005:Psychocomp</bibkey>
    </paper>
    <paper id="0508">
-        <title>Statistics vs. UG in Language Acquisition: Does a Bigram Analysis Predict Auxiliary Inversion?</title>
+        <title>Statistics vs. <fixed-case>UG</fixed-case> in Language Acquisition: Does a Bigram Analysis Predict Auxiliary Inversion?</title>
         <author><first>Xuân-Nga Cao</first><last>Kam</last></author>
         <author><first>Iglika</first><last>Stoyneshka</last></author>
         <author><first>Lidiya</first><last>Tornyova</last></author>
@@ -866,7 +867,7 @@
         <bibkey>dellorletta-EtAl:2005:Psychocomp</bibkey>
    </paper>
    <paper id="0510">
-        <title>The Acquisition and Use of Argument Structure Constructions: A Bayesian Model</title>
+        <title>The Acquisition and Use of Argument Structure Constructions: A <fixed-case>B</fixed-case>ayesian Model</title>
         <author><first>Afra</first><last>Alishahi</last></author>
         <author><first>Suzanne</first><last>Stevenson</last></author>
         <booktitle>Proceedings of the Workshop on Psychocomputational Models of Human Language Acquisition</booktitle>
@@ -905,7 +906,7 @@
         <bibkey>CoNLL:2005</bibkey>
    </paper>
    <paper id="0601">
-        <title>Effective use of WordNet Semantics via Kernel-Based Learning</title>
+        <title>Effective use of <fixed-case>WordNet</fixed-case> Semantics via Kernel-Based Learning</title>
         <author><first>Roberto</first><last>Basili</last></author>
         <author><first>Marco</first><last>Cammisa</last></author>
         <author><first>Alessandro</first><last>Moschitti</last></author>
@@ -983,7 +984,7 @@
         <bibkey>niu-EtAl:2005:CoNLL</bibkey>
    </paper>
    <paper id="0606">
-        <title>Computing Word Similarity and Identifying Cognates with Pair Hidden Markov Models</title>
+        <title>Computing Word Similarity and Identifying Cognates with Pair Hidden <fixed-case>M</fixed-case>arkov Models</title>
         <author><first>Wesley</first><last>Mackay</last></author>
         <author><first>Grzegorz</first><last>Kondrak</last></author>
         <booktitle>Proceedings of the Ninth Conference on Computational Natural Language Learning (CoNLL-2005)</booktitle>
@@ -997,7 +998,7 @@
         <bibkey>mackay-kondrak:2005:CoNLL</bibkey>
    </paper>
    <paper id="0607">
-        <title>A Bayesian Mixture Model for Term Re-occurrence and Burstiness</title>
+        <title>A <fixed-case>B</fixed-case>ayesian Mixture Model for Term Re-occurrence and Burstiness</title>
         <author><first>Avik</first><last>Sarkar</last></author>
         <author><first>Paul H.</first><last>Garthwaite</last></author>
         <author><first>Anne</first><last>De Roeck</last></author>
@@ -1040,7 +1041,7 @@
         <bibkey>li-roth:2005:CoNLL</bibkey>
    </paper>
    <paper id="0610">
-        <title>Using Uneven Margins SVM and Perceptron for Information Extraction</title>
+        <title>Using Uneven Margins <fixed-case>SVM</fixed-case> and Perceptron for Information Extraction</title>
         <author><first>Yaoyong</first><last>Li</last></author>
         <author><first>Kalina</first><last>Bontcheva</last></author>
         <author><first>Hamish</first><last>Cunningham</last></author>
@@ -1069,7 +1070,7 @@
         <bibkey>vandenbosch-daelemans:2005:CoNLL</bibkey>
    </paper>
    <paper id="0612">
-        <title>An Expectation Maximization Approach to Pronoun Resolution</title>
+        <title>An <fixed-case>E</fixed-case>xpectation <fixed-case>M</fixed-case>aximization Approach to Pronoun Resolution</title>
         <author><first>Colin</first><last>Cherry</last></author>
         <author><first>Shane</first><last>Bergsma</last></author>
         <booktitle>Proceedings of the Ninth Conference on Computational Natural Language Learning (CoNLL-2005)</booktitle>
@@ -1152,7 +1153,7 @@
         <bibkey>freitag:2005:CoNLL</bibkey>
    </paper>
    <paper id="0618">
-        <title>Beyond the Pipeline: Discrete Optimization in NLP</title>
+        <title>Beyond the Pipeline: Discrete Optimization in <fixed-case>NLP</fixed-case></title>
         <author><first>Tomasz</first><last>Marciniak</last></author>
         <author><first>Michael</first><last>Strube</last></author>
         <booktitle>Proceedings of the Ninth Conference on Computational Natural Language Learning (CoNLL-2005)</booktitle>
@@ -1181,7 +1182,7 @@
         <bibkey>hachey-alex-becker:2005:CoNLL</bibkey>
    </paper>
    <paper id="0620">
-        <title>Introduction to the CoNLL-2005 Shared Task: Semantic Role Labeling</title>
+        <title>Introduction to the <fixed-case>CoNLL</fixed-case>-2005 Shared Task: Semantic Role Labeling</title>
         <author><first>Xavier</first><last>Carreras</last></author>
         <author><first>Lluís</first><last>Màrquez</last></author>
         <booktitle>Proceedings of the Ninth Conference on Computational Natural Language Learning (CoNLL-2005)</booktitle>
@@ -1349,7 +1350,7 @@
         <bibkey>moschitti-EtAl:2005:CoNLL</bibkey>
    </paper>
    <paper id="0631">
-        <title>Semantic Role Labeling Using libSVM</title>
+        <title>Semantic Role Labeling Using <fixed-case>libSVM</fixed-case></title>
         <author><first>Necati Ercan</first><last>Ozgencil</last></author>
         <author><first>Nancy</first><last>McCracken</last></author>
         <booktitle>Proceedings of the Ninth Conference on Computational Natural Language Learning (CoNLL-2005)</booktitle>
@@ -1452,7 +1453,7 @@
         <bibkey>tjongkimsang-EtAl:2005:CoNLL</bibkey>
    </paper>
    <paper id="0638">
-        <title>Exploiting Full Parsing Information to Label Semantic Roles Using an Ensemble of ME and SVM via Integer Linear Programming</title>
+        <title>Exploiting Full Parsing Information to Label Semantic Roles Using an Ensemble of <fixed-case>ME</fixed-case> and <fixed-case>SVM</fixed-case> via Integer Linear Programming</title>
         <author><first>Tzong-Han</first><last>Tsai</last></author>
         <author><first>Chia-Wei</first><last>Wu</last></author>
         <author><first>Yu-Chun</first><last>Lin</last></author>
@@ -1495,7 +1496,7 @@
         <bibkey>Semitic:2005</bibkey>
    </paper>
    <paper id="0701">
-        <title>Memory-Based Morphological Analysis Generation and Part-of-Speech Tagging of Arabic</title>
+        <title>Memory-Based Morphological Analysis Generation and Part-of-Speech Tagging of <fixed-case>A</fixed-case>rabic</title>
         <author><first>Erwin</first><last>Marsi</last></author>
         <author><first>Antal</first><last>van den Bosch</last></author>
         <author><first>Abdelhadi</first><last>Soudi</last></author>
@@ -1510,7 +1511,7 @@
         <bibkey>marsi-vandenbosch-soudi:2005:Semitic</bibkey>
    </paper>
    <paper id="0702">
-        <title>A Finite-State Morphological Grammar of Hebrew</title>
+        <title>A Finite-State Morphological Grammar of <fixed-case>H</fixed-case>ebrew</title>
         <author><first>Shlomo</first><last>Yona</last></author>
         <author><first>Shuly</first><last>Wintner</last></author>
         <booktitle>Proceedings of the ACL Workshop on Computational Approaches to Semitic Languages</booktitle>
@@ -1524,7 +1525,7 @@
         <bibkey>yona-wintner:2005:Semitic</bibkey>
    </paper>
    <paper id="0703">
-        <title>Morphological Analysis and Generation for Arabic Dialects</title>
+        <title>Morphological Analysis and Generation for <fixed-case>A</fixed-case>rabic Dialects</title>
         <author><first>Nizar</first><last>Habash</last></author>
         <author><first>Owen</first><last>Rambow</last></author>
         <author><first>George</first><last>Kiraz</last></author>
@@ -1539,7 +1540,7 @@
         <bibkey>habash-rambow-kiraz:2005:Semitic</bibkey>
    </paper>
    <paper id="0704">
-        <title>Examining the Effect of Improved Context Sensitive Morphology on Arabic Information Retrieval</title>
+        <title>Examining the Effect of Improved Context Sensitive Morphology on <fixed-case>A</fixed-case>rabic Information Retrieval</title>
         <author><first>Kareem</first><last>Darwish</last></author>
         <author><first>Hany</first><last>Hassan</last></author>
         <author><first>Ossama</first><last>Emam</last></author>
@@ -1554,7 +1555,7 @@
         <bibkey>darwish-hassan-emam:2005:Semitic</bibkey>
    </paper>
    <paper id="0705">
-        <title>Modifying a Natural Language Processing System for European Languages to Treat Arabic in Information Processing and Information Retrieval Applications</title>
+        <title>Modifying a Natural Language Processing System for <fixed-case>E</fixed-case>uropean Languages to Treat <fixed-case>A</fixed-case>rabic in Information Processing and Information Retrieval Applications</title>
         <author><first>Gregory</first><last>Grefenstette</last></author>
         <author><first>Nasredine</first><last>Semmar</last></author>
         <author><first>Faiza</first><last>Elkateb-Gara</last></author>
@@ -1569,7 +1570,7 @@
         <bibkey>grefenstette-semmar-elkatebgara:2005:Semitic</bibkey>
    </paper>
    <paper id="0706">
-        <title>Choosing an Optimal Architecture for Segmentation and POS-Tagging of Modern Hebrew</title>
+        <title>Choosing an Optimal Architecture for Segmentation and <fixed-case>POS</fixed-case>-Tagging of <fixed-case>M</fixed-case>odern <fixed-case>H</fixed-case>ebrew</title>
         <author><first>Roy</first><last>Bar-Haim</last></author>
         <author><first>Khalil</first><last>Sima’an</last></author>
         <author><first>Yoad</first><last>Winter</last></author>
@@ -1584,7 +1585,7 @@
         <bibkey>barhaim-simaan-winter:2005:Semitic</bibkey>
    </paper>
    <paper id="0707">
-        <title>Part of Speech Tagging for Amharic using Conditional Random Fields</title>
+        <title>Part of Speech Tagging for <fixed-case>A</fixed-case>mharic using Conditional Random Fields</title>
         <author><first>Sisay</first><last>Fissaha Adafre</last></author>
         <booktitle>Proceedings of the ACL Workshop on Computational Approaches to Semitic Languages</booktitle>
         <month>June</month>
@@ -1597,7 +1598,7 @@
         <bibkey>fissahaadafre:2005:Semitic</bibkey>
    </paper>
    <paper id="0708">
-        <title>POS Tagging of Dialectal Arabic: A Minimally Supervised Approach</title>
+        <title><fixed-case>POS</fixed-case> Tagging of Dialectal <fixed-case>A</fixed-case>rabic: A Minimally Supervised Approach</title>
         <author><first>Kevin</first><last>Duh</last></author>
         <author><first>Katrin</first><last>Kirchhoff</last></author>
         <booktitle>Proceedings of the ACL Workshop on Computational Approaches to Semitic Languages</booktitle>
@@ -1611,7 +1612,7 @@
         <bibkey>duh-kirchhoff:2005:Semitic</bibkey>
    </paper>
    <paper id="0709">
-        <title>The Impact of Morphological Stemming on Arabic Mention Detection and Coreference Resolution</title>
+        <title>The Impact of Morphological Stemming on <fixed-case>A</fixed-case>rabic Mention Detection and Coreference Resolution</title>
         <author><first>Imed</first><last>Zitouni</last></author>
         <author><first>Jeffrey</first><last>Sorensen</last></author>
         <author><first>Xiaoqiang</first><last>Luo</last></author>
@@ -1627,7 +1628,7 @@
         <bibkey>zitouni-EtAl:2005:Semitic</bibkey>
    </paper>
    <paper id="0710">
-        <title>Classifying Amharic News Text Using Self-Organizing Maps</title>
+        <title>Classifying <fixed-case>A</fixed-case>mharic News Text Using Self-Organizing Maps</title>
         <author><first>Samuel</first><last>Eyassu</last></author>
         <author><first>Björn</first><last>Gambäck</last></author>
         <booktitle>Proceedings of the ACL Workshop on Computational Approaches to Semitic Languages</booktitle>
@@ -1655,7 +1656,7 @@
         <bibkey>nelken-shieber:2005:Semitic</bibkey>
    </paper>
    <paper id="0712">
-        <title>An Integrated Approach for Arabic-English Named Entity Translation</title>
+        <title>An Integrated Approach for <fixed-case>A</fixed-case>rabic-<fixed-case>E</fixed-case>nglish Named Entity Translation</title>
         <author><first>Hany</first><last>Hassan</last></author>
         <author><first>Jeffrey</first><last>Sorensen</last></author>
         <booktitle>Proceedings of the ACL Workshop on Computational Approaches to Semitic Languages</booktitle>
@@ -1783,7 +1784,7 @@
         <bibkey>drabek-yarowsky:2005:WPT</bibkey>
    </paper>
    <paper id="0808">
-        <title>A Hybrid Approach to Align Sentences and Words in English-Hindi Parallel Corpora</title>
+        <title>A Hybrid Approach to Align Sentences and Words in <fixed-case>E</fixed-case>nglish-<fixed-case>H</fixed-case>indi Parallel Corpora</title>
         <author><first>Niraj</first><last>Aswani</last></author>
         <author><first>Robert</first><last>Gaizauskas</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -1812,7 +1813,7 @@
         <bibkey>martin-mihalcea-pedersen:2005:WPT</bibkey>
    </paper>
    <paper id="0810">
-        <title>NUKTI: English-Inuktitut Word Alignment System Description</title>
+        <title><fixed-case>NUKTI</fixed-case>: <fixed-case>E</fixed-case>nglish-<fixed-case>I</fixed-case>nuktitut Word Alignment System Description</title>
         <author><first>Philippe</first><last>Langlais</last></author>
         <author><first>Fabrizio</first><last>Gotti</last></author>
         <author><first>Guihong</first><last>Cao</last></author>
@@ -1827,7 +1828,7 @@
         <bibkey>langlais-gotti-cao:2005:WPT</bibkey>
    </paper>
    <paper id="0811">
-        <title>Models for Inuktitut-English Word Alignment</title>
+        <title>Models for <fixed-case>I</fixed-case>nuktitut-<fixed-case>E</fixed-case>nglish Word Alignment</title>
         <author><first>Charles</first><last>Schafer</last></author>
         <author><first>Elliott</first><last>Drábek</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -1841,7 +1842,7 @@
         <bibkey>schafer-drabek:2005:WPT</bibkey>
    </paper>
    <paper id="0812">
-        <title>Improved HMM Alignment Models for Languages with Scarce Resources</title>
+        <title>Improved <fixed-case>HMM</fixed-case> Alignment Models for Languages with Scarce Resources</title>
         <author><first>Adam</first><last>Lopez</last></author>
         <author><first>Philip</first><last>Resnik</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -1871,7 +1872,7 @@
         <bibkey>brown-EtAl:2005:WPT</bibkey>
    </paper>
    <paper id="0814">
-        <title>ISI’s Participation in the Romanian-English Alignment Task</title>
+        <title><fixed-case>ISI</fixed-case>‘s Participation in the <fixed-case>R</fixed-case>omanian-<fixed-case>E</fixed-case>nglish Alignment Task</title>
         <author><first>Alexander</first><last>Fraser</last></author>
         <author><first>Daniel</first><last>Marcu</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -1885,7 +1886,7 @@
         <bibkey>fraser-marcu:2005:WPT</bibkey>
    </paper>
    <paper id="0815">
-        <title>Experiments Using MAR for Aligning Corpora</title>
+        <title>Experiments Using <fixed-case>MAR</fixed-case> for Aligning Corpora</title>
         <author><first>Juan Miguel</first><last>Vilar</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
         <month>June</month>
@@ -1928,7 +1929,7 @@
         <bibkey>tufis-EtAl:2005:WPT</bibkey>
    </paper>
    <paper id="0818">
-        <title>LIHLA: Shared Task System Description</title>
+        <title><fixed-case>LIHLA</fixed-case>: Shared Task System Description</title>
         <author><first>Helena M.</first><last>Caseli</last></author>
         <author><first>Maria G. V.</first><last>Nunes</last></author>
         <author><first>Mikel L.</first><last>Forcada</last></author>
@@ -1943,7 +1944,7 @@
         <bibkey>caseli-nunes-forcada:2005:WPT</bibkey>
    </paper>
    <paper id="0819">
-        <title>Aligning Words in English-Hindi Parallel Corpora</title>
+        <title>Aligning Words in <fixed-case>E</fixed-case>nglish-<fixed-case>H</fixed-case>indi Parallel Corpora</title>
         <author><first>Niraj</first><last>Aswani</last></author>
         <author><first>Robert</first><last>Gaizauskas</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -1957,7 +1958,7 @@
         <bibkey>aswani-gaizauskas:2005:WPT2</bibkey>
    </paper>
    <paper id="0820">
-        <title>Shared Task: Statistical Machine Translation between European Languages</title>
+        <title>Shared Task: Statistical Machine Translation between <fixed-case>E</fixed-case>uropean Languages</title>
         <author><first>Philipp</first><last>Koehn</last></author>
         <author><first>Christof</first><last>Monz</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -1985,7 +1986,7 @@
         <bibkey>kirchhoff-yang:2005:WPT</bibkey>
    </paper>
    <paper id="0822">
-        <title>PORTAGE: A Phrase-Based Machine Translation System</title>
+        <title><fixed-case>PORTAGE</fixed-case>: A Phrase-Based Machine Translation System</title>
         <author><first>Fatiha</first><last>Sadat</last></author>
         <author><first>Howard</first><last>Johnson</last></author>
         <author><first>Akakpo</first><last>Agbago</last></author>
@@ -2004,7 +2005,7 @@
         <bibkey>sadat-EtAl:2005:WPT</bibkey>
    </paper>
    <paper id="0823">
-        <title>Statistical Machine Translation of Euparl Data by using Bilingual N-grams</title>
+        <title>Statistical Machine Translation of <fixed-case>E</fixed-case>uparl Data by using Bilingual N-grams</title>
         <author><first>Rafael E.</first><last>Banchs</last></author>
         <author><first>Josep M.</first><last>Crego</last></author>
         <author><first>Adrià</first><last>de Gispert</last></author>
@@ -2021,7 +2022,7 @@
         <bibkey>banchs-EtAl:2005:WPT</bibkey>
    </paper>
    <paper id="0824">
-        <title>RALI: SMT Shared Task System Description</title>
+        <title><fixed-case>RALI</fixed-case>: <fixed-case>SMT</fixed-case> Shared Task System Description</title>
         <author><first>Philippe</first><last>Langlais</last></author>
         <author><first>Guihong</first><last>Cao</last></author>
         <author><first>Fabrizio</first><last>Gotti</last></author>
@@ -2050,7 +2051,7 @@
         <bibkey>zhao-vogel:2005:WPT</bibkey>
    </paper>
    <paper id="0826">
-        <title>Combining Linguistic Data Views for Phrase-based SMT</title>
+        <title>Combining Linguistic Data Views for Phrase-based <fixed-case>SMT</fixed-case></title>
         <author><first>Jesús</first><last>Giménez</last></author>
         <author><first>Lluís</first><last>Màrquez</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -2150,7 +2151,7 @@
         <bibkey>henderson-morgan:2005:WPT</bibkey>
    </paper>
    <paper id="0833">
-        <title>Hybrid Example-Based SMT: the Best of Both Worlds?</title>
+        <title>Hybrid Example-Based <fixed-case>SMT</fixed-case>: the Best of Both Worlds?</title>
         <author><first>Declan</first><last>Groves</last></author>
         <author><first>Andy</first><last>Way</last></author>
         <booktitle>Proceedings of the ACL Workshop on Building and Using Parallel Texts</booktitle>
@@ -2221,7 +2222,7 @@
         <bibkey>MTSumm:2005</bibkey>
    </paper>
    <paper id="0901">
-        <title>A Methodology for Extrinsic Evaluation of Text Summarization: Does ROUGE Correlate?</title>
+        <title>A Methodology for Extrinsic Evaluation of Text Summarization: Does <fixed-case>ROUGE</fixed-case> Correlate?</title>
         <author><first>Bonnie</first><last>Dorr</last></author>
         <author><first>Christof</first><last>Monz</last></author>
         <author><first>Stacy</first><last>President</last></author>
@@ -2312,7 +2313,7 @@
         <bibkey>lin-demnerfushman:2005:MTSumm</bibkey>
    </paper>
    <paper id="0907">
-        <title>Evaluating DUC 2004 Tasks with the QARLA Framework</title>
+        <title>Evaluating <fixed-case>DUC</fixed-case> 2004 Tasks with the <fixed-case>QARLA</fixed-case> Framework</title>
         <author><first>Enrique</first><last>Amigó</last></author>
         <author><first>Julio</first><last>Gonzalo</last></author>
         <author><first>Anselmo</first><last>Peñas</last></author>
@@ -2328,7 +2329,7 @@
         <bibkey>amigo-EtAl:2005:MTSumm</bibkey>
    </paper>
    <paper id="0908">
-        <title>On Some Pitfalls in Automatic Evaluation and Significance Testing for MT</title>
+        <title>On Some Pitfalls in Automatic Evaluation and Significance Testing for <fixed-case>MT</fixed-case></title>
         <author><first>Stefan</first><last>Riezler</last></author>
         <author><first>John T.</first><last>Maxwell</last></author>
         <booktitle>Proceedings of the ACL Workshop on Intrinsic and Extrinsic Evaluation Measures for Machine Translation and/or Summarization</booktitle>
@@ -2342,7 +2343,7 @@
         <bibkey>riezler-maxwell:2005:MTSumm</bibkey>
    </paper>
    <paper id="0909">
-        <title>METEOR: An Automatic Metric for MT Evaluation with Improved Correlation with Human Judgments</title>
+        <title><fixed-case>METEOR</fixed-case>: An Automatic Metric for <fixed-case>MT</fixed-case> Evaluation with Improved Correlation with Human Judgments</title>
         <author><first>Satanjeev</first><last>Banerjee</last></author>
         <author><first>Alon</first><last>Lavie</last></author>
         <booktitle>Proceedings of the ACL Workshop on Intrinsic and Extrinsic Evaluation Measures for Machine Translation and/or Summarization</booktitle>
@@ -2369,7 +2370,7 @@
         <bibkey>DLA:2005</bibkey>
    </paper>
    <paper id="1001">
-        <title>Data Homogeneity and Semantic Role Tagging in Chinese</title>
+        <title>Data Homogeneity and Semantic Role Tagging in <fixed-case>C</fixed-case>hinese</title>
         <author><first>Oi Yee</first><last>Kwong</last></author>
         <author><first>Benjamin K.</first><last>Tsou</last></author>
         <booktitle>Proceedings of the ACL-SIGLEX Workshop on Deep Lexical Acquisition</booktitle>
@@ -2529,7 +2530,7 @@
    </paper>
 
 <paper id="1101">
-<title>TextTree Construction for Parser and Treebank Development</title>
+<title><fixed-case>TextTree</fixed-case> Construction for Parser and Treebank Development</title>
 <author><first>Paula S.</first><last>Newman</last></author>
 </paper>
 
@@ -2540,7 +2541,7 @@
 </paper>
 
 <paper id="1103">
-<title>Interleaved Preparation and Output in the COMIC Fission Module</title>
+<title>Interleaved Preparation and Output in the <fixed-case>COMIC</fixed-case> Fission Module</title>
 <author><first>Mary Ellen</first><last>Foster</last></author>
 </paper>
 
@@ -2571,7 +2572,7 @@
 </paper>
 
 <paper id="1108">
-<title>XFST2FSA: Comparing Two Finite-State Toolboxes</title>
+<title><fixed-case>XFST2FSA</fixed-case>: Comparing Two Finite-State Toolboxes</title>
 <author><first>Yael</first><last>Cohen-Sygal</last></author>
 <author><first>Shuly</first><last>Wintner</last></author>
 </paper>
@@ -2636,7 +2637,7 @@
         <bibkey>corley-mihalcea:2005:SemEq</bibkey>
    </paper>
    <paper id="1204">
-        <title>Training Data Modification for SMT Considering Groups of Synonymous Sentences</title>
+        <title>Training Data Modification for <fixed-case>SMT</fixed-case> Considering Groups of Synonymous Sentences</title>
         <author><first>Hideki</first><last>Kashioka</last></author>
         <booktitle>Proceedings of the ACL Workshop on Empirical Modeling of Semantic Equivalence and Entailment</booktitle>
         <month>June</month>
@@ -2805,7 +2806,7 @@
         <bibkey>tsuruoka-ananiadou-tsujii:2005:Biolink</bibkey>
    </paper>
    <paper id="1305">
-        <title>MedTag: A Collection of Biomedical Annotations</title>
+        <title><fixed-case>MedTag</fixed-case>: A Collection of Biomedical Annotations</title>
         <author><first>Lawrence H.</first><last>Smith</last></author>
         <author><first>Lorraine</first><last>Tanabe</last></author>
         <author><first>Thomas</first><last>Rindflesch</last></author>
@@ -2853,7 +2854,7 @@
         <bibkey>ramani-EtAl:2005:Biolink</bibkey>
    </paper>
    <paper id="1308">
-        <title>IntEx: A Syntactic Role Driven Protein-Protein Interaction Extractor for Bio-Medical Text</title>
+        <title><fixed-case>IntEx</fixed-case>: A Syntactic Role Driven Protein-Protein Interaction Extractor for Bio-Medical Text</title>
         <author><first>Syed Toufeeq</first><last>Ahmed</last></author>
         <author><first>Deepthi</first><last>Chidambaram</last></author>
         <author><first>Hasan</first><last>Davulcu</last></author>
@@ -2882,7 +2883,7 @@
         <bibkey>IWPT:2005</bibkey>
    </paper>
    <paper id="1501">
-        <title>Efficient and Robust LFG Parsing: SxLFG</title>
+        <title>Efficient and Robust <fixed-case>LFG</fixed-case> Parsing: <fixed-case>SxLFG</fixed-case></title>
         <author><first>Pierre</first><last>Boullier</last></author>
         <author><first>Benoît</first><last>Sagot</last></author>
         <booktitle>Proceedings of the Ninth International Workshop on Parsing Technology</booktitle>
@@ -3008,7 +3009,7 @@
         <bibkey>musillo-merlo:2005:IWPT</bibkey>
    </paper>
    <paper id="1510">
-        <title>Probabilistic Models for Disambiguation of an HPSG-Based Chart Generator</title>
+        <title>Probabilistic Models for Disambiguation of an <fixed-case>HPSG</fixed-case>-Based Chart Generator</title>
         <author><first>Hiroko</first><last>Nakanishi</last></author>
         <author><first>Yusuke</first><last>Miyao</last></author>
         <author><first>Jun’ichi</first><last>Tsujii</last></author>
@@ -3023,7 +3024,7 @@
         <bibkey>nakanishi-miyao-tsujii:2005:IWPT</bibkey>
    </paper>
    <paper id="1511">
-        <title>Efficacy of Beam Thresholding, Unification Filtering and Hybrid Parsing in Probabilistic HPSG Parsing</title>
+        <title>Efficacy of Beam Thresholding, Unification Filtering and Hybrid Parsing in Probabilistic <fixed-case>HPSG</fixed-case> Parsing</title>
         <author><first>Takashi</first><last>Ninomiya</last></author>
         <author><first>Yoshimasa</first><last>Tsuruoka</last></author>
         <author><first>Yusuke</first><last>Miyao</last></author>
@@ -3039,7 +3040,7 @@
         <bibkey>ninomiya-EtAl:2005:IWPT</bibkey>
    </paper>
    <paper id="1512">
-        <title>Head-Driven PCFGs with Latent-Head Statistics</title>
+        <title>Head-Driven <fixed-case>PCFGs</fixed-case> with Latent-Head Statistics</title>
         <author><first>Detlef</first><last>Prescher</last></author>
         <booktitle>Proceedings of the Ninth International Workshop on Parsing Technology</booktitle>
         <month>October</month>
@@ -3193,7 +3194,7 @@
         <bibkey>clergerie:2005:IWPT</bibkey>
    </paper>
    <paper id="1523">
-        <title>Parsing Generalized ID/LP Grammars</title>
+        <title>Parsing Generalized <fixed-case>ID/LP</fixed-case> Grammars</title>
         <author><first>Michael W.</first><last>Daniels</last></author>
         <booktitle>Proceedings of the Ninth International Workshop on Parsing Technology</booktitle>
         <month>October</month>
@@ -3206,7 +3207,7 @@
         <bibkey>daniels:2005:IWPT</bibkey>
    </paper>
    <paper id="1524">
-        <title>TFLEX: Speeding Up Deep Parsing with Strategic Pruning</title>
+        <title><fixed-case>TFLEX</fixed-case>: Speeding Up Deep Parsing with Strategic Pruning</title>
         <author><first>Myroslava O.</first><last>Dzikovska</last></author>
         <author><first>Carolyn P.</first><last>Rose</last></author>
         <booktitle>Proceedings of the Ninth International Workshop on Parsing Technology</booktitle>
@@ -3252,7 +3253,7 @@
         <bibkey>elsner-EtAl:2005:IWPT</bibkey>
    </paper>
    <paper id="1527">
-        <title>SUPPLE: A Practical Parser for Natural Language Engineering Applications</title>
+        <title><fixed-case>SUPPLE</fixed-case>: A Practical Parser for Natural Language Engineering Applications</title>
         <author><first>Robert</first><last>Gaizauskas</last></author>
         <author><first>Mark</first><last>Hepple</last></author>
         <author><first>Horacio</first><last>Saggion</last></author>
@@ -3269,7 +3270,7 @@
         <bibkey>gaizauskas-EtAl:2005:IWPT</bibkey>
    </paper>
    <paper id="1528">
-        <title>k-NN for Local Probability Estimation in Generative Parsing Models</title>
+        <title><fixed-case>k-NN</fixed-case> for Local Probability Estimation in Generative Parsing Models</title>
         <author><first>Deirdre</first><last>Hogan</last></author>
         <booktitle>Proceedings of the Ninth International Workshop on Parsing Technology</booktitle>
         <month>October</month>

--- a/import/W06.xml
+++ b/import/W06.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W06">
    <paper id="0100">
         <title>Proceedings of the Fifth SIGHAN Workshop on Chinese Language Processing</title>
@@ -1241,7 +1242,7 @@
         <bibkey>somasundaran-EtAl:2006:Frontiers</bibkey>
    </paper>
    <paper id="0608">
-        <title>The Hinoki Sensebank — A Large-Scale Word Sense Tagged Corpus of Japanese —</title>
+        <title>The Hinoki Sensebank — A Large-Scale Word Sense Tagged Corpus of <fixed-case>Japanese</fixed-case> —</title>
         <author><first>Takaaki</first><last>Tanaka</last></author>
         <author><first>Francis</first><last>Bond</last></author>
         <author><first>Sanae</first><last>Fujita</last></author>
@@ -1256,7 +1257,7 @@
         <bibkey>tanaka-bond-fujita:2006:Frontiers</bibkey>
    </paper>
    <paper id="0609">
-        <title>Issues in Synchronizing the English Treebank and PropBank</title>
+        <title>Issues in Synchronizing the <fixed-case>English</fixed-case> Treebank and PropBank</title>
         <author><first>Olga</first><last>Babko-Malaya</last></author>
         <author><first>Ann</first><last>Bies</last></author>
         <author><first>Ann</first><last>Taylor</last></author>
@@ -1304,7 +1305,7 @@
         <bibkey>teich-bateman-eckart:2006:Frontiers</bibkey>
    </paper>
    <paper id="0612">
-        <title>Constructing an English Valency Lexicon</title>
+        <title>Constructing an <fixed-case>English</fixed-case> Valency Lexicon</title>
         <author><first>Jiří</first><last>Semecký</last></author>
         <author><first>Silvie</first><last>Cinková</last></author>
         <booktitle>Proceedings of the Workshop on Frontiers in Linguistically Annotated Corpora 2006</booktitle>
@@ -1646,7 +1647,7 @@
         <bibkey>MLRI:2006</bibkey>
    </paper>
    <paper id="1001">
-        <title>Lexical Markup Framework (LMF) for NLP Multilingual Resources</title>
+        <title>Lexical Markup Framework (<fixed-case>LMF</fixed-case>) for <fixed-case>NLP</fixed-case> Multilingual Resources</title>
         <author><first>Gil</first><last>Francopoulo</last></author>
         <author><first>Nuria</first><last>Bel</last></author>
         <author><first>Monte</first><last>George</last></author>
@@ -1665,7 +1666,7 @@
         <bibkey>francopoulo-EtAl:2006:MLRI</bibkey>
    </paper>
    <paper id="1002">
-        <title>The Role of Lexical Resources in CJK Natural Language Processing</title>
+        <title>The Role of Lexical Resources in <fixed-case>CJK</fixed-case> Natural Language Processing</title>
         <author><first>Jack</first><last>Halpern</last></author>
         <booktitle>Proceedings of the Workshop on Multilingual Language Resources and Interoperability</booktitle>
         <month>July</month>
@@ -1697,7 +1698,7 @@
         <bibkey>soria-EtAl:2006:MLRI</bibkey>
    </paper>
    <paper id="1004">
-        <title>The LexALP Information System: Term Bank and Corpus for Multilingual Legal Terminology Consolidated</title>
+        <title>The <fixed-case>LexALP</fixed-case> Information System: Term Bank and Corpus for Multilingual Legal Terminology Consolidated</title>
         <author><first>Verena</first><last>Lyding</last></author>
         <author><first>Elena</first><last>Chiocchetti</last></author>
         <author><first>Gilles</first><last>Sérasset</last></author>
@@ -2816,7 +2817,7 @@
         <bibkey>TAG:2006</bibkey>
    </paper>
    <paper id="1501">
-        <title>The Hidden TAG Model: Synchronous Grammars for Parsing Resource-Poor Languages</title>
+        <title>The Hidden <fixed-case>TAG</fixed-case> Model: Synchronous Grammars for Parsing Resource-Poor Languages</title>
         <author><first>David</first><last>Chiang</last></author>
         <author><first>Owen</first><last>Rambow</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -2862,7 +2863,7 @@
         <bibkey>kinyon-EtAl:2006:TAG</bibkey>
    </paper>
    <paper id="1504">
-        <title>The Weak Generative Capacity of Linear Tree-Adjoining Grammars</title>
+        <title>The Weak Generative Capacity of Linear <fixed-case>T</fixed-case>ree-<fixed-case>A</fixed-case>djoining <fixed-case>Grammars</fixed-case></title>
         <author><first>David</first><last>Chiang</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
         <month>July</month>
@@ -2875,7 +2876,7 @@
         <bibkey>chiang:2006:TAG</bibkey>
    </paper>
    <paper id="1505">
-        <title>A Tree Adjoining Grammar Analysis of the Syntax and Semantics of <i>It</i>-Clefts</title>
+        <title>A <fixed-case>Tree</fixed-case> <fixed-case>Adjoining</fixed-case> <fixed-case>Grammar</fixed-case> Analysis of the Syntax and Semantics of <i>It</i>-Clefts</title>
         <author><first>Chung-hye</first><last>Han</last></author>
         <author><first>Nancy</first><last>Hedberg</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -2889,7 +2890,7 @@
         <bibkey>han-hedberg:2006:TAG</bibkey>
    </paper>
    <paper id="1506">
-        <title>Pied-Piping in Relative Clauses: Syntax and Compositional Semantics Based on Synchronous Tree Adjoining Grammar</title>
+        <title>Pied-Piping in Relative Clauses: Syntax and Compositional Semantics Based on <fixed-case>Synchronous</fixed-case> <fixed-case>Tree</fixed-case> <fixed-case>Adjoining</fixed-case> <fixed-case>Grammar</fixed-case></title>
         <author><first>Chung-hye</first><last>Han</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
         <month>July</month>
@@ -2902,7 +2903,7 @@
         <bibkey>han:2006:TAG</bibkey>
    </paper>
    <paper id="1507">
-        <title>Negative Concord and Restructuring in Palestinian Arabic: A Comparison of TAG and CCG Analyses</title>
+        <title>Negative Concord and Restructuring in Palestinian Arabic: A Comparison of <fixed-case>TAG</fixed-case> and <fixed-case>CCG</fixed-case> Analyses</title>
         <author><first>Frederick M.</first><last>Hoyt</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
         <month>July</month>
@@ -2915,7 +2916,7 @@
         <bibkey>hoyt:2006:TAG</bibkey>
    </paper>
    <paper id="1508">
-        <title>Stochastic Multiple Context-Free Grammar for RNA Pseudoknot Modeling</title>
+        <title>Stochastic Multiple <fixed-case>C</fixed-case>ontext-<fixed-case>F</fixed-case>ree <fixed-case>Grammar</fixed-case> for <fixed-case>RNA</fixed-case> Pseudoknot Modeling</title>
         <author><first>Yuki</first><last>Kato</last></author>
         <author><first>Hiroyuki</first><last>Seki</last></author>
         <author><first>Tadao</first><last>Kasami</last></author>
@@ -2930,7 +2931,7 @@
         <bibkey>kato-seki-kasami:2006:TAG</bibkey>
    </paper>
    <paper id="1509">
-        <title>Binding of Anaphors in LTAG</title>
+        <title>Binding of Anaphors in <fixed-case>LTAG</fixed-case></title>
         <author><first>Neville</first><last>Ryant</last></author>
         <author><first>Tatjana</first><last>Scheffler</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -2944,7 +2945,7 @@
         <bibkey>ryant-scheffler:2006:TAG</bibkey>
    </paper>
    <paper id="1510">
-        <title>Quantifier Scope in German: An MCTAG Analysis</title>
+        <title>Quantifier Scope in German: An <fixed-case>MCTAG</fixed-case> Analysis</title>
         <author><first>Laura</first><last>Kallmeyer</last></author>
         <author><first>Maribel</first><last>Romero</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -2958,7 +2959,7 @@
         <bibkey>kallmeyer-romero:2006:TAG</bibkey>
    </paper>
    <paper id="1511">
-        <title>Licensing German Negative Polarity Items in LTAG</title>
+        <title>Licensing German Negative Polarity Items in <fixed-case>LTAG</fixed-case></title>
         <author><first>Timm</first><last>Lichte</last></author>
         <author><first>Laura</first><last>Kallmeyer</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -2972,7 +2973,7 @@
         <bibkey>lichte-kallmeyer:2006:TAG</bibkey>
    </paper>
    <paper id="1512">
-        <title>Semantic Interpretation of Unrealized Syntactic Material in LTAG</title>
+        <title>Semantic Interpretation of Unrealized Syntactic Material in <fixed-case>LTAG</fixed-case></title>
         <author><first>Olga</first><last>Babko-Malaya</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
         <month>July</month>
@@ -2985,7 +2986,7 @@
         <bibkey>babkomalaya:2006:TAG</bibkey>
    </paper>
    <paper id="1513">
-        <title>Three Reasons to Adopt TAG-Based Surface Realisation</title>
+        <title>Three Reasons to Adopt <fixed-case>TAG</fixed-case>-Based Surface Realisation</title>
         <author><first>Claire</first><last>Gardent</last></author>
         <author><first>Eric</first><last>Kow</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -2999,7 +3000,7 @@
         <bibkey>gardent-kow:2006:TAG</bibkey>
    </paper>
    <paper id="1514">
-        <title>Generating XTAG Parsers from Algebraic Specifications</title>
+        <title>Generating <fixed-case>XTAG</fixed-case> Parsers from Algebraic Specifications</title>
         <author><first>Carlos</first><last>Gómez-Rodríguez</last></author>
         <author><first>Miguel A.</first><last>Alonso</last></author>
         <author><first>Manuel</first><last>Vilares</last></author>
@@ -3014,7 +3015,7 @@
         <bibkey>gomezrodriguez-alonso-vilares:2006:TAG</bibkey>
    </paper>
    <paper id="1515">
-        <title>Constraint-Based Computational Semantics: A Comparison between LTAG and LRS</title>
+        <title>Constraint-Based Computational Semantics: A Comparison between <fixed-case>LTAG</fixed-case> and <fixed-case>LRS</fixed-case></title>
         <author><first>Laura</first><last>Kallmeyer</last></author>
         <author><first>Frank</first><last>Richter</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -3028,7 +3029,7 @@
         <bibkey>kallmeyer-richter:2006:TAG</bibkey>
    </paper>
    <paper id="1516">
-        <title>SemTAG, the LORIA toolbox for TAG-based Parsing and Generation</title>
+        <title><fixed-case>SemTAG</fixed-case>, the <fixed-case>LORIA</fixed-case> toolbox for <fixed-case>TAG</fixed-case>-based Parsing and Generation</title>
         <author><first>Eric</first><last>Kow</last></author>
         <author><first>Yannick</first><last>Parmentier</last></author>
         <author><first>Claire</first><last>Gardent</last></author>
@@ -3043,7 +3044,7 @@
         <bibkey>kow-parmentier-gardent:2006:TAG</bibkey>
    </paper>
    <paper id="1517">
-        <title>Extended Cross-Serial Dependencies in Tree Adjoining Grammars</title>
+        <title>Extended Cross-Serial Dependencies in <fixed-case>Tree</fixed-case> <fixed-case>Adjoining</fixed-case> <fixed-case>Grammars</fixed-case></title>
         <author><first>Marco</first><last>Kuhlmann</last></author>
         <author><first>Mathias</first><last>Möhl</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -3057,7 +3058,7 @@
         <bibkey>kuhlmann-mohl:2006:TAG</bibkey>
    </paper>
    <paper id="1518">
-        <title>Using LTAG-Based Features for Semantic Role Labeling</title>
+        <title>Using <fixed-case>LTAG</fixed-case>-Based Features for Semantic Role Labeling</title>
         <author><first>Yudong</first><last>Liu</last></author>
         <author><first>Anoop</first><last>Sarkar</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -3084,7 +3085,7 @@
         <bibkey>park:2006:TAG</bibkey>
    </paper>
    <paper id="1520">
-        <title>Handling Unlike Coordinated Phrases in TAG by Mixing Syntactic Category and Grammatical Function</title>
+        <title>Handling Unlike Coordinated Phrases in <fixed-case>TAG</fixed-case> by Mixing Syntactic Category and Grammatical Function</title>
         <author><first>Carlos A.</first><last>Prolo</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
         <month>July</month>
@@ -3097,7 +3098,7 @@
         <bibkey>prolo:2006:TAG</bibkey>
    </paper>
    <paper id="1521">
-        <title>Parsing TAG with Abstract Categorial Grammar</title>
+        <title>Parsing <fixed-case>TAG</fixed-case> with <fixed-case>Abstract</fixed-case> <fixed-case>Categorial</fixed-case> <fixed-case>Grammar</fixed-case></title>
         <author><first>Sylvain</first><last>Salvati</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
         <month>July</month>
@@ -3110,7 +3111,7 @@
         <bibkey>salvati:2006:TAG</bibkey>
    </paper>
    <paper id="1522">
-        <title>Modeling and Analysis of Elliptic Coordination by Dynamic Exploitation of Derivation Forests in LTAG Parsing</title>
+        <title>Modeling and Analysis of Elliptic Coordination by Dynamic Exploitation of Derivation Forests in <fixed-case>LTAG</fixed-case> Parsing</title>
         <author><first>Djamé</first><last>Seddah</last></author>
         <author><first>Benoît</first><last>Sagot</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
@@ -3124,7 +3125,7 @@
         <bibkey>seddah-sagot:2006:TAG</bibkey>
    </paper>
    <paper id="1523">
-        <title>‘Single Cycle’ Languages: Empirical Evidence for TAG-Adjoining</title>
+        <title>‘Single Cycle’ Languages: Empirical Evidence for <fixed-case>TAG</fixed-case>-Adjoining</title>
         <author><first>Arthur</first><last>Stepanov</last></author>
         <booktitle>Proceedings of the Eighth International Workshop on Tree Adjoining Grammar and Related Formalisms</booktitle>
         <month>July</month>
@@ -5111,7 +5112,7 @@
         <bibkey>titov-henderson:2006:CoNLL-X</bibkey>
    </paper>
    <paper id="2903">
-        <title>Non-Local Modeling with a Mixture of PCFGs</title>
+        <title>Non-Local Modeling with a Mixture of <fixed-case>PCFG</fixed-case>s</title>
         <author><first>Slav</first><last>Petrov</last></author>
         <author><first>Leon</first><last>Barrett</last></author>
         <author><first>Dan</first><last>Klein</last></author>
@@ -5126,7 +5127,7 @@
         <bibkey>petrov-barrett-klein:2006:CoNLL-X</bibkey>
    </paper>
    <paper id="2904">
-        <title>Improved Large Margin Dependency Parsing via Local Constraints and Laplacian Regularization</title>
+        <title>Improved Large Margin Dependency Parsing via Local Constraints and <fixed-case>L</fixed-case>aplacian Regularization</title>
         <author><first>Qin Iris</first><last>Wang</last></author>
         <author><first>Colin</first><last>Cherry</last></author>
         <author><first>Dan</first><last>Lizotte</last></author>
@@ -5142,7 +5143,7 @@
         <bibkey>wang-EtAl:2006:CoNLL-X</bibkey>
    </paper>
    <paper id="2905">
-        <title>What are the Productive Units of Natural Language Grammar? A DOP Approach to the Automatic Identification of Constructions.</title>
+        <title>What are the Productive Units of Natural Language Grammar? A <fixed-case>DOP</fixed-case> Approach to the Automatic Identification of Constructions.</title>
         <author><first>Willem</first><last>Zuidema</last></author>
         <booktitle>Proceedings of the Tenth Conference on Computational Natural Language Learning (CoNLL-X)</booktitle>
         <month>June</month>
@@ -5241,7 +5242,7 @@
         <bibkey>ando:2006:CoNLL-X</bibkey>
    </paper>
    <paper id="2912">
-        <title>Unsupervised Parsing with U-DOP</title>
+        <title>Unsupervised Parsing with <fixed-case>U-DOP</fixed-case></title>
         <author><first>Rens</first><last>Bod</last></author>
         <booktitle>Proceedings of the Tenth Conference on Computational Natural Language Learning (CoNLL-X)</booktitle>
         <month>June</month>
@@ -5268,7 +5269,7 @@
         <bibkey>atterer-schutze:2006:CoNLL-X</bibkey>
    </paper>
    <paper id="2914">
-        <title>Word Distributions for Thematic Segmentation in a Support Vector Machine Approach</title>
+        <title>Word Distributions for Thematic Segmentation in a <fixed-case>S</fixed-case>upport <fixed-case>V</fixed-case>ector <fixed-case>M</fixed-case>achine Approach</title>
         <author><first>Maria</first><last>Georgescul</last></author>
         <author><first>Alexander</first><last>Clark</last></author>
         <author><first>Susan</first><last>Armstrong</last></author>
@@ -7085,7 +7086,7 @@
         <bibkey>huang-knight-joshi:2006:CHPJI-NLP</bibkey>
    </paper>
    <paper id="3602">
-        <title>Efficient Dynamic Programming Search Algorithms for Phrase-Based SMT</title>
+        <title>Efficient Dynamic Programming Search Algorithms for Phrase-Based <fixed-case>SMT</fixed-case></title>
         <author><first>Christoph</first><last>Tillmann</last></author>
         <booktitle>Proceedings of the Workshop on Computationally Hard Problems and Joint Inference in Speech and Language Processing</booktitle>
         <month>June</month>
@@ -7140,7 +7141,7 @@
         <bibkey>ginter-myllari-salakoski:2006:CHPJI-NLP</bibkey>
    </paper>
    <paper id="3606">
-        <title>Practical Markov Logic Containing First-Order Quantifiers with Application to Identity Uncertainty</title>
+        <title>Practical <fixed-case>M</fixed-case>arkov Logic Containing First-Order Quantifiers with Application to Identity Uncertainty</title>
         <author><first>Aron</first><last>Culotta</last></author>
         <author><first>Andrew</first><last>McCallum</last></author>
         <booktitle>Proceedings of the Workshop on Computationally Hard Problems and Joint Inference in Speech and Language Processing</booktitle>

--- a/import/W07.xml
+++ b/import/W07.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W07">
    <paper id="0100">
         <title>Proceedings of the Workshop on Computational Approaches to Figurative Language</title>
@@ -81,7 +82,7 @@
         <bibkey>TextGraphs-2:2007</bibkey>
    </paper>
    <paper id="0201">
-        <title>Analysis of the Wikipedia Category Graph for NLP Applications</title>
+        <title>Analysis of the <fixed-case>Wikipedia</fixed-case> Category Graph for <fixed-case>NLP</fixed-case> Applications</title>
         <author><first>Torsten</first><last>Zesch</last></author>
         <author><first>Iryna</first><last>Gurevych</last></author>
         <booktitle>Proceedings of the Second Workshop on TextGraphs: Graph-Based Algorithms for Natural Language Processing</booktitle>
@@ -94,7 +95,7 @@
         <bibkey>zesch-gurevych:2007:TextGraphs-2</bibkey>
    </paper>
    <paper id="0202">
-        <title>Multi-level Association Graphs - A New Graph-Based Model for Information Retrieval</title>
+        <title>Multi-level Association Graphs - A New Graph-Based Model for <fixed-case>Information</fixed-case> <fixed-case>Retrieval</fixed-case></title>
         <author><first>Hans Friedrich</first><last>Witschel</last></author>
         <booktitle>Proceedings of the Second Workshop on TextGraphs: Graph-Based Algorithms for Natural Language Processing</booktitle>
         <year>2007</year>
@@ -147,7 +148,7 @@
         <bibkey>jedynak-karakos:2007:TextGraphs-2</bibkey>
    </paper>
    <paper id="0206">
-        <title>Transductive Structured Classification through Constrained Min-Cuts</title>
+        <title>Transductive Structured Classification through Constrained <fixed-case>Min-Cuts</fixed-case></title>
         <author><first>Kuzman</first><last>Ganchev</last></author>
         <author><first>Fernando</first><last>Pereira</last></author>
         <booktitle>Proceedings of the Second Workshop on TextGraphs: Graph-Based Algorithms for Natural Language Processing</booktitle>
@@ -244,7 +245,7 @@
         <bibkey>choudhury-EtAl:2007:TextGraphs-2</bibkey>
    </paper>
    <paper id="0213">
-        <title>Vertex Degree Distribution for the Graph of Word Co-Occurrences in Russian</title>
+        <title>Vertex Degree Distribution for the Graph of Word Co-Occurrences in <fixed-case>Russian</fixed-case></title>
         <author><first>Victor</first><last>Kapustin</last></author>
         <author><first>Anna</first><last>Jamsen</last></author>
         <booktitle>Proceedings of the Second Workshop on TextGraphs: Graph-Based Algorithms for Natural Language Processing</booktitle>
@@ -889,7 +890,7 @@
         <bibkey>menezes-quirk:2007:WMT</bibkey>
    </paper>
    <paper id="0702">
-        <title>CCG Supertags in Factored Statistical Machine Translation</title>
+        <title><fixed-case>CCG</fixed-case> Supertags in Factored Statistical Machine Translation</title>
         <author><first>Alexandra</first><last>Birch</last></author>
         <author><first>Miles</first><last>Osborne</last></author>
         <author><first>Philipp</first><last>Koehn</last></author>
@@ -921,7 +922,7 @@
         <bibkey>kashani-EtAl:2007:WMT</bibkey>
    </paper>
    <paper id="0704">
-        <title>Exploring Different Representational Units in English-to-Turkish Statistical Machine Translation</title>
+        <title>Exploring Different Representational Units in <fixed-case>English-to-Turkish</fixed-case> Statistical Machine Translation</title>
         <author><first>Kemal</first><last>Oflazer</last></author>
         <author><first>Ilknur</first><last>Durgar El-Kahlout</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
@@ -965,7 +966,7 @@
         <bibkey>xiong-liu-lin:2007:WMT</bibkey>
    </paper>
    <paper id="0707">
-        <title>Word Error Rates: Decomposition over POS classes and Applications for Error Analysis</title>
+        <title>Word Error Rates: Decomposition over <fixed-case>POS</fixed-case> classes and Applications for Error Analysis</title>
         <author><first>Maja</first><last>Popovic</last></author>
         <author><first>Hermann</first><last>Ney</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
@@ -1025,7 +1026,7 @@
         <bibkey>nguyen-mahajan-he:2007:WMT</bibkey>
    </paper>
    <paper id="0711">
-        <title>Using Word-Dependent Transition Models in HMM-Based Word Alignment for Statistical Machine Translation</title>
+        <title>Using Word-Dependent Transition Models in <fixed-case>HMM</fixed-case>-Based Word Alignment for Statistical Machine Translation</title>
         <author><first>Xiaodong</first><last>He</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
         <month>June</month>
@@ -1113,7 +1114,7 @@
         <bibkey>madnani-EtAl:2007:WMT</bibkey>
    </paper>
    <paper id="0717">
-        <title>Mixture-Model Adaptation for SMT</title>
+        <title>Mixture-Model Adaptation for <fixed-case>SMT</fixed-case></title>
         <author><first>George</first><last>Foster</last></author>
         <author><first>Roland</first><last>Kuhn</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
@@ -1205,7 +1206,7 @@
         <bibkey>civera-juan:2007:WMT</bibkey>
    </paper>
    <paper id="0723">
-        <title>Getting to Know Moses: Initial Experiments on German-English Factored Translation</title>
+        <title>Getting to Know Moses: Initial Experiments on <fixed-case>German-English</fixed-case> Factored Translation</title>
         <author><first>Maria</first><last>Holmqvist</last></author>
         <author><first>Sara</first><last>Stymne</last></author>
         <author><first>Lars</first><last>Ahrenberg</last></author>
@@ -1220,7 +1221,7 @@
         <bibkey>holmqvist-stymne-ahrenberg:2007:WMT</bibkey>
    </paper>
    <paper id="0724">
-        <title>NRC’s PORTAGE System for WMT 2007</title>
+        <title><fixed-case>NRC</fixed-case>‘s <fixed-case>PORTAGE</fixed-case> System for <fixed-case>WMT</fixed-case> 2007</title>
         <author><first>Nicola</first><last>Ueffing</last></author>
         <author><first>Michel</first><last>Simard</last></author>
         <author><first>Samuel</first><last>Larkin</last></author>
@@ -1236,7 +1237,7 @@
         <bibkey>ueffing-EtAl:2007:WMT</bibkey>
    </paper>
    <paper id="0725">
-        <title>Building a Statistical Machine Translation System for French Using the Europarl Corpus</title>
+        <title>Building a Statistical Machine Translation System for <fixed-case>French</fixed-case> Using the <fixed-case>Europarl</fixed-case> Corpus</title>
         <author><first>Holger</first><last>Schwenk</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
         <month>June</month>
@@ -1249,7 +1250,7 @@
         <bibkey>schwenk:2007:WMT</bibkey>
    </paper>
    <paper id="0726">
-        <title>Multi-Engine Machine Translation with an Open-Source SMT Decoder</title>
+        <title>Multi-Engine Machine Translation with an Open-Source <fixed-case>SMT</fixed-case> Decoder</title>
         <author><first>Yu</first><last>Chen</last></author>
         <author><first>Andreas</first><last>Eisele</last></author>
         <author><first>Christian</first><last>Federmann</last></author>
@@ -1267,7 +1268,7 @@
         <bibkey>chen-EtAl:2007:WMT</bibkey>
    </paper>
    <paper id="0727">
-        <title>The ISL Phrase-Based MT System for the 2007 ACL Workshop on Statistical Machine Translation</title>
+        <title>The <fixed-case>ISL</fixed-case> Phrase-Based <fixed-case>MT</fixed-case> System for the 2007 <fixed-case>ACL</fixed-case> Workshop on Statistical Machine Translation</title>
         <author><first>Matthias</first><last>Paulik</last></author>
         <author><first>Kay</first><last>Rottmann</last></author>
         <author><first>Jan</first><last>Niehues</last></author>
@@ -1313,7 +1314,7 @@
         <bibkey>dyer:2007:WMT</bibkey>
    </paper>
    <paper id="0730">
-        <title>UCB System Description for the WMT 2007 Shared Task</title>
+        <title><fixed-case>UCB</fixed-case> System Description for the <fixed-case>WMT</fixed-case> 2007 Shared Task</title>
         <author><first>Preslav</first><last>Nakov</last></author>
         <author><first>Marti</first><last>Hearst</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
@@ -1327,7 +1328,7 @@
         <bibkey>nakov-hearst:2007:WMT</bibkey>
    </paper>
    <paper id="0731">
-        <title>The Syntax Augmented MT (SAMT) System at the Shared Task for the 2007 ACL Workshop on Statistical Machine Translation</title>
+        <title>The Syntax Augmented <fixed-case>MT</fixed-case> (<fixed-case>SAMT</fixed-case>) System at the Shared Task for the 2007 <fixed-case>ACL</fixed-case> Workshop on Statistical Machine Translation</title>
         <author><first>Andreas</first><last>Zollmann</last></author>
         <author><first>Ashish</first><last>Venugopal</last></author>
         <author><first>Matthias</first><last>Paulik</last></author>
@@ -1343,7 +1344,7 @@
         <bibkey>zollmann-EtAl:2007:WMT</bibkey>
    </paper>
    <paper id="0732">
-        <title>Statistical Post-Editing on SYSTRAN’s Rule-Based Translation System</title>
+        <title>Statistical Post-Editing on <fixed-case>SYSTRAN</fixed-case>‘s Rule-Based Translation System</title>
         <author><first>Loïc</first><last>Dugast</last></author>
         <author><first>Jean</first><last>Senellart</last></author>
         <author><first>Philipp</first><last>Koehn</last></author>
@@ -1372,7 +1373,7 @@
         <bibkey>koehn-schroeder:2007:WMT</bibkey>
    </paper>
    <paper id="0734">
-        <title>METEOR: An Automatic Metric for MT Evaluation with High Levels of Correlation with Human Judgments</title>
+        <title><fixed-case>METEOR</fixed-case>: An Automatic Metric for <fixed-case>MT</fixed-case> Evaluation with High Levels of Correlation with Human Judgments</title>
         <author><first>Alon</first><last>Lavie</last></author>
         <author><first>Abhaya</first><last>Agarwal</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
@@ -1386,7 +1387,7 @@
         <bibkey>lavie-agarwal:2007:WMT</bibkey>
    </paper>
    <paper id="0735">
-        <title>English-to-Czech Factored Machine Translation</title>
+        <title><fixed-case>English-to-Czech</fixed-case> Factored Machine Translation</title>
         <author><first>Ondřej</first><last>Bojar</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
         <month>June</month>
@@ -1428,7 +1429,7 @@
         <bibkey>mohit-hwa:2007:WMT</bibkey>
    </paper>
    <paper id="0738">
-        <title>Linguistic Features for Automatic Evaluation of Heterogenous MT Systems</title>
+        <title>Linguistic Features for Automatic Evaluation of Heterogenous <fixed-case>MT</fixed-case> Systems</title>
         <author><first>Jesús</first><last>Giménez</last></author>
         <author><first>Lluís</first><last>Màrquez</last></author>
         <booktitle>Proceedings of the Second Workshop on Statistical Machine Translation</booktitle>
@@ -3583,7 +3584,7 @@
         <bibkey>LAW:2007</bibkey>
    </paper>
    <paper id="1501">
-        <title>GrAF: A Graph-based Format for Linguistic Annotations</title>
+        <title><fixed-case>GrAF</fixed-case>: A Graph-based Format for Linguistic Annotations</title>
         <author><first>Nancy</first><last>Ide</last></author>
         <author><first>Keith</first><last>Suderman</last></author>
         <booktitle>Proceedings of the Linguistic Annotation Workshop</booktitle>
@@ -3597,7 +3598,7 @@
         <bibkey>ide-suderman:2007:LAW</bibkey>
    </paper>
    <paper id="1502">
-        <title>Efficient Annotation with the Jena ANnotation Environment (JANE)</title>
+        <title>Efficient Annotation with the <fixed-case>Jena ANnotation Environment (JANE)</fixed-case></title>
         <author><first>Katrin</first><last>Tomanek</last></author>
         <author><first>Joachim</first><last>Wermter</last></author>
         <author><first>Udo</first><last>Hahn</last></author>
@@ -3639,7 +3640,7 @@
         <bibkey>foster:2007:LAW</bibkey>
    </paper>
    <paper id="1505">
-        <title>An Annotation Type System for a Data-Driven NLP Pipeline</title>
+        <title>An Annotation Type System for a Data-Driven <fixed-case>NLP</fixed-case> Pipeline</title>
         <author><first>Udo</first><last>Hahn</last></author>
         <author><first>Ekaterina</first><last>Buyko</last></author>
         <author><first>Katrin</first><last>Tomanek</last></author>
@@ -3671,7 +3672,7 @@
         <bibkey>boyd:2007:LAW</bibkey>
    </paper>
    <paper id="1507">
-        <title>Usage of XSL Stylesheets for the Annotation of the Sámi Language Corpora.</title>
+        <title>Usage of <fixed-case>XSL</fixed-case> Stylesheets for the Annotation of the Sámi Language Corpora.</title>
         <author><first>Saara</first><last>Huhmarniemi</last></author>
         <author><first>Sjur N.</first><last>Moshagen</last></author>
         <author><first>Trond</first><last>Trosterud</last></author>
@@ -3722,7 +3723,7 @@
         <bibkey>ganchev-EtAl:2007:LAW</bibkey>
    </paper>
    <paper id="1510">
-        <title>Querying Multimodal Annotation: A Concordancer for GeM</title>
+        <title>Querying Multimodal Annotation: A Concordancer for <fixed-case>GeM</fixed-case></title>
         <author><first>Martin</first><last>Thomas</last></author>
         <booktitle>Proceedings of the Linguistic Annotation Workshop</booktitle>
         <month>June</month>
@@ -3844,7 +3845,7 @@
         <bibkey>verhagen-stubbs-pustejovsky:2007:LAW</bibkey>
    </paper>
    <paper id="1518">
-        <title>XARA: An XML- and Rule-based Semantic Role Labeler</title>
+        <title><fixed-case>XARA</fixed-case>: An <fixed-case>XML</fixed-case>- and Rule-based Semantic Role Labeler</title>
         <author><first>Gerwert</first><last>Stevens</last></author>
         <booktitle>Proceedings of the Linguistic Annotation Workshop</booktitle>
         <month>June</month>
@@ -3857,7 +3858,7 @@
         <bibkey>stevens:2007:LAW</bibkey>
    </paper>
    <paper id="1519">
-        <title>ITU Treebank Annotation Tool</title>
+        <title><fixed-case>ITU</fixed-case> Treebank Annotation Tool</title>
         <author><first>Gülşen</first><last>Eryiğit</last></author>
         <booktitle>Proceedings of the Linguistic Annotation Workshop</booktitle>
         <month>June</month>
@@ -3951,7 +3952,7 @@
         <bibkey>rodriguez-EtAl:2007:LAW</bibkey>
    </paper>
    <paper id="1525">
-        <title>PoCoS - Potsdam Coreference Scheme</title>
+        <title><fixed-case>PoCoS</fixed-case> - <fixed-case>Potsdam Coreference Scheme</fixed-case></title>
         <author><first>Olga</first><last>Krasavina</last></author>
         <author><first>Christian</first><last>Chiarcos</last></author>
         <booktitle>Proceedings of the Linguistic Annotation Workshop</booktitle>
@@ -3965,7 +3966,7 @@
         <bibkey>krasavina-chiarcos:2007:LAW</bibkey>
    </paper>
    <paper id="1526">
-        <title>Multiple-step Treebank Conversion: From Dependency to Penn Format</title>
+        <title>Multiple-step Treebank Conversion: From Dependency to <fixed-case>Penn</fixed-case> Format</title>
         <author><first>Cristina</first><last>Bosco</last></author>
         <booktitle>Proceedings of the Linguistic Annotation Workshop</booktitle>
         <month>June</month>
@@ -3991,7 +3992,7 @@
         <bibkey>girju:2007:LAW</bibkey>
    </paper>
    <paper id="1528">
-        <title>IGT-XML: An XML Format for Interlinearized Glossed Text</title>
+        <title><fixed-case>IGT-XML</fixed-case>: An <fixed-case>XML</fixed-case> Format for Interlinearized Glossed Text</title>
         <author><first>Alexis</first><last>Palmer</last></author>
         <author><first>Katrin</first><last>Erk</last></author>
         <booktitle>Proceedings of the Linguistic Annotation Workshop</booktitle>

--- a/import/W08.xml
+++ b/import/W08.xml
@@ -5274,12 +5274,12 @@
     </paper>
 
     <paper id="2201">
-    <title><fixed-case>A New Life for Semantic Annotations?</fixed-case></title>
+    <title>A New Life for Semantic Annotations?</title>
     <author><first>Harry</first><last>Bunt</last></author>
     </paper>
 
     <paper id="2202">
-    <title><fixed-case>Combining Knowledge-based Methods and Supervised Learning for Effective Italian Word Sense Disambiguation</fixed-case></title>
+    <title>Combining Knowledge-based Methods and Supervised Learning for Effective <fixed-case>I</fixed-case>talian Word Sense Disambiguation</title>
     <author><first>Pierpaolo</first><last>Basile</last></author>
     <author><first>Marco</first><last>de Gemmis</last></author>
     <author><first>Pasquale</first><last>Lops</last></author>
@@ -5287,19 +5287,19 @@
     </paper>
 
     <paper id="2203">
-    <title><fixed-case>Semantic Representations of Syntactically Marked Discourse Status in Crosslinguistic Perspective</fixed-case></title>
+    <title>Semantic Representations of Syntactically Marked Discourse Status in Crosslinguistic Perspective</title>
     <author><first>Emily M.</first><last>Bender</last></author>
     <author><first>David</first><last>Goss-Grubbs</last></author>
     </paper>
 
     <paper id="2204">
-    <title><fixed-case>High Precision Analysis of NPs with a Deep Processing Grammar</fixed-case></title>
+    <title>High Precision Analysis of <fixed-case>NP</fixed-case>s with a Deep Processing Grammar</title>
     <author><first>António</first><last>Branco</last></author>
     <author><first>Francisco</first><last>Costa</last></author>
     </paper>
 
     <paper id="2205">
-    <title><fixed-case>Augmenting WordNet for Deep Understanding of Text</fixed-case></title>
+    <title>Augmenting WordNet for Deep Understanding of Text</title>
     <author><first>Peter</first><last>Clark</last></author>
     <author><first>Christiane</first><last>Fellbaum</last></author>
     <author><first>Jerry R.</first><last>Hobbs</last></author>
@@ -5309,18 +5309,18 @@
     </paper>
 
     <paper id="2206">
-    <title><fixed-case>How Well Do Semantic Relatedness Measures Perform? A Meta-Study</fixed-case></title>
+    <title>How Well Do Semantic Relatedness Measures Perform? A Meta-Study</title>
     <author><first>Irene</first><last>Cramer</last></author>
     </paper>
 
     <paper id="2207">
-    <title><fixed-case>KnowNet: A Proposal for Building Highly Connected and Dense Knowledge Bases from the Web</fixed-case></title>
+    <title><fixed-case>K</fixed-case>now<fixed-case>N</fixed-case>et: A Proposal for Building Highly Connected and Dense Knowledge Bases from the <fixed-case>W</fixed-case>eb</title>
     <author><first>Montse</first><last>Cuadros</last></author>
     <author><first>German</first><last>Rigau</last></author>
     </paper>
 
     <paper id="2208">
-    <title><fixed-case>Combining Word Sense and Usage for Modeling Frame Semantics</fixed-case></title>
+    <title>Combining Word Sense and Usage for Modeling Frame Semantics</title>
     <author><first>Diego</first><last>De Cao</last></author>
     <author><first>Danilo</first><last>Croce</last></author>
     <author><first>Marco</first><last>Pennacchiotti</last></author>
@@ -5328,19 +5328,19 @@
     </paper>
 
     <paper id="2209">
-    <title><fixed-case>Answering Why-Questions in Closed Domains from a Discourse Model</fixed-case></title>
+    <title>Answering Why-Questions in Closed Domains from a Discourse Model</title>
     <author><first>Rodolfo</first><last>Delmonte</last></author>
     <author><first>Emanuele</first><last>Pianta</last></author>
     </paper>
 
     <paper id="2210">
-    <title><fixed-case>Analyzing the Explanation Structure of Procedural Texts: Dealing with Advice and Warnings</fixed-case></title>
+    <title>Analyzing the Explanation Structure of Procedural Texts: Dealing with Advice and Warnings</title>
     <author><first>Lionel</first><last>Fontan</last></author>
     <author><first>Patrick</first><last>Saint-Dizier</last></author>
     </paper>
 
     <paper id="2211">
-    <title><fixed-case>From Predicting Predominant Senses to Local Context for Word Sense Disambiguation</fixed-case></title>
+    <title>From Predicting Predominant Senses to Local Context for Word Sense Disambiguation</title>
     <author><first>Rob</first><last>Koeling</last></author>
     <author><first>Diana</first><last>McCarthy</last></author>
     </paper>
@@ -5352,90 +5352,90 @@
     </paper>
 
     <paper id="2213">
-    <title><fixed-case>Analysis of ASL Motion Capture Data towards Identification of Verb Type</fixed-case></title>
+    <title>Analysis of <fixed-case>ASL</fixed-case> Motion Capture Data towards Identification of Verb Type</title>
     <author><first>Evguenia</first><last>Malaia</last></author>
     <author><first>John</first><last>Borneman</last></author>
     <author><first>Ronnie B.</first><last>Wilbur</last></author>
     </paper>
 
     <paper id="2214">
-    <title><fixed-case>The Idiom–Reference Connection</fixed-case></title>
+    <title>The Idiom–Reference Connection</title>
     <author><first>Marjorie</first><last>McShane</last></author>
     <author><first>Sergei</first><last>Nirenburg</last></author>
     </paper>
 
     <paper id="2215">
-    <title><fixed-case>Resolving Paraphrases to Support Modeling Language Perception in an Intelligent Agent</fixed-case></title>
+    <title>Resolving Paraphrases to Support Modeling Language Perception in an Intelligent Agent</title>
     <author><first>Sergei</first><last>Nirenburg</last></author>
     <author><first>Marjorie</first><last>McShane</last></author>
     <author><first>Stephen</first><last>Beale</last></author>
     </paper>
 
     <paper id="2216">
-    <title><fixed-case>Everyday Language is Highly Intensional</fixed-case></title>
+    <title>Everyday Language is Highly Intensional</title>
     <author><first>Allan</first><last>Ramsay</last></author>
     <author><first>Debora</first><last>Field</last></author>
     </paper>
 
     <paper id="2217">
-    <title><fixed-case>Refining the Meaning of Sense Labels in PDTB: “Concession”</fixed-case></title>
+    <title>Refining the Meaning of Sense Labels in <fixed-case>PDTB</fixed-case>: “Concession”</title>
     <author><first>Livio</first><last>Robaldo</last></author>
     <author><first>Eleni</first><last>Miltsakaki</last></author>
     <author><first>Jerry R.</first><last>Hobbs</last></author>
     </paper>
 
     <paper id="2218">
-    <title><fixed-case>Connective-based Local Coherence Analysis: A Lexicon for Recognizing Causal Relationships</fixed-case></title>
+    <title>Connective-based Local Coherence Analysis: A Lexicon for Recognizing Causal Relationships</title>
     <author><first>Manfred</first><last>Stede</last></author>
     </paper>
 
     <paper id="2219">
-    <title><fixed-case>Open Knowledge Extraction through Compositional Language Processing</fixed-case></title>
+    <title>Open Knowledge Extraction through Compositional Language Processing</title>
     <author><first>Benjamin</first><last>Van Durme</last></author>
     <author><first>Lenhart</first><last>Schubert</last></author>
     </paper>
 
     <paper id="2220">
-    <title><fixed-case>Introduction to the Shared Task on Comparing Semantic Representations</fixed-case></title>
+    <title>Introduction to the Shared Task on Comparing Semantic Representations</title>
     <author><first>Johan</first><last>Bos</last></author>
     </paper>
 
     <paper id="2221">
-    <title><fixed-case>Boeing’s NLP System and the Challenges of Semantic Representation</fixed-case></title>
+    <title><fixed-case>B</fixed-case>oeing’s <fixed-case>NLP</fixed-case> System and the Challenges of Semantic Representation</title>
     <author><first>Peter</first><last>Clark</last></author>
     <author><first>Phil</first><last>Harrison</last></author>
     </paper>
 
     <paper id="2222">
-    <title><fixed-case>Wide-Coverage Semantic Analysis with Boxer</fixed-case></title>
+    <title>Wide-Coverage Semantic Analysis with <fixed-case>B</fixed-case>oxer</title>
     <author><first>Johan</first><last>Bos</last></author>
     </paper>
 
     <paper id="2223">
-    <title><fixed-case>Semantic and Pragmatic Computing with GETARUNS</fixed-case></title>
+    <title>Semantic and Pragmatic Computing with <fixed-case>GETARUNS</fixed-case></title>
     <author><first>Rodolfo</first><last>Delmonte</last></author>
     </paper>
 
     <paper id="2224">
-    <title><fixed-case>LXGram in the Shared Task “Comparing Semantic Representations” of STEP 2008</fixed-case></title>
+    <title><fixed-case>LXG</fixed-case>ram in the Shared Task “<fixed-case>C</fixed-case>omparing <fixed-case>S</fixed-case>emantic <fixed-case>R</fixed-case>epresentations” of <fixed-case>STEP</fixed-case> 2008</title>
     <author><first>António</first><last>Branco</last></author>
     <author><first>Francisco</first><last>Costa</last></author>
     </paper>
 
     <paper id="2225">
-    <title><fixed-case>Baseline Evaluation of WSD and Semantic Dependency in OntoSem</fixed-case></title>
+    <title>Baseline Evaluation of <fixed-case>WSD</fixed-case> and Semantic Dependency in <fixed-case>O</fixed-case>nto<fixed-case>S</fixed-case>em</title>
     <author><first>Sergei</first><last>Nirenburg</last></author>
     <author><first>Stephen</first><last>Beale</last></author>
     <author><first>Marjorie</first><last>McShane</last></author>
     </paper>
 
     <paper id="2226">
-    <title><fixed-case>The TextCap Semantic Interpreter</fixed-case></title>
+    <title>The <fixed-case>T</fixed-case>ext<fixed-case>C</fixed-case>ap Semantic Interpreter</title>
     <author><first>Charles B.</first><last>Callaway</last></author>
     </paper>
 
     <paper id="2227">
-    <title><fixed-case>Deep Semantic Analysis of Text</fixed-case></title>
+    <title>Deep Semantic Analysis of Text</title>
     <author><first>James F.</first><last>Allen</last></author>
     <author><first>Mary</first><last>Swift</last></author>
     <author><first>Will</first><last>de Beaumont</last></author>
@@ -5450,7 +5450,7 @@
     </paper>
 
     <paper id="2229">
-    <title><fixed-case>Representing and Visualizing Calendar Expressions in Texts</fixed-case></title>
+    <title>Representing and Visualizing Calendar Expressions in Texts</title>
     <author><first>Delphine</first><last>Battistelli</last></author>
     <author><first>Javier</first><last>Couto</last></author>
     <author><first>Jean-Luc</first><last>Minel</last></author>
@@ -5458,21 +5458,21 @@
     </paper>
 
     <paper id="2230">
-    <title><fixed-case>Addressing the Resource Bottleneck to Create Large-Scale Annotated Texts</fixed-case></title>
+    <title>Addressing the Resource Bottleneck to Create Large-Scale Annotated Texts</title>
     <author><first>Jon</first><last>Chamberlain</last></author>
     <author><first>Massimo</first><last>Poesio</last></author>
     <author><first>Udo</first><last>Kruschwitz</last></author>
     </paper>
 
     <paper id="2231">
-    <title><fixed-case>A Resource-Poor Approach for Linking Ontology Classes to Wikipedia Articles</fixed-case></title>
+    <title>A Resource-Poor Approach for Linking Ontology Classes to <fixed-case>W</fixed-case>ikipedia Articles</title>
     <author><first>Nils</first><last>Reiter</last></author>
     <author><first>Matthias</first><last>Hartung</last></author>
     <author><first>Anette</first><last>Frank</last></author>
     </paper>
 
     <paper id="2232">
-    <title><fixed-case>Top-Down Cohesion Segmentation in Summarization</fixed-case></title>
+    <title>Top-Down Cohesion Segmentation in Summarization</title>
     <author><first>Doina</first><last>Tatar</last></author>
     <author><first>Andreea Diana</first><last>Mihis</last></author>
     <author><first>Gabriela</first><last>Serban</last></author>

--- a/import/W08.xml
+++ b/import/W08.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W08">
    <paper id="0100">
         <title>Proceedings of the 9th SIGdial Workshop on Discourse and Dialogue</title>
@@ -496,7 +497,7 @@
         <bibkey>bender-xia-bansleben:2008:TeachCL</bibkey>
    </paper>
    <paper id="0203">
-        <title>Freshmen’s CL Curriculum: The Benefits of Redundancy</title>
+        <title>Freshmen’s <fixed-case>CL</fixed-case> Curriculum: The Benefits of Redundancy</title>
         <author><first>Heike</first><last>Zinsmeister</last></author>
         <booktitle>Proceedings of the Third Workshop on Issues in Teaching Computational Linguistics</booktitle>
         <month>June</month>
@@ -535,7 +536,7 @@
         <bibkey>foslerlussier:2008:TeachCL</bibkey>
    </paper>
    <paper id="0206">
-        <title>The Evolution of a Statistical NLP Course</title>
+        <title>The Evolution of a Statistical <fixed-case>NLP</fixed-case> Course</title>
         <author><first>Fei</first><last>Xia</last></author>
         <booktitle>Proceedings of the Third Workshop on Issues in Teaching Computational Linguistics</booktitle>
         <month>June</month>
@@ -548,7 +549,7 @@
         <bibkey>xia:2008:TeachCL</bibkey>
    </paper>
    <paper id="0207">
-        <title>Exploring Large-Data Issues in the Curriculum: A Case Study with MapReduce</title>
+        <title>Exploring Large-Data Issues in the Curriculum: A Case Study with <fixed-case>MapReduce</fixed-case></title>
         <author><first>Jimmy</first><last>Lin</last></author>
         <booktitle>Proceedings of the Third Workshop on Issues in Teaching Computational Linguistics</booktitle>
         <month>June</month>
@@ -577,7 +578,7 @@
         <bibkey>bird-EtAl:2008:TeachCL</bibkey>
    </paper>
    <paper id="0209">
-        <title>Combining Open-Source with Research to Re-engineer a Hands-on Introductory NLP Course</title>
+        <title>Combining Open-Source with Research to Re-engineer a Hands-on Introductory <fixed-case>NLP</fixed-case> Course</title>
         <author><first>Nitin</first><last>Madnani</last></author>
         <author><first>Bonnie J.</first><last>Dorr</last></author>
         <booktitle>Proceedings of the Third Workshop on Issues in Teaching Computational Linguistics</booktitle>
@@ -605,7 +606,7 @@
         <bibkey>hockey-christian:2008:TeachCL</bibkey>
    </paper>
    <paper id="0211">
-        <title>The North American Computational Linguistics Olympiad (NACLO)</title>
+        <title>The North American Computational Linguistics Olympiad (<fixed-case>NACLO</fixed-case>)</title>
         <author><first>Dragomir R.</first><last>Radev</last></author>
         <author><first>Lori</first><last>Levin</last></author>
         <author><first>Thomas E.</first><last>Payne</last></author>
@@ -634,7 +635,7 @@
         <bibkey>eisner-smith:2008:TeachCL</bibkey>
    </paper>
    <paper id="0213">
-        <title>Studying Discourse and Dialogue with SIDGrid</title>
+        <title>Studying Discourse and Dialogue with <fixed-case>SIDGrid</fixed-case></title>
         <author><first>Gina-Anne</first><last>Levow</last></author>
         <booktitle>Proceedings of the Third Workshop on Issues in Teaching Computational Linguistics</booktitle>
         <month>June</month>
@@ -647,7 +648,7 @@
         <bibkey>levow:2008:TeachCL</bibkey>
    </paper>
    <paper id="0214">
-        <title>Teaching NLP to Computer Science Majors via Applications and Experiments</title>
+        <title>Teaching <fixed-case>NLP</fixed-case> to Computer Science Majors via Applications and Experiments</title>
         <author><first>Reva</first><last>Freedman</last></author>
         <booktitle>Proceedings of the Third Workshop on Issues in Teaching Computational Linguistics</booktitle>
         <month>June</month>
@@ -791,7 +792,7 @@
         <bibkey>fossum-knight-abney:2008:WMT</bibkey>
    </paper>
    <paper id="0307">
-        <title>Using Shallow Syntax Information to Improve Word Alignment and Reordering for SMT</title>
+        <title>Using Shallow Syntax Information to Improve Word Alignment and Reordering for <fixed-case>SMT</fixed-case></title>
         <author><first>Josep M.</first><last>Crego</last></author>
         <author><first>Nizar</first><last>Habash</last></author>
         <booktitle>Proceedings of the Third Workshop on Statistical Machine Translation</booktitle>
@@ -836,7 +837,7 @@
         <bibkey>callisonburch-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0310">
-        <title>Limsi’s Statistical Translation Systems for WMT’08</title>
+        <title>Limsi’s Statistical Translation Systems for <fixed-case>WMT</fixed-case>‘08</title>
         <author><first>Daniel</first><last>Déchelotte</last></author>
         <author><first>Gilles</first><last>Adda</last></author>
         <author><first>Alexandre</first><last>Allauzen</last></author>
@@ -856,7 +857,7 @@
         <bibkey>dechelotte-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0311">
-        <title>The MetaMorpho Translation System</title>
+        <title>The <fixed-case>MetaMorpho</fixed-case> Translation System</title>
         <author><first>Attila</first><last>Novák</last></author>
         <author><first>László</first><last>Tihanyi</last></author>
         <author><first>Gábor</first><last>Prószéky</last></author>
@@ -871,7 +872,7 @@
         <bibkey>novak-tihanyi-proszeky:2008:WMT</bibkey>
    </paper>
    <paper id="0312">
-        <title>Meteor, M-BLEU and M-TER: Evaluation Metrics for High-Correlation with Human Rankings of Machine Translation Output</title>
+        <title>Meteor, <fixed-case>M-BLEU</fixed-case> and <fixed-case>M-TER</fixed-case>: Evaluation Metrics for High-Correlation with Human Rankings of Machine Translation Output</title>
         <author><first>Abhaya</first><last>Agarwal</last></author>
         <author><first>Alon</first><last>Lavie</last></author>
         <booktitle>Proceedings of the Third Workshop on Statistical Machine Translation</booktitle>
@@ -885,7 +886,7 @@
         <bibkey>agarwal-lavie:2008:WMT</bibkey>
    </paper>
    <paper id="0313">
-        <title>First Steps towards a General Purpose French/English Statistical Machine Translation System</title>
+        <title>First Steps towards a General Purpose <fixed-case>French/English</fixed-case> Statistical Machine Translation System</title>
         <author><first>Holger</first><last>Schwenk</last></author>
         <author><first>Jean-Baptiste</first><last>Fouet</last></author>
         <author><first>Jean</first><last>Senellart</last></author>
@@ -900,7 +901,7 @@
         <bibkey>schwenk-fouet-senellart:2008:WMT</bibkey>
    </paper>
    <paper id="0314">
-        <title>The University of Washington Machine Translation System for ACL WMT 2008</title>
+        <title>The <fixed-case>University</fixed-case> of <fixed-case>Washington</fixed-case> Machine Translation System for <fixed-case>ACL</fixed-case> <fixed-case>WMT</fixed-case> 2008</title>
         <author><first>Amittai</first><last>Axelrod</last></author>
         <author><first>Mei</first><last>Yang</last></author>
         <author><first>Kevin</first><last>Duh</last></author>
@@ -916,7 +917,7 @@
         <bibkey>axelrod-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0315">
-        <title>The TALP-UPC Ngram-Based Statistical Machine Translation System for ACL-WMT 2008</title>
+        <title>The <fixed-case>TALP</fixed-case>-<fixed-case>UPC</fixed-case> <fixed-case>Ngram</fixed-case>-Based Statistical Machine Translation System for <fixed-case>ACL</fixed-case>-<fixed-case>WMT</fixed-case> 2008</title>
         <author><first>Maxim</first><last>Khalilov</last></author>
         <author><first>Adolfo</first><last>Hernández H.</last></author>
         <author><first>Marta R.</first><last>Costa-jussà</last></author>
@@ -937,7 +938,7 @@
         <bibkey>khalilov-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0316">
-        <title>European Language Translation with Weighted Finite State Transducers: The CUED MT System for the 2008 ACL Workshop on SMT</title>
+        <title>European Language Translation with Weighted Finite State Transducers: The <fixed-case>CUED</fixed-case> <fixed-case>MT</fixed-case> System for the 2008 <fixed-case>ACL</fixed-case> Workshop on <fixed-case>SMT</fixed-case></title>
         <author><first>Graeme</first><last>Blackwood</last></author>
         <author><first>Adrià</first><last>de Gispert</last></author>
         <author><first>Jamie</first><last>Brunning</last></author>
@@ -953,7 +954,7 @@
         <bibkey>blackwood-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0317">
-        <title>Effects of Morphological Analysis in Translation between German and English</title>
+        <title>Effects of Morphological Analysis in Translation between <fixed-case>German</fixed-case> and <fixed-case>English</fixed-case></title>
         <author><first>Sara</first><last>Stymne</last></author>
         <author><first>Maria</first><last>Holmqvist</last></author>
         <author><first>Lars</first><last>Ahrenberg</last></author>
@@ -968,7 +969,7 @@
         <bibkey>stymne-holmqvist-ahrenberg:2008:WMT</bibkey>
    </paper>
    <paper id="0318">
-        <title>Towards better Machine Translation Quality for the German-English Language Pairs</title>
+        <title>Towards better Machine Translation Quality for the <fixed-case>German-English</fixed-case> Language Pairs</title>
         <author><first>Philipp</first><last>Koehn</last></author>
         <author><first>Abhishek</first><last>Arun</last></author>
         <author><first>Hieu</first><last>Hoang</last></author>
@@ -983,7 +984,7 @@
         <bibkey>koehn-arun-hoang:2008:WMT</bibkey>
    </paper>
    <paper id="0319">
-        <title>Phrase-Based and Deep Syntactic English-to-Czech Statistical Machine Translation</title>
+        <title>Phrase-Based and Deep Syntactic <fixed-case>English</fixed-case>-to-<fixed-case>Czech</fixed-case> Statistical Machine Translation</title>
         <author><first>Ondřej</first><last>Bojar</last></author>
         <author><first>Jan</first><last>Hajič</last></author>
         <booktitle>Proceedings of the Third Workshop on Statistical Machine Translation</booktitle>
@@ -997,7 +998,7 @@
         <bibkey>bojar-hajivc:2008:WMT</bibkey>
    </paper>
    <paper id="0320">
-        <title>Improving English-Spanish Statistical Machine Translation: Experiments in Domain Adaptation, Sentence Paraphrasing, Tokenization, and Recasing</title>
+        <title>Improving <fixed-case>English-Spanish</fixed-case> Statistical Machine Translation: Experiments in Domain Adaptation, Sentence Paraphrasing, Tokenization, and Recasing</title>
         <author><first>Preslav</first><last>Nakov</last></author>
         <booktitle>Proceedings of the Third Workshop on Statistical Machine Translation</booktitle>
         <month>June</month>
@@ -1025,7 +1026,7 @@
         <bibkey>bach-gao-vogel:2008:WMT</bibkey>
    </paper>
    <paper id="0322">
-        <title>Kernel Regression Framework for Machine Translation: UCL System Description for WMT 2008 Shared Translation Task</title>
+        <title>Kernel Regression Framework for Machine Translation: <fixed-case>UCL</fixed-case> System Description for <fixed-case>WMT</fixed-case> 2008 Shared Translation Task</title>
         <author><first>Zhuoran</first><last>Wang</last></author>
         <author><first>John</first><last>Shawe-Taylor</last></author>
         <booktitle>Proceedings of the Third Workshop on Statistical Machine Translation</booktitle>
@@ -1053,7 +1054,7 @@
         <bibkey>nikoulina-dymetman:2008:WMT</bibkey>
    </paper>
    <paper id="0324">
-        <title>Statistical Transfer Systems for French-English and German-English Machine Translation</title>
+        <title>Statistical Transfer Systems for <fixed-case>French-English</fixed-case> and <fixed-case>German-English</fixed-case> Machine Translation</title>
         <author><first>Greg</first><last>Hanneman</last></author>
         <author><first>Edmund</first><last>Huber</last></author>
         <author><first>Abhaya</first><last>Agarwal</last></author>
@@ -1072,7 +1073,7 @@
         <bibkey>hanneman-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0325">
-        <title>TectoMT: Highly Modular MT System with Tectogrammatics Used as Transfer Layer</title>
+        <title><fixed-case>TectoMT</fixed-case>: Highly Modular <fixed-case>MT</fixed-case> System with Tectogrammatics Used as Transfer Layer</title>
         <author><first>Zdenek</first><last>Zabokrtsky</last></author>
         <author><first>Jan</first><last>Ptacek</last></author>
         <author><first>Petr</first><last>Pajas</last></author>
@@ -1087,7 +1088,7 @@
         <bibkey>zabokrtsky-ptacek-pajas:2008:WMT</bibkey>
    </paper>
    <paper id="0326">
-        <title>MaTrEx: The DCU MT System for WMT 2008</title>
+        <title><fixed-case>MaTrEx</fixed-case>: The <fixed-case>DCU</fixed-case> <fixed-case>MT</fixed-case> System for <fixed-case>WMT</fixed-case> 2008</title>
         <author><first>John</first><last>Tinsley</last></author>
         <author><first>Yanjun</first><last>Ma</last></author>
         <author><first>Sylwia</first><last>Ozdowska</last></author>
@@ -1103,7 +1104,7 @@
         <bibkey>tinsley-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0327">
-        <title>Can we Relearn an RBMT System?</title>
+        <title>Can we Relearn an <fixed-case>RBMT</fixed-case> System?</title>
         <author><first>Loïc</first><last>Dugast</last></author>
         <author><first>Jean</first><last>Senellart</last></author>
         <author><first>Philipp</first><last>Koehn</last></author>
@@ -1152,7 +1153,7 @@
         <bibkey>rosti-EtAl:2008:WMT</bibkey>
    </paper>
    <paper id="0330">
-        <title>The Role of Pseudo References in MT Evaluation</title>
+        <title>The Role of Pseudo References in <fixed-case>MT</fixed-case> Evaluation</title>
         <author><first>Joshua</first><last>Albrecht</last></author>
         <author><first>Rebecca</first><last>Hwa</last></author>
         <booktitle>Proceedings of the Third Workshop on Statistical Machine Translation</booktitle>
@@ -1179,7 +1180,7 @@
         <bibkey>duh:2008:WMT</bibkey>
    </paper>
    <paper id="0332">
-        <title>A Smorgasbord of Features for Automatic MT Evaluation</title>
+        <title>A Smorgasbord of Features for Automatic <fixed-case>MT</fixed-case> Evaluation</title>
         <author><first>Jesús</first><last>Giménez</last></author>
         <author><first>Lluís</first><last>Màrquez</last></author>
         <booktitle>Proceedings of the Third Workshop on Statistical Machine Translation</booktitle>
@@ -1193,7 +1194,7 @@
         <bibkey>gimenez-marquez:2008:WMT</bibkey>
    </paper>
    <paper id="0333">
-        <title>Fast, Easy, and Cheap: Construction of Statistical Machine Translation Models with MapReduce</title>
+        <title>Fast, Easy, and Cheap: Construction of Statistical Machine Translation Models with <fixed-case>MapReduce</fixed-case></title>
         <author><first>Chris</first><last>Dyer</last></author>
         <author><first>Aaron</first><last>Cordova</last></author>
         <author><first>Alex</first><last>Mont</last></author>
@@ -1223,7 +1224,7 @@
         <bibkey>finch-sumita:2008:WMT</bibkey>
    </paper>
    <paper id="0335">
-        <title>Improved Statistical Machine Translation by Multiple Chinese Word Segmentation</title>
+        <title>Improved Statistical Machine Translation by Multiple <fixed-case>Chinese</fixed-case> Word Segmentation</title>
         <author><first>Ruiqiang</first><last>Zhang</last></author>
         <author><first>Keiji</first><last>Yasuda</last></author>
         <author><first>Eiichiro</first><last>Sumita</last></author>
@@ -1238,7 +1239,7 @@
         <bibkey>zhang-yasuda-sumita:2008:WMT</bibkey>
    </paper>
    <paper id="0336">
-        <title>Optimizing Chinese Word Segmentation for Machine Translation Performance</title>
+        <title>Optimizing <fixed-case>Chinese</fixed-case> Word Segmentation for Machine Translation Performance</title>
         <author><first>Pi-Chuan</first><last>Chang</last></author>
         <author><first>Michel</first><last>Galley</last></author>
         <author><first>Christopher D.</first><last>Manning</last></author>
@@ -1265,7 +1266,7 @@
         <bibkey>SSST:2008</bibkey>
    </paper>
    <paper id="0401">
-        <title>Imposing Constraints from the Source Tree on ITG Constraints for SMT</title>
+        <title>Imposing Constraints from the Source Tree on <fixed-case>ITG</fixed-case> Constraints for <fixed-case>SMT</fixed-case></title>
         <author><first>Hirofumi</first><last>Yamamoto</last></author>
         <author><first>Hideo</first><last>Okuma</last></author>
         <author><first>Eiichiro</first><last>Sumita</last></author>
@@ -1323,7 +1324,7 @@
         <bibkey>subotin:2008:SSST</bibkey>
    </paper>
    <paper id="0405">
-        <title>A Rule-Driven Dynamic Programming Decoder for Statistical MT</title>
+        <title>A Rule-Driven Dynamic Programming Decoder for Statistical <fixed-case>MT</fixed-case></title>
         <author><first>Christoph</first><last>Tillmann</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Second Workshop on Syntax and Structure in Statistical Translation (SSST-2)</booktitle>
         <month>June</month>
@@ -1336,7 +1337,7 @@
         <bibkey>tillmann:2008:SSST</bibkey>
    </paper>
    <paper id="0406">
-        <title>Syntactic Reordering Integrated with Phrase-Based SMT</title>
+        <title>Syntactic Reordering Integrated with Phrase-Based <fixed-case>SMT</fixed-case></title>
         <author><first>Jakob</first><last>Elming</last></author>
         <booktitle>Proceedings of the ACL-08: HLT Second Workshop on Syntax and Structure in Statistical Translation (SSST-2)</booktitle>
         <month>June</month>
@@ -2099,7 +2100,7 @@
         <bibkey>morley:2008:SIGMORPHON</bibkey>
    </paper>
    <paper id="0703">
-        <title>A Bayesian Model of Natural Language Phonology: Generating Alternations from Underlying Forms</title>
+        <title>A <fixed-case>B</fixed-case>ayesian Model of Natural Language Phonology: Generating Alternations from Underlying Forms</title>
         <author><first>David</first><last>Ellis</last></author>
         <booktitle>Proceedings of the Tenth Meeting of ACL Special Interest Group on Computational Morphology and Phonology</booktitle>
         <month>June</month>
@@ -2112,7 +2113,7 @@
         <bibkey>ellis:2008:SIGMORPHON</bibkey>
    </paper>
    <paper id="0704">
-        <title>Unsupervised Word Segmentation for Sesotho Using Adaptor Grammars</title>
+        <title>Unsupervised Word Segmentation for <fixed-case>S</fixed-case>esotho Using Adaptor Grammars</title>
         <author><first>Mark</first><last>Johnson</last></author>
         <booktitle>Proceedings of the Tenth Meeting of ACL Special Interest Group on Computational Morphology and Phonology</booktitle>
         <month>June</month>
@@ -2152,7 +2153,7 @@
         <bibkey>bane-riggle:2008:SIGMORPHON</bibkey>
    </paper>
    <paper id="0707">
-        <title>Phonotactic Probability and the Maori Passive: A Computational Approach</title>
+        <title>Phonotactic Probability and the <fixed-case>M</fixed-case>aori Passive: A Computational Approach</title>
         <author><first>‘Ōiwi</first><last>Parker Jones</last></author>
         <booktitle>Proceedings of the Tenth Meeting of ACL Special Interest Group on Computational Morphology and Phonology</booktitle>
         <month>June</month>
@@ -2165,7 +2166,7 @@
         <bibkey>parkerjones:2008:SIGMORPHON</bibkey>
    </paper>
    <paper id="0708">
-        <title>Evaluating an Agglutinative Segmentation Model for ParaMor</title>
+        <title>Evaluating an Agglutinative Segmentation Model for <fixed-case>ParaMor</fixed-case></title>
         <author><first>Christian</first><last>Monson</last></author>
         <author><first>Alon</first><last>Lavie</last></author>
         <author><first>Jaime</first><last>Carbonell</last></author>
@@ -2517,7 +2518,7 @@
         <bibkey>PaGe:2008</bibkey>
    </paper>
    <paper id="1001">
-        <title>Lexicalised Parsing of German V2</title>
+        <title>Lexicalised Parsing of <fixed-case>German</fixed-case> <fixed-case>V2</fixed-case></title>
         <author><first>Yo</first><last>Sato</last></author>
         <booktitle>Proceedings of the Workshop on Parsing German</booktitle>
         <month>June</month>
@@ -2530,7 +2531,7 @@
         <bibkey>sato:2008:PaGe</bibkey>
    </paper>
    <paper id="1002">
-        <title>Parse Selection with a German HPSG Grammar</title>
+        <title>Parse Selection with a <fixed-case>German</fixed-case> <fixed-case>HPSG</fixed-case> Grammar</title>
         <author><first>Berthold</first><last>Crysmann</last></author>
         <booktitle>Proceedings of the Workshop on Parsing German</booktitle>
         <month>June</month>
@@ -2543,7 +2544,7 @@
         <bibkey>crysmann:2008:PaGe</bibkey>
    </paper>
    <paper id="1003">
-        <title>Part-of-Speech Tagging with a Symbolic Full Parser: Using the TIGER Treebank to Evaluate Fips</title>
+        <title>Part-of-Speech Tagging with a Symbolic Full Parser: Using the <fixed-case>TIGER</fixed-case> Treebank to Evaluate Fips</title>
         <author><first>Yves</first><last>Scherrer</last></author>
         <booktitle>Proceedings of the Workshop on Parsing German</booktitle>
         <month>June</month>
@@ -2570,7 +2571,7 @@
         <bibkey>boyd-meurers:2008:PaGe</bibkey>
    </paper>
    <paper id="1005">
-        <title>Parsing German with Latent Variable Grammars</title>
+        <title>Parsing <fixed-case>German</fixed-case> with Latent Variable Grammars</title>
         <author><first>Slav</first><last>Petrov</last></author>
         <author><first>Dan</first><last>Klein</last></author>
         <booktitle>Proceedings of the Workshop on Parsing German</booktitle>
@@ -2584,7 +2585,7 @@
         <bibkey>petrov-klein:2008:PaGe</bibkey>
    </paper>
    <paper id="1006">
-        <title>Parsing Three German Treebanks: Lexicalized and Unlexicalized Baselines</title>
+        <title>Parsing Three <fixed-case>German</fixed-case> Treebanks: Lexicalized and Unlexicalized Baselines</title>
         <author><first>Anna</first><last>Rafferty</last></author>
         <author><first>Christopher D.</first><last>Manning</last></author>
         <booktitle>Proceedings of the Workshop on Parsing German</booktitle>
@@ -2598,7 +2599,7 @@
         <bibkey>rafferty-manning:2008:PaGe</bibkey>
    </paper>
    <paper id="1007">
-        <title>A Dependency-Driven Parser for German Dependency and Constituency Representations</title>
+        <title>A Dependency-Driven Parser for <fixed-case>German</fixed-case> Dependency and Constituency Representations</title>
         <author><first>Johan</first><last>Hall</last></author>
         <author><first>Joakim</first><last>Nivre</last></author>
         <booktitle>Proceedings of the Workshop on Parsing German</booktitle>
@@ -2612,7 +2613,7 @@
         <bibkey>hall-nivre:2008:PaGe</bibkey>
    </paper>
    <paper id="1008">
-        <title>The PaGe 2008 Shared Task on Parsing German</title>
+        <title>The <fixed-case>PaGe</fixed-case> 2008 Shared Task on Parsing German</title>
         <author><first>Sandra</first><last>Kübler</last></author>
         <booktitle>Proceedings of the Workshop on Parsing German</booktitle>
         <month>June</month>
@@ -3446,7 +3447,7 @@
         <bibkey>PE:2008</bibkey>
    </paper>
    <paper id="1301">
-        <title>The Stanford Typed Dependencies Representation</title>
+        <title>The <fixed-case>S</fixed-case>tanford Typed Dependencies Representation</title>
         <author><first>Marie-Catherine</first><last>de Marneffe</last></author>
         <author><first>Christopher D.</first><last>Manning</last></author>
         <booktitle>Coling 2008: Proceedings of the workshop on Cross-Framework and Cross-Domain Parser Evaluation</booktitle>
@@ -3732,7 +3733,7 @@
         <bibkey>ettelaie-georgiou-narayanan:2008:SLT4MED</bibkey>
    </paper>
    <paper id="1502">
-        <title>Speech Translation with Grammatical Framework</title>
+        <title>Speech Translation with <fixed-case>G</fixed-case>rammatical <fixed-case>F</fixed-case>ramework</title>
         <author><first>Björn</first><last>Bringert</last></author>
         <booktitle>Coling 2008: Proceedings of the workshop on Speech Processing for Safety Critical Translation and Pervasive Applications</booktitle>
         <month>August</month>
@@ -3761,7 +3762,7 @@
         <bibkey>jung-EtAl:2008:SLT4MED</bibkey>
    </paper>
    <paper id="1504">
-        <title>Economical Global Access to a VoiceXML Gateway Using Open Source Technologies</title>
+        <title>Economical Global Access to a <fixed-case>VoiceXML</fixed-case> Gateway Using <fixed-case>O</fixed-case>pen <fixed-case>S</fixed-case>ource Technologies</title>
         <author><first>Kulwinder</first><last>Singh</last></author>
         <author><first>Dong-Won</first><last>Park</last></author>
         <booktitle>Coling 2008: Proceedings of the workshop on Speech Processing for Safety Critical Translation and Pervasive Applications</booktitle>
@@ -3814,7 +3815,7 @@
         <bibkey>rayner-EtAl:2008:SLT4MED1</bibkey>
    </paper>
    <paper id="1507">
-        <title>Language Understanding in Maryland Virtual Patient</title>
+        <title>Language Understanding in <fixed-case>M</fixed-case>aryland Virtual Patient</title>
         <author><first>Sergei</first><last>Nirenburg</last></author>
         <author><first>Stephen</first><last>Beale</last></author>
         <author><first>Marjorie</first><last>McShane</last></author>
@@ -4046,7 +4047,7 @@
         <bibkey>kron-EtAl:2008:GEAF</bibkey>
    </paper>
    <paper id="1703">
-        <title>A More Precise Analysis of Punctuation for Broad-Coverage Surface Realization with CCG</title>
+        <title>A More Precise Analysis of Punctuation for Broad-Coverage Surface Realization with <fixed-case>CCG</fixed-case></title>
         <author><first>Michael</first><last>White</last></author>
         <author><first>Rajakrishnan</first><last>Rajkumar</last></author>
         <booktitle>Coling 2008: Proceedings of the workshop on Grammar Engineering Across Frameworks</booktitle>
@@ -4073,7 +4074,7 @@
         <bibkey>santaholma:2008:GEAF</bibkey>
    </paper>
    <paper id="1705">
-        <title>Speeding up LFG Parsing Using C-Structure Pruning</title>
+        <title>Speeding up <fixed-case>LFG</fixed-case> Parsing Using C-Structure Pruning</title>
         <author><first>Aoife</first><last>Cahill</last></author>
         <author><first>John T.</first><last>Maxwell III</last></author>
         <author><first>Paul</first><last>Meurer</last></author>
@@ -4589,7 +4590,7 @@
         <bibkey>ichioka-fukumoto:2008:TG3</bibkey>
    </paper>
    <paper id="2006">
-        <title>Affinity Measures Based on the Graph Laplacian</title>
+        <title>Affinity Measures Based on the Graph <fixed-case>L</fixed-case>aplacian</title>
         <author><first>Delip</first><last>Rao</last></author>
         <author><first>David</first><last>Yarowsky</last></author>
         <author><first>Chris</first><last>Callison-Burch</last></author>
@@ -5273,12 +5274,12 @@
     </paper>
 
     <paper id="2201">
-    <title>A New Life for Semantic Annotations?</title>
+    <title><fixed-case>A New Life for Semantic Annotations?</fixed-case></title>
     <author><first>Harry</first><last>Bunt</last></author>
     </paper>
 
     <paper id="2202">
-    <title>Combining Knowledge-based Methods and Supervised Learning for Effective Italian Word Sense Disambiguation</title>
+    <title><fixed-case>Combining Knowledge-based Methods and Supervised Learning for Effective Italian Word Sense Disambiguation</fixed-case></title>
     <author><first>Pierpaolo</first><last>Basile</last></author>
     <author><first>Marco</first><last>de Gemmis</last></author>
     <author><first>Pasquale</first><last>Lops</last></author>
@@ -5286,19 +5287,19 @@
     </paper>
 
     <paper id="2203">
-    <title>Semantic Representations of Syntactically Marked Discourse Status in Crosslinguistic Perspective</title>
+    <title><fixed-case>Semantic Representations of Syntactically Marked Discourse Status in Crosslinguistic Perspective</fixed-case></title>
     <author><first>Emily M.</first><last>Bender</last></author>
     <author><first>David</first><last>Goss-Grubbs</last></author>
     </paper>
 
     <paper id="2204">
-    <title>High Precision Analysis of NPs with a Deep Processing Grammar</title>
+    <title><fixed-case>High Precision Analysis of NPs with a Deep Processing Grammar</fixed-case></title>
     <author><first>António</first><last>Branco</last></author>
     <author><first>Francisco</first><last>Costa</last></author>
     </paper>
 
     <paper id="2205">
-    <title>Augmenting WordNet for Deep Understanding of Text</title>
+    <title><fixed-case>Augmenting WordNet for Deep Understanding of Text</fixed-case></title>
     <author><first>Peter</first><last>Clark</last></author>
     <author><first>Christiane</first><last>Fellbaum</last></author>
     <author><first>Jerry R.</first><last>Hobbs</last></author>
@@ -5308,18 +5309,18 @@
     </paper>
 
     <paper id="2206">
-    <title>How Well Do Semantic Relatedness Measures Perform? A Meta-Study</title>
+    <title><fixed-case>How Well Do Semantic Relatedness Measures Perform? A Meta-Study</fixed-case></title>
     <author><first>Irene</first><last>Cramer</last></author>
     </paper>
 
     <paper id="2207">
-    <title>KnowNet: A Proposal for Building Highly Connected and Dense Knowledge Bases from the Web</title>
+    <title><fixed-case>KnowNet: A Proposal for Building Highly Connected and Dense Knowledge Bases from the Web</fixed-case></title>
     <author><first>Montse</first><last>Cuadros</last></author>
     <author><first>German</first><last>Rigau</last></author>
     </paper>
 
     <paper id="2208">
-    <title>Combining Word Sense and Usage for Modeling Frame Semantics</title>
+    <title><fixed-case>Combining Word Sense and Usage for Modeling Frame Semantics</fixed-case></title>
     <author><first>Diego</first><last>De Cao</last></author>
     <author><first>Danilo</first><last>Croce</last></author>
     <author><first>Marco</first><last>Pennacchiotti</last></author>
@@ -5327,19 +5328,19 @@
     </paper>
 
     <paper id="2209">
-    <title>Answering Why-Questions in Closed Domains from a Discourse Model</title>
+    <title><fixed-case>Answering Why-Questions in Closed Domains from a Discourse Model</fixed-case></title>
     <author><first>Rodolfo</first><last>Delmonte</last></author>
     <author><first>Emanuele</first><last>Pianta</last></author>
     </paper>
 
     <paper id="2210">
-    <title>Analyzing the Explanation Structure of Procedural Texts: Dealing with Advice and Warnings</title>
+    <title><fixed-case>Analyzing the Explanation Structure of Procedural Texts: Dealing with Advice and Warnings</fixed-case></title>
     <author><first>Lionel</first><last>Fontan</last></author>
     <author><first>Patrick</first><last>Saint-Dizier</last></author>
     </paper>
 
     <paper id="2211">
-    <title>From Predicting Predominant Senses to Local Context for Word Sense Disambiguation</title>
+    <title><fixed-case>From Predicting Predominant Senses to Local Context for Word Sense Disambiguation</fixed-case></title>
     <author><first>Rob</first><last>Koeling</last></author>
     <author><first>Diana</first><last>McCarthy</last></author>
     </paper>
@@ -5351,90 +5352,90 @@
     </paper>
 
     <paper id="2213">
-    <title>Analysis of ASL Motion Capture Data towards Identification of Verb Type</title>
+    <title><fixed-case>Analysis of ASL Motion Capture Data towards Identification of Verb Type</fixed-case></title>
     <author><first>Evguenia</first><last>Malaia</last></author>
     <author><first>John</first><last>Borneman</last></author>
     <author><first>Ronnie B.</first><last>Wilbur</last></author>
     </paper>
 
     <paper id="2214">
-    <title>The Idiom–Reference Connection</title>
+    <title><fixed-case>The Idiom–Reference Connection</fixed-case></title>
     <author><first>Marjorie</first><last>McShane</last></author>
     <author><first>Sergei</first><last>Nirenburg</last></author>
     </paper>
 
     <paper id="2215">
-    <title>Resolving Paraphrases to Support Modeling Language Perception in an Intelligent Agent</title>
+    <title><fixed-case>Resolving Paraphrases to Support Modeling Language Perception in an Intelligent Agent</fixed-case></title>
     <author><first>Sergei</first><last>Nirenburg</last></author>
     <author><first>Marjorie</first><last>McShane</last></author>
     <author><first>Stephen</first><last>Beale</last></author>
     </paper>
 
     <paper id="2216">
-    <title>Everyday Language is Highly Intensional</title>
+    <title><fixed-case>Everyday Language is Highly Intensional</fixed-case></title>
     <author><first>Allan</first><last>Ramsay</last></author>
     <author><first>Debora</first><last>Field</last></author>
     </paper>
 
     <paper id="2217">
-    <title>Refining the Meaning of Sense Labels in PDTB: “Concession”</title>
+    <title><fixed-case>Refining the Meaning of Sense Labels in PDTB: “Concession”</fixed-case></title>
     <author><first>Livio</first><last>Robaldo</last></author>
     <author><first>Eleni</first><last>Miltsakaki</last></author>
     <author><first>Jerry R.</first><last>Hobbs</last></author>
     </paper>
 
     <paper id="2218">
-    <title>Connective-based Local Coherence Analysis: A Lexicon for Recognizing Causal Relationships</title>
+    <title><fixed-case>Connective-based Local Coherence Analysis: A Lexicon for Recognizing Causal Relationships</fixed-case></title>
     <author><first>Manfred</first><last>Stede</last></author>
     </paper>
 
     <paper id="2219">
-    <title>Open Knowledge Extraction through Compositional Language Processing</title>
+    <title><fixed-case>Open Knowledge Extraction through Compositional Language Processing</fixed-case></title>
     <author><first>Benjamin</first><last>Van Durme</last></author>
     <author><first>Lenhart</first><last>Schubert</last></author>
     </paper>
 
     <paper id="2220">
-    <title>Introduction to the Shared Task on Comparing Semantic Representations</title>
+    <title><fixed-case>Introduction to the Shared Task on Comparing Semantic Representations</fixed-case></title>
     <author><first>Johan</first><last>Bos</last></author>
     </paper>
 
     <paper id="2221">
-    <title>Boeing’s NLP System and the Challenges of Semantic Representation</title>
+    <title><fixed-case>Boeing’s NLP System and the Challenges of Semantic Representation</fixed-case></title>
     <author><first>Peter</first><last>Clark</last></author>
     <author><first>Phil</first><last>Harrison</last></author>
     </paper>
 
     <paper id="2222">
-    <title>Wide-Coverage Semantic Analysis with Boxer</title>
+    <title><fixed-case>Wide-Coverage Semantic Analysis with Boxer</fixed-case></title>
     <author><first>Johan</first><last>Bos</last></author>
     </paper>
 
     <paper id="2223">
-    <title>Semantic and Pragmatic Computing with GETARUNS</title>
+    <title><fixed-case>Semantic and Pragmatic Computing with GETARUNS</fixed-case></title>
     <author><first>Rodolfo</first><last>Delmonte</last></author>
     </paper>
 
     <paper id="2224">
-    <title>LXGram in the Shared Task “Comparing Semantic Representations” of STEP 2008</title>
+    <title><fixed-case>LXGram in the Shared Task “Comparing Semantic Representations” of STEP 2008</fixed-case></title>
     <author><first>António</first><last>Branco</last></author>
     <author><first>Francisco</first><last>Costa</last></author>
     </paper>
 
     <paper id="2225">
-    <title>Baseline Evaluation of WSD and Semantic Dependency in OntoSem</title>
+    <title><fixed-case>Baseline Evaluation of WSD and Semantic Dependency in OntoSem</fixed-case></title>
     <author><first>Sergei</first><last>Nirenburg</last></author>
     <author><first>Stephen</first><last>Beale</last></author>
     <author><first>Marjorie</first><last>McShane</last></author>
     </paper>
 
     <paper id="2226">
-    <title>The TextCap Semantic Interpreter</title>
+    <title><fixed-case>The TextCap Semantic Interpreter</fixed-case></title>
     <author><first>Charles B.</first><last>Callaway</last></author>
     </paper>
 
     <paper id="2227">
-    <title>Deep Semantic Analysis of Text</title>
+    <title><fixed-case>Deep Semantic Analysis of Text</fixed-case></title>
     <author><first>James F.</first><last>Allen</last></author>
     <author><first>Mary</first><last>Swift</last></author>
     <author><first>Will</first><last>de Beaumont</last></author>
@@ -5449,7 +5450,7 @@
     </paper>
 
     <paper id="2229">
-    <title>Representing and Visualizing Calendar Expressions in Texts</title>
+    <title><fixed-case>Representing and Visualizing Calendar Expressions in Texts</fixed-case></title>
     <author><first>Delphine</first><last>Battistelli</last></author>
     <author><first>Javier</first><last>Couto</last></author>
     <author><first>Jean-Luc</first><last>Minel</last></author>
@@ -5457,21 +5458,21 @@
     </paper>
 
     <paper id="2230">
-    <title>Addressing the Resource Bottleneck to Create Large-Scale Annotated Texts</title>
+    <title><fixed-case>Addressing the Resource Bottleneck to Create Large-Scale Annotated Texts</fixed-case></title>
     <author><first>Jon</first><last>Chamberlain</last></author>
     <author><first>Massimo</first><last>Poesio</last></author>
     <author><first>Udo</first><last>Kruschwitz</last></author>
     </paper>
 
     <paper id="2231">
-    <title>A Resource-Poor Approach for Linking Ontology Classes to Wikipedia Articles</title>
+    <title><fixed-case>A Resource-Poor Approach for Linking Ontology Classes to Wikipedia Articles</fixed-case></title>
     <author><first>Nils</first><last>Reiter</last></author>
     <author><first>Matthias</first><last>Hartung</last></author>
     <author><first>Anette</first><last>Frank</last></author>
     </paper>
 
     <paper id="2232">
-    <title>Top-Down Cohesion Segmentation in Summarization</title>
+    <title><fixed-case>Top-Down Cohesion Segmentation in Summarization</fixed-case></title>
     <author><first>Doina</first><last>Tatar</last></author>
     <author><first>Andreea Diana</first><last>Mihis</last></author>
     <author><first>Gabriela</first><last>Serban</last></author>

--- a/import/W09.xml
+++ b/import/W09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W09">
    <paper id="0100">
         <title>Proceedings of the EACL 2009 Workshop on the Interaction between Linguistics and Computational Linguistics: Virtuous, Vicious or Vacuous?</title>
@@ -77,7 +78,7 @@
         <bibkey>uszkoreit:2009:EACL2009_VVV</bibkey>
    </paper>
    <paper id="0106">
-        <title>Linguistically Naïve != Language Independent: Why NLP Needs Linguistic Typology</title>
+        <title>Linguistically Naïve != Language Independent: Why <fixed-case>NLP</fixed-case> Needs Linguistic Typology</title>
         <author><first>Emily M.</first><last>Bender</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on the Interaction between Linguistics and Computational Linguistics: Virtuous, Vicious or Vacuous?</booktitle>
         <month>March</month>
@@ -211,7 +212,7 @@
         <bibkey>zhang-chan:2009:GEMS</bibkey>
    </paper>
    <paper id="0205">
-        <title>BagPack: A General Framework to Represent Semantic Relations</title>
+        <title>Bag<fixed-case>P</fixed-case>ack: A General Framework to Represent Semantic Relations</title>
         <author><first>Amaç</first><last>Herdağdelen</last></author>
         <author><first>Marco</first><last>Baroni</last></author>
         <booktitle>Proceedings of the Workshop on Geometrical Models of Natural Language Semantics</booktitle>
@@ -270,7 +271,7 @@
         <bibkey>erk-pado:2009:GEMS</bibkey>
    </paper>
    <paper id="0209">
-        <title>SVD Feature Selection for Probabilistic Taxonomy Learning</title>
+        <title><fixed-case>SVD</fixed-case> Feature Selection for Probabilistic Taxonomy Learning</title>
         <author><first>Francesca</first><last>Fallucchi</last></author>
         <author><first>Fabio Massimo</first><last>Zanzotto</last></author>
         <booktitle>Proceedings of the Workshop on Geometrical Models of Natural Language Semantics</booktitle>
@@ -329,7 +330,7 @@
         <bibkey>dorow-EtAl:2009:GEMS</bibkey>
    </paper>
    <paper id="0213">
-        <title>Handling Sparsity for Verb Noun MWE Token Classification</title>
+        <title>Handling Sparsity for Verb Noun <fixed-case>MWE</fixed-case> Token Classification</title>
         <author><first>Mona</first><last>Diab</last></author>
         <author><first>Madhav</first><last>Krishna</last></author>
         <booktitle>Proceedings of the Workshop on Geometrical Models of Natural Language Semantics</booktitle>
@@ -442,7 +443,7 @@
         <bibkey>wieling-prokic-nerbonne:2009:LaTeCH-SHELTR</bibkey>
    </paper>
    <paper id="0305">
-        <title>A Web-Enabled and Speech-Enhanced Parallel Corpus of Greek-Bulgarian Cultural Texts</title>
+        <title>A Web-Enabled and Speech-Enhanced Parallel Corpus of <fixed-case>G</fixed-case>reek-<fixed-case>B</fixed-case>ulgarian Cultural Texts</title>
         <author><first>Voula</first><last>Giouli</last></author>
         <author><first>Nikos</first><last>Glaros</last></author>
         <author><first>Kiril</first><last>Simov</last></author>
@@ -458,7 +459,7 @@
         <bibkey>giouli-EtAl:2009:LaTeCH-SHELTR</bibkey>
    </paper>
    <paper id="0306">
-        <title>The Development of the “Index Thomisticus” Treebank Valency Lexicon</title>
+        <title>The Development of the “<fixed-case>I</fixed-case>ndex <fixed-case>T</fixed-case>homisticus” Treebank Valency Lexicon</title>
         <author><first>Barbara</first><last>McGillivray</last></author>
         <author><first>Marco</first><last>Passarotti</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Language Technology and Resources for Cultural Heritage, Social Sciences, Humanities, and Education (LaTeCH – SHELT&amp;R 2009)</booktitle>
@@ -472,7 +473,7 @@
         <bibkey>mcgillivray-passarotti:2009:LaTeCH-SHELTR</bibkey>
    </paper>
    <paper id="0307">
-        <title>Applying NLP Technologies to the Collection and Enrichment of Language Data on the Web to Aid Linguistic Research</title>
+        <title>Applying <fixed-case>NLP</fixed-case> Technologies to the Collection and Enrichment of Language Data on the Web to Aid Linguistic Research</title>
         <author><first>Fei</first><last>Xia</last></author>
         <author><first>William</first><last>Lewis</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Language Technology and Resources for Cultural Heritage, Social Sciences, Humanities, and Education (LaTeCH – SHELT&amp;R 2009)</booktitle>
@@ -530,7 +531,7 @@
         <bibkey>WMT:2009</bibkey>
    </paper>
    <paper id="0401">
-        <title>Findings of the 2009 Workshop on Statistical Machine Translation</title>
+        <title>Findings of the 2009 <fixed-case>W</fixed-case>orkshop on <fixed-case>S</fixed-case>tatistical <fixed-case>M</fixed-case>achine <fixed-case>T</fixed-case>ranslation</title>
         <author><first>Chris</first><last>Callison-Burch</last></author>
         <author><first>Philipp</first><last>Koehn</last></author>
         <author><first>Christof</first><last>Monz</last></author>
@@ -560,7 +561,7 @@
         <bibkey>popovic-ney:2009:WMT</bibkey>
    </paper>
    <paper id="0403">
-        <title>A Simple Automatic MT Evaluation Metric</title>
+        <title>A Simple Automatic <fixed-case>MT</fixed-case> Evaluation Metric</title>
         <author><first>Petr</first><last>Homola</last></author>
         <author><first>Vladislav</first><last>Kuboň</last></author>
         <author><first>Pavel</first><last>Pecina</last></author>
@@ -591,7 +592,7 @@
         <bibkey>pado-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0405">
-        <title>Combining Multi-Engine Translations with Moses</title>
+        <title>Combining Multi-Engine Translations with <fixed-case>M</fixed-case>oses</title>
         <author><first>Yu</first><last>Chen</last></author>
         <author><first>Michael</first><last>Jellinghaus</last></author>
         <author><first>Andreas</first><last>Eisele</last></author>
@@ -611,7 +612,7 @@
         <bibkey>chen-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0406">
-        <title>CMU System Combination for WMT’09</title>
+        <title><fixed-case>CMU</fixed-case> System Combination for <fixed-case>WMT</fixed-case>‘09</title>
         <author><first>Almut Silja</first><last>Hildebrand</last></author>
         <author><first>Stephan</first><last>Vogel</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
@@ -625,7 +626,7 @@
         <bibkey>hildebrand-vogel:2009:WMT</bibkey>
    </paper>
    <paper id="0407">
-        <title>The RWTH System Combination System for WMT 2009</title>
+        <title>The <fixed-case>RWTH</fixed-case> System Combination System for <fixed-case>WMT</fixed-case> 2009</title>
         <author><first>Gregor</first><last>Leusch</last></author>
         <author><first>Evgeny</first><last>Matusov</last></author>
         <author><first>Hermann</first><last>Ney</last></author>
@@ -655,7 +656,7 @@
         <bibkey>heafield-hanneman-lavie:2009:WMT</bibkey>
    </paper>
    <paper id="0409">
-        <title>Incremental Hypothesis Alignment with Flexible Matching for Building Confusion Networks: BBN System Description for WMT09 System Combination Task</title>
+        <title>Incremental Hypothesis Alignment with Flexible Matching for Building Confusion Networks: <fixed-case>BBN</fixed-case> System Description for <fixed-case>WMT</fixed-case>09 System Combination Task</title>
         <author><first>Antti-Veikko</first><last>Rosti</last></author>
         <author><first>Bing</first><last>Zhang</last></author>
         <author><first>Spyros</first><last>Matsoukas</last></author>
@@ -671,7 +672,7 @@
         <bibkey>rosti-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0410">
-        <title>The RWTH Machine Translation System for WMT 2009</title>
+        <title>The <fixed-case>RWTH</fixed-case> Machine Translation System for <fixed-case>WMT</fixed-case> 2009</title>
         <author><first>Maja</first><last>Popović</last></author>
         <author><first>David</first><last>Vilar</last></author>
         <author><first>Daniel</first><last>Stein</last></author>
@@ -707,7 +708,7 @@
         <bibkey>federmann-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0412">
-        <title>NUS at WMT09: Domain Adaptation Experiments for English-Spanish Machine Translation of News Commentary Text</title>
+        <title><fixed-case>NUS</fixed-case> at <fixed-case>WMT</fixed-case>09: Domain Adaptation Experiments for <fixed-case>E</fixed-case>nglish-<fixed-case>S</fixed-case>panish Machine Translation of News Commentary Text</title>
         <author><first>Preslav</first><last>Nakov</last></author>
         <author><first>Hwee Tou</first><last>Ng</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
@@ -721,7 +722,7 @@
         <bibkey>nakov-ng:2009:WMT</bibkey>
    </paper>
    <paper id="0413">
-        <title>The Universität Karlsruhe Translation System for the EACL-WMT 2009</title>
+        <title>The <fixed-case>U</fixed-case>niversität <fixed-case>K</fixed-case>arlsruhe Translation System for the <fixed-case>EACL-WMT</fixed-case> 2009</title>
         <author><first>Jan</first><last>Niehues</last></author>
         <author><first>Teresa</first><last>Herrmann</last></author>
         <author><first>Muntsin</first><last>Kolss</last></author>
@@ -737,7 +738,7 @@
         <bibkey>niehues-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0414">
-        <title>The TALP-UPC Phrase-Based Translation System for EACL-WMT 2009</title>
+        <title>The <fixed-case>TALP-UPC</fixed-case> Phrase-Based Translation System for <fixed-case>EACL-WMT</fixed-case> 2009</title>
         <author><first>José A. R.</first><last>Fonollosa</last></author>
         <author><first>Maxim</first><last>Khalilov</last></author>
         <author><first>Marta R.</first><last>Costa-jussà</last></author>
@@ -771,7 +772,7 @@
         <bibkey>wehrli-nerima-scherrer:2009:WMT</bibkey>
    </paper>
    <paper id="0416">
-        <title>MATREX: The DCU MT System for WMT 2009</title>
+        <title><fixed-case>MATREX</fixed-case>: The <fixed-case>DCU</fixed-case> <fixed-case>MT</fixed-case> System for <fixed-case>WMT</fixed-case> 2009</title>
         <author><first>Jinhua</first><last>Du</last></author>
         <author><first>Yifan</first><last>He</last></author>
         <author><first>Sergio</first><last>Penkale</last></author>
@@ -787,7 +788,7 @@
         <bibkey>du-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0417">
-        <title>LIMSI’s Statistical Translation Systems for WMT’09</title>
+        <title><fixed-case>LIMSI</fixed-case>‘s Statistical Translation Systems for <fixed-case>WMT</fixed-case>‘09</title>
         <author><first>Alexandre</first><last>Allauzen</last></author>
         <author><first>Josep</first><last>Crego</last></author>
         <author><first>Aurélien</first><last>Max</last></author>
@@ -803,7 +804,7 @@
         <bibkey>allauzen-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0418">
-        <title>NICT@WMT09: Model Adaptation and Transliteration for Spanish-English SMT</title>
+        <title><fixed-case>NICT@WMT09</fixed-case>: Model Adaptation and Transliteration for <fixed-case>S</fixed-case>panish-<fixed-case>E</fixed-case>nglish <fixed-case>SMT</fixed-case></title>
         <author><first>Michael</first><last>Paul</last></author>
         <author><first>Andrew</first><last>Finch</last></author>
         <author><first>Eiichiro</first><last>Sumita</last></author>
@@ -818,7 +819,7 @@
         <bibkey>paul-finch-sumita:2009:WMT</bibkey>
    </paper>
    <paper id="0419">
-        <title>Statistical Post Editing and Dictionary Extraction: Systran/Edinburgh Submissions for ACL-WMT2009</title>
+        <title>Statistical Post Editing and Dictionary Extraction: <fixed-case>S</fixed-case>ystran/<fixed-case>E</fixed-case>dinburgh Submissions for <fixed-case>ACL-WMT</fixed-case>2009</title>
         <author><first>Loïc</first><last>Dugast</last></author>
         <author><first>Jean</first><last>Senellart</last></author>
         <author><first>Philipp</first><last>Koehn</last></author>
@@ -833,7 +834,7 @@
         <bibkey>dugast-senellart-koehn:2009:WMT</bibkey>
    </paper>
    <paper id="0420">
-        <title>Experiments in Morphosyntactic Processing for Translating to and from German</title>
+        <title>Experiments in Morphosyntactic Processing for Translating to and from <fixed-case>G</fixed-case>erman</title>
         <author><first>Alexander</first><last>Fraser</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
         <month>March</month>
@@ -846,7 +847,7 @@
         <bibkey>fraser:2009:WMT</bibkey>
    </paper>
    <paper id="0421">
-        <title>Improving Alignment for SMT by Reordering and Augmenting the Training Corpus</title>
+        <title>Improving Alignment for <fixed-case>SMT</fixed-case> by Reordering and Augmenting the Training Corpus</title>
         <author><first>Maria</first><last>Holmqvist</last></author>
         <author><first>Sara</first><last>Stymne</last></author>
         <author><first>Jody</first><last>Foo</last></author>
@@ -862,7 +863,7 @@
         <bibkey>holmqvist-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0422">
-        <title>English-Czech MT in 2008</title>
+        <title><fixed-case>E</fixed-case>nglish-<fixed-case>C</fixed-case>zech <fixed-case>MT</fixed-case> in 2008</title>
         <author><first>Ondřej</first><last>Bojar</last></author>
         <author><first>David</first><last>Mareček</last></author>
         <author><first>Václav</first><last>Novák</last></author>
@@ -881,7 +882,7 @@
         <bibkey>bojar-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0423">
-        <title>SMT and SPE Machine Translation Systems for WMT’09</title>
+        <title><fixed-case>SMT</fixed-case> and <fixed-case>SPE</fixed-case> Machine Translation Systems for <fixed-case>WMT</fixed-case>‘09</title>
         <author><first>Holger</first><last>Schwenk</last></author>
         <author><first>Sadaf</first><last>Abdul Rauf</last></author>
         <author><first>Loïc</first><last>Barrault</last></author>
@@ -897,7 +898,7 @@
         <bibkey>schwenk-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0424">
-        <title>Joshua: An Open Source Toolkit for Parsing-Based Machine Translation</title>
+        <title><fixed-case>Joshua</fixed-case>: An Open Source Toolkit for Parsing-Based Machine Translation</title>
         <author><first>Zhifei</first><last>Li</last></author>
         <author><first>Chris</first><last>Callison-Burch</last></author>
         <author><first>Chris</first><last>Dyer</last></author>
@@ -917,7 +918,7 @@
         <bibkey>li-EtAl:2009:WMT1</bibkey>
    </paper>
    <paper id="0425">
-        <title>An Improved Statistical Transfer System for French-English Machine Translation</title>
+        <title>An Improved Statistical Transfer System for <fixed-case>F</fixed-case>rench-<fixed-case>E</fixed-case>nglish Machine Translation</title>
         <author><first>Greg</first><last>Hanneman</last></author>
         <author><first>Vamshi</first><last>Ambati</last></author>
         <author><first>Jonathan H.</first><last>Clark</last></author>
@@ -934,7 +935,7 @@
         <bibkey>hanneman-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0426">
-        <title>The University of Maryland Statistical Machine Translation System for the Fourth Workshop on Machine Translation</title>
+        <title>The <fixed-case>U</fixed-case>niversity of <fixed-case>M</fixed-case>aryland Statistical Machine Translation System for the <fixed-case>F</fixed-case>ourth <fixed-case>W</fixed-case>orkshop on <fixed-case>M</fixed-case>achine <fixed-case>T</fixed-case>ranslation</title>
         <author><first>Chris</first><last>Dyer</last></author>
         <author><first>Hendra</first><last>Setiawan</last></author>
         <author><first>Yuval</first><last>Marton</last></author>
@@ -950,7 +951,7 @@
         <bibkey>dyer-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0427">
-        <title>Toward Using Morphology in French-English Phrase-Based SMT</title>
+        <title>Toward Using Morphology in <fixed-case>F</fixed-case>rench-<fixed-case>E</fixed-case>nglish Phrase-Based <fixed-case>SMT</fixed-case></title>
         <author><first>Marine</first><last>Carpuat</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
         <month>March</month>
@@ -963,7 +964,7 @@
         <bibkey>carpuat:2009:WMT</bibkey>
    </paper>
    <paper id="0428">
-        <title>MorphoLogic’s Submission for the WMT 2009 Shared Task</title>
+        <title><fixed-case>MorphoLogic</fixed-case>‘s Submission for the <fixed-case>WMT</fixed-case> 2009 Shared Task</title>
         <author><first>Attila</first><last>Novák</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
         <month>March</month>
@@ -976,7 +977,7 @@
         <bibkey>novak:2009:WMT</bibkey>
    </paper>
    <paper id="0429">
-        <title>Edinburgh’s Submission to all Tracks of the WMT 2009 Shared Task with Reordering and Speed Improvements to Moses</title>
+        <title>Edinburgh’s Submission to all Tracks of the <fixed-case>WMT</fixed-case> 2009 Shared Task with Reordering and Speed Improvements to <fixed-case>M</fixed-case>oses</title>
         <author><first>Philipp</first><last>Koehn</last></author>
         <author><first>Barry</first><last>Haddow</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
@@ -990,7 +991,7 @@
         <bibkey>koehn-haddow:2009:WMT</bibkey>
    </paper>
    <paper id="0430">
-        <title>Mining a Comparable Text Corpus for a Vietnamese-French Statistical Machine Translation System</title>
+        <title>Mining a Comparable Text Corpus for a <fixed-case>V</fixed-case>ietnamese-<fixed-case>F</fixed-case>rench Statistical Machine Translation System</title>
         <author><first>Thi Ngoc Diep</first><last>Do</last></author>
         <author><first>Viet Bac</first><last>Le</last></author>
         <author><first>Brigitte</first><last>Bigi</last></author>
@@ -1007,7 +1008,7 @@
         <bibkey>do-EtAl:2009:WMT</bibkey>
    </paper>
    <paper id="0431">
-        <title>Improving Arabic-Chinese Statistical Machine Translation using English as Pivot Language</title>
+        <title>Improving <fixed-case>A</fixed-case>rabic-<fixed-case>C</fixed-case>hinese Statistical Machine Translation using <fixed-case>E</fixed-case>nglish as Pivot Language</title>
         <author><first>Nizar</first><last>Habash</last></author>
         <author><first>Jun</first><last>Hu</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
@@ -1035,7 +1036,7 @@
         <bibkey>bertoldi-federico:2009:WMT</bibkey>
    </paper>
    <paper id="0433">
-        <title>Chinese Syntactic Reordering for Adequate Generation of Korean Verbal Phrases in Chinese-to-Korean SMT</title>
+        <title><fixed-case>C</fixed-case>hinese Syntactic Reordering for Adequate Generation of <fixed-case>K</fixed-case>orean Verbal Phrases in <fixed-case>C</fixed-case>hinese-to-<fixed-case>K</fixed-case>orean <fixed-case>SMT</fixed-case></title>
         <author><first>Jin-Ji</first><last>Li</last></author>
         <author><first>Jungi</first><last>Kim</last></author>
         <author><first>Dong-Il</first><last>Kim</last></author>
@@ -1066,7 +1067,7 @@
         <bibkey>birch-blunsom-osborne:2009:WMT</bibkey>
    </paper>
    <paper id="0435">
-        <title>A POS-Based Model for Long-Range Reorderings in SMT</title>
+        <title>A <fixed-case>POS</fixed-case>-Based Model for Long-Range Reorderings in <fixed-case>SMT</fixed-case></title>
         <author><first>Jan</first><last>Niehues</last></author>
         <author><first>Muntsin</first><last>Kolss</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
@@ -1141,7 +1142,7 @@
         <bibkey>foster-kuhn:2009:WMT</bibkey>
    </paper>
    <paper id="0440">
-        <title>On the Robustness of Syntactic and Semantic Features for Automatic MT Evaluation</title>
+        <title>On the Robustness of Syntactic and Semantic Features for Automatic <fixed-case>MT</fixed-case> Evaluation</title>
         <author><first>Jesús</first><last>Giménez</last></author>
         <author><first>Lluís</first><last>Màrquez</last></author>
         <booktitle>Proceedings of the Fourth Workshop on Statistical Machine Translation</booktitle>
@@ -1155,7 +1156,7 @@
         <bibkey>gimenez-marquez:2009:WMT</bibkey>
    </paper>
    <paper id="0441">
-        <title>Fluency, Adequacy, or HTER? Exploring Different Human Judgments with a Tunable MT Metric</title>
+        <title>Fluency, Adequacy, or <fixed-case>HTER</fixed-case>? <fixed-case>E</fixed-case>xploring Different Human Judgments with a Tunable <fixed-case>MT</fixed-case> Metric</title>
         <author><first>Matthew</first><last>Snover</last></author>
         <author><first>Nitin</first><last>Madnani</last></author>
         <author><first>Bonnie</first><last>Dorr</last></author>
@@ -1183,7 +1184,7 @@
         <bibkey>SRSL:2009</bibkey>
    </paper>
    <paper id="0501">
-        <title>Extreme-Case Formulations in Cypriot Greek</title>
+        <title>Extreme-Case Formulations in <fixed-case>C</fixed-case>ypriot <fixed-case>G</fixed-case>reek</title>
         <author><first>Maria</first><last>Christodoulidou</last></author>
         <booktitle>Proceedings of SRSL 2009, the 2nd Workshop on Semantic Representation of Spoken Language</booktitle>
         <month>March</month>
@@ -1297,7 +1298,7 @@
         <bibkey>lison-kruijff:2009:SRSL</bibkey>
    </paper>
    <paper id="0509">
-        <title>RUBISC - a Robust Unification-Based Incremental Semantic Chunker</title>
+        <title><fixed-case>RUBISC</fixed-case> - a Robust Unification-Based Incremental Semantic Chunker</title>
         <author><first>Michaela</first><last>Atterer</last></author>
         <author><first>David</first><last>Schlangen</last></author>
         <booktitle>Proceedings of SRSL 2009, the 2nd Workshop on Semantic Representation of Spoken Language</booktitle>
@@ -1338,7 +1339,7 @@
         <bibkey>ENLG:2009</bibkey>
    </paper>
    <paper id="0601">
-        <title>Using NLG to Help Language-Impaired Users Tell Stories and Participate in Social Dialogues</title>
+        <title>Using <fixed-case>NLG</fixed-case> to Help Language-Impaired Users Tell Stories and Participate in Social Dialogues</title>
         <author><first>Ehud</first><last>Reiter</last></author>
         <author><first>Ross</first><last>Turner</last></author>
         <author><first>Norman</first><last>Alm</last></author>
@@ -1383,7 +1384,7 @@
         <bibkey>belz-kow:2009:ENLG</bibkey>
    </paper>
    <paper id="0604">
-        <title>Is Sentence Compression an NLG task?</title>
+        <title>Is Sentence Compression an <fixed-case>NLG</fixed-case> task?</title>
         <author><first>Erwin</first><last>Marsi</last></author>
         <author><first>Emiel</first><last>Krahmer</last></author>
         <author><first>Iris</first><last>Hendrickx</last></author>
@@ -1499,7 +1500,7 @@
         <bibkey>janarthanam-lemon:2009:ENLG1</bibkey>
    </paper>
    <paper id="0612">
-        <title>An Alignment-Capable Microplanner for Natural Language Generation</title>
+        <title>An Alignment-Capable Microplanner for <fixed-case>N</fixed-case>atural <fixed-case>L</fixed-case>anguage <fixed-case>G</fixed-case>eneration</title>
         <author><first>Hendrik</first><last>Buschmeier</last></author>
         <author><first>Kirsten</first><last>Bergmann</last></author>
         <author><first>Stefan</first><last>Kopp</last></author>
@@ -1514,7 +1515,7 @@
         <bibkey>buschmeier-bergmann-kopp:2009:ENLG</bibkey>
    </paper>
    <paper id="0613">
-        <title>SimpleNLG: A Realisation Engine for Practical Applications</title>
+        <title><fixed-case>SimpleNLG</fixed-case>: A Realisation Engine for Practical Applications</title>
         <author><first>Albert</first><last>Gatt</last></author>
         <author><first>Ehud</first><last>Reiter</last></author>
         <booktitle>Proceedings of the 12th European Workshop on Natural Language Generation (ENLG 2009)</booktitle>
@@ -1528,7 +1529,7 @@
         <bibkey>gatt-reiter:2009:ENLG</bibkey>
    </paper>
    <paper id="0614">
-        <title>A Wizard-of-Oz Environment to Study Referring Expression Generation in a Situated Spoken Dialogue Task</title>
+        <title>A <fixed-case>W</fixed-case>izard-of-<fixed-case>O</fixed-case>z Environment to Study Referring Expression Generation in a Situated Spoken Dialogue Task</title>
         <author><first>Srinivasan</first><last>Janarthanam</last></author>
         <author><first>Oliver</first><last>Lemon</last></author>
         <booktitle>Proceedings of the 12th European Workshop on Natural Language Generation (ENLG 2009)</booktitle>
@@ -1585,7 +1586,7 @@
         <bibkey>schutte:2009:ENLG</bibkey>
    </paper>
    <paper id="0618">
-        <title>A Japanese Corpus of Referring Expressions Used in a Situated Collaboration Task</title>
+        <title>A <fixed-case>J</fixed-case>apanese Corpus of Referring Expressions Used in a Situated Collaboration Task</title>
         <author><first>Philipp</first><last>Spanger</last></author>
         <author><first>Yasuhara</first><last>Masaaki</last></author>
         <author><first>Iida</first><last>Ryu</last></author>
@@ -1690,7 +1691,7 @@
         <bibkey>harbusch-kempen:2009:ENLG</bibkey>
    </paper>
    <paper id="0625">
-        <title>Towards Empirical Evaluation of Affective Tactical NLG</title>
+        <title>Towards Empirical Evaluation of Affective Tactical <fixed-case>NLG</fixed-case></title>
         <author><first>Ielka</first><last>van der Sluis</last></author>
         <author><first>Chris</first><last>Mellish</last></author>
         <booktitle>Proceedings of the 12th European Workshop on Natural Language Generation (ENLG 2009)</booktitle>
@@ -1704,7 +1705,7 @@
         <bibkey>vandersluis-mellish:2009:ENLG</bibkey>
    </paper>
    <paper id="0626">
-        <title>What Game Theory Can Do for NLG: The Case of Vague Language (Invited Talk)</title>
+        <title>What Game Theory Can Do for <fixed-case>NLG</fixed-case>: The Case of Vague Language (Invited Talk)</title>
         <author><first>Kees</first><last>van Deemter</last></author>
         <booktitle>Proceedings of the 12th European Workshop on Natural Language Generation (ENLG 2009)</booktitle>
         <month>March</month>
@@ -1717,7 +1718,7 @@
         <bibkey>vandeemter:2009:ENLG</bibkey>
    </paper>
    <paper id="0627">
-        <title>Generation Challenges 2009: Preface</title>
+        <title>Generation <fixed-case>C</fixed-case>hallenges 2009: Preface</title>
         <author><first>Anja</first><last>Belz</last></author>
         <author><first>Albert</first><last>Gatt</last></author>
         <booktitle>Proceedings of the 12th European Workshop on Natural Language Generation (ENLG 2009)</booktitle>
@@ -1731,7 +1732,7 @@
         <bibkey>belz-gatt:2009:ENLG</bibkey>
    </paper>
    <paper id="0628">
-        <title>Report on the First NLG Challenge on Generating Instructions in Virtual Environments (GIVE)</title>
+        <title>Report on the <fixed-case>F</fixed-case>irst <fixed-case>NLG</fixed-case> <fixed-case>C</fixed-case>hallenge on <fixed-case>G</fixed-case>enerating <fixed-case>I</fixed-case>nstructions in <fixed-case>V</fixed-case>irtual <fixed-case>E</fixed-case>nvironments <fixed-case>(GIVE)</fixed-case></title>
         <author><first>Donna</first><last>Byron</last></author>
         <author><first>Alexander</first><last>Koller</last></author>
         <author><first>Kristina</first><last>Striegnitz</last></author>
@@ -1750,7 +1751,7 @@
         <bibkey>byron-EtAl:2009:ENLG</bibkey>
    </paper>
    <paper id="0629">
-        <title>The TUNA-REG Challenge 2009: Overview and Evaluation Results</title>
+        <title>The <fixed-case>TUNA-REG</fixed-case> <fixed-case>C</fixed-case>hallenge 2009: Overview and Evaluation Results</title>
         <author><first>Albert</first><last>Gatt</last></author>
         <author><first>Anja</first><last>Belz</last></author>
         <author><first>Eric</first><last>Kow</last></author>
@@ -1765,7 +1766,7 @@
         <bibkey>gatt-belz-kow:2009:ENLG</bibkey>
    </paper>
    <paper id="0630">
-        <title>Realizing the Costs: Template-Based Surface Realisation in the GRAPH Approach to Referring Expression Generation</title>
+        <title>Realizing the Costs: Template-Based Surface Realisation in the <fixed-case>GRAPH</fixed-case> Approach to Referring Expression Generation</title>
         <author><first>Ivo</first><last>Brugman</last></author>
         <author><first>Mariët</first><last>Theune</last></author>
         <author><first>Emiel</first><last>Krahmer</last></author>
@@ -1794,7 +1795,7 @@
         <bibkey>bohnet:2009:ENLG</bibkey>
    </paper>
    <paper id="0632">
-        <title>Evolutionary and Case-Based Approaches to REG: NIL-UCM-EvoTAP, NIL-UCM-ValuesCBR and NIL-UCM-EvoCBR</title>
+        <title>Evolutionary and Case-Based Approaches to <fixed-case>REG</fixed-case>: <fixed-case>NIL-UCM-EvoTAP</fixed-case>, <fixed-case>NIL-UCM-ValuesCBR</fixed-case> and <fixed-case>NIL-UCM-EvoCBR</fixed-case></title>
         <author><first>Raquel</first><last>Hervás</last></author>
         <author><first>Pablo</first><last>Gervás</last></author>
         <booktitle>Proceedings of the 12th European Workshop on Natural Language Generation (ENLG 2009)</booktitle>
@@ -1808,7 +1809,7 @@
         <bibkey>hervas-gervas:2009:ENLG</bibkey>
    </paper>
    <paper id="0633">
-        <title>USP-EACH: Improved Frequency-based Greedy Attribute Selection</title>
+        <title><fixed-case>USP-EACH</fixed-case>: Improved Frequency-based Greedy Attribute Selection</title>
         <author><first>Diego Jesus</first><last>de Lucena</last></author>
         <author><first>Ivandré</first><last>Paraboni</last></author>
         <booktitle>Proceedings of the 12th European Workshop on Natural Language Generation (ENLG 2009)</booktitle>
@@ -1854,7 +1855,7 @@
         <bibkey>AfLaT:2009</bibkey>
    </paper>
    <paper id="0701">
-        <title>Collecting and Evaluating Speech Recognition Corpora for Nine Southern Bantu Languages</title>
+        <title>Collecting and Evaluating Speech Recognition Corpora for Nine <fixed-case>S</fixed-case>outhern <fixed-case>B</fixed-case>antu Languages</title>
         <author><first>Jaco</first><last>Badenhorst</last></author>
         <author><first>Charl</first><last>Van Heerden</last></author>
         <author><first>Marelie</first><last>Davel</last></author>
@@ -1870,7 +1871,7 @@
         <bibkey>badenhorst-EtAl:2009:AfLaT</bibkey>
    </paper>
    <paper id="0702">
-        <title>The SAWA Corpus: A Parallel Corpus English - Swahili</title>
+        <title>The <fixed-case>SAWA</fixed-case> Corpus: A Parallel Corpus <fixed-case>E</fixed-case>nglish - <fixed-case>S</fixed-case>wahili</title>
         <author><first>Guy</first><last>De Pauw</last></author>
         <author><first>Peter Waiganjo</first><last>Wagacha</last></author>
         <author><first>Gilles-Maurice</first><last>de Schryver</last></author>
@@ -1885,7 +1886,7 @@
         <bibkey>depauw-wagacha-deschryver:2009:AfLaT</bibkey>
    </paper>
    <paper id="0703">
-        <title>Information Structure in African Languages: Corpora and Tools</title>
+        <title>Information Structure in <fixed-case>A</fixed-case>frican <fixed-case>L</fixed-case>anguages: Corpora and Tools</title>
         <author><first>Christian</first><last>Chiarcos</last></author>
         <author><first>Ines</first><last>Fiedler</last></author>
         <author><first>Mira</first><last>Grubic</last></author>
@@ -1906,7 +1907,7 @@
         <bibkey>chiarcos-EtAl:2009:AfLaT</bibkey>
    </paper>
    <paper id="0704">
-        <title>A Computational Approach to Yorùbá Morphology</title>
+        <title>A Computational Approach to <fixed-case>Y</fixed-case>orùbá Morphology</title>
         <author><first>Raphael</first><last>Finkel</last></author>
         <author><first>Odetunji Ajadi</first><last>Odejobi</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
@@ -1920,7 +1921,7 @@
         <bibkey>finkel-odejobi:2009:AfLaT</bibkey>
    </paper>
    <paper id="0705">
-        <title>Using Technology Transfer to Advance Automatic Lemmatisation for Setswana</title>
+        <title>Using Technology Transfer to Advance Automatic Lemmatisation for <fixed-case>S</fixed-case>etswana</title>
         <author><first>Hendrik Johannes</first><last>Groenewald</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
         <month>March</month>
@@ -1933,7 +1934,7 @@
         <bibkey>groenewald:2009:AfLaT</bibkey>
    </paper>
    <paper id="0706">
-        <title>Part-of-Speech Tagging of Northern Sotho: Disambiguating Polysemous Function Words</title>
+        <title>Part-of-Speech Tagging of <fixed-case>N</fixed-case>orthern <fixed-case>S</fixed-case>otho: Disambiguating Polysemous Function Words</title>
         <author><first>Gertrud</first><last>Faaß</last></author>
         <author><first>Ulrich</first><last>Heid</last></author>
         <author><first>Elsabé</first><last>Taljard</last></author>
@@ -1949,7 +1950,7 @@
         <bibkey>faass-EtAl:2009:AfLaT</bibkey>
    </paper>
    <paper id="0707">
-        <title>Development of an Amharic Text-to-Speech System Using Cepstral Method</title>
+        <title>Development of an <fixed-case>A</fixed-case>mharic Text-to-Speech System Using Cepstral Method</title>
         <author><first>Tadesse</first><last>Anberbir</last></author>
         <author><first>Tomio</first><last>Takara</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
@@ -1963,7 +1964,7 @@
         <bibkey>anberbir-takara:2009:AfLaT</bibkey>
    </paper>
    <paper id="0708">
-        <title>Building Capacities in Human Language Technology for African Languages</title>
+        <title>Building Capacities in Human Language Technology for <fixed-case>A</fixed-case>frican Languages</title>
         <author><first>Tunde</first><last>Adegbola</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
         <month>March</month>
@@ -1976,7 +1977,7 @@
         <bibkey>adegbola:2009:AfLaT</bibkey>
    </paper>
    <paper id="0709">
-        <title>Initial Fieldwork for LWAZI: A Telephone-Based Spoken Dialog System for Rural South Africa</title>
+        <title>Initial Fieldwork for <fixed-case>LWAZI</fixed-case>: A Telephone-Based Spoken Dialog System for Rural <fixed-case>S</fixed-case>outh <fixed-case>A</fixed-case>frica</title>
         <author><first>Tebogo</first><last>Gumede</last></author>
         <author><first>Madelaine</first><last>Plauché</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
@@ -1990,7 +1991,7 @@
         <bibkey>gumede-plauche:2009:AfLaT</bibkey>
    </paper>
    <paper id="0710">
-        <title>Setswana Tokenisation and Computational Verb Morphology: Facing the Challenge of a Disjunctive Orthography</title>
+        <title><fixed-case>S</fixed-case>etswana Tokenisation and Computational Verb Morphology: Facing the Challenge of a Disjunctive Orthography</title>
         <author><first>Rigardt</first><last>Pretorius</last></author>
         <author><first>Ansu</first><last>Berg</last></author>
         <author><first>Laurette</first><last>Pretorius</last></author>
@@ -2006,7 +2007,7 @@
         <bibkey>pretorius-EtAl:2009:AfLaT</bibkey>
    </paper>
    <paper id="0711">
-        <title>Interlinear Glossing and its Role in Theoretical and Descriptive Studies of African and other Lesser–Documented Languages</title>
+        <title>Interlinear Glossing and its Role in Theoretical and Descriptive Studies of <fixed-case>A</fixed-case>frican and other Lesser–Documented Languages</title>
         <author><first>Dorothee</first><last>Beermann</last></author>
         <author><first>Pavel</first><last>Mihaylov</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
@@ -2020,7 +2021,7 @@
         <bibkey>beermann-mihaylov:2009:AfLaT</bibkey>
    </paper>
    <paper id="0712">
-        <title>Towards an Electronic Dictionary of Tamajaq Language in Niger</title>
+        <title>Towards an Electronic Dictionary of <fixed-case>T</fixed-case>amajaq Language in <fixed-case>N</fixed-case>iger</title>
         <author><first>Chantal</first><last>Enguehard</last></author>
         <author><first>Issouf</first><last>Modi</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
@@ -2034,7 +2035,7 @@
         <bibkey>enguehard-modi:2009:AfLaT</bibkey>
    </paper>
    <paper id="0713">
-        <title>A Repository of Free Lexical Resources for African Languages: The Project and the Method</title>
+        <title>A Repository of Free Lexical Resources for <fixed-case>A</fixed-case>frican Languages: The Project and the Method</title>
         <author><first>Piotr</first><last>Bański</last></author>
         <author><first>Beata</first><last>Wójtowicz</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
@@ -2048,7 +2049,7 @@
         <bibkey>banski-wojtowicz:2009:AfLaT</bibkey>
    </paper>
    <paper id="0714">
-        <title>Exploiting Cross-Linguistic Similarities in Zulu and Xhosa Computational Morphology</title>
+        <title>Exploiting Cross-Linguistic Similarities in <fixed-case>Z</fixed-case>ulu and <fixed-case>X</fixed-case>hosa Computational Morphology</title>
         <author><first>Laurette</first><last>Pretorius</last></author>
         <author><first>Sonja</first><last>Bosch</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
@@ -2062,7 +2063,7 @@
         <bibkey>pretorius-bosch:2009:AfLaT</bibkey>
    </paper>
    <paper id="0715">
-        <title>Methods for Amharic Part-of-Speech Tagging</title>
+        <title>Methods for <fixed-case>A</fixed-case>mharic Part-of-Speech Tagging</title>
         <author><first>Björn</first><last>Gambäck</last></author>
         <author><first>Fredrik</first><last>Olsson</last></author>
         <author><first>Atelach</first><last>Alemu Argaw</last></author>
@@ -2078,7 +2079,7 @@
         <bibkey>gamback-EtAl:2009:AfLaT</bibkey>
    </paper>
    <paper id="0716">
-        <title>An Ontology for Accessing Transcription Systems (OATS)</title>
+        <title>An Ontology for Accessing Transcription Systems (<fixed-case>OATS</fixed-case>)</title>
         <author><first>Steven</first><last>Moran</last></author>
         <booktitle>Proceedings of the First Workshop on Language Technologies for African Languages</booktitle>
         <month>March</month>
@@ -2103,7 +2104,7 @@
         <bibkey>Semitic:2009</bibkey>
    </paper>
    <paper id="0801">
-        <title>How to Establish a Verbal Paradigm on the Basis of Ancient Syriac Manuscripts</title>
+        <title>How to Establish a Verbal Paradigm on the Basis of Ancient <fixed-case>S</fixed-case>yriac Manuscripts</title>
         <author><first>Wido</first><last>van Peursen</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Computational Approaches to Semitic Languages</booktitle>
         <month>March</month>
@@ -2116,7 +2117,7 @@
         <bibkey>vanpeursen:2009:Semitic</bibkey>
    </paper>
    <paper id="0802">
-        <title>The Karamel System and Semitic Languages: Structured Multi-Tiered Morphology</title>
+        <title>The <fixed-case>K</fixed-case>aramel System and <fixed-case>S</fixed-case>emitic Languages: Structured Multi-Tiered Morphology</title>
         <author><first>François</first><last>Barthélemy</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Computational Approaches to Semitic Languages</booktitle>
         <month>March</month>
@@ -2129,7 +2130,7 @@
         <bibkey>barthelemy:2009:Semitic</bibkey>
    </paper>
    <paper id="0803">
-        <title>Revisiting Multi-Tape Automata for Semitic Morphological Analysis and Generation</title>
+        <title>Revisiting Multi-Tape Automata for <fixed-case>S</fixed-case>emitic <fixed-case>M</fixed-case>orphological Analysis and Generation</title>
         <author><first>Mans</first><last>Hulden</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Computational Approaches to Semitic Languages</booktitle>
         <month>March</month>
@@ -2142,7 +2143,7 @@
         <bibkey>hulden:2009:Semitic</bibkey>
    </paper>
    <paper id="0804">
-        <title>A Hybrid Approach for Building Arabic Diacritizer</title>
+        <title>A Hybrid Approach for Building <fixed-case>A</fixed-case>rabic Diacritizer</title>
         <author><first>Khaled</first><last>Shaalan</last></author>
         <author><first>Hitham</first><last>M. Abo Bakr</last></author>
         <author><first>Ibrahim</first><last>Ziedan</last></author>
@@ -2157,7 +2158,7 @@
         <bibkey>shaalan-mabobakr-ziedan:2009:Semitic</bibkey>
    </paper>
    <paper id="0805">
-        <title>Unsupervised Concept Discovery In Hebrew Using Simple Unsupervised Word Prefix Segmentation for Hebrew and Arabic</title>
+        <title>Unsupervised Concept Discovery In <fixed-case>H</fixed-case>ebrew Using Simple Unsupervised Word Prefix Segmentation for <fixed-case>H</fixed-case>ebrew and <fixed-case>A</fixed-case>rabic</title>
         <author><first>Elad</first><last>Dinur</last></author>
         <author><first>Dmitry</first><last>Davidov</last></author>
         <author><first>Ari</first><last>Rappoport</last></author>
@@ -2172,7 +2173,7 @@
         <bibkey>dinur-davidov-rappoport:2009:Semitic</bibkey>
    </paper>
    <paper id="0806">
-        <title>Automatic Treebank-Based Acquisition of Arabic LFG Dependency Structures</title>
+        <title>Automatic Treebank-Based Acquisition of <fixed-case>A</fixed-case>rabic <fixed-case>LFG</fixed-case> Dependency Structures</title>
         <author><first>Lamia</first><last>Tounsi</last></author>
         <author><first>Mohammed</first><last>Attia</last></author>
         <author><first>Josef</first><last>van Genabith</last></author>
@@ -2187,7 +2188,7 @@
         <bibkey>tounsi-attia-vangenabith:2009:Semitic</bibkey>
    </paper>
    <paper id="0807">
-        <title>Spoken Arabic Dialect Identification Using Phonotactic Modeling</title>
+        <title>Spoken <fixed-case>A</fixed-case>rabic Dialect Identification Using Phonotactic Modeling</title>
         <author><first>Fadi</first><last>Biadsy</last></author>
         <author><first>Julia</first><last>Hirschberg</last></author>
         <author><first>Nizar</first><last>Habash</last></author>
@@ -2202,7 +2203,7 @@
         <bibkey>biadsy-hirschberg-habash:2009:Semitic</bibkey>
    </paper>
    <paper id="0808">
-        <title>Structure-Based Evaluation of an Arabic Semantic Query Expansion Using the JIRS Passage Retrieval System</title>
+        <title>Structure-Based Evaluation of an <fixed-case>A</fixed-case>rabic Semantic Query Expansion Using the <fixed-case>JIRS</fixed-case> Passage Retrieval System</title>
         <author><first>Lahsen</first><last>Abouenour</last></author>
         <author><first>Karim</first><last>Bouzoubaa</last></author>
         <author><first>Paolo</first><last>Rosso</last></author>
@@ -2217,7 +2218,7 @@
         <bibkey>abouenour-bouzoubaa-rosso:2009:Semitic</bibkey>
    </paper>
    <paper id="0809">
-        <title>Syntactic Reordering for English-Arabic Phrase-Based Machine Translation</title>
+        <title>Syntactic Reordering for <fixed-case>E</fixed-case>nglish-<fixed-case>A</fixed-case>rabic Phrase-Based Machine Translation</title>
         <author><first>Jakob</first><last>Elming</last></author>
         <author><first>Nizar</first><last>Habash</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Computational Approaches to Semitic Languages</booktitle>
@@ -2313,7 +2314,7 @@
         <bibkey>dickinson-jochim:2009:Cognitive</bibkey>
    </paper>
    <paper id="0906">
-        <title>Darwinised Data-Oriented Parsing - Statistical NLP with Added Sex and Death</title>
+        <title>Darwinised Data-Oriented Parsing - Statistical <fixed-case>NLP</fixed-case> with Added Sex and Death</title>
         <author><first>Dave</first><last>Cochran</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Cognitive Aspects of Computational Language Acquisition</booktitle>
         <month>March</month>
@@ -2396,7 +2397,7 @@
         <bibkey>geertzen:2009:CLAGI</bibkey>
    </paper>
    <paper id="1004">
-        <title>Experiments Using OSTIA for a Language Production Task</title>
+        <title>Experiments Using <fixed-case>OSTIA</fixed-case> for a Language Production Task</title>
         <author><first>Dana</first><last>Angluin</last></author>
         <author><first>Leonor</first><last>Becerra-Bonache</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Computational Linguistic Aspects of Grammatical Inference</booktitle>
@@ -2410,7 +2411,7 @@
         <bibkey>angluin-becerrabonache:2009:CLAGI</bibkey>
    </paper>
    <paper id="1005">
-        <title>GREAT: A Finite-State Machine Translation Toolkit Implementing a Grammatical Inference Approach for Transducer Inference (GIATI)</title>
+        <title><fixed-case>GREAT</fixed-case>: A Finite-State Machine Translation Toolkit Implementing a Grammatical Inference Approach for Transducer Inference (<fixed-case>GIATI</fixed-case>)</title>
         <author><first>Jorge</first><last>González</last></author>
         <author><first>Francisco</first><last>Casacuberta</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Computational Linguistic Aspects of Grammatical Inference</booktitle>
@@ -2453,7 +2454,7 @@
         <bibkey>stehouwer-vanzaanen:2009:CLAGI</bibkey>
    </paper>
    <paper id="1008">
-        <title>On Statistical Parsing of French with Supervised and Semi-Supervised Strategies</title>
+        <title>On Statistical Parsing of <fixed-case>F</fixed-case>rench with Supervised and Semi-Supervised Strategies</title>
         <author><first>Marie</first><last>Candito</last></author>
         <author><first>Benoit</first><last>Crabbé</last></author>
         <author><first>Djamé</first><last>Seddah</last></author>
@@ -2482,7 +2483,7 @@
         <bibkey>luque-infantelopez:2009:CLAGI</bibkey>
    </paper>
    <paper id="1010">
-        <title>Comparing Learners for Boolean partitions: Implications for Morphological Paradigms</title>
+        <title>Comparing Learners for <fixed-case>B</fixed-case>oolean partitions: Implications for Morphological Paradigms</title>
         <author><first>Katya</first><last>Pertsova</last></author>
         <booktitle>Proceedings of the EACL 2009 Workshop on Computational Linguistic Aspects of Grammatical Inference</booktitle>
         <month>March</month>
@@ -3958,7 +3959,7 @@
         <bibkey>SETQA-NLP:2009</bibkey>
    </paper>
    <paper id="1501">
-        <title>Building Test Suites for UIMA Components</title>
+        <title>Building Test Suites for <fixed-case>UIMA</fixed-case> Components</title>
         <author><first>Philip</first><last>Ogren</last></author>
         <author><first>Steven</first><last>Bethard</last></author>
         <booktitle>Proceedings of the Workshop on Software Engineering, Testing, and Quality Assurance for Natural Language Processing (SETQA-NLP 2009)</booktitle>
@@ -4000,7 +4001,7 @@
         <bibkey>hockey-rayner:2009:SETQA-NLP</bibkey>
    </paper>
    <paper id="1504">
-        <title>Integrated NLP Evaluation System for Pluggable Evaluation Metrics with Extensive Interoperable Toolkit</title>
+        <title>Integrated <fixed-case>NLP</fixed-case> Evaluation System for Pluggable Evaluation Metrics with Extensive Interoperable Toolkit</title>
         <author><first>Yoshinobu</first><last>Kano</last></author>
         <author><first>Luke</first><last>McCrohon</last></author>
         <author><first>Sophia</first><last>Ananiadou</last></author>
@@ -4031,7 +4032,7 @@
         <bibkey>germann-joanis-larkin:2009:SETQA-NLP</bibkey>
    </paper>
    <paper id="1506">
-        <title>Scaling up a NLU system from text to dialogue understanding</title>
+        <title>Scaling up a <fixed-case>NLU</fixed-case> system from text to dialogue understanding</title>
         <author><first>Rodolfo</first><last>Delmonte</last></author>
         <author><first>Antonella</first><last>Bristot</last></author>
         <author><first>Gloria</first><last>Voltolina</last></author>
@@ -4047,7 +4048,7 @@
         <bibkey>delmonte-EtAl:2009:SETQA-NLP</bibkey>
    </paper>
    <paper id="1507">
-        <title>Towards Agile and Test-Driven Development in NLP Applications</title>
+        <title>Towards Agile and Test-Driven Development in <fixed-case>NLP</fixed-case> Applications</title>
         <author><first>Jana</first><last>Sukkarieh</last></author>
         <author><first>Jyoti</first><last>Kamal</last></author>
         <booktitle>Proceedings of the Workshop on Software Engineering, Testing, and Quality Assurance for Natural Language Processing (SETQA-NLP 2009)</booktitle>
@@ -4061,7 +4062,7 @@
         <bibkey>sukkarieh-kamal:2009:SETQA-NLP</bibkey>
    </paper>
    <paper id="1508">
-        <title>Grammar Engineering for CCG using Ant and XSLT</title>
+        <title>Grammar Engineering for <fixed-case>CCG</fixed-case> using Ant and <fixed-case>XSLT</fixed-case></title>
         <author><first>Scott</first><last>Martin</last></author>
         <author><first>Rajakrishnan</first><last>Rajkumar</last></author>
         <author><first>Michael</first><last>White</last></author>
@@ -4108,7 +4109,7 @@
         <bibkey>waterman:2009:SETQA-NLP</bibkey>
    </paper>
    <paper id="1511">
-        <title>Modular resource development and diagnostic evaluation framework for fast NLP system improvement</title>
+        <title>Modular resource development and diagnostic evaluation framework for fast <fixed-case>NLP</fixed-case> system improvement</title>
         <author><first>Gaël</first><last>de Chalendar</last></author>
         <author><first>Damien</first><last>Nouvel</last></author>
         <booktitle>Proceedings of the Workshop on Software Engineering, Testing, and Quality Assurance for Natural Language Processing (SETQA-NLP 2009)</booktitle>
@@ -4430,7 +4431,7 @@
         <bibkey>gillick-favre:2009:ILPNLP</bibkey>
    </paper>
    <paper id="1803">
-        <title>Bounding and Comparing Methods for Correlation Clustering Beyond ILP</title>
+        <title>Bounding and Comparing Methods for Correlation Clustering Beyond <fixed-case>ILP</fixed-case></title>
         <author><first>Micha</first><last>Elsner</last></author>
         <author><first>Warren</first><last>Schudy</last></author>
         <booktitle>Proceedings of the Workshop on Integer Linear Programming for Natural Language Processing</booktitle>
@@ -5220,7 +5221,7 @@
         <bibkey>sogaard-kuhn:2009:SSST</bibkey>
    </paper>
    <paper id="2304">
-        <title>Improving Phrase-Based Translation via Word Alignments from Stochastic Inversion Transduction Grammars</title>
+        <title>Improving Phrase-Based Translation via Word Alignments from <fixed-case>S</fixed-case>tochastic <fixed-case>I</fixed-case>nversion <fixed-case>T</fixed-case>ransduction <fixed-case>G</fixed-case>rammars</title>
         <author><first>Markus</first><last>Saers</last></author>
         <author><first>Dekai</first><last>Wu</last></author>
         <booktitle>Proceedings of the Third Workshop on Syntax and Structure in Statistical Translation (SSST-3) at NAACL HLT 2009</booktitle>
@@ -5234,7 +5235,7 @@
         <bibkey>saers-wu:2009:SSST</bibkey>
    </paper>
    <paper id="2305">
-        <title>References Extension for the Automatic Evaluation of MT by Syntactic Hybridization</title>
+        <title>References Extension for the Automatic Evaluation of <fixed-case>MT</fixed-case> by Syntactic Hybridization</title>
         <author><first>Bo</first><last>Wang</last></author>
         <author><first>Tiejun</first><last>Zhao</last></author>
         <author><first>Muyun</first><last>Yang</last></author>
@@ -5266,7 +5267,7 @@
         <bibkey>jiang-EtAl:2009:SSST</bibkey>
    </paper>
    <paper id="2307">
-        <title>Discriminative Reordering with Chinese Grammatical Relations Features</title>
+        <title>Discriminative Reordering with <fixed-case>C</fixed-case>hinese Grammatical Relations Features</title>
         <author><first>Pi-Chuan</first><last>Chang</last></author>
         <author><first>Huihsin</first><last>Tseng</last></author>
         <author><first>Dan</first><last>Jurafsky</last></author>
@@ -7590,7 +7591,7 @@
         <bibkey>ALR-7:2009</bibkey>
    </paper>
    <paper id="3401">
-        <title>Enhancing the Japanese WordNet</title>
+        <title>Enhancing the <fixed-case>J</fixed-case>apanese <fixed-case>WordNet</fixed-case></title>
         <author><first>Francis</first><last>Bond</last></author>
         <author><first>Hitoshi</first><last>Isahara</last></author>
         <author><first>Sanae</first><last>Fujita</last></author>
@@ -7608,7 +7609,7 @@
         <bibkey>bond-EtAl:2009:ALR-7</bibkey>
    </paper>
    <paper id="3402">
-        <title>An Empirical Study of Vietnamese Noun Phrase Chunking with Discriminative Sequence Models</title>
+        <title>An Empirical Study of <fixed-case>V</fixed-case>ietnamese Noun Phrase Chunking with Discriminative Sequence Models</title>
         <author><first>Le Minh</first><last>Nguyen</last></author>
         <author><first>Huong Thao</first><last>Nguyen</last></author>
         <author><first>Phuong Thai</first><last>Nguyen</last></author>
@@ -7625,7 +7626,7 @@
         <bibkey>nguyen-EtAl:2009:ALR-7</bibkey>
    </paper>
    <paper id="3403">
-        <title>Corpus-based Sinhala Lexicon</title>
+        <title>Corpus-based <fixed-case>S</fixed-case>inhala Lexicon</title>
         <author><first>Ruvan</first><last>Weerasinghe</last></author>
         <author><first>Dulip</first><last>Herath</last></author>
         <author><first>Viraj</first><last>Welgama</last></author>
@@ -7640,7 +7641,7 @@
         <bibkey>weerasinghe-herath-welgama:2009:ALR-7</bibkey>
    </paper>
    <paper id="3404">
-        <title>Analysis and Development of Urdu POS Tagged Corpus</title>
+        <title>Analysis and Development of <fixed-case>U</fixed-case>rdu <fixed-case>POS</fixed-case> Tagged Corpus</title>
         <author><first>Ahmed</first><last>Muaz</last></author>
         <author><first>Aasim</first><last>Ali</last></author>
         <author><first>Sarmad</first><last>Hussain</last></author>
@@ -7672,7 +7673,7 @@
         <bibkey>ohtake-EtAl:2009:ALR-7</bibkey>
    </paper>
    <paper id="3406">
-        <title>Assas-band, an Affix-Exception-List Based Urdu Stemmer</title>
+        <title>Assas-band, an Affix-Exception-List Based <fixed-case>U</fixed-case>rdu Stemmer</title>
         <author><first>Qurat-ul-Ain</first><last>Akram</last></author>
         <author><first>Asma</first><last>Naseer</last></author>
         <author><first>Sarmad</first><last>Hussain</last></author>
@@ -7687,7 +7688,7 @@
         <bibkey>akram-naseer-hussain:2009:ALR-7</bibkey>
    </paper>
    <paper id="3407">
-        <title>Automated Mining Of Names Using Parallel Hindi-English Corpus</title>
+        <title>Automated Mining Of Names Using Parallel <fixed-case>H</fixed-case>indi-<fixed-case>E</fixed-case>nglish Corpus</title>
         <author><first>R. Mahesh K.</first><last>Sinha</last></author>
         <booktitle>Proceedings of the 7th Workshop on Asian Language Resources</booktitle>
         <month>August</month>
@@ -7700,7 +7701,7 @@
         <bibkey>sinha:2009:ALR-7</bibkey>
    </paper>
    <paper id="3408">
-        <title>Basic Language Resources for Diverse Asian Languages: A Streamlined Approach for Resource Creation</title>
+        <title>Basic Language Resources for Diverse <fixed-case>A</fixed-case>sian Languages: A Streamlined Approach for Resource Creation</title>
         <author><first>Heather</first><last>Simpson</last></author>
         <author><first>Kazuaki</first><last>Maeda</last></author>
         <author><first>Christopher</first><last>Cieri</last></author>
@@ -7715,7 +7716,7 @@
         <bibkey>simpson-maeda-cieri:2009:ALR-7</bibkey>
    </paper>
    <paper id="3409">
-        <title>Finite-State Description of Vietnamese Reduplication</title>
+        <title>Finite-State Description of <fixed-case>V</fixed-case>ietnamese Reduplication</title>
         <author><first>Le Hong</first><last>Phuong</last></author>
         <author><first>Nguyen</first><last>Thi Minh Huyen</last></author>
         <author><first>Roussanaly</first><last>Azim</last></author>
@@ -7730,7 +7731,7 @@
         <bibkey>phuong-thiminhhuyen-azim:2009:ALR-7</bibkey>
    </paper>
    <paper id="3410">
-        <title>Construction of Chinese Segmented and POS-tagged Conversational Corpora and Their Evaluations on Spontaneous Speech Recognitions</title>
+        <title>Construction of <fixed-case>C</fixed-case>hinese Segmented and <fixed-case>POS</fixed-case>-tagged Conversational Corpora and Their Evaluations on Spontaneous Speech Recognitions</title>
         <author><first>Xinhui</first><last>Hu</last></author>
         <author><first>Ryosuke</first><last>Isotani</last></author>
         <author><first>Satoshi</first><last>Nakamura</last></author>
@@ -7745,7 +7746,7 @@
         <bibkey>hu-isotani-nakamura:2009:ALR-7</bibkey>
    </paper>
    <paper id="3411">
-        <title>Bengali Verb Subcategorization Frame Acquisition - A Baseline Model</title>
+        <title><fixed-case>B</fixed-case>engali Verb Subcategorization Frame Acquisition - A Baseline Model</title>
         <author><first>Somnath</first><last>Banerjee</last></author>
         <author><first>Dipankar</first><last>Das</last></author>
         <author><first>Sivaji</first><last>Bandyopadhyay</last></author>
@@ -7760,7 +7761,7 @@
         <bibkey>banerjee-das-bandyopadhyay:2009:ALR-7</bibkey>
    </paper>
    <paper id="3412">
-        <title>Phonological and Logographic Influences on Errors in Written Chinese Words</title>
+        <title>Phonological and Logographic Influences on Errors in Written <fixed-case>C</fixed-case>hinese Words</title>
         <author><first>Chao-Lin</first><last>Liu</last></author>
         <author><first>Kan-Wen</first><last>Tien</last></author>
         <author><first>Min-Hua</first><last>Lai</last></author>
@@ -7792,7 +7793,7 @@
         <bibkey>budiono-riza-hakim:2009:ALR-7</bibkey>
    </paper>
    <paper id="3414">
-        <title>A Syntactic Resource for Thai: CG Treebank</title>
+        <title>A Syntactic Resource for <fixed-case>T</fixed-case>hai: <fixed-case>CG</fixed-case> Treebank</title>
         <author><first>Taneth</first><last>Ruangrajitpakorn</last></author>
         <author><first>Kanokorn</first><last>Trakultaweekoon</last></author>
         <author><first>Thepchai</first><last>Supnithi</last></author>
@@ -7807,7 +7808,7 @@
         <bibkey>ruangrajitpakorn-trakultaweekoon-supnithi:2009:ALR-7</bibkey>
    </paper>
    <paper id="3415">
-        <title>Part of Speech Tagging for Mongolian Corpus</title>
+        <title>Part of Speech Tagging for <fixed-case>M</fixed-case>ongolian Corpus</title>
         <author><first>Purev</first><last>Jaimai</last></author>
         <author><first>Odbayar</first><last>Chimeddorj</last></author>
         <booktitle>Proceedings of the 7th Workshop on Asian Language Resources</booktitle>
@@ -7821,7 +7822,7 @@
         <bibkey>jaimai-chimeddorj:2009:ALR-7</bibkey>
    </paper>
    <paper id="3416">
-        <title>Interaction Grammar for the Persian Language: Noun and Adjectival Phrases</title>
+        <title>Interaction Grammar for the <fixed-case>P</fixed-case>ersian Language: Noun and Adjectival Phrases</title>
         <author><first>Masood</first><last>Ghayoomi</last></author>
         <author><first>Bruno</first><last>Guillaume</last></author>
         <booktitle>Proceedings of the 7th Workshop on Asian Language Resources</booktitle>
@@ -7835,7 +7836,7 @@
         <bibkey>ghayoomi-guillaume:2009:ALR-7</bibkey>
    </paper>
    <paper id="3417">
-        <title>KTimeML: Specification of Temporal and Event Expressions in Korean Text</title>
+        <title><fixed-case>KTimeML</fixed-case>: Specification of Temporal and Event Expressions in <fixed-case>K</fixed-case>orean Text</title>
         <author><first>Seohyun</first><last>Im</last></author>
         <author><first>Hyunjo</first><last>You</last></author>
         <author><first>Hayun</first><last>Jang</last></author>
@@ -7852,7 +7853,7 @@
         <bibkey>im-EtAl:2009:ALR-7</bibkey>
    </paper>
    <paper id="3418">
-        <title>CWN-LMF: Chinese WordNet in the Lexical Markup Framework</title>
+        <title><fixed-case>CWN-LMF</fixed-case>: <fixed-case>C</fixed-case>hinese <fixed-case>WordNet</fixed-case> in the <fixed-case>L</fixed-case>exical <fixed-case>M</fixed-case>arkup <fixed-case>F</fixed-case>ramework</title>
         <author><first>Lung-Hao</first><last>Lee</last></author>
         <author><first>Shu-Kai</first><last>Hsieh</last></author>
         <author><first>Chu-Ren</first><last>Huang</last></author>
@@ -7867,7 +7868,7 @@
         <bibkey>lee-hsieh-huang:2009:ALR-7</bibkey>
    </paper>
    <paper id="3419">
-        <title>Philippine Language Resources: Trends and Directions</title>
+        <title><fixed-case>P</fixed-case>hilippine Language Resources: Trends and Directions</title>
         <author><first>Rachel Edita</first><last>Roxas</last></author>
         <author><first>Charibeth</first><last>Cheng</last></author>
         <author><first>Nathalie Rose</first><last>Lim</last></author>
@@ -7882,7 +7883,7 @@
         <bibkey>roxas-cheng-lim:2009:ALR-7</bibkey>
    </paper>
    <paper id="3420">
-        <title>Thai WordNet Construction</title>
+        <title><fixed-case>T</fixed-case>hai <fixed-case>WordNet</fixed-case> Construction</title>
         <author><first>Sareewan</first><last>Thoongsup</last></author>
         <author><first>Thatsanee</first><last>Charoenporn</last></author>
         <author><first>Kergrit</first><last>Robkop</last></author>
@@ -7901,7 +7902,7 @@
         <bibkey>thoongsup-EtAl:2009:ALR-7</bibkey>
    </paper>
    <paper id="3421">
-        <title>Query Expansion using LMF-Compliant Lexical Resources</title>
+        <title>Query Expansion using <fixed-case>LMF</fixed-case>-Compliant Lexical Resources</title>
         <author><first>Takenobu</first><last>Tokunaga</last></author>
         <author><first>Dain</first><last>Kaplan</last></author>
         <author><first>Nicoletta</first><last>Calzolari</last></author>
@@ -7924,7 +7925,7 @@
         <bibkey>tokunaga-EtAl:2009:ALR-7</bibkey>
    </paper>
    <paper id="3422">
-        <title>Thai National Corpus: A Progress Report</title>
+        <title><fixed-case>T</fixed-case>hai National Corpus: A Progress Report</title>
         <author><first>Wirote</first><last>Aroonmanakun</last></author>
         <author><first>Kachen</first><last>Tansiri</last></author>
         <author><first>Pairit</first><last>Nittayanuparp</last></author>
@@ -7939,7 +7940,7 @@
         <bibkey>aroonmanakun-tansiri-nittayanuparp:2009:ALR-7</bibkey>
    </paper>
    <paper id="3423">
-        <title>The FLaReNet Thematic Network: A Global Forum for Cooperation</title>
+        <title>The <fixed-case>FLaReNet</fixed-case> Thematic Network: A Global Forum for Cooperation</title>
         <author><first>Nicoletta</first><last>Calzolari</last></author>
         <author><first>Claudia</first><last>Soria</last></author>
         <booktitle>Proceedings of the 7th Workshop on Asian Language Resources</booktitle>
@@ -7953,7 +7954,7 @@
         <bibkey>calzolari-soria:2009:ALR-7</bibkey>
    </paper>
    <paper id="3424">
-        <title>Towards Building Advanced Natural Language Applications - An Overview of the Existing Primary Resources and Applications in Nepali</title>
+        <title>Towards Building Advanced Natural Language Applications - An Overview of the Existing Primary Resources and Applications in <fixed-case>N</fixed-case>epali</title>
         <author><first>Bal Krishna</first><last>Bal</last></author>
         <booktitle>Proceedings of the 7th Workshop on Asian Language Resources</booktitle>
         <month>August</month>
@@ -7966,7 +7967,7 @@
         <bibkey>bal:2009:ALR-7</bibkey>
    </paper>
    <paper id="3425">
-        <title>Using Search Engine to Construct a Scalable Corpus for Vietnamese Lexical Development for Word Segmentation</title>
+        <title>Using Search Engine to Construct a Scalable Corpus for <fixed-case>V</fixed-case>ietnamese Lexical Development for Word Segmentation</title>
         <author><first>Doan</first><last>Nguyen</last></author>
         <booktitle>Proceedings of the 7th Workshop on Asian Language Resources</booktitle>
         <month>August</month>
@@ -7979,7 +7980,7 @@
         <bibkey>nguyen:2009:ALR-7</bibkey>
    </paper>
    <paper id="3426">
-        <title>Word Segmentation Standard in Chinese, Japanese and Korean</title>
+        <title>Word Segmentation Standard in <fixed-case>C</fixed-case>hinese, <fixed-case>J</fixed-case>apanese and <fixed-case>K</fixed-case>orean</title>
         <author><first>Key-Sun</first><last>Choi</last></author>
         <author><first>Hitoshi</first><last>Isahara</last></author>
         <author><first>Kyoko</first><last>Kanzaki</last></author>
@@ -10059,7 +10060,7 @@
         <bibkey>bavelas:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3905">
-        <title>Incremental Reference Resolution: The Task, Metrics for Evaluation, and a Bayesian Filtering Model that is Sensitive to Disfluencies</title>
+        <title>Incremental Reference Resolution: The Task, Metrics for Evaluation, and a <fixed-case>B</fixed-case>ayesian Filtering Model that is Sensitive to Disfluencies</title>
         <author><first>David</first><last>Schlangen</last></author>
         <author><first>Timo</first><last>Baumann</last></author>
         <author><first>Michaela</first><last>Atterer</last></author>
@@ -10166,7 +10167,7 @@
         <bibkey>howes-healey-mills:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3912">
-        <title>Interactive Gesture in Dialogue: a PTT Model</title>
+        <title>Interactive Gesture in Dialogue: a <fixed-case>PTT</fixed-case> Model</title>
         <author><first>Hannes</first><last>Rieser</last></author>
         <author><first>Massimo</first><last>Poesio</last></author>
         <booktitle>Proceedings of the SIGDIAL 2009 Conference</booktitle>
@@ -10253,7 +10254,7 @@
         <bibkey>meguro-EtAl:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3918">
-        <title>On NoMatchs, NoInputs and BargeIns: Do Non-Acoustic Features Support Anger Detection?</title>
+        <title>On <fixed-case>NoMatchs</fixed-case>, <fixed-case>NoInputs</fixed-case> and <fixed-case>BargeIns</fixed-case>: Do Non-Acoustic Features Support Anger Detection?</title>
         <author><first>Alexander</first><last>Schmitt</last></author>
         <author><first>Tobias</first><last>Heinroth</last></author>
         <author><first>Jackson</first><last>Liscombe</last></author>
@@ -10268,7 +10269,7 @@
         <bibkey>schmitt-heinroth-liscombe:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3919">
-        <title>Estimating Probability of Correctness for ASR N-Best Lists</title>
+        <title>Estimating Probability of Correctness for <fixed-case>ASR</fixed-case> <fixed-case>N-Best</fixed-case> Lists</title>
         <author><first>Jason</first><last>Williams</last></author>
         <author><first>Suhrid</first><last>Balakrishnan</last></author>
         <booktitle>Proceedings of the SIGDIAL 2009 Conference</booktitle>
@@ -10311,7 +10312,7 @@
         <bibkey>stoyanchev-stent:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3922">
-        <title>Automatic Generation of Information State Update Dialogue Systems that Dynamically Create Voice XML, as Demonstrated on the iPhone</title>
+        <title>Automatic Generation of Information State Update Dialogue Systems that Dynamically Create Voice <fixed-case>XML</fixed-case>, as Demonstrated on the <fixed-case>iPhone</fixed-case></title>
         <author><first>Helen</first><last>Hastie</last></author>
         <author><first>Xingkun</first><last>Liu</last></author>
         <author><first>Oliver</first><last>Lemon</last></author>
@@ -10342,7 +10343,7 @@
         <bibkey>balchandran-EtAl:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3924">
-        <title>Leveraging POMDPs Trained with User Simulations and Rule-based Dialogue Management in a Spoken Dialogue System</title>
+        <title>Leveraging <fixed-case>POMDPs</fixed-case> Trained with User Simulations and Rule-based Dialogue Management in a Spoken Dialogue System</title>
         <author><first>Sebastian</first><last>Varges</last></author>
         <author><first>Silvia</first><last>Quarteroni</last></author>
         <author><first>Giuseppe</first><last>Riccardi</last></author>
@@ -10376,7 +10377,7 @@
         <bibkey>dharo-EtAl:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3926">
-        <title>Modeling User Satisfaction with Hidden Markov Models</title>
+        <title>Modeling User Satisfaction with Hidden <fixed-case>M</fixed-case>arkov Models</title>
         <author><first>Klaus-Peter</first><last>Engelbrecht</last></author>
         <author><first>Florian</first><last>Gödde</last></author>
         <author><first>Felix</first><last>Hartard</last></author>
@@ -10448,7 +10449,7 @@
         <bibkey>zhang-chai:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3931">
-        <title>Artificial Companions as Dialogue Agents</title>
+        <title>Artificial <fixed-case>C</fixed-case>ompanions as Dialogue Agents</title>
         <author><first>Yorick</first><last>Wilks</last></author>
         <booktitle>Proceedings of the SIGDIAL 2009 Conference</booktitle>
         <month>September</month>
@@ -10552,7 +10553,7 @@
         <bibkey>purver-EtAl:2009:SIGDIAL1</bibkey>
    </paper>
    <paper id="3938">
-        <title>k-Nearest Neighbor Monte-Carlo Control Algorithm for POMDP-Based Dialogue Systems</title>
+        <title><fixed-case>k-Nearest</fixed-case> Neighbor <fixed-case>Monte-Carlo</fixed-case> Control Algorithm for <fixed-case>POMDP</fixed-case>-Based Dialogue Systems</title>
         <author><first>Fabrice</first><last>Lefèvre</last></author>
         <author><first>Milica</first><last>Gašić</last></author>
         <author><first>Filip</first><last>Jurčíček</last></author>
@@ -10572,7 +10573,7 @@
         <bibkey>lefevre-EtAl:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3939">
-        <title>Comparison of Classification and Ranking Approaches to Pronominal Anaphora Resolution in Czech</title>
+        <title>Comparison of Classification and Ranking Approaches to Pronominal Anaphora Resolution in <fixed-case>C</fixed-case>zech</title>
         <author><first>Giang Linh</first><last>Ngụy</last></author>
         <author><first>Václav</first><last>Novák</last></author>
         <author><first>Zdeněk</first><last>abokrtský</last></author>
@@ -10629,7 +10630,7 @@
         <bibkey>gustafson-merkes:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3943">
-        <title>TELIDA: A Package for Manipulation and Visualization of Timed Linguistic Data</title>
+        <title><fixed-case>TELIDA</fixed-case>: A Package for Manipulation and Visualization of Timed Linguistic Data</title>
         <author><first>Titus</first><last>von der Malsburg</last></author>
         <author><first>Timo</first><last>Baumann</last></author>
         <author><first>David</first><last>Schlangen</last></author>
@@ -10748,7 +10749,7 @@
         <bibkey>black-eskenazi:2009:SIGDIAL</bibkey>
    </paper>
    <paper id="3951">
-        <title>Unsupervised Classification of Dialogue Acts using a Dirichlet Process Mixture Model</title>
+        <title>Unsupervised Classification of Dialogue Acts using a <fixed-case>D</fixed-case>irichlet Process Mixture Model</title>
         <author><first>Nigel</first><last>Crook</last></author>
         <author><first>Ramon</first><last>Granell</last></author>
         <author><first>Stephen</first><last>Pulman</last></author>

--- a/import/W09.xml
+++ b/import/W09.xml
@@ -1081,7 +1081,7 @@
         <bibkey>niehues-kolss:2009:WMT</bibkey>
    </paper>
    <paper id="0436">
-        <title>Disambiguating “DE” for Chinese-English Machine Translation</title>
+        <title>Disambiguating “<fixed-case>DE</fixed-case>” for <fixed-case>C</fixed-case>hinese-<fixed-case>E</fixed-case>nglish Machine Translation</title>
         <author><first>Pi-Chuan</first><last>Chang</last></author>
         <author><first>Daniel</first><last>Jurafsky</last></author>
         <author><first>Christopher D.</first><last>Manning</last></author>

--- a/import/W10.xml
+++ b/import/W10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W10">
     <paper id="0100">
 	 <title>Proceedings of the NAACL HLT 2010 Workshop on Active Learning for Natural Language Processing</title>
@@ -7691,7 +7692,7 @@
         <bibkey>hovy:2010:W10-31</bibkey>
    </paper>
    <paper id="3110">
-        <title>What’s great and what’s not: learning to classify the scope of negation for improved sentiment analysis</title>
+        <title>What<fixed-case>'</fixed-case>s great and what<fixed-case>'</fixed-case>s not: learning to classify the scope of negation for improved sentiment analysis</title>
         <author><first>Isaac</first><last>Councill</last></author>
         <author><first>Ryan</first><last>McDonald</last></author>
         <author><first>Leonid</first><last>Velikovich</last></author>
@@ -8114,7 +8115,7 @@
         <bibkey>wen-EtAl:2010:ALR</bibkey>
    </paper>
    <paper id="3300">
-        <title>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </title>
+        <title>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></title>
         <editor><first>Alessandro</first><last>Oltramari</last></editor>
         <editor><first>Piek</first><last>Vossen</last></editor>
         <editor><first>Qin</first><last>Lu</last></editor>
@@ -8134,7 +8135,7 @@
         <author><first>Aitor</first><last>Soroa</last></author>
         <author><first>Monica</first><last>Monachini</last></author>
         <author><first>Roberto</first><last>Bartolini</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8149,7 +8150,7 @@
         <author><first>Masaaki</first><last>Nagata</last></author>
         <author><first>Yumi</first><last>Shibaki</last></author>
         <author><first>Kazuhide</first><last>Yamamoto</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8166,7 +8167,7 @@
         <author><first>Christian</first><last>Boitet</last></author>
         <author><first>Asanobu</first><last>Kitamoto</last></author>
         <author><first>Mathieu</first><last>Mangeot</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8180,7 +8181,7 @@
         <title>Finding Medical Term Variations using Parallel Corpora and Distributional Similarity</title>
         <author><first>Lonneke</first><last>van der Plas</last></author>
         <author><first>Jorg</first><last>Tiedemann</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8193,7 +8194,7 @@
    <paper id="3305">
         <title>Learning Semantic Network Patterns for Hypernymy Extraction</title>
         <author><first>Tim</first><last>vor der Bruck</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8209,7 +8210,7 @@
         <author><first>Eun-Kyung</first><last>Kim</last></author>
         <author><first>Sang-Ah</first><last>Shim</last></author>
         <author><first>Key-Sun</first><last>Choi</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8224,7 +8225,7 @@
         <author><first>Mike</first><last>Conway</last></author>
         <author><first>John</first><last>Dowling</last></author>
         <author><first>Wendy</first><last>Chapman</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8240,7 +8241,7 @@
         <author><first>Leonid</first><last>Iomdin</last></author>
         <author><first>Victor</first><last>Sizov</last></author>
         <author><first>Svetlana</first><last>Timoshenko</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8255,7 +8256,7 @@
         <author><first>Anais</first><last>Cadilhac</last></author>
         <author><first>Farah</first><last>Benamara</last></author>
         <author><first>Nathalie</first><last>Aussenac-Gilles</last></author>
-        <booktitle>Proceedings of the 6th Workshop on  Ontologies and Lexical Resources </booktitle>
+        <booktitle>Proceedings of the <fixed-case>6th</fixed-case> Workshop on <fixed-case> Ontologies and Lexical Resources </fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8435,7 +8436,7 @@
         <bibkey>zock-schwab-rakotonanahary:2010:COGALEX</bibkey>
    </paper>
    <paper id="3500">
-        <title>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</title>
+        <title>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></title>
         <editor><first>Iryna</first><last>Gurevych</last></editor>
         <editor><first>Torsten</first><last>Zesch</last></editor>
         <month>August</month>
@@ -8451,7 +8452,7 @@
         <author><first>Yumi</first><last>Shibaki</last></author>
         <author><first>Masaaki</first><last>Nagata</last></author>
         <author><first>Kazuhide</first><last>Yamamoto</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8465,7 +8466,7 @@
         <title>Using the Wikipedia Link Structure to Correct the Wikipedia Link Structure</title>
         <author><first>Benjamin Mark</first><last>Pateman</last></author>
         <author><first>Colin</first><last>Johnson</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8483,7 +8484,7 @@
         <author><first>Alessandro</first><last>Marchetti</last></author>
         <author><first>Emanuele</first><last>Pianta</last></author>
         <author><first>Kateryna</first><last>Tymoshenko</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8497,7 +8498,7 @@
         <title>Expanding textual entailment corpora fromWikipedia using co-training</title>
         <author><first>Fabio Massimo</first><last>Zanzotto</last></author>
         <author><first>Marco</first><last>Pennacchiotti</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8512,7 +8513,7 @@
         <author><first>Ji</first><last>Fang</last></author>
         <author><first>Bob</first><last>Price</last></author>
         <author><first>Lotti</first><last>Price</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8527,7 +8528,7 @@
         <author><first>Stephan</first><last>Gouws</last></author>
         <author><first>G-J</first><last>van Rooyen</last></author>
         <author><first>Herman A.</first><last>Engelbrecht</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8545,7 +8546,7 @@
         <author><first>Nasir</first><last>Touheed</last></author>
         <author><first>Emanuele</first><last>Pianta</last></author>
         <author><first>Kateryna</first><last>Tymoshenko</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -8561,7 +8562,7 @@
         <author><first>Takeshi</first><last>Abekawa</last></author>
         <author><first>Eiichiro</first><last>Sumita</last></author>
         <author><first>Kyo</first><last>Kageura</last></author>
-        <booktitle>Proceedings of the 2nd Workshop on The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</booktitle>
+        <booktitle>Proceedings of the <fixed-case>2nd</fixed-case> Workshop on <fixed-case>The People’s Web Meets NLP: Collaboratively Constructed Semantic Resources</fixed-case></booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9321,7 +9322,7 @@
         <bibkey>miura-EtAl:2010:NLPIX</bibkey>
    </paper>
    <paper id="4000">
-        <title>Proceedings of the 4th Workshop on Cross Lingual Information Access</title>
+        <title>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</title>
         <editor><first>Sudeshna</first><last>Sarkar</last></editor>
         <editor><first>Min</first><last>Zhang</last></editor>
         <editor><first>Adam</first><last>Lopez</last></editor>
@@ -9337,7 +9338,7 @@
    <paper id="4001">
         <title>Word Sense Disambiguation and IR</title>
         <author><first>Pushpak</first><last>Bhattacharyya</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9350,7 +9351,7 @@
    <paper id="4002">
         <title>Multiliguality at NTCIR, and moving on ...</title>
         <author><first>Tetsuya</first><last>Sakai</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9366,7 +9367,7 @@
         <author><first>Antoine</first><last>Doucet</last></author>
         <author><first>Roman</first><last>Yangarber</last></author>
         <author><first>Nadine</first><last>Lucas</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9380,7 +9381,7 @@
         <title>How to Get the Same News from Different Language News Papers</title>
         <author><first>T Pattabhi</first><last>R K Rao</last></author>
         <author><first>Sobha</first><last>Lalitha Devi</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9396,7 +9397,7 @@
         <author><first>Michael</first><last>Zock</last></author>
         <author><first>Andrew</first><last>Trotman</last></author>
         <author><first>Yue</first><last>Xu</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9412,7 +9413,7 @@
         <author><first>Alfredo</first><last>Maldonado Guerra</last></author>
         <author><first>Yvette</first><last>Graham</last></author>
         <author><first>Andy</first><last>Way</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9427,7 +9428,7 @@
         <author><first>Diptesh</first><last>Chatterjee</last></author>
         <author><first>Sudeshna</first><last>Sarkar</last></author>
         <author><first>Arpit</first><last>Mishra</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9443,7 +9444,7 @@
         <author><first>Shlomo</first><last>Geva</last></author>
         <author><first>Andrew</first><last>Trotman</last></author>
         <author><first>Yue</first><last>Xu</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9460,7 +9461,7 @@
         <author><first>Didier</first><last>Schwab</last></author>
         <author><first>Hervé</first><last>Blanchon</last></author>
         <author><first>Christian</first><last>Boitet</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9478,7 +9479,7 @@
         <author><first>Daniel</first><last>Keim</last></author>
         <author><first>Hagay</first><last>Lipman</last></author>
         <author><first>Assaf</first><last>Ben Gur</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9494,7 +9495,7 @@
         <author><first>Manoj</first><last>Chinnakotla</last></author>
         <author><first>Mitesh</first><last>Khapra</last></author>
         <author><first>Pushpak</first><last>Bhattacharyya</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>
@@ -9508,7 +9509,7 @@
         <title>Multilinguization and Personalization of NL-based Systems</title>
         <author><first>Najeh</first><last>Hajlaoui</last></author>
         <author><first>Christian</first><last>Boitet</last></author>
-        <booktitle>Proceedings of the 4th Workshop on Cross Lingual Information Access</booktitle>
+        <booktitle>Proceedings of the <fixed-case>4th</fixed-case> Workshop on Cross Lingual Information Access</booktitle>
         <month>August</month>
         <year>2010</year>
         <address>Beijing, China</address>

--- a/import/W11.xml
+++ b/import/W11.xml
@@ -903,7 +903,7 @@
   </paper>
 
   <paper id="0309">
-    <title>Subword and Spatiotemporal Models for Identifying Actionable Information in <fixed-case>Haitian Kreyol</fixed-case></title>
+    <title>Subword and Spatiotemporal Models for Identifying Actionable Information in <fixed-case>H</fixed-case>aitian <fixed-case>K</fixed-case>reyol</title>
     <author><first>Robert</first><last>Munro</last></author>
     <booktitle>Proceedings of the Fifteenth Conference on Computational Natural Language Learning</booktitle>
     <month>June</month>
@@ -1720,7 +1720,7 @@
   </paper>
 
   <paper id="0602">
-    <title>A <fixed-case>Bayesian</fixed-case> Belief Updating Model of Phonetic Recalibration and Selective Adaptation</title>
+    <title>A <fixed-case>B</fixed-case>ayesian Belief Updating Model of Phonetic Recalibration and Selective Adaptation</title>
     <author><first>Dave</first><last>Kleinschmidt</last></author>
     <author><first>T. Florian</first><last>Jaeger</last></author>
     <booktitle>Proceedings of the 2nd Workshop on Cognitive Modeling and Computational Linguistics</booktitle>
@@ -1764,7 +1764,7 @@
   </paper>
 
   <paper id="0605">
-    <title>Top-Down Recognizers for <fixed-case>MCFGs</fixed-case> and <fixed-case>MGs</fixed-case></title>
+    <title>Top-Down Recognizers for <fixed-case>MCFG</fixed-case>s and <fixed-case>MG</fixed-case>s</title>
     <author><first>Edward</first><last>Stabler</last></author>
     <booktitle>Proceedings of the 2nd Workshop on Cognitive Modeling and Computational Linguistics</booktitle>
     <month>June</month>
@@ -12253,7 +12253,7 @@
         <bibkey>hulden:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4407">
-        <title>E-Dictionaries and Finite-State Automata for the Recognition of Named Entities</title>
+        <title><fixed-case>E</fixed-case>-Dictionaries and Finite-State Automata for the Recognition of Named Entities</title>
         <author><first>Cvetana</first><last>Krstev</last></author>
         <author><first>Duško</first><last>Vitas</last></author>
         <author><first>Ivan</first><last>Obradović</last></author>
@@ -12282,7 +12282,7 @@
         <bibkey>hanneforth:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4409">
-        <title>Open Source WFST Tools for LVCSR Cascade Development</title>
+        <title>Open Source <fixed-case>WFST</fixed-case> Tools for <fixed-case>LVCSR</fixed-case> Cascade Development</title>
         <author><first>Josef R.</first><last>Novak</last></author>
         <author><first>Nobuaki</first><last>Minematsu</last></author>
         <author><first>Keikichi</first><last>Hirose</last></author>
@@ -12297,7 +12297,7 @@
         <bibkey>novak-minematsu-hirose:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4410">
-        <title>Intersection of Multitape Transducers vs. Cascade of Binary Transducers: The Example of Egyptian Hieroglyphs Transliteration</title>
+        <title>Intersection of Multitape Transducers vs. Cascade of Binary Transducers: The Example of <fixed-case>E</fixed-case>gyptian Hieroglyphs Transliteration</title>
         <author><first>François</first><last>Barthélemy</last></author>
         <author><first>Serge</first><last>Rosmorduc</last></author>
         <booktitle>Proceedings of the 9th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
@@ -12311,7 +12311,7 @@
         <bibkey>barthelemy-rosmorduc:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4411">
-        <title>A Note on Sequential Rule-Based POS Tagging</title>
+        <title>A Note on Sequential Rule-Based <fixed-case>POS</fixed-case> Tagging</title>
         <author><first>Sylvain</first><last>Schmitz</last></author>
         <booktitle>Proceedings of the 9th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
         <month>July</month>
@@ -12324,7 +12324,7 @@
         <bibkey>schmitz:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4412">
-        <title>FTrace: A Tool for Finite-State Morphology</title>
+        <title><fixed-case>FTrace</fixed-case>: A Tool for Finite-State Morphology</title>
         <author><first>James</first><last>Kilbury</last></author>
         <author><first>Katina</first><last>Bontcheva</last></author>
         <author><first>Younes</first><last>Samih</last></author>
@@ -12339,7 +12339,7 @@
         <bibkey>kilbury-bontcheva-samih:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4413">
-        <title>Incremental Construction of Millstream Configurations Using Graph Transformation</title>
+        <title>Incremental Construction of <fixed-case>M</fixed-case>illstream Configurations Using Graph Transformation</title>
         <author><first>Suna</first><last>Bensch</last></author>
         <author><first>Frank</first><last>Drewes</last></author>
         <author><first>Helmut</first><last>Jürgensen</last></author>
@@ -12355,7 +12355,7 @@
         <bibkey>bensch-EtAl:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4414">
-        <title>Stochastic K-TSS Bi-Languages for Machine Translation</title>
+        <title>Stochastic <fixed-case>K-TSS</fixed-case> Bi-Languages for Machine Translation</title>
         <author><first>M. Inés</first><last>Torres</last></author>
         <author><first>Francisco</first><last>Casacuberta</last></author>
         <booktitle>Proceedings of the 9th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
@@ -12399,7 +12399,7 @@
         <bibkey>altantawy-habash-rambow:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4417">
-        <title>An Open-Source Finite State Morphological Transducer for Modern Standard Arabic</title>
+        <title>An Open-Source Finite State Morphological Transducer for Modern Standard <fixed-case>A</fixed-case>rabic</title>
         <author><first>Mohammed</first><last>Attia</last></author>
         <author><first>Pavel</first><last>Pecina</last></author>
         <author><first>Antonio</first><last>Toral</last></author>
@@ -12416,7 +12416,7 @@
         <bibkey>attia-EtAl:2011:FSMNLP</bibkey>
    </paper>
    <paper id="4418">
-        <title>Recognition and Translation of Arabic Named Entities with NooJ Using a New Representation Model</title>
+        <title>Recognition and Translation of <fixed-case>A</fixed-case>rabic Named Entities with <fixed-case>NooJ</fixed-case> Using a New Representation Model</title>
         <author><first>Héla</first><last>Fehri</last></author>
         <author><first>Kais</first><last>Haddar</last></author>
         <author><first>Abdelmajid</first><last>Ben Hamadou</last></author>

--- a/import/W12.xml
+++ b/import/W12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W12">
    <paper id="0100">
         <title>Proceedings of the Joint Workshop on Exploiting Synergies between Information Retrieval and Machine Translation (ESIRMT) and Hybrid Approaches to Machine Translation (HyTra)</title>
@@ -5328,7 +5329,7 @@
   </paper>
 
   <paper id="2400">
-    <title>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</title>
+    <title><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</title>
     <editor><first>Kevin B.</first><last>Cohen</last></editor>
     <editor><first>Dina</first><last>Demner-Fushman</last></editor>
     <editor><first>Sophia</first><last>Ananiadou</last></editor>
@@ -5348,7 +5349,7 @@
     <title>Graph-based alignment of narratives for automated neurological assessment</title>
     <author><first>Emily</first><last>Prud’hommeaux</last></author>
     <author><first>Brian</first><last>Roark</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5363,7 +5364,7 @@
     <title>Bootstrapping Biomedical Ontologies for Scientific Text using NELL</title>
     <author><first>Dana</first><last>Movshovitz-Attias</last></author>
     <author><first>William</first><last>W. Cohen</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5380,7 +5381,7 @@
     <author><first>Laëtitia</first><last>Dupuch</last></author>
     <author><first>Thierry</first><last>Hamon</last></author>
     <author><first>Natalia</first><last>Grabar</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5396,7 +5397,7 @@
     <author><first>Preethi</first><last>Raghavan</last></author>
     <author><first>Eric</first><last>Fosler-Lussier</last></author>
     <author><first>Albert</first><last>Lai</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5413,7 +5414,7 @@
     <author><first>Nicola</first><last>Stokes</last></author>
     <author><first>Joe</first><last>Carthy</last></author>
     <author><first>John</first><last>Dunnion</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5428,7 +5429,7 @@
     <title>Alignment-HMM-based Extraction of Abbreviations from Biomedical Text</title>
     <author><first>Dana</first><last>Movshovitz-Attias</last></author>
     <author><first>William</first><last>W. Cohen</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5444,7 +5445,7 @@
     <author><first>Danielle L.</first><last>Mowery</last></author>
     <author><first>Sumithra</first><last>Velupillai</last></author>
     <author><first>Wendy W.</first><last>Chapman</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5461,7 +5462,7 @@
     <author><first>Brett</first><last>South</last></author>
     <author><first>Shuying</first><last>Shen</last></author>
     <author><first>Stephane</first><last>Meystre</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5477,7 +5478,7 @@
     <author><first>Timothy</first><last>Miller</last></author>
     <author><first>Dmitriy</first><last>Dligach</last></author>
     <author><first>Guergana</first><last>Savova</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5498,7 +5499,7 @@
     <author><first>Yves</first><last>Van de Peer</last></author>
     <author><first>Sophia</first><last>Ananiadou</last></author>
     <author><first>Tapio</first><last>Salakoski</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5513,7 +5514,7 @@
     <title>An improved corpus of disease mentions in PubMed citations</title>
     <author><first>Rezarta</first><last>Islamaj Dogan</last></author>
     <author><first>Zhiyong</first><last>Lu</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5531,7 +5532,7 @@
     <author><first>Tomoko</first><last>Ohta</last></author>
     <author><first>Jin-Dong</first><last>Kim</last></author>
     <author><first>Sophia</first><last>Ananiadou</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5550,7 +5551,7 @@
     <author><first>Zina</first><last>Badji</last></author>
     <author><first>Natalia</first><last>Grabar</last></author>
     <author><first>Sergei</first><last>Silvestrov</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5567,7 +5568,7 @@
     <author><first>Noriko</first><last>Tomuro</last></author>
     <author><first>Pattanasak</first><last>Mongkolwat</last></author>
     <author><first>Dina</first><last>Demner-Fushman</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5585,7 +5586,7 @@
     <author><first>Michael</first><last>Crivaro</last></author>
     <author><first>Bensiin</first><last>Borukhov</last></author>
     <author><first>Marie</first><last>Meteer</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5604,7 +5605,7 @@
     <author><first>Tyler</first><last>Forbush</last></author>
     <author><first>Scott</first><last>DuVall</last></author>
     <author><first>Wendy</first><last>Chapman</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5622,7 +5623,7 @@
     <author><first>Mike</first><last>Crivaro</last></author>
     <author><first>Michael</first><last>Shafir</last></author>
     <author><first>Attapol</first><last>Thamrongrattanarit</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5640,7 +5641,7 @@
     <author><first>Jose Luis</first><last>Ambite</last></author>
     <author><first>Yigal</first><last>Arens</last></author>
     <author><first>Chun-Nan</first><last>Hsu</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5658,7 +5659,7 @@
     <author><first>William W.</first><last>Cohen</last></author>
     <author><first>Jelena</first><last>Jakovljevic</last></author>
     <author><first>John L.</first><last>Woolford</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5673,7 +5674,7 @@
     <title>RankPref: Ranking Sentences Describing Relations between Biomedical Entities with an Application</title>
     <author><first>Catalina Oana</first><last>Tudor</last></author>
     <author><first>K</first><last>Vijay-Shanker</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5690,7 +5691,7 @@
     <author><first>Jee-Hyub</first><last>Kim</last></author>
     <author><first>Samuel</first><last>Croset</last></author>
     <author><first>Dietrich</first><last>Rebholz-Schuhmann</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5706,7 +5707,7 @@
     <author><first>Binod</first><last>Gyawali</last></author>
     <author><first>Thamar</first><last>Solorio</last></author>
     <author><first>Yassine</first><last>Benajiba</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5723,7 +5724,7 @@
     <author><first>Won</first><last>Kim</last></author>
     <author><first>Don</first><last>Comeau</last></author>
     <author><first>W. John</first><last>Wilbur</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5738,7 +5739,7 @@
     <title>Effect of small sample size on text categorization with support vector machines</title>
     <author><first>Pawel</first><last>Matykiewicz</last></author>
     <author><first>John</first><last>Pestian</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5753,7 +5754,7 @@
     <title>PubAnnotation - a persistent and sharable corpus and annotation repository</title>
     <author><first>Jin-Dong</first><last>Kim</last></author>
     <author><first>Yue</first><last>Wang</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5769,7 +5770,7 @@
     <author><first>Richard</first><last>Boyce</last></author>
     <author><first>Gregory</first><last>Gardner</last></author>
     <author><first>Henk</first><last>Harkema</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5786,7 +5787,7 @@
     <author><first>Laura</first><last>Wojtulewicz</last></author>
     <author><first>Neel</first><last>Mehta</last></author>
     <author><first>Graciela</first><last>Gonzalez</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5804,7 +5805,7 @@
     <author><first>Zhonghua</first><last>Yu</last></author>
     <author><first>Li</first><last>Chen</last></author>
     <author><first>Yongguang</first><last>Jiang</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5820,7 +5821,7 @@
     <author><first>Weiwei</first><last>Cheng</last></author>
     <author><first>Judita</first><last>Preiss</last></author>
     <author><first>Mark</first><last>Stevenson</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -5835,7 +5836,7 @@
     <title>Boosting the protein name recognition performance by bootstrapping on selected text</title>
     <author><first>Yue</first><last>Wang</last></author>
     <author><first>Jin-Dong</first><last>Kim</last></author>
-    <booktitle>BioNLP: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
+    <booktitle><fixed-case>BioNLP</fixed-case>: Proceedings of the 2012 Workshop on Biomedical Natural Language Processing</booktitle>
     <month>June</month>
     <year>2012</year>
     <address>Montrèal, Canada</address>
@@ -13544,7 +13545,7 @@
   </paper>
 
   <paper id="6203">
-    <title>Handling Unknown Words in Arabic FST Morphology</title>
+    <title>Handling Unknown Words in <fixed-case>Arabic</fixed-case> <fixed-case>FST</fixed-case> Morphology</title>
     <author><first>Khaled</first><last>Shaalan</last></author>
     <author><first>Mohammed</first><last>Attia</last></author>
     <booktitle>Proceedings of the 10th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
@@ -13559,7 +13560,7 @@
   </paper>
 
   <paper id="6204">
-    <title>Urdu - Roman Transliteration via Finite State Transducers</title>
+    <title><fixed-case>Urdu</fixed-case> - <fixed-case>Roman</fixed-case> Transliteration via Finite State Transducers</title>
     <author><first>Tina</first><last>Bögel</last></author>
     <booktitle>Proceedings of the 10th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
     <month>July</month>
@@ -13573,7 +13574,7 @@
   </paper>
 
   <paper id="6205">
-    <title>Integrating Aspectually Relevant Properties of Verbs into a Morphological Analyzer for English</title>
+    <title>Integrating Aspectually Relevant Properties of Verbs into a Morphological Analyzer for <fixed-case>English</fixed-case></title>
     <author><first>Katina</first><last>Bontcheva</last></author>
     <booktitle>Proceedings of the 10th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
     <month>July</month>
@@ -13604,7 +13605,7 @@
   </paper>
 
   <paper id="6207">
-    <title>DAGGER: A Toolkit for Automata on Directed Acyclic Graphs</title>
+    <title><fixed-case>DAGGER</fixed-case>: A Toolkit for Automata on Directed Acyclic Graphs</title>
     <author><first>Daniel</first><last>Quernheim</last></author>
     <author><first>Kevin</first><last>Knight</last></author>
     <booktitle>Proceedings of the 10th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
@@ -13619,7 +13620,7 @@
   </paper>
 
   <paper id="6208">
-    <title>WFST-Based Grapheme-to-Phoneme Conversion: Open Source tools for Alignment, Model-Building and Decoding</title>
+    <title><fixed-case>WFST</fixed-case>-Based Grapheme-to-Phoneme Conversion: Open Source tools for Alignment, Model-Building and Decoding</title>
     <author><first>Josef R.</first><last>Novak</last></author>
     <author><first>Nobuaki</first><last>Minematsu</last></author>
     <author><first>Keikichi</first><last>Hirose</last></author>
@@ -13635,7 +13636,7 @@
   </paper>
 
   <paper id="6209">
-    <title>Kleene, a Free and Open-Source Language for Finite-State Programming</title>
+    <title><fixed-case>Kleene</fixed-case>, a Free and Open-Source Language for Finite-State Programming</title>
     <author><first>Kenneth R.</first><last>Beesley</last></author>
     <booktitle>Proceedings of the 10th International Workshop on Finite State Methods and Natural Language Processing</booktitle>
     <month>July</month>
@@ -13683,7 +13684,7 @@
   </paper>
 
   <paper id="6212">
-    <title>Developing an Open-Source FST Grammar for Verb Chain Transfer in a Spanish-Basque MT System</title>
+    <title>Developing an Open-Source <fixed-case>FST</fixed-case> Grammar for Verb Chain Transfer in a <fixed-case>Spanish-Basque MT</fixed-case> System</title>
     <author><first>Aingeru</first><last>Mayor</last></author>
     <author><first>Mans</first><last>Hulden</last></author>
     <author><first>Gorka</first><last>Labaka</last></author>
@@ -13699,7 +13700,7 @@
   </paper>
 
   <paper id="6213">
-    <title>Conversion of Procedural Morphologies to Finite-State Morphologies: A Case Study of Arabic</title>
+    <title>Conversion of Procedural Morphologies to Finite-State Morphologies: A Case Study of <fixed-case>Arabic</fixed-case></title>
     <author><first>Mans</first><last>Hulden</last></author>
     <author><first>Younes</first><last>Samih</last></author>
     <booktitle>Proceedings of the 10th International Workshop on Finite State Methods and Natural Language Processing</booktitle>

--- a/import/W13.xml
+++ b/import/W13.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W13">
   <paper id="0100">
     <title>Proceedings of the 10th International Conference on Computational Semantics (IWCS 2013) – Long Papers</title>
@@ -1597,7 +1598,7 @@
   </paper>
 
   <paper id="1002">
-    <title>Introducing PersPred, a Syntactic and Semantic Database for Persian Complex Predicates</title>
+    <title>Introducing <fixed-case>P</fixed-case>ers<fixed-case>P</fixed-case>red, a Syntactic and Semantic Database for <fixed-case>P</fixed-case>ersian Complex Predicates</title>
     <author><first>Pollet</first><last>Samvelian</last></author>
     <author><first>Pegah</first><last>Faghiri</last></author>
     <booktitle>Proceedings of the 9th Workshop on Multiword Expressions</booktitle>
@@ -1675,7 +1676,7 @@
   </paper>
 
   <paper id="1007">
-    <title>Modelling the Internal Variability of MWEs</title>
+    <title>Modelling the Internal Variability of <fixed-case>MWE</fixed-case>s</title>
     <author><first>Malvina</first><last>Nissim</last></author>
     <booktitle>Proceedings of the 9th Workshop on Multiword Expressions</booktitle>
     <month>June</month>
@@ -1721,7 +1722,7 @@
   </paper>
 
   <paper id="1010">
-    <title>Automatic Identification of Bengali Noun-Noun Compounds Using Random Forest</title>
+    <title>Automatic Identification of <fixed-case>B</fixed-case>engali Noun-Noun Compounds Using Random Forest</title>
     <author><first>Vivekananda</first><last>Gayen</last></author>
     <author><first>Kamal</first><last>Sarkar</last></author>
     <booktitle>Proceedings of the 9th Workshop on Multiword Expressions</booktitle>
@@ -1753,7 +1754,7 @@
   </paper>
 
   <paper id="1012">
-    <title>Exploring MWEs for Knowledge Acquisition from Corporate Technical Documents</title>
+    <title>Exploring <fixed-case>MWE</fixed-case>s for Knowledge Acquisition from Corporate Technical Documents</title>
     <author><first>Bell</first><last>Manrique-Losada</last></author>
     <author><first>Carlos M.</first><last>Zapata-Jaramillo</last></author>
     <author><first>Diego A.</first><last>Burgos</last></author>
@@ -1784,7 +1785,7 @@
   </paper>
 
   <paper id="1014">
-    <title>Identifying Pronominal Verbs: Towards Automatic Disambiguation of the Clitic ‘se’ in Portuguese</title>
+    <title>Identifying Pronominal Verbs: Towards Automatic Disambiguation of the Clitic ‘se’ in <fixed-case>P</fixed-case>ortuguese</title>
     <author><first>Magali</first><last>Sanches Duran</last></author>
     <author><first>Carolina Evaristo</first><last>Scarton</last></author>
     <author><first>Sandra Maria</first><last>Aluísio</last></author>
@@ -1832,7 +1833,7 @@
   </paper>
 
   <paper id="1017">
-    <title>Combining Different Features of Idiomaticity for the Automatic Classification of Noun+Verb Expressions in Basque</title>
+    <title>Combining Different Features of Idiomaticity for the Automatic Classification of Noun+Verb Expressions in <fixed-case>B</fixed-case>asque</title>
     <author><first>Antton</first><last>Gurrutxaga</last></author>
     <author><first>Iñaki</first><last>Alegria</last></author>
     <booktitle>Proceedings of the 9th Workshop on Multiword Expressions</booktitle>
@@ -1863,7 +1864,7 @@
   </paper>
 
   <paper id="1019">
-    <title>Constructional Intensifying Adjectives in Italian</title>
+    <title>Constructional Intensifying Adjectives in <fixed-case>I</fixed-case>talian</title>
     <author><first>Sara</first><last>Berlanda</last></author>
     <booktitle>Proceedings of the 9th Workshop on Multiword Expressions</booktitle>
     <month>June</month>
@@ -1891,7 +1892,7 @@
   </paper>
 
   <paper id="1021">
-    <title>Construction of English MWE Dictionary and its Application to POS Tagging</title>
+    <title>Construction of <fixed-case>E</fixed-case>nglish <fixed-case>MWE</fixed-case> Dictionary and its Application to <fixed-case>POS</fixed-case> Tagging</title>
     <author><first>Yutaro</first><last>Shigeto</last></author>
     <author><first>Ai</first><last>Azuma</last></author>
     <author><first>Sorami</first><last>Hisamoto</last></author>
@@ -3516,7 +3517,7 @@
   </paper>
 
   <paper id="1803">
-    <title>ZeuScansion: a tool for scansion of English poetry</title>
+    <title><fixed-case>Z</fixed-case>eu<fixed-case>S</fixed-case>cansion: a tool for scansion of <fixed-case>E</fixed-case>nglish poetry</title>
     <author><first>Manex</first><last>Agirrezabal</last></author>
     <author><first>Bertol</first><last>Arrieta</last></author>
     <author><first>Aitzol</first><last>Astigarraga</last></author>
@@ -3533,7 +3534,7 @@
   </paper>
 
   <paper id="1804">
-    <title>A Convexity-based Generalization of Viterbi for Non-Deterministic Weighted Automata</title>
+    <title>A Convexity-based Generalization of <fixed-case>V</fixed-case>iterbi for Non-Deterministic Weighted Automata</title>
     <author><first>Marc</first><last>Dymetman</last></author>
     <booktitle>Proceedings of the 11th International Conference on Finite State Methods and Natural Language Processing</booktitle>
     <month>July</month>
@@ -3593,7 +3594,7 @@
   </paper>
 
   <paper id="1808">
-    <title>Optimizing Rule-Based Morphosyntactic Analysis of Richly Inflected Languages - a Polish Example</title>
+    <title>Optimizing Rule-Based Morphosyntactic Analysis of Richly Inflected Languages - a <fixed-case>P</fixed-case>olish Example</title>
     <author><first>Dominika</first><last>Pawlik</last></author>
     <author><first>Aleksander</first><last>Zabłocki</last></author>
     <author><first>Bartosz</first><last>Zaborowski</last></author>
@@ -3610,7 +3611,7 @@
   </paper>
 
   <paper id="1809">
-    <title>Finite State Morphology Tool for Latvian</title>
+    <title>Finite State Morphology Tool for <fixed-case>L</fixed-case>atvian</title>
     <author><first>Daiga</first><last>Deksne</last></author>
     <booktitle>Proceedings of the 11th International Conference on Finite State Methods and Natural Language Processing</booktitle>
     <month>July</month>
@@ -3654,7 +3655,7 @@
   </paper>
 
   <paper id="1812">
-    <title>Using NooJ for semantic annotation of Italian language corpora in the domain of motion: a cognitive-grounded approach</title>
+    <title>Using <fixed-case>N</fixed-case>oo<fixed-case>J</fixed-case> for semantic annotation of <fixed-case>I</fixed-case>talian language corpora in the domain of motion: a cognitive-grounded approach</title>
     <author><first>Edoardo</first><last>Salza</last></author>
     <booktitle>Proceedings of the 11th International Conference on Finite State Methods and Natural Language Processing</booktitle>
     <month>July</month>
@@ -3697,7 +3698,7 @@
   </paper>
 
   <paper id="1815">
-    <title>A Finite-State Approach to Translate SNOMED CT Terms into Basque Using Medical Prefixes and Suffixes</title>
+    <title>A Finite-State Approach to Translate <fixed-case>SNOMED CT</fixed-case> Terms into <fixed-case>B</fixed-case>asque Using Medical Prefixes and Suffixes</title>
     <author><first>Olatz</first><last>Perez-de-Vinaspre</last></author>
     <author><first>Maite</first><last>Oronoz</last></author>
     <author><first>Manex</first><last>Agirrezabal</last></author>
@@ -3714,7 +3715,7 @@
   </paper>
 
   <paper id="1816">
-    <title>Syncretism and How to Deal with it in a Morphological Analyzer: a German Example</title>
+    <title>Syncretism and How to Deal with it in a Morphological Analyzer: a <fixed-case>G</fixed-case>erman Example</title>
     <author><first>Katina</first><last>Bontcheva</last></author>
     <booktitle>Proceedings of the 11th International Conference on Finite State Methods and Natural Language Processing</booktitle>
     <month>July</month>
@@ -3728,7 +3729,7 @@
   </paper>
 
   <paper id="1817">
-    <title>Finite State Approach to the Kazakh Nominal Paradigm</title>
+    <title>Finite State Approach to the <fixed-case>K</fixed-case>azakh Nominal Paradigm</title>
     <author><first>Bakyt M</first><last>Kairakbay</last></author>
     <author><first>David L</first><last>Zaurbekov</last></author>
     <booktitle>Proceedings of the 11th International Conference on Finite State Methods and Natural Language Processing</booktitle>
@@ -5018,7 +5019,7 @@
         <bibkey>WMT:2013</bibkey>
    </paper>
    <paper id="2201">
-        <title>Findings of the 2013 Workshop on Statistical Machine Translation</title>
+        <title>Findings of the 2013 <fixed-case>Workshop on Statistical Machine Translation</fixed-case></title>
         <author><first>Ondřej</first><last>Bojar</last></author>
         <author><first>Christian</first><last>Buck</last></author>
         <author><first>Chris</first><last>Callison-Burch</last></author>
@@ -5040,7 +5041,7 @@
         <bibkey>bojar-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2202">
-        <title>Results of the WMT13 Metrics Shared Task</title>
+        <title>Results of the <fixed-case>WMT13</fixed-case> Metrics Shared Task</title>
         <author><first>Matouš</first><last>Macháček</last></author>
         <author><first>Ondřej</first><last>Bojar</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5055,7 +5056,7 @@
         <bibkey>machavcek-bojar:2013:WMT</bibkey>
    </paper>
    <paper id="2203">
-        <title>The Feasibility of HMEANT as a Human MT Evaluation Metric</title>
+        <title>The Feasibility of <fixed-case>HMEANT</fixed-case> as a Human <fixed-case>MT</fixed-case> Evaluation Metric</title>
         <author><first>Alexandra</first><last>Birch</last></author>
         <author><first>Barry</first><last>Haddow</last></author>
         <author><first>Ulrich</first><last>Germann</last></author>
@@ -5073,7 +5074,7 @@
         <bibkey>birch-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2204">
-        <title>LIMSI @ WMT13</title>
+        <title><fixed-case>LIMSI</fixed-case> @ <fixed-case>WMT13</fixed-case></title>
         <author><first>Alexander</first><last>Allauzen</last></author>
         <author><first>Nicolas</first><last>Pécheux</last></author>
         <author><first>Quoc Khanh</first><last>Do</last></author>
@@ -5093,7 +5094,7 @@
         <bibkey>allauzen-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2205">
-        <title>The CMU Machine Translation Systems at WMT 2013: Syntax, Synthetic Translation Options, and Pseudo-References</title>
+        <title>The <fixed-case>CMU</fixed-case> Machine Translation Systems at <fixed-case>WMT</fixed-case> 2013: Syntax, Synthetic Translation Options, and Pseudo-References</title>
         <author><first>Waleed</first><last>Ammar</last></author>
         <author><first>Victor</first><last>Chahuneau</last></author>
         <author><first>Michael</first><last>Denkowski</last></author>
@@ -5128,7 +5129,7 @@
         <bibkey>bicici:2013:WMT1</bibkey>
    </paper>
    <paper id="2207">
-        <title>CUni Multilingual Matrix in the WMT 2013 Shared Task</title>
+        <title><fixed-case>CUni</fixed-case> Multilingual Matrix in the <fixed-case>WMT</fixed-case> 2013 Shared Task</title>
         <author><first>Karel</first><last>Bílek</last></author>
         <author><first>Daniel</first><last>Zeman</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5142,7 +5143,7 @@
         <bibkey>bilek-zeman:2013:WMT</bibkey>
    </paper>
    <paper id="2208">
-        <title>Chimera – Three Heads for English-to-Czech Translation</title>
+        <title>Chimera – Three Heads for <fixed-case>English-to-Czech</fixed-case> Translation</title>
         <author><first>Ondřej</first><last>Bojar</last></author>
         <author><first>Rudolf</first><last>Rosa</last></author>
         <author><first>Aleš</first><last>Tamchyna</last></author>
@@ -5157,7 +5158,7 @@
         <bibkey>bojar-rosa-tamchyna:2013:WMT</bibkey>
    </paper>
    <paper id="2209">
-        <title>Yandex School of Data Analysis Machine Translation Systems for WMT13</title>
+        <title>Yandex School of Data Analysis Machine Translation Systems for <fixed-case>WMT</fixed-case>13</title>
         <author><first>Alexey</first><last>Borisov</last></author>
         <author><first>Jacob</first><last>Dlougach</last></author>
         <author><first>Irina</first><last>Galinskaya</last></author>
@@ -5172,7 +5173,7 @@
         <bibkey>borisov-dlougach-galinskaya:2013:WMT</bibkey>
    </paper>
    <paper id="2210">
-        <title>The Karlsruhe Institute of Technology Translation Systems for the WMT 2013</title>
+        <title>The <fixed-case>Karlsruhe</fixed-case> <fixed-case>Institute</fixed-case> of <fixed-case>Technology</fixed-case> Translation Systems for the <fixed-case>WMT</fixed-case> 2013</title>
         <author><first>Eunah</first><last>Cho</last></author>
         <author><first>Thanh-Le</first><last>Ha</last></author>
         <author><first>Mohammed</first><last>Mediani</last></author>
@@ -5205,7 +5206,7 @@
         <bibkey>durgarelkahlout-mermer:2013:WMT</bibkey>
    </paper>
    <paper id="2212">
-        <title>Edinburgh’s Machine Translation Systems for European Language Pairs</title>
+        <title>Edinburgh’s Machine Translation Systems for <fixed-case>European</fixed-case> Language Pairs</title>
         <author><first>Nadir</first><last>Durrani</last></author>
         <author><first>Barry</first><last>Haddow</last></author>
         <author><first>Kenneth</first><last>Heafield</last></author>
@@ -5221,7 +5222,7 @@
         <bibkey>durrani-EtAl:2013:WMT1</bibkey>
    </paper>
    <paper id="2213">
-        <title>Munich-Edinburgh-Stuttgart Submissions of OSM Systems at WMT13</title>
+        <title><fixed-case>Munich-Edinburgh-Stuttgart</fixed-case> Submissions of <fixed-case>OSM</fixed-case> Systems at <fixed-case>WMT</fixed-case>13</title>
         <author><first>Nadir</first><last>Durrani</last></author>
         <author><first>Alexander</first><last>Fraser</last></author>
         <author><first>Helmut</first><last>Schmid</last></author>
@@ -5255,7 +5256,7 @@
         <bibkey>eidelman-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2215">
-        <title>The TALP-UPC Phrase-Based Translation Systems for WMT13: System Combination with Morphology Generation, Domain Adaptation and Corpus Filtering</title>
+        <title>The <fixed-case>TALP-UPC</fixed-case> Phrase-Based Translation Systems for <fixed-case>WMT</fixed-case>13: System Combination with Morphology Generation, Domain Adaptation and Corpus Filtering</title>
         <author><first>Lluís</first><last>Formiga</last></author>
         <author><first>Marta R.</first><last>Costa-jussà</last></author>
         <author><first>José B.</first><last>Mariño</last></author>
@@ -5273,7 +5274,7 @@
         <bibkey>formiga-EtAl:2013:WMT1</bibkey>
    </paper>
    <paper id="2216">
-        <title>PhraseFix: Statistical Post-Editing of TectoMT</title>
+        <title><fixed-case>PhraseFix</fixed-case>: Statistical Post-Editing of <fixed-case>TectoMT</fixed-case></title>
         <author><first>Petra</first><last>Galuščáková</last></author>
         <author><first>Martin</first><last>Popel</last></author>
         <author><first>Ondřej</first><last>Bojar</last></author>
@@ -5288,7 +5289,7 @@
         <bibkey>galuvsvcakova-popel-bojar:2013:WMT</bibkey>
    </paper>
    <paper id="2217">
-        <title>Feature-Rich Phrase-based Translation: Stanford University’s Submission to the WMT 2013 Translation Task</title>
+        <title>Feature-Rich Phrase-based Translation: <fixed-case>Stanford</fixed-case> <fixed-case>University’s</fixed-case> Submission to the <fixed-case>WMT</fixed-case> 2013 Translation Task</title>
         <author><first>Spence</first><last>Green</last></author>
         <author><first>Daniel</first><last>Cer</last></author>
         <author><first>Kevin</first><last>Reschke</last></author>
@@ -5309,7 +5310,7 @@
         <bibkey>green-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2218">
-        <title>Factored Machine Translation Systems for Russian-English</title>
+        <title>Factored Machine Translation Systems for <fixed-case>Russian-English</fixed-case></title>
         <author><first>Stéphane</first><last>Huet</last></author>
         <author><first>Elena</first><last>Manishina</last></author>
         <author><first>Fabrice</first><last>Lefèvre</last></author>
@@ -5324,7 +5325,7 @@
         <bibkey>huet-manishina-lefevre:2013:WMT</bibkey>
    </paper>
    <paper id="2219">
-        <title>Omnifluent English-to-French and Russian-to-English Systems for the 2013 Workshop on Statistical Machine Translation</title>
+        <title>Omnifluent <fixed-case>English-to-French</fixed-case> and <fixed-case>Russian-to-English</fixed-case> Systems for the 2013 <fixed-case>Workshop on Statistical Machine Translation</fixed-case></title>
         <author><first>Evgeny</first><last>Matusov</last></author>
         <author><first>Gregor</first><last>Leusch</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5367,7 +5368,7 @@
         <bibkey>nadejde-williams-koehn:2013:WMT</bibkey>
    </paper>
    <paper id="2222">
-        <title>Shallow Semantically-Informed PBSMT and HPBSMT</title>
+        <title>Shallow Semantically-Informed <fixed-case>PBSMT</fixed-case> and <fixed-case>HPBSMT</fixed-case></title>
         <author><first>Tsuyoshi</first><last>Okita</last></author>
         <author><first>Qun</first><last>Liu</last></author>
         <author><first>Josef</first><last>van Genabith</last></author>
@@ -5382,7 +5383,7 @@
         <bibkey>okita-liu-vangenabith:2013:WMT</bibkey>
    </paper>
    <paper id="2223">
-        <title>Joint WMT 2013 Submission of the QUAERO Project</title>
+        <title>Joint <fixed-case>WMT</fixed-case> 2013 Submission of the <fixed-case>QUAERO</fixed-case> Project</title>
         <author><first>Stephan</first><last>Peitz</last></author>
         <author><first>Saab</first><last>Mansour</last></author>
         <author><first>Matthias</first><last>Huck</last></author>
@@ -5408,7 +5409,7 @@
         <bibkey>peitz-EtAl:2013:WMT1</bibkey>
    </paper>
    <paper id="2224">
-        <title>The RWTH Aachen Machine Translation System for WMT 2013</title>
+        <title>The <fixed-case>RWTH</fixed-case> Aachen Machine Translation System for <fixed-case>WMT</fixed-case> 2013</title>
         <author><first>Stephan</first><last>Peitz</last></author>
         <author><first>Saab</first><last>Mansour</last></author>
         <author><first>Jan-Thorsten</first><last>Peter</last></author>
@@ -5428,7 +5429,7 @@
         <bibkey>peitz-EtAl:2013:WMT2</bibkey>
    </paper>
    <paper id="2225">
-        <title>The University of Cambridge Russian-English System at WMT13</title>
+        <title>The <fixed-case>University</fixed-case> of <fixed-case>Cambridge</fixed-case> <fixed-case>Russian-English</fixed-case> System at <fixed-case>WMT</fixed-case>13</title>
         <author><first>Juan</first><last>Pino</last></author>
         <author><first>Aurelien</first><last>Waite</last></author>
         <author><first>Tong</first><last>Xiao</last></author>
@@ -5464,7 +5465,7 @@
         <bibkey>post-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2227">
-        <title>The CNGL-DCU-Prompsit Translation Systems for WMT13</title>
+        <title>The <fixed-case>CNGL-DCU-Prompsit</fixed-case> Translation Systems for <fixed-case>WMT</fixed-case>13</title>
         <author><first>Raphael</first><last>Rubino</last></author>
         <author><first>Antonio</first><last>Toral</last></author>
         <author><first>Santiago</first><last>Cortés Vaíllo</last></author>
@@ -5483,7 +5484,7 @@
         <bibkey>rubino-EtAl:2013:WMT1</bibkey>
    </paper>
    <paper id="2228">
-        <title>QCRI-MES Submission at WMT13: Using Transliteration Mining to Improve Statistical Machine Translation</title>
+        <title><fixed-case>QCRI-MES</fixed-case> Submission at <fixed-case>WMT</fixed-case>13: Using Transliteration Mining to Improve Statistical Machine Translation</title>
         <author><first>Hassan</first><last>Sajjad</last></author>
         <author><first>Svetlana</first><last>Smekalova</last></author>
         <author><first>Nadir</first><last>Durrani</last></author>
@@ -5500,7 +5501,7 @@
         <bibkey>sajjad-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2229">
-        <title>Tunable Distortion Limits and Corpus Cleaning for SMT</title>
+        <title>Tunable Distortion Limits and Corpus Cleaning for <fixed-case>SMT</fixed-case></title>
         <author><first>Sara</first><last>Stymne</last></author>
         <author><first>Christian</first><last>Hardmeier</last></author>
         <author><first>Jörg</first><last>Tiedemann</last></author>
@@ -5516,7 +5517,7 @@
         <bibkey>stymne-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2230">
-        <title>Munich-Edinburgh-Stuttgart Submissions at WMT13: Morphological and Syntactic Processing for SMT</title>
+        <title><fixed-case>Munich-Edinburgh-Stuttgart</fixed-case> Submissions at <fixed-case>WMT</fixed-case>13: Morphological and Syntactic Processing for <fixed-case>SMT</fixed-case></title>
         <author><first>Marion</first><last>Weller</last></author>
         <author><first>Max</first><last>Kisselew</last></author>
         <author><first>Svetlana</first><last>Smekalova</last></author>
@@ -5536,7 +5537,7 @@
         <bibkey>weller-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2231">
-        <title>Coping with the Subjectivity of Human Judgements in MT Quality Estimation</title>
+        <title>Coping with the Subjectivity of Human Judgements in <fixed-case>MT</fixed-case> Quality Estimation</title>
         <author><first>Marco</first><last>Turchi</last></author>
         <author><first>Matteo</first><last>Negri</last></author>
         <author><first>Marcello</first><last>Federico</last></author>
@@ -5579,7 +5580,7 @@
         <bibkey>irvine-callisonburch:2013:WMT</bibkey>
    </paper>
    <paper id="2234">
-        <title>Generating English Determiners in Phrase-Based Translation with Synthetic Translation Options</title>
+        <title>Generating <fixed-case>English</fixed-case> Determiners in Phrase-Based Translation with Synthetic Translation Options</title>
         <author><first>Yulia</first><last>Tsvetkov</last></author>
         <author><first>Chris</first><last>Dyer</last></author>
         <author><first>Lori</first><last>Levin</last></author>
@@ -5609,7 +5610,7 @@
         <bibkey>lewis-eetemadi:2013:WMT</bibkey>
    </paper>
    <paper id="2236">
-        <title>Multi-Task Learning for Improved Discriminative Training in SMT</title>
+        <title>Multi-Task Learning for Improved Discriminative Training in <fixed-case>SMT</fixed-case></title>
         <author><first>Patrick</first><last>Simianer</last></author>
         <author><first>Stefan</first><last>Riezler</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5638,7 +5639,7 @@
         <bibkey>mathur-mauro-federico:2013:WMT</bibkey>
    </paper>
    <paper id="2238">
-        <title>Length-Incremental Phrase Training for SMT</title>
+        <title>Length-Incremental Phrase Training for <fixed-case>SMT</fixed-case></title>
         <author><first>Joern</first><last>Wuebker</last></author>
         <author><first>Hermann</first><last>Ney</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5681,7 +5682,7 @@
         <bibkey>avramidis-popovic:2013:WMT</bibkey>
    </paper>
    <paper id="2241">
-        <title>SHEF-Lite: When Less is More for Translation Quality Estimation</title>
+        <title><fixed-case>SHEF-Lite</fixed-case>: When Less is More for Translation Quality Estimation</title>
         <author><first>Daniel</first><last>Beck</last></author>
         <author><first>Kashif</first><last>Shah</last></author>
         <author><first>Trevor</first><last>Cohn</last></author>
@@ -5710,7 +5711,7 @@
         <bibkey>bicici:2013:WMT2</bibkey>
    </paper>
    <paper id="2243">
-        <title>FBK-UEdin Participation to the WMT13 Quality Estimation Shared Task</title>
+        <title><fixed-case>FBK-UEdin</fixed-case> Participation to the <fixed-case>WMT</fixed-case>13 Quality Estimation Shared Task</title>
         <author><first>José Guilherme</first><last>Camargo de Souza</last></author>
         <author><first>Christian</first><last>Buck</last></author>
         <author><first>Marco</first><last>Turchi</last></author>
@@ -5726,7 +5727,7 @@
         <bibkey>camargodesouza-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2244">
-        <title>The TALP-UPC Approach to System Selection: Asiya Features and Pairwise Classification Using Random Forests</title>
+        <title>The <fixed-case>TALP-UPC</fixed-case> Approach to System Selection: <fixed-case>Asiya</fixed-case> Features and Pairwise Classification Using Random Forests</title>
         <author><first>Lluís</first><last>Formiga</last></author>
         <author><first>Meritxell</first><last>Gonzàlez</last></author>
         <author><first>Alberto</first><last>Barrón-Cedeño</last></author>
@@ -5761,7 +5762,7 @@
         <bibkey>han-EtAl:2013:WMT1</bibkey>
    </paper>
    <paper id="2246">
-        <title>MT Quality Estimation: The CMU System for WMT’13</title>
+        <title><fixed-case>MT</fixed-case> Quality Estimation: The <fixed-case>CMU</fixed-case> System for <fixed-case>WMT</fixed-case>‘13</title>
         <author><first>Silja</first><last>Hildebrand</last></author>
         <author><first>Stephan</first><last>Vogel</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5775,7 +5776,7 @@
         <bibkey>hildebrand-vogel:2013:WMT</bibkey>
    </paper>
    <paper id="2247">
-        <title>LORIA System for the WMT13 Quality Estimation Shared Task</title>
+        <title><fixed-case>LORIA</fixed-case> System for the <fixed-case>WMT</fixed-case>13 Quality Estimation Shared Task</title>
         <author><first>David</first><last>Langlois</last></author>
         <author><first>Kamel</first><last>Smaili</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5789,7 +5790,7 @@
         <bibkey>langlois-smaili:2013:WMT</bibkey>
    </paper>
    <paper id="2248">
-        <title>LIG System for WMT13 QE Task: Investigating the Usefulness of Features in Word Confidence Estimation for MT</title>
+        <title><fixed-case>LIG</fixed-case> System for <fixed-case>WMT</fixed-case>13 <fixed-case>QE</fixed-case> Task: Investigating the Usefulness of Features in Word Confidence Estimation for <fixed-case>MT</fixed-case></title>
         <author><first>Ngoc Quang</first><last>Luong</last></author>
         <author><first>Benjamin</first><last>Lecouteux</last></author>
         <author><first>Laurent</first><last>Besacier</last></author>
@@ -5804,7 +5805,7 @@
         <bibkey>luong-lecouteux-besacier:2013:WMT</bibkey>
    </paper>
    <paper id="2249">
-        <title>DCU-Symantec at the WMT 2013 Quality Estimation Shared Task</title>
+        <title><fixed-case>DCU-Symantec</fixed-case> at the <fixed-case>WMT</fixed-case> 2013 Quality Estimation Shared Task</title>
         <author><first>Raphael</first><last>Rubino</last></author>
         <author><first>Joachim</first><last>Wagner</last></author>
         <author><first>Jennifer</first><last>Foster</last></author>
@@ -5822,7 +5823,7 @@
         <bibkey>rubino-EtAl:2013:WMT2</bibkey>
    </paper>
    <paper id="2250">
-        <title>LIMSI Submission for the WMT’13 Quality Estimation Task: an Experiment with N-Gram Posteriors</title>
+        <title><fixed-case>LIMSI</fixed-case> Submission for the <fixed-case>WMT</fixed-case>‘13 Quality Estimation Task: an Experiment with N-Gram Posteriors</title>
         <author><first>Anil Kumar</first><last>Singh</last></author>
         <author><first>Guillaume</first><last>Wisniewski</last></author>
         <author><first>François</first><last>Yvon</last></author>
@@ -5850,7 +5851,7 @@
         <bibkey>fishel:2013:WMT</bibkey>
    </paper>
    <paper id="2252">
-        <title>Are ACT’s Scores Increasing with Better Translation Quality?</title>
+        <title>Are <fixed-case>ACT’s</fixed-case> Scores Increasing with Better Translation Quality?</title>
         <author><first>Najeh</first><last>Hajlaoui</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
         <month>August</month>
@@ -5863,7 +5864,7 @@
         <bibkey>hajlaoui:2013:WMT</bibkey>
    </paper>
    <paper id="2253">
-        <title>A Description of Tunable Machine Translation Evaluation Systems in WMT13 Metrics Task</title>
+        <title>A Description of Tunable Machine Translation Evaluation Systems in <fixed-case>WMT</fixed-case>13 Metrics Task</title>
         <author><first>Aaron Li-Feng</first><last>Han</last></author>
         <author><first>Derek F.</first><last>Wong</last></author>
         <author><first>Lidia S.</first><last>Chao</last></author>
@@ -5882,7 +5883,7 @@
         <bibkey>han-EtAl:2013:WMT2</bibkey>
    </paper>
    <paper id="2254">
-        <title>MEANT at WMT 2013: A Tunable, Accurate yet Inexpensive Semantic Frame Based MT Evaluation Metric</title>
+        <title><fixed-case>MEANT</fixed-case> at <fixed-case>WMT</fixed-case> 2013: A Tunable, Accurate yet Inexpensive Semantic Frame Based <fixed-case>MT</fixed-case> Evaluation Metric</title>
         <author><first>Chi-kiu</first><last>Lo</last></author>
         <author><first>Dekai</first><last>Wu</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5910,7 +5911,7 @@
         <bibkey>moreau-rubino:2013:WMT</bibkey>
    </paper>
    <paper id="2256">
-        <title>DCU Participation in WMT2013 Metrics Task</title>
+        <title><fixed-case>DCU</fixed-case> Participation in <fixed-case>WMT</fixed-case>2013 Metrics Task</title>
         <author><first>Xiaofeng</first><last>Wu</last></author>
         <author><first>Hui</first><last>Yu</last></author>
         <author><first>Qun</first><last>Liu</last></author>
@@ -5925,7 +5926,7 @@
         <bibkey>wu-yu-liu:2013:WMT</bibkey>
    </paper>
    <paper id="2257">
-        <title>Efficient Solutions for Word Reordering in German-English Phrase-Based Statistical Machine Translation</title>
+        <title>Efficient Solutions for Word Reordering in <fixed-case>German-English</fixed-case> Phrase-Based Statistical Machine Translation</title>
         <author><first>Arianna</first><last>Bisazza</last></author>
         <author><first>Marcello</first><last>Federico</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -5955,7 +5956,7 @@
         <bibkey>huck-EtAl:2013:WMT</bibkey>
    </paper>
    <paper id="2259">
-        <title>A Dependency-Constrained Hierarchical Model with Moses</title>
+        <title>A Dependency-Constrained Hierarchical Model with <fixed-case>Moses</fixed-case></title>
         <author><first>Yvette</first><last>Graham</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
         <month>August</month>
@@ -5997,7 +5998,7 @@
         <bibkey>zaidan-chowdhary:2013:WMT</bibkey>
    </paper>
    <paper id="2262">
-        <title>Multi-Rate HMMs for Word Alignment</title>
+        <title><fixed-case>Multi-Rate</fixed-case> <fixed-case>HMMs</fixed-case> for Word Alignment</title>
         <author><first>Elif</first><last>Eyigöz</last></author>
         <author><first>Daniel</first><last>Gildea</last></author>
         <author><first>Kemal</first><last>Oflazer</last></author>
@@ -6012,7 +6013,7 @@
         <bibkey>eyigoz-gildea-oflazer:2013:WMT</bibkey>
    </paper>
    <paper id="2263">
-        <title>Hidden Markov Tree Model for Word Alignment</title>
+        <title>Hidden <fixed-case>Markov</fixed-case> Tree Model for Word Alignment</title>
         <author><first>Shuhei</first><last>Kondo</last></author>
         <author><first>Kevin</first><last>Duh</last></author>
         <author><first>Yuji</first><last>Matsumoto</last></author>
@@ -6027,7 +6028,7 @@
         <bibkey>kondo-duh-matsumoto:2013:WMT</bibkey>
    </paper>
    <paper id="2264">
-        <title>An MT Error-Driven Discriminative Word Lexicon using Sentence Structure Features</title>
+        <title>An <fixed-case>MT</fixed-case> Error-Driven Discriminative Word Lexicon using Sentence Structure Features</title>
         <author><first>Jan</first><last>Niehues</last></author>
         <author><first>Alex</first><last>Waibel</last></author>
         <booktitle>Proceedings of the Eighth Workshop on Statistical Machine Translation</booktitle>
@@ -7896,7 +7897,7 @@
         <bibkey>MOL:2013</bibkey>
    </paper>
    <paper id="3001">
-        <title>Distributions on Minimalist Grammar Derivations</title>
+        <title>Distributions on <fixed-case>Minimalist Grammar</fixed-case> Derivations</title>
         <author><first>Tim</first><last>Hunter</last></author>
         <author><first>Chris</first><last>Dyer</last></author>
         <booktitle>Proceedings of the 13th Meeting on the Mathematics of Language (MoL 13)</booktitle>
@@ -7910,7 +7911,7 @@
         <bibkey>hunter-dyer:2013:MOL</bibkey>
    </paper>
    <paper id="3002">
-        <title>Order and Optionality: Minimalist Grammars with Adjunction</title>
+        <title>Order and Optionality: <fixed-case>Minimalist Grammar</fixed-case>s with Adjunction</title>
         <author><first>Meaghan</first><last>Fowlie</last></author>
         <booktitle>Proceedings of the 13th Meeting on the Mathematics of Language (MoL 13)</booktitle>
         <month>August</month>
@@ -7923,7 +7924,7 @@
         <bibkey>fowlie:2013:MOL</bibkey>
    </paper>
    <paper id="3003">
-        <title>On the Parameterized Complexity of Linear Context-Free Rewriting Systems</title>
+        <title>On the Parameterized Complexity of <fixed-case>Linear Context-Free Rewriting System</fixed-case>s</title>
         <author><first>Martin</first><last>Berglund</last></author>
         <author><first>Henrik</first><last>Björklund</last></author>
         <author><first>Frank</first><last>Drewes</last></author>
@@ -7951,7 +7952,7 @@
         <bibkey>fernando:2013:MOL</bibkey>
    </paper>
    <paper id="3005">
-        <title>The Frobenius Anatomy of Relative Pronouns</title>
+        <title>The <fixed-case>Frobenius</fixed-case> Anatomy of Relative Pronouns</title>
         <author><first>Stephen</first><last>Clark</last></author>
         <author><first>Bob</first><last>Coecke</last></author>
         <author><first>Mehrnoosh</first><last>Sadrzadeh</last></author>
@@ -13338,7 +13339,7 @@
   </paper>
 
   <paper id="4901">
-    <title>Working with a small dataset - semi-supervised dependency parsing for Irish</title>
+    <title>Working with a small dataset - semi-supervised dependency parsing for <fixed-case>Irish</fixed-case></title>
     <author><first>Teresa</first><last>Lynn</last></author>
     <author><first>Jennifer</first><last>Foster</last></author>
     <author><first>Mark</first><last>Dras</last></author>
@@ -13354,7 +13355,7 @@
   </paper>
 
   <paper id="4902">
-    <title>Lithuanian Dependency Parsing with Rich Morphological Features</title>
+    <title><fixed-case>Lithuanian</fixed-case> Dependency Parsing with Rich Morphological Features</title>
     <author><first>Jurgita</first><last>Kapociute-Dzikiene</last></author>
     <author><first>Joakim</first><last>Nivre</last></author>
     <author><first>Algis</first><last>Krupavicius</last></author>
@@ -13370,7 +13371,7 @@
   </paper>
 
   <paper id="4903">
-    <title>Parsing Croatian and Serbian by Using Croatian Dependency Treebanks</title>
+    <title>Parsing <fixed-case>Croatian</fixed-case> and <fixed-case>Serbian</fixed-case> by Using <fixed-case>Croatian</fixed-case> Dependency Treebanks</title>
     <author><first>Željko</first><last>Agić</last></author>
     <author><first>Danijela</first><last>Merkler</last></author>
     <author><first>Daša</first><last>Berović</last></author>
@@ -13386,7 +13387,7 @@
   </paper>
 
   <paper id="4904">
-    <title>A Cross-Task Flexible Transition Model for Arabic Tokenization, Affix Detection, Affix Labeling, POS Tagging, and Dependency Parsing</title>
+    <title>A Cross-Task Flexible Transition Model for <fixed-case>Arabic</fixed-case> Tokenization, Affix Detection, Affix Labeling, <fixed-case>POS</fixed-case> Tagging, and Dependency Parsing</title>
     <author><first>Stephen</first><last>Tratz</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
     <month>October</month>
@@ -13400,7 +13401,7 @@
   </paper>
 
   <paper id="4905">
-    <title>The LIGM-Alpage architecture for the SPMRL 2013 Shared Task: Multiword Expression Analysis and Dependency Parsing</title>
+    <title>The <fixed-case>LIGM</fixed-case>-<fixed-case>Alpage</fixed-case> architecture for the <fixed-case>SPMRL</fixed-case> 2013 Shared Task: Multiword Expression Analysis and Dependency Parsing</title>
     <author><first>Matthieu</first><last>Constant</last></author>
     <author><first>Marie</first><last>Candito</last></author>
     <author><first>Djamé</first><last>Seddah</last></author>
@@ -13416,7 +13417,7 @@
   </paper>
 
   <paper id="4906">
-    <title>Exploring beam-based shift-reduce dependency parsing with DyALog: Results from the SPMRL 2013 shared task</title>
+    <title>Exploring beam-based shift-reduce dependency parsing with <fixed-case>DyALog</fixed-case>: Results from the <fixed-case>SPMRL</fixed-case> 2013 shared task</title>
     <author><first>Eric</first><last>De La Clergerie</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
     <month>October</month>
@@ -13430,7 +13431,7 @@
   </paper>
 
   <paper id="4907">
-    <title>Effective Morphological Feature Selection with MaltOptimizer at the SPMRL 2013 Shared Task</title>
+    <title>Effective Morphological Feature Selection with <fixed-case>MaltOptimizer</fixed-case> at the <fixed-case>SPMRL</fixed-case> 2013 Shared Task</title>
     <author><first>Miguel</first><last>Ballesteros</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
     <month>October</month>
@@ -13444,7 +13445,7 @@
   </paper>
 
   <paper id="4908">
-    <title>Exploiting the Contribution of Morphological Information to Parsing: the BASQUE TEAM system in the SPRML’2013 Shared Task</title>
+    <title>Exploiting the Contribution of Morphological Information to Parsing: the <fixed-case>BASQUE</fixed-case> <fixed-case>TEAM</fixed-case> system in the <fixed-case>SPRML</fixed-case>‘2013 Shared Task</title>
     <author><first>Iakes</first><last>Goenaga</last></author>
     <author><first>Koldo</first><last>Gojenola</last></author>
     <author><first>Nerea</first><last>Ezeiza</last></author>
@@ -13460,7 +13461,7 @@
   </paper>
 
   <paper id="4909">
-    <title>The AI-KU System at the SPMRL 2013 Shared Task : Unsupervised Features for Dependency Parsing</title>
+    <title>The <fixed-case>AI</fixed-case>-<fixed-case>KU</fixed-case> System at the <fixed-case>SPMRL</fixed-case> 2013 Shared Task : Unsupervised Features for Dependency Parsing</title>
     <author><first>Volkan</first><last>Cirik</last></author>
     <author><first>Hüsnü</first><last>Sensoy</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
@@ -13475,7 +13476,7 @@
   </paper>
 
   <paper id="4910">
-    <title>SPMRL’13 Shared Task System: The CADIM Arabic Dependency Parser</title>
+    <title><fixed-case>SPMRL</fixed-case>‘13 Shared Task System: The <fixed-case>CADIM</fixed-case> <fixed-case>Arabic</fixed-case> Dependency Parser</title>
     <author><first>Yuval</first><last>Marton</last></author>
     <author><first>Nizar</first><last>Habash</last></author>
     <author><first>Owen</first><last>Rambow</last></author>
@@ -13492,7 +13493,7 @@
   </paper>
 
   <paper id="4911">
-    <title>A Statistical Approach to Prediction of Empty Categories in Hindi Dependency Treebank</title>
+    <title>A Statistical Approach to Prediction of Empty Categories in <fixed-case>Hindi</fixed-case> Dependency Treebank</title>
     <author><first>Puneeth</first><last>Kukkadapu</last></author>
     <author><first>Prashanth</first><last>Mannem</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
@@ -13507,7 +13508,7 @@
   </paper>
 
   <paper id="4912">
-    <title>An Empirical Study on the Effect of Morphological and Lexical Features in Persian Dependency Parsing</title>
+    <title>An Empirical Study on the Effect of Morphological and Lexical Features in <fixed-case>Persian</fixed-case> Dependency Parsing</title>
     <author><first>Mojtaba</first><last>Khallash</last></author>
     <author><first>Ali</first><last>Hadian</last></author>
     <author><first>Behrouz</first><last>Minaei-Bidgoli</last></author>
@@ -13523,7 +13524,7 @@
   </paper>
 
   <paper id="4913">
-    <title>Constructing a Practical Constituent Parser from a Japanese Treebank with Function Labels</title>
+    <title>Constructing a Practical Constituent Parser from a <fixed-case>Japanese</fixed-case> Treebank with Function Labels</title>
     <author><first>Takaaki</first><last>Tanaka</last></author>
     <author><first>Masaaki</first><last>NAGATA</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
@@ -13538,7 +13539,7 @@
   </paper>
 
   <paper id="4914">
-    <title>Context Based Statistical Morphological Analyzer and its Effect on Hindi Dependency Parsing</title>
+    <title>Context Based Statistical Morphological Analyzer and its Effect on <fixed-case>Hindi</fixed-case> Dependency Parsing</title>
     <author><first>Deepak Kumar</first><last>Malladi</last></author>
     <author><first>Prashanth</first><last>Mannem</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
@@ -13553,7 +13554,7 @@
   </paper>
 
   <paper id="4915">
-    <title>Representation of Morphosyntactic Units and Coordination Structures in the Turkish Dependency Treebank</title>
+    <title>Representation of Morphosyntactic Units and Coordination Structures in the <fixed-case>Turkish</fixed-case> Dependency Treebank</title>
     <author><first>Umut</first><last>Sulubacak</last></author>
     <author><first>Gülşen</first><last>Eryiğit</last></author>
     <booktitle>Proceedings of the Fourth Workshop on Statistical Parsing of Morphologically-Rich Languages</booktitle>
@@ -13568,7 +13569,7 @@
   </paper>
 
   <paper id="4916">
-    <title>(Re)ranking Meets Morphosyntax: State-of-the-art Results from the SPMRL 2013 Shared Task</title>
+    <title>(Re)ranking Meets Morphosyntax: State-of-the-art Results from the <fixed-case>SPMRL</fixed-case> 2013 Shared Task</title>
     <author><first>Anders</first><last>Björkelund</last></author>
     <author><first>Ozlem</first><last>Cetinoglu</last></author>
     <author><first>Richárd</first><last>Farkas</last></author>
@@ -13586,7 +13587,7 @@
   </paper>
 
   <paper id="4917">
-    <title>Overview of the SPMRL 2013 Shared Task: A Cross-Framework Evaluation of Parsing Morphologically Rich Languages</title>
+    <title>Overview of the <fixed-case>SPMRL</fixed-case> 2013 Shared Task: A Cross-Framework Evaluation of Parsing Morphologically Rich Languages</title>
     <author><first>Djamé</first><last>Seddah</last></author>
     <author><first>Reut</first><last>Tsarfaty</last></author>
     <author><first>Sandra</first><last>Kübler</last></author>
@@ -13622,7 +13623,7 @@
   </paper>
 
   <paper id="5000">
-    <title>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</title>
+    <title>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</title>
     <editor><first>Zornitsa</first><last>Kozareva</last></editor>
     <editor><first>Irina</first><last>Matveeva</last></editor>
     <editor><first>Gabor</first><last>Melli</last></editor>
@@ -13640,7 +13641,7 @@
     <title>Event-Centered Information Retrieval Using Kernels on Event Graphs</title>
     <author><first>Goran</first><last>Glavaš</last></author>
     <author><first>Jan</first><last>Šnajder</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13652,14 +13653,14 @@
   </paper>
 
   <paper id="5002">
-    <title>JoBimText Visualizer: A Graph-based Approach to Contextualizing Distributional Similarity</title>
+    <title><fixed-case>JoBimText</fixed-case> Visualizer: A Graph-based Approach to Contextualizing Distributional Similarity</title>
     <author><first>Chris</first><last>Biemann</last></author>
     <author><first>Bonaventura</first><last>Coppola</last></author>
     <author><first>Michael R.</first><last>Glass</last></author>
     <author><first>Alfio</first><last>Gliozzo</last></author>
     <author><first>Matthew</first><last>Hatem</last></author>
     <author><first>Martin</first><last>Riedl</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13675,7 +13676,7 @@
     <author><first>Sumit</first><last>Bhagwani</last></author>
     <author><first>Shrutiranjan</first><last>Satapathy</last></author>
     <author><first>Harish</first><last>Karnick</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13691,7 +13692,7 @@
     <author><first>Ai</first><last>He</last></author>
     <author><first>Shefali</first><last>Sharma</last></author>
     <author><first>Chun-Nan</first><last>Hsu</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13706,7 +13707,7 @@
     <title>Graph-Based Unsupervised Learning of Word Similarities Using Heterogeneous Feature Types</title>
     <author><first>Avneesh</first><last>Saluja</last></author>
     <author><first>Jiri</first><last>Navratil</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13721,7 +13722,7 @@
     <title>From Global to Local Similarities: A Graph-Based Contextualization Method using Distributional Thesauri</title>
     <author><first>Martin</first><last>Riedl</last></author>
     <author><first>Chris</first><last>Biemann</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13738,7 +13739,7 @@
     <author><first>Issei</first><last>Sato</last></author>
     <author><first>Hidekazu</first><last>Oiwa</last></author>
     <author><first>Hiroshi</first><last>Nakagawa</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13753,7 +13754,7 @@
     <title>Graph-Structures Matching for Review Relevance Identification</title>
     <author><first>Lakshmi</first><last>Ramachandran</last></author>
     <author><first>Edward</first><last>Gehringer</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13768,7 +13769,7 @@
     <title>Automatic Extraction of Reasoning Chains from Textual Reports</title>
     <author><first>Gleb</first><last>Sizov</last></author>
     <author><first>Pinar</first><last>Öztürk</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13780,13 +13781,13 @@
   </paper>
 
   <paper id="5010">
-    <title>Graph-based Approaches for Organization Entity Resolution in MapReduce</title>
+    <title>Graph-based Approaches for Organization Entity Resolution in <fixed-case>MapReduce</fixed-case></title>
     <author><first>Hakan</first><last>Kardes</last></author>
     <author><first>Deepak</first><last>Konidena</last></author>
     <author><first>Siddharth</first><last>Agrawal</last></author>
     <author><first>Micah</first><last>Huff</last></author>
     <author><first>Ang</first><last>Sun</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>
@@ -13806,7 +13807,7 @@
     <author><first>Pascal</first><last>Francq</last></author>
     <author><first>Hugues</first><last>Bersini</last></author>
     <author><first>Marco</first><last>Saerens</last></author>
-    <booktitle>Proceedings of TextGraphs-8 Graph-based Methods for Natural Language Processing</booktitle>
+    <booktitle>Proceedings of <fixed-case>TextGraphs</fixed-case>-8 Graph-based Methods for Natural Language Processing</booktitle>
     <month>October</month>
     <year>2013</year>
     <address>Seattle, Washington, USA</address>

--- a/import/W14.xml
+++ b/import/W14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W14">
   <paper id="0100">
     <title>Proceedings of the Seventh Global Wordnet Conference</title>
@@ -1697,7 +1698,7 @@ Quantifying the Influence of MT Output in the Translators’ Performance: A Case
     <bibkey>sanchesduran-EtAl:2014:WaC9</bibkey>
   </paper>
   <paper id="0405">
-    <title>bs,hr,srWaC - Web Corpora of Bosnian, Croatian and Serbian</title>
+    <title><fixed-case>bs,hr,sr</fixed-case>WaC - Web Corpora of Bosnian, Croatian and Serbian</title>
     <author>
       <first>Nikola</first>
       <last>Ljubešić</last>

--- a/import/W14.xml
+++ b/import/W14.xml
@@ -1698,7 +1698,7 @@ Quantifying the Influence of MT Output in the Translators’ Performance: A Case
     <bibkey>sanchesduran-EtAl:2014:WaC9</bibkey>
   </paper>
   <paper id="0405">
-    <title><fixed-case>bs,hr,sr</fixed-case>WaC - Web Corpora of Bosnian, Croatian and Serbian</title>
+    <title>{bs,hr,sr}WaC - Web Corpora of Bosnian, Croatian and Serbian</title>
     <author>
       <first>Nikola</first>
       <last>Ljubešić</last>

--- a/import/W15.xml
+++ b/import/W15.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W15">
   <paper id="0100">
     <title>Proceedings of the 11th International Conference on Computational Semantics</title>
@@ -7245,10 +7246,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Kevin</first>
       <last>Knight</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7264,10 +7262,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Catherine</first>
       <last>Pelachaud</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7283,10 +7278,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Sebastian</first>
       <last>Riedel</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7310,10 +7302,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Richard</first>
       <last>Johansson</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7341,10 +7330,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Nina</first>
       <last>Tahmasebi</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7388,10 +7374,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Bolette</first>
       <last>Sandford Pedersen</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7411,10 +7394,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Tino</first>
       <last>Didriksen</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7425,7 +7405,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>bick-didriksen:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1808">
-    <title>Automatic Lemmatisation of Lithuanian MWEs</title>
+    <title>Automatic Lemmatisation of Lithuanian <fixed-case>MWE</fixed-case>s</title>
     <author>
       <first>Loïc</first>
       <last>Boizou</last>
@@ -7438,10 +7418,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Erika</first>
       <last>Rimkutė</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7465,10 +7442,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Dietrich</first>
       <last>Klakow</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7488,10 +7462,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Johan</first>
       <last>Boye</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7511,10 +7482,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Luis</first>
       <last>Nieto Piña</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7530,10 +7498,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Peter Juel</first>
       <last>Henrichsen</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7557,10 +7522,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Andrius</first>
       <last>Utka</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7587,10 +7549,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Anders</first>
       <last>Søgaard</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7629,10 +7588,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Filip</first>
       <last>Ginter</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7656,10 +7612,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Lilja</first>
       <last>Øvrelid</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7679,10 +7632,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Vasile</first>
       <last>Rus</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7702,10 +7652,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Filip</first>
       <last>Ginter</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7725,10 +7672,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Natalia</first>
       <last>Loukachevitch</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7751,10 +7695,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Joakim</first>
       <last>Nivre</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7786,10 +7727,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Filip</first>
       <last>Ginter</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7809,10 +7747,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Francis</first>
       <last>Tyers</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7852,10 +7787,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Miriam</first>
       <last>Butt</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7871,10 +7803,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Jörg</first>
       <last>Tiedemann</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7898,10 +7827,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Andreas</first>
       <last>Søeborg Kirkedal</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7929,10 +7855,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Mikael</first>
       <last>Parkvall</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7952,10 +7875,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Francis M.</first>
       <last>Tyers</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -7983,10 +7903,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Aušra</first>
       <last>Mackutė-Varoneckienė</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8010,10 +7927,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Kadri</first>
       <last>Muischenk</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8024,15 +7938,12 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>ojamaa-EtAl:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1830">
-    <title>Adapting word2vec to Named Entity Recognition</title>
+    <title>Adapting <fixed-case>word2vec</fixed-case> to Named Entity Recognition</title>
     <author>
       <first>Scharolta</first>
       <last>Katharina Sienčnik</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8060,10 +7971,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Anders</first>
       <last>Søgaard</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8083,10 +7991,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Malvina</first>
       <last>Nissim</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8130,10 +8035,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Johan</first>
       <last>Falkenjack</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8160,10 +8062,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Lars</first>
       <last>Wallin</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8179,10 +8078,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Gustavo</first>
       <last>Henrique Paetzold</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8193,18 +8089,12 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>henriquepaetzold:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1836">
-    <title>
-       Helping Swedish words come to their senses: word-sense disambiguation
-      based on sense associations from the SALDO lexicon 
-    </title>
+    <title>Helping Swedish words come to their senses: word-sense disambiguation based on sense associations from the <fixed-case>SALDO</fixed-case> lexicon</title>
     <author>
       <first>Ildikó</first>
       <last>Pilán</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8215,10 +8105,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>pilan:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1837">
-    <title>
-       Using sub-word n-gram models for dealing with OOV in large vocabulary
-      speech recognition for Latvian 
-    </title>
+    <title>Using sub-word n-gram models for dealing with <fixed-case>OOV</fixed-case> in large vocabulary speech recognition for Latvian</title>
     <author>
       <first>Askars</first>
       <last>Salimbajevs</last>
@@ -8227,10 +8114,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Jevgenijs</first>
       <last>Strigins</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8241,10 +8125,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>salimbajevs-strigins:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1838">
-    <title>
-       Analysing Inconsistencies and Errors in PoS Tagging in two Icelandic Gold
-      Standards 
-    </title>
+    <title>Analysing Inconsistencies and Errors in <fixed-case>PoS</fixed-case> Tagging in two Icelandic Gold Standards</title>
     <author>
       <first>Steinþór</first>
       <last>Steingrímsson</last>
@@ -8257,10 +8138,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Eiríkur</first>
       <last>Rögnvaldsson</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8271,7 +8149,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>steingrimsson-EtAl:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1839">
-    <title>From digital library to n-grams: NB N-gram</title>
+    <title>From digital library to n-grams: <fixed-case>NB</fixed-case> N-gram</title>
     <author>
       <first>Magnus</first>
       <last>Breder Birkenes</last>
@@ -8288,10 +8166,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Johanne</first>
       <last>Ostad</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8302,15 +8177,12 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>brederbirkenes-EtAl:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1840">
-    <title>The Corpus of American Norwegian Speech (CANS)</title>
+    <title>The Corpus of American Norwegian Speech (<fixed-case>CANS</fixed-case>)</title>
     <author>
       <first>Janne Bondi</first>
       <last>Johannessen</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8326,10 +8198,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Johan</first>
       <last>Bos</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8340,7 +8209,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>bos:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1842">
-    <title>Extracting Semantic Frames using hfst-pmatch</title>
+    <title>Extracting Semantic Frames using <fixed-case>hfst-pmatch</fixed-case></title>
     <author>
       <first>Sam</first>
       <last>Hardwick</last>
@@ -8353,10 +8222,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Krister</first>
       <last>Lindén</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8367,18 +8233,12 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>hardwick-EtAl:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1843">
-    <title>
-       discoursegraphs: A graph-based merging tool and converter for multilayer
-      annotated corpora 
-    </title>
+    <title><fixed-case>discoursegraphs</fixed-case>: A graph-based merging tool and converter for multilayer annotated corpora</title>
     <author>
       <first>Arne</first>
       <last>Neumann</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8394,10 +8254,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Tommi A.</first>
       <last>Pirinen</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8417,10 +8274,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
       <first>Arne</first>
       <last>Jönsson</last>
     </author>
-    <booktitle>
-       Proceedings of the 20th Nordic Conference of Computational Linguistics
-      (NODALIDA 2015) 
-    </booktitle>
+    <booktitle>Proceedings of the 20th Nordic Conference of Computational Linguistics (<fixed-case>NODALIDA</fixed-case> 2015)</booktitle>
     <month>May</month>
     <year>2015</year>
     <address>Vilnius, Lithuania</address>
@@ -8842,7 +8696,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>ahrenberg:2015:Depling</bibkey>
   </paper>
   <paper id="2104">
-    <title>Targeted Paraphrasing on Deep Syntactic Layer for MT Evaluation</title>
+    <title>Targeted Paraphrasing on Deep Syntactic Layer for <fixed-case>MT</fixed-case> Evaluation</title>
     <author>
       <first>Petra</first>
       <last>Barančíková</last>
@@ -9500,7 +9354,7 @@ From mutual dependency to multiple dimensions: remarks on the DG analysis of “
     <bibkey>osborne:2015:Depling</bibkey>
   </paper>
   <paper id="2129">
-    <title>A DG Account of the Descriptive and Resultative de-Constructions in Chinese</title>
+    <title>A <fixed-case>DG</fixed-case> Account of the Descriptive and Resultative de-Constructions in Chinese</title>
     <author>
       <first>Timothy</first>
       <last>Osborne</last>
@@ -9588,7 +9442,7 @@ From mutual dependency to multiple dimensions: remarks on the DG analysis of “
     <bibkey>rysova-rysova:2015:Depling</bibkey>
   </paper>
   <paper id="2133">
-    <title>ParsPer: A Dependency Parser for Persian</title>
+    <title><fixed-case>ParsPer</fixed-case>: A Dependency Parser for Persian</title>
     <author>
       <first>Mojgan</first>
       <last>Seraji</last>
@@ -9692,10 +9546,7 @@ From mutual dependency to multiple dimensions: remarks on the DG analysis of “
     <bibkey>vsindlerova-fuvcikova-urevsova:2015:Depling</bibkey>
   </paper>
   <paper id="2137">
-    <title>
-       Cross-Lingual Dependency Parsing with Universal Dependencies and
-      Predicted PoS Labels 
-    </title>
+    <title>Cross-Lingual Dependency Parsing with Universal Dependencies and Predicted <fixed-case>PoS</fixed-case> Labels</title>
     <author>
       <first>Jörg</first>
       <last>Tiedemann</last>
@@ -23626,7 +23477,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>ENLG:2015</bibkey>
   </paper>
   <paper id="4701">
-    <title>A Simple Surface Realization Engine for Telugu</title>
+    <title>A Simple Surface Realization Engine for <fixed-case>T</fixed-case>elugu</title>
     <author>
       <first>Sasi Raja Sekhar</first>
       <last>Dokkara</last>
@@ -23651,10 +23502,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>dokkara-penumathsa-sripada:2015:ENLG</bibkey>
   </paper>
   <paper id="4702">
-    <title>
-       Input Seed Features for Guiding the Generation Process: A Statistical
-      Approach for Spanish 
-    </title>
+    <title>Input Seed Features for Guiding the Generation Process: A Statistical Approach for <fixed-case>S</fixed-case>panish</title>
     <author>
       <first>Cristina</first>
       <last>Barros</last>
@@ -23675,7 +23523,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>barros-lloret:2015:ENLG</bibkey>
   </paper>
   <paper id="4703">
-    <title>A Domain Agnostic Approach to Verbalizing n-ary Events without Parallel Corpora</title>
+    <title>A Domain Agnostic Approach to Verbalizing <fixed-case>n</fixed-case>-ary Events without Parallel Corpora</title>
     <author>
       <first>Bikash</first>
       <last>Gyawali</last>
@@ -23700,7 +23548,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>gyawali-gardent-cerisara:2015:ENLG</bibkey>
   </paper>
   <paper id="4704">
-    <title>Inducing Clause-Combining Rules: A Case Study with the SPaRKy Restaurant Corpus</title>
+    <title>Inducing Clause-Combining Rules: A Case Study with the <fixed-case>SPaRKy</fixed-case> Restaurant Corpus</title>
     <author>
       <first>Michael</first>
       <last>White</last>
@@ -23802,7 +23650,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>farrell-pace-rosner:2015:ENLG</bibkey>
   </paper>
   <paper id="4708">
-    <title>A Snapshot of NLG Evaluation Practices 2005 - 2014</title>
+    <title>A Snapshot of <fixed-case>NLG</fixed-case> Evaluation Practices 2005 - 2014</title>
     <author>
       <first>Dimitra</first>
       <last>Gkatzia</last>
@@ -23823,10 +23671,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>gkatzia-mahamood:2015:ENLG</bibkey>
   </paper>
   <paper id="4709">
-    <title>
-       Japanese Word Reordering Executed Concurrently with Dependency Parsing
-      and Its Evaluation 
-    </title>
+    <title><fixed-case>J</fixed-case>apanese Word Reordering Executed Concurrently with Dependency Parsing and Its Evaluation</title>
     <author>
       <first>Tomohiro</first>
       <last>Ohno</last>
@@ -23909,7 +23754,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>sevens-EtAl:2015:ENLG</bibkey>
   </paper>
   <paper id="4712">
-    <title>Translating Italian to LIS in the Rail Stations</title>
+    <title>Translating <fixed-case>I</fixed-case>talian to <fixed-case>LIS</fixed-case> in the Rail Stations</title>
     <author>
       <first>Alessandro</first>
       <last>Mazzei</last>
@@ -23926,7 +23771,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>mazzei:2015:ENLG</bibkey>
   </paper>
   <paper id="4713">
-    <title>Response Generation in Dialogue Using a Tailored PCFG Parser</title>
+    <title>Response Generation in Dialogue Using a Tailored <fixed-case>PCFG</fixed-case> Parser</title>
     <author>
       <first>Caixia</first>
       <last>Yuan</last>
@@ -23951,10 +23796,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>yuan-wang-he:2015:ENLG</bibkey>
   </paper>
   <paper id="4714">
-    <title>
-       Generating Récit from Sensor Data: Evaluation of a Task Model for Story
-      Planning and Preliminary Experiments with GPS Data 
-    </title>
+    <title>Generating Récit from Sensor Data: Evaluation of a Task Model for Story Planning and Preliminary Experiments with <fixed-case>GPS</fixed-case> Data</title>
     <author>
       <first>Belén A.</first>
       <last>Baez Miranda</last>
@@ -24077,7 +23919,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <bibkey>fischer-demberg-klakow:2015:ENLG</bibkey>
   </paper>
   <paper id="4719">
-    <title>JSrealB: A Bilingual Text Realizer for Web Programming</title>
+    <title><fixed-case>JSrealB</fixed-case>: A Bilingual Text Realizer for Web Programming</title>
     <author>
       <first>Paul</first>
       <last>Molins</last>

--- a/import/W15.xml
+++ b/import/W15.xml
@@ -7385,7 +7385,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>martinezalonso-EtAl:2015:NODALIDA</bibkey>
   </paper>
   <paper id="1807">
-    <title>CG-3 — Beyond Classical Constraint Grammar</title>
+    <title><fixed-case>CG</fixed-case>-3 — Beyond Classical Constraint Grammar</title>
     <author>
       <first>Eckhard</first>
       <last>Bick</last>
@@ -9071,9 +9071,7 @@ Computational cognitive modeling of inflectional verb morphology in Spanish-spea
     <bibkey>husain-vasishth:2015:Depling</bibkey>
   </paper>
   <paper id="2118">
-    <title> 
-
-From mutual dependency to multiple dimensions: remarks on the DG analysis of “functional heads” in Hungarian </title>
+    <title> From mutual dependency to multiple dimensions: remarks on the <fixed-case>DG</fixed-case> analysis of “functional heads” in <fixed-case>H</fixed-case>ungarian </title>
     <author>
       <first>András</first>
       <last>Imrényi</last>

--- a/import/W16.xml
+++ b/import/W16.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W16">
   <paper id="0100">
     <title>Proceedings of the Workshop on Human-Computer Question Answering</title>
@@ -5965,7 +5966,7 @@ Don’t Let Notes Be Misunderstood: A Negation Detection Method for Assessing Ri
     <bibkey>cao-rei:2016:RepL4NLP</bibkey>
   </paper>
   <paper id="1604">
-    <title>On the Compositionality and Semantic Interpretation of English Noun Compounds</title>
+    <title>On the Compositionality and Semantic Interpretation of <fixed-case>E</fixed-case>nglish Noun Compounds</title>
     <author>
       <first>Corina</first>
       <last>Dima</last>
@@ -6102,10 +6103,7 @@ Don’t Let Notes Be Misunderstood: A Negation Detection Method for Assessing Ri
     <bibkey>lau-baldwin:2016:RepL4NLP</bibkey>
   </paper>
   <paper id="1610">
-    <title>
-       Quantifying the Vanishing Gradient and Long Distance Dependency Problem
-      in Recursive Neural Networks and Recursive LSTMs 
-    </title>
+    <title>Quantifying the Vanishing Gradient and Long Distance Dependency Problem in Recursive Neural Networks and Recursive <fixed-case>LSTM</fixed-case>s</title>
     <author>
       <first>Phong</first>
       <last>Le</last>
@@ -6126,7 +6124,7 @@ Don’t Let Notes Be Misunderstood: A Negation Detection Method for Assessing Ri
     <bibkey>le-zuidema:2016:RepL4NLP</bibkey>
   </paper>
   <paper id="1611">
-    <title>LSTM-Based Mixture-of-Experts for Knowledge-Aware Dialogues</title>
+    <title><fixed-case>LSTM</fixed-case>-Based Mixture-of-Experts for Knowledge-Aware Dialogues</title>
     <author>
       <first>Phong</first>
       <last>Le</last>
@@ -36437,7 +36435,7 @@ Summarization of multi-party conversation is one of the important tasks in natur
     <bibkey>DMTW:2016</bibkey>
   </paper>
   <paper id="6401">
-    <title>Moses &amp; Treex Hybrid MT Systems Bestiary</title>
+    <title>Moses <fixed-case>&amp;</fixed-case> Treex Hybrid <fixed-case>MT</fixed-case> Systems Bestiary</title>
     <author>
       <first>Rudolf</first>
       <last>Rosa</last>
@@ -36469,7 +36467,7 @@ Summarization of multi-party conversation is one of the important tasks in natur
     <pages>1-10</pages>
   </paper>
   <paper id="6402">
-    <title>Factoring Adjunction in Hierarchical Phrase-Based SMT</title>
+    <title>Factoring Adjunction in Hierarchical Phrase-Based <fixed-case>SMT</fixed-case></title>
     <author>
       <first>Sophie</first>
       <last>Arnoult</last>
@@ -36587,7 +36585,7 @@ Summarization of multi-party conversation is one of the important tasks in natur
     <pages>39-46</pages>
   </paper>
   <paper id="6406">
-    <title>Incorporation of a valency lexicon into a TectoMT pipeline</title>
+    <title>Incorporation of a valency lexicon into a <fixed-case>TectoMT</fixed-case> pipeline</title>
     <author>
       <first>Natalia</first>
       <last>Klyueva</last>

--- a/import/W17.xml
+++ b/import/W17.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W17">
   <paper id="0100">
     <title>

--- a/import/W19.xml
+++ b/import/W19.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W19">
    <paper id="0100">
         <title>Proceedings of the Society for Computation in Linguistics (SCiL) 2019</title>

--- a/import/W77.xml
+++ b/import/W77.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W77">
   <paper id="0100">
     <title>Proceedings of the 1st Nordic Conference of Computational Linguistics (NODALIDA 1977)</title>

--- a/import/W79.xml
+++ b/import/W79.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W79">
   <paper id="0100">
     <title>Proceedings of the 2nd Nordic Conference of Computational Linguistics (NODALIDA 1979)</title>

--- a/import/W81.xml
+++ b/import/W81.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W81">
   <paper id="0100">
     <title>Proceedings of the 3rd Nordic Conference of Computational Linguistics (NODALIDA 1981)</title>

--- a/import/W83.xml
+++ b/import/W83.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W83">
   <paper id="0100">
     <title>Proceedings of the 4th Nordic Conference of Computational Linguistics (NODALIDA 1983)</title>

--- a/import/W85.xml
+++ b/import/W85.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W85">
   <paper id="0100">
     <title>Proceedings of the 5th Nordic Conference of Computational Linguistics (NODALIDA 1985)</title>

--- a/import/W87.xml
+++ b/import/W87.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W87">
   <paper id="0100">
     <title>Proceedings of the 6th Nordic Conference of Computational Linguistics (NODALIDA 1987)</title>

--- a/import/W89.xml
+++ b/import/W89.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W89">
   <paper id="0100">
     <title>Proceedings of the 7th Nordic Conference of Computational Linguistics (NODALIDA 1989)</title>

--- a/import/W90.xml
+++ b/import/W90.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W90">
  <paper id="0100">
  <title>Proceedings of the Fifth International Workshop on Natural Language Generation</title>

--- a/import/W91.xml
+++ b/import/W91.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W91">
  <paper id="0100">
  <title>Reversible Grammar in Natural Language Processing</title>

--- a/import/W93.xml
+++ b/import/W93.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W93">
  <paper id="0100">
  <title>Acquisition of Lexical Knowledge from Text</title>

--- a/import/W95.xml
+++ b/import/W95.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W95">
  <paper id="0100">
  <title>Third Workshop on Very Large Corpora</title>

--- a/import/W98.xml
+++ b/import/W98.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W98">
 
   <paper id="0100">

--- a/import/W99.xml
+++ b/import/W99.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="W99">
  <paper id="0100">
  <title>The Relation of Discourse/Dialogue Structure and Reference</title>

--- a/import/X93.xml
+++ b/import/X93.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="X93">
 	<paper id="1000">
 		<title>TIPSTER TEXT PROGRAM: PHASE I: Proceedings of a Workshop held at Fredricksburg, Virginia, September 19-23, 1993</title>

--- a/import/X96.xml
+++ b/import/X96.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="X96">
 	<paper id="1000">
 		<title>TIPSTER TEXT PROGRAM PHASE II: Proceedings of a Workshop held at Vienna, Virginia, May 6-8, 1996</title>

--- a/import/X98.xml
+++ b/import/X98.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="X98">
 	<paper id="1000">
 		<title>TIPSTER TEXT PROGRAM PHASE III: Proceedings of a Workshop held at Baltimore, Maryland, October 13-15, 1998</title>

--- a/import/Y08.xml
+++ b/import/Y08.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Y08">
    <paper id="1000">
         <title>Proceedings of the 22nd Pacific Asia Conference on Language, Information and Computation</title>

--- a/import/Y09.xml
+++ b/import/Y09.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Y09">
    <paper id="1000">
         <title>Proceedings of the 23rd Pacific Asia Conference on Language, Information and Computation, Volume 1</title>

--- a/import/Y10.xml
+++ b/import/Y10.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Y10">
    <paper id="1000">
         <title>Proceedings of the 24th Pacific Asia Conference on Language, Information and Computation</title>

--- a/import/Y11.xml
+++ b/import/Y11.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Y11">
    <paper id="1000">
         <title>Proceedings of the 25th Pacific Asia Conference on Language, Information and Computation</title>

--- a/import/Y12.xml
+++ b/import/Y12.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Y12">
    <paper id="1000">
         <title>Proceedings of the 26th Pacific Asia Conference on Language, Information, and Computation</title>

--- a/import/Y14.xml
+++ b/import/Y14.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="Y14">
    <paper id="1000">
         <title>Proceedings of the 28th Pacific Asia Conference on Language, Information and Computing</title>


### PR DESCRIPTION
Automatic projection of curly braces in BibTeX entries (for protecting fixed-case words) into XML as <fixed-case> tags.

- `{\cmd ...}` does _not_ protect case, and even braces within don't protect case (this is how BibTeX apparently works)
- `{$...$}` is not tagged, because I figure the conversion back to BibTeX can add the curly braces easily
- In `\cmd{...}`, the argument is not tagged, because I didn't see any cases where it was clearly intended to protect case.

The script asks for manual intervention when the XML has been changed from the BibTeX; I'll make those changes later.

To protect a word like `English`, one is supposed to write `{E}nglish`, but a lot of people (myself included) write `{English}`. The reason is that if a bib style wanted to make the title all-caps, the `nglish` should not be protected. It would be very easy to modify the script to interpret `{English}` as `{E}nglish`, but there are some edge cases, like a system named `{fokas}` where the lowercasing apparently _should_ be protected. So the script currently follows the curly braces strictly, but let me know if you want the other behavior.