### PR TITLE
Added missing SemEval, *SEM entries for 2016, 2018

### DIFF
--- a/import/siglex.yaml
+++ b/import/siglex.yaml
@@ -2,11 +2,16 @@ Name: Special Interest Group on the Lexicon (SIGLEX)
 ShortName: SIGLEX
 URL: http://www.clres.com/siglex.html
 Meetings: 
+  - 2018:
+    - S18-1000 # SemEval
+    - S18-2000 # *Sem
   - 2017:
     - S17-1000 # *Sem
     - S17-2000 # SemEval
     - W17-1700 # Proceedings of the 13th Workshop on Multiword Expressions (MWE 2017)
   - 2016:
+    - S16-1000 # SemEval
+    - S16-2000 # *Sem
     - W16-1800 # MWE
   - 2015:
     - S15-1000 # *Sem


### PR DESCRIPTION
These events were, until now, only listed under SIGSEM. However, they are co-organized by SIGLEX. (See e-mail disscussion.)