### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.6
+python: 3.7
 
 before_install:
   - sudo apt-get update
@@ -7,6 +7,9 @@ before_install:
 install:
   - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
   - pip install -r bin/requirements.txt
+  - sudo apt-get install -y jing
 
 script:
+  - jing -c import/schema.rnc import/*.xml
+  - jing import/schema.rng import/*.xml
   - python bin/create_hugo_yaml.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+dist: xenial
 language: python
 python: 3.7
+sudo: true
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
+python: 3.6
 
 before_install:
   - sudo apt-get update
 
 install:
   - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
-  - sudo pip install -r bin/requirements.txt
+  - pip install -r bin/requirements.txt
 
 script:
   - python bin/create_hugo_yaml.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
 install:
   - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
   - pip install -r bin/requirements.txt
-  - sudo apt-get install -y jing
+  - sudo apt-get install -y jing bibutils
 
 script:
   - jing -c import/schema.rnc import/*.xml
   - jing import/schema.rng import/*.xml
-  - python bin/create_hugo_yaml.py
+  - bin/build_hugo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+before_install:
+  - sudo apt-get update
+
+install:
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
+  - sudo pip install -r bin/requirements.txt
+
+script:
+  - python bin/create_hugo_yaml.py


### PR DESCRIPTION
Re #102 

This adds a simple configuration file for Travis CI that tests
- whether all XML files conform to the RelaxNG schema (both compact & standard version)
- whether the full Hugo build pipeline can be run without errors.

To actually enable running Travis on the repo it needs to be linked up with it, which I believe has to be done by a member of acl-org.