### PR TITLE
added missing redirects, added formatting (#215)

### DIFF
--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -26,6 +26,12 @@ RewriteRule ^/?(.*) https://www.aclweb.org/anthology/$1 [R=301,L]
 RewriteCond %{HTTPS} !=on
 RewriteRule ^(.*)$ https://%{SERVER_NAME}/anthology/$1 [R=301,L]
 
+## Old paths
+# Redirect old canonical paths (e.g., P/P17/P17-1069.pdf -> https://www.aclweb.org/anthology/P17-1069)
+# Note that since capture patterns can't be reused in the capture portion of the string, this is a leaky match
+# that will also redirect X/Z19/P17-1069.pdf -> /anthology-files/pdf/P/P17/1-69.pdf
+RewriteRule ^[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(.pdf)?$ https://www.aclweb.org/anthology/$1$2-$3 [R=301]
+
 ## PDF redirection
 # Canonical URL (a plain ACL ID with no file extension, e.g., P17-1069 -> P/P17/P17-1069.pdf)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
@@ -35,11 +41,6 @@ RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ /anthology-files/pdf/$1/$1$2/
 
 # PDF link (e.g., P17-1069.pdf -> P/P17/P17-1069.pdf)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
-
-# Old canonical link to flat canonical link (e.g., P/P17/P17-1069.pdf -> /anthology-files/pdf/P/P17/P17-1069.pdf)
-# Note that since capture patterns can't be reused in the capture portion of the string, this is a leaky match
-# that will also redirect X/Z19/P17-1069.pdf -> /anthology-files/pdf/P/P17/1-69.pdf
-RewriteRule ^[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
 
 # Revisions and errata (e.g., P17-1069v2)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -26,23 +26,35 @@ RewriteRule ^/?(.*) https://www.aclweb.org/anthology/$1 [R=301,L]
 RewriteCond %{HTTPS} !=on
 RewriteRule ^(.*)$ https://%{SERVER_NAME}/anthology/$1 [R=301,L]
 
+## PDF redirection
 # Canonical URL (a plain ACL ID with no file extension, e.g., P17-1069 -> P/P17/P17-1069.pdf)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
+
 # Volume URLs (e.g., P17-1 -> P/P17/P17-1.pdf)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ $1/$1$2/$1$2-$3.pdf [L,NC]
+RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
+
 # PDF link (e.g., P17-1069.pdf -> P/P17/P17-1069.pdf)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ $1/$1$2/$1$2-$3.pdf [L,NC]
+RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
+
+# Old canonical link to flat canonical link (e.g., P/P17/P17-1069.pdf -> /anthology-files/pdf/P/P17/P17-1069.pdf)
+# Note that since capture patterns can't be reused in the capture portion of the string, this is a leaky match
+# that will also redirect X/Z19/P17-1069.pdf -> /anthology-files/pdf/P/P17/1-69.pdf
+RewriteRule ^[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
+
 # Revisions and errata (e.g., P17-1069v2)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)$ $1/$1$2/$1$2-$3$4.pdf [L,NC]
+RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
+
 # Attachments (e.g., P17-1069.Poster.pdf -> /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)
 RewriteRule ^attachments/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]
-# Old rule matching files with additional annotations on the canonical URL; I (MJP) am actually not sure whether every actually fires
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ $1/$1$2/$1$2-$3$4 [L,NC]
 
+# Old rule matching files with additional annotations on the canonical URL; I (MJP) am actually not sure whether every actually fires
+#RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ $1/$1$2/$1$2-$3$4 [L,NC]
+
+## Paper and author pages and bibtex
 # The Paper metadata page (e.g., P17-1069/ -> papers/P/P17/P17-1069/index.html)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])\/$ papers/$1/$1$2/$1$2-$3/ [L,NC]
 
-# BibTeX file (e.g., anthology/P17-1069.bib -> anthology/P/P17/P17-1069.bib)
+# BibTeX file (e.g., P17-1069.bib -> papers/P/P17/P17-1069.bib)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])\.([a-z]+)$ papers/$1/$1$2/$1$2-$3.$4 [L,NC]
 
 # Author pages (e.g., people/arya-d-mccarthy -> people/a/arya-d-mccarthy)


### PR DESCRIPTION
We weren't properly redirecting the following to the new file location under `/anthology-files/pdf`

- volumes
- pdf extensions on the canonical URL
- revisions
- the old canonical path (e.g., https://www.aclweb.org/anthology/E/E14/E14-1049.pdf)