### PR TITLE
canonical path for attachments

### DIFF
--- a/bin/anthology/data.py
+++ b/bin/anthology/data.py
@@ -21,8 +21,8 @@
 # changed.
 ################################################################################
 
-ANTHOLOGY_URL = "http://www.aclweb.org/anthology/{}"
-ATTACHMENT_URL = "http://anthology.aclweb.org/attachments/{}/{}/{}"
+ANTHOLOGY_URL = "https://www.aclweb.org/anthology/{}"
+ATTACHMENT_URL = "https://www.aclweb.org/anthology/attachments/{}"
 
 
 def get_journal_title(top_level_id, volume_title):

--- a/bin/anthology/utils.py
+++ b/bin/anthology/utils.py
@@ -77,7 +77,7 @@ def infer_attachment_url(filename):
     if urlparse(filename).netloc:
         return filename
     # Otherwise, treat it as an internal filename
-    return data.ATTACHMENT_URL.format(filename[0], filename[:3], filename)
+    return data.ATTACHMENT_URL.format(filename)
 
 
 _MONTH_TO_NUM = {

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -34,7 +34,9 @@ RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ $1/$1$2/$1$2-$3.pdf [L,NC]
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ $1/$1$2/$1$2-$3.pdf [L,NC]
 # Revisions and errata (e.g., P17-1069v2)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)$ $1/$1$2/$1$2-$3$4.pdf [L,NC]
-# Attachments (e.g., P17-1069.Poster.pdf); I (MJP) am actually not sure this is used, since attachments are hosted under attachments/
+# Attachments (e.g., P17-1069.Poster.pdf -> /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)
+RewriteRule ^attachments/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]
+# Old rule matching files with additional annotations on the canonical URL; I (MJP) am actually not sure whether every actually fires
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ $1/$1$2/$1$2-$3$4 [L,NC]
 
 # The Paper metadata page (e.g., P17-1069/ -> papers/P/P17/P17-1069/index.html)


### PR DESCRIPTION
Creates a canonical path for attachments. Also adjusts the canonical URL to be HTTPS instead of HTTP.

Related to #216.