### PR TITLE
Add first names to L06.xml

### DIFF
--- a/bin/auto_first_names.py
+++ b/bin/auto_first_names.py
@@ -1,0 +1,81 @@
+"""
+Try to automatically fill in author first names.
+
+Bugs:
+
+- If two authors on the same paper have same last name, one of them will get the wrong 
+  first name. This could be remedied somewhat by using the first initial as a clue. 
+  Otherwise, we should check for duplicate names.
+- If name is broken across two lines, there is no first name.
+- Strip whitespace, punct from XML names too
+- Strip "and" from beginning
+- NFKC normalization
+"""
+
+import tika.parser
+import requests
+import sys
+import lxml.etree as etree
+import re
+import unicodedata
+
+if len(sys.argv) != 3:
+    sys.exit("usage: auto_first_names.py <input-xml> <output-xml>")
+
+tree = etree.parse(sys.argv[1])
+for paper in tree.findall('paper'):
+    print("paper", paper.attrib['id'])
+    url = paper.find('url') and paper.find('url').text
+    if url is None: url = paper.find('href') and paper.find('href').text
+    if url is None: url = paper.attrib.get('href', None)
+    if url is None:
+        print('no url found; skipping')
+        print()
+        continue
+
+    print("getting", url)
+    try:
+        req = requests.get(url)
+        raw = tika.parser.from_buffer(req.content)
+        text = [line for line in raw['content'].splitlines() if line.strip() != ""]
+    except KeyboardInterrupt:
+        raise
+    except Exception as e:
+        print("error: {}".format(e))
+        continue
+
+    index = {}
+    for line in text[:20]:
+        if line.strip() == 'Abstract': break
+        print('> '+line)
+        names = re.split(r',\s*|\s+and\s+|,\s*and\s+|&', line)
+        for name in names:
+            # strip leading and trailing numbers, punctuation, symbols, whitespace
+            # bugs: can a name end in an apostrophe?
+            while len(name) > 0 and unicodedata.category(name[0])[0] in "NPSZ":
+                name = name[1:]
+            while len(name) > 0 and unicodedata.category(name[-1])[0] in "NPSZ":
+                name = name[:-1]
+            for part in name.split():
+                if part not in index: # ignore subsequent mentions, which may be from text
+                    index[part.lower()] = name
+
+    for xauthor in paper.findall('author'):
+        xfirst = xauthor.find('first')
+        xlast = xauthor.find('last')
+        xnametext = '{} {}'.format(xfirst.text, xlast.text) # just used for logging
+        assert(len(xfirst) == len(xlast) == 0)
+        if xlast.text.lower() not in index:
+            print("warning: {} not found; skipping".format(xnametext))
+            continue
+        pname = index[xlast.text.lower()]
+        i = pname.lower().find(xlast.text.lower())
+        newfirst = pname[:i].strip()
+        afterlast = pname[i+len(xlast.text):].strip()
+        if afterlast:
+            print("warning: {}: trailing string after last name: {}".format(xnametext, afterlast))
+        print("{} {} -> {} {}".format(xfirst.text, xlast.text, newfirst, xlast.text))
+        xfirst.text = newfirst
+    
+    print()
+tree.write(sys.argv[2], xml_declaration=True, encoding='UTF-8', with_tail=True)

--- a/data/xml/H01.xml
+++ b/data/xml/H01.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="H01">
 
 <paper id="1000">
@@ -6,148 +7,148 @@
 
 <paper id="1001">
   <title>Activity detection for information access to oral communication</title>
-  <author><first>K.</first><last>Ries</last></author>
-  <author><first>A.</first><last>Waibel</last></author>
+  <author><first>Klaus</first><last>Ries</last></author>
+  <author><first>Alex</first><last>Waibel</last></author>
 </paper>
 
 <paper id="1002">
   <title>Adapting an Example-Based Translation System to Chinese</title>
-  <author><first>Y.</first><last>Zhang</last></author>
-  <author><first>R.D.</first><last>Brown</last></author>
-  <author><first>R.E.</first><last>Frederking</last></author>
+  <author><first>Ying</first><last>Zhang</last></author>
+  <author><first>Ralf D.</first><last>Brown</last></author>
+  <author><first>Robert E.</first><last>Frederking</last></author>
 </paper>
 
 <paper id="1003">
   <title>Advances in meeting recognition</title>
-  <author><first>A.</first><last>Waibel</last></author>
-  <author><first>H.</first><last>Yu</last></author>
-  <author><first>T.</first><last>Schultz</last></author>
-  <author><first>Y.</first><last>Pan</last></author>
-  <author><first>M.</first><last>Bett</last></author>
-  <author><first>M.</first><last>Westphal</last></author>
-  <author><first>H.</first><last>Soltau</last></author>
-  <author><first>T.</first><last>Schaaf</last></author>
-  <author><first>F.</first><last>Metze</last></author>
+  <author><first>Alex</first><last>Waibel</last></author>
+  <author><first>Hua</first><last>Yu</last></author>
+  <author><first>Tanja</first><last>Schultz</last></author>
+  <author><first>Yue</first><last>Pan</last></author>
+  <author><first>Michael</first><last>Bett</last></author>
+  <author><first>Martin</first><last>Westphal</last></author>
+  <author><first>Hagen</first><last>Soltau</last></author>
+  <author><first>Thomas</first><last>Schaaf</last></author>
+  <author><first>Florian</first><last>Metze</last></author>
 </paper>
 
 <paper id="1004">
   <title>Amount of Information Presented in a Complex List: Effects on User Performance</title>
-  <author><first>D.</first><last>Dutton</last></author>
-  <author><first>M.</first><last>Walker</last></author>
-  <author><first>S.</first><last>Chu</last></author>
-  <author><first>J.</first><last>Hubbell</last></author>
-  <author><first>S.</first><last>Narayanan</last></author>
+  <author><first>Dawn</first><last>Dutton</last></author>
+  <author><first>Marilyn</first><last>Walker</last></author>
+  <author><first>Selina</first><last>Chu</last></author>
+  <author><first>James</first><last>Hubbell</last></author>
+  <author><first>Shrikanth</first><last>Narayanan</last></author>
 </paper>
 
 <paper id="1005">
   <title>The Annotation Graph Toolkit: Software Components for Building Linguistic Annotation Tools</title>
-  <author><first>K.</first><last>Maeda</last></author>
-  <author><first>S.</first><last>Bird</last></author>
-  <author><first>X.</first><last>Ma</last></author>
-  <author><first>H.</first><last>Lee</last></author>
+  <author><first>Kazuaki</first><last>Maeda</last></author>
+  <author><first>Steven</first><last>Bird</last></author>
+  <author><first>Xiaoyi</first><last>Ma</last></author>
+  <author><first>Haejoong</first><last>Lee</last></author>
 </paper>
 
 <paper id="1006">
   <title>Answering What-Is Questions by Virtual Annotation</title>
-  <author><first>J.</first><last>Prager</last></author>
-  <author><first>D.</first><last>Radev</last></author>
-  <author><first>K.</first><last>Czuba</last></author>
+  <author><first>John</first><last>Prager</last></author>
+  <author><first>Dragomir</first><last>Radev</last></author>
+  <author><first>Krzysztof</first><last>Czuba</last></author>
 </paper>
 
 <paper id="1007">
   <title>Architecture and Design Considerations in NESPOLE!: a Speech Translation System for E-commerce Applications</title>
-  <author><first>A.</first><last>Lavie</last></author>
-  <author><first>C.</first><last>Langley</last></author>
-  <author><first>A.</first><last>Waibel</last></author>
-  <author><first>F.</first><last>Pianesi</last></author>
-  <author><first>G.</first><last>Lazzari</last></author>
-  <author><first>P.</first><last>Coletti</last></author>
-  <author><first>L.</first><last>Taddei</last></author>
-  <author><first>F.</first><last>Balducci</last></author>
+  <author><first>Alon</first><last>Lavie</last></author>
+  <author><first>Chad</first><last>Langley</last></author>
+  <author><first>Alex</first><last>Waibel</last></author>
+  <author><first>Fabio</first><last>Pianesi</last></author>
+  <author><first>Gianni</first><last>Lazzari</last></author>
+  <author><first>Paolo</first><last>Coletti</last></author>
+  <author><first>Loredana</first><last>Taddei</last></author>
+  <author><first>Franco</first><last>Balducci</last></author>
 </paper>
 
 <paper id="1008">
   <title>Assigning Belief Scores to Names in Queries</title>
-  <author><first>C.</first><last>Dozier</last></author>
+  <author><first>Christopher</first><last>Dozier</last></author>
 </paper>
 
 <paper id="1009">
   <title>Automatic Pattern Acquisition for Japanese Information Extraction</title>
-  <author><first>K.</first><last>Sudo</last></author>
-  <author><first>S.</first><last>Sekine</last></author>
-  <author><first>R.</first><last>Grishman</last></author>
+  <author><first>Kiyoshi</first><last>Sudo</last></author>
+  <author><first>Satoshi</first><last>Sekine</last></author>
+  <author><first>Ralph</first><last>Grishman</last></author>
 </paper>
 
 <paper id="1010">
   <title>Automatic Predicate Argument Analysis of the Penn TreeBank</title>
-  <author><first>M.</first><last>Palmer</last></author>
-  <author><first>J.</first><last>Rosenzweig</last></author>
-  <author><first>S.</first><last>Cotton</last></author>
+  <author><first>Martha</first><last>Palmer</last></author>
+  <author><first>Joseph</first><last>Rosenzweig</last></author>
+  <author><first>Scott</first><last>Cotton</last></author>
 </paper>
 
 <paper id="1011">
   <title>Automatic Title Generation for Spoken Broadcast News</title>
-  <author><first>R.</first><last>Jin</last></author>
-  <author><first>A.</first><last>Hauptmann</last></author>
+  <author><first>Rong</first><last>Jin</last></author>
+  <author><first>Alexander G.</first><last>Hauptmann</last></author>
 </paper>
 
 <paper id="1012">
   <title>A Conversational Interface for Online Shopping</title>
-  <author><first>J.</first><last>Chai</last></author>
-  <author><first>V.</first><last>Horvath</last></author>
-  <author><first>N.</first><last>Kambhatla</last></author>
-  <author><first>N.</first><last>Nicolov</last></author>
-  <author><first>M.</first><last>Stys-Budzikowska</last></author>
+  <author><first>Joyce</first><last>Chai</last></author>
+  <author><first>Veronika</first><last>Horvath</last></author>
+  <author><first>Nanda</first><last>Kambhatla</last></author>
+  <author><first>Nicolas</first><last>Nicolov</last></author>
+  <author><first>Margo</first><last>Stys-Budzikowska</last></author>
 </paper>
 
 <paper id="1013">
   <title>Conversational Sales Assistant for Online Shopping</title>
-  <author><first>M.</first><last>Budzikowska</last></author>
-  <author><first>J.</first><last>Chai</last></author>
-  <author><first>S.</first><last>Govindappa</last></author>
-  <author><first>V.</first><last>Horvath</last></author>
-  <author><first>N.</first><last>Kambhatla</last></author>
-  <author><first>N.</first><last>Nicolov</last></author>
-  <author><first>W.</first><last>Zadrozny</last></author>
+  <author><first>Margo</first><last>Budzikowska</last></author>
+  <author><first>Joyce</first><last>Chai</last></author>
+  <author><first>Sunil</first><last>Govindappa</last></author>
+  <author><first>Veronika</first><last>Horvath</last></author>
+  <author><first>Nanda</first><last>Kambhatla</last></author>
+  <author><first>Nicolas</first><last>Nicolov</last></author>
+  <author><first>Wlodek</first><last>Zadrozny</last></author>
 </paper>
 
 <paper id="1014">
   <title>Converting Dependency Structures to Phrase Structures</title>
-  <author><first>F.</first><last>Xia</last></author>
-  <author><first>M.</first><last>Palmer</last></author>
+  <author><first>Fei</first><last>Xia</last></author>
+  <author><first>Martha</first><last>Palmer</last></author>
 </paper>
 
 <paper id="1015">
   <title>DATE: A Dialogue Act Tagging Scheme for Evaluation of Spoken Dialogue Systems</title>
-  <author><first>M.</first><last>Walker</last></author>
-  <author><first>R.</first><last>Passonneau</last></author>
+  <author><first>Marilyn</first><last>Walker</last></author>
+  <author><first>Rebecca</first><last>Passonneau</last></author>
 </paper>
 
 <paper id="1016">
   <title>Development of the HRL Route Navigation Dialogue System</title>
-  <author><first>R.</first><last>Belvin</last></author>
-  <author><first>R.</first><last>Burns</last></author>
-  <author><first>C.</first><last>Hein</last></author>
+  <author><first>Robert</first><last>Belvin</last></author>
+  <author><first>Ron</first><last>Burns</last></author>
+  <author><first>Cheryl</first><last>Hein</last></author>
 </paper>
 
 <paper id="1017">
   <title>Dialogue Interaction with the DARPA Communicator Infrastructure: The Development of Useful Software</title>
-  <author><first>S.</first><last>Bayer</last></author>
-  <author><first>C.</first><last>Doran</last></author>
-  <author><first>B.</first><last>George</last></author>
+  <author><first>Samuel</first><last>Bayer</last></author>
+  <author><first>Christine</first><last>Doran</last></author>
+  <author><first>Bryan</first><last>George</last></author>
 </paper>
 
 <paper id="1018">
   <title>Domain Portability in Speech-to-Speech Translation</title>
-  <author><first>A.</first><last>Lavie</last></author>
-  <author><first>L</first><last>Levin</last></author>
-  <author><first>T.</first><last>Schultz</last></author>
-  <author><first>C.</first><last>Langley</last></author>
-  <author><first>B.</first><last>Han</last></author>
-  <author><first>A.</first><last>Tribble</last></author>
-  <author><first>D.</first><last>Gates</last></author>
-  <author><first>D.</first><last>Wallace</last></author>
-  <author><first>K.</first><last>Peterson</last></author>
+  <author><first>Alon</first><last>Lavie</last></author>
+  <author><first>Lori</first><last>Levin</last></author>
+  <author><first>Tanja</first><last>Schultz</last></author>
+  <author><first>Chad</first><last>Langley</last></author>
+  <author><first>Benjamin</first><last>Han</last></author>
+  <author><first>Alicia</first><last>Tribble</last></author>
+  <author><first>Donna</first><last>Gates</last></author>
+  <author><first>Dorcas</first><last>Wallace</last></author>
+  <author><first>Kay</first><last>Peterson</last></author>
 </paper>
 
 <paper id="1019">
@@ -159,324 +160,326 @@
 
 <paper id="1020">
   <title>Entry Vocabulary - a Technology to Enhance Digital Search</title>
-  <author><first>F.</first><last>Gey</last></author>
-  <author><first>M.</first><last>Buckland</last></author>
-  <author><first>A.</first><last>Chen</last></author>
-  <author><first>R.</first><last>Larson</last></author>
+  <author><first>Fredric</first><last>Gey</last></author>
+  <author><first>Michael</first><last>Buckland</last></author>
+  <author><first>Aitao</first><last>Chen</last></author>
+  <author><first>Ray</first><last>Larson</last></author>
 </paper>
 
 <paper id="1021">
   <title>Evaluating Question-Answering Techniques in Chinese</title>
-  <author><first>X.</first><last>Li</last></author>
-  <author><first>W.B.</first><last>Croft</last></author>
+  <author><first>Xiaoyan</first><last>Li</last></author>
+  <author><first>W. Bruce</first><last>Croft</last></author>
 </paper>
 
 <paper id="1022">
   <title>An Evaluation Corpus For Temporal Summarization</title>
-  <author><first>V.</first><last>Khandelwal</last></author>
-  <author><first>R.</first><last>Gupta</last></author>
-  <author><first>J.</first><last>Allan</last></author>
+  <author><first>Vikash</first><last>Khandelwal</last></author>
+  <author><first>Rahul</first><last>Gupta</last></author>
+  <author><first>James</first><last>Allan</last></author>
 </paper>
 
 <paper id="1023">
   <title>Evaluation Results for the Talk’n’Travel System</title>
-  <author><first>D.</first><last>Stallard</last></author>
+  <author><first>David</first><last>Stallard</last></author>
 </paper>
 
 <paper id="1024">
   <title>Experiments in Multi-Modal Automatic Content Extraction</title>
-  <author><first>L.</first><last>Ramshaw</last></author>
-  <author><first>E.</first><last>Boschee</last></author>
-  <author><first>S.</first><last>Bratus</last></author>
-  <author><first>S.</first><last>Miller</last></author>
-  <author><first>R.</first><last>Stone</last></author>
-  <author><first>R.</first><last>Weischedel</last></author>
-  <author><first>A.</first><last>Zamanian</last></author>
+  <author><first>Lance</first><last>Ramshaw</last></author>
+  <author><first>Elizabeth</first><last>Boschee</last></author>
+  <author><first>Sergey</first><last>Bratus</last></author>
+  <author><first>Scott</first><last>Miller</last></author>
+  <author><first>Rebecca</first><last>Stone</last></author>
+  <author><first>Ralph</first><last>Weischedel</last></author>
+  <author><first>Alex</first><last>Zamanian</last></author>
 </paper>
 
 <paper id="1025">
   <title>Exploring Speech-Enabled Dialogue with the Galaxy Communicator Infrastructure</title>
-  <author><first>S.</first><last>Bayer</last></author>
-  <author><first>C.</first><last>Doran</last></author>
-  <author><first>B.</first><last>George</last></author>
+  <author><first>Samuel</first><last>Bayer</last></author>
+  <author><first>Christine</first><last>Doran</last></author>
+  <author><first>Bryan</first><last>George</last></author>
 </paper>
 
 <paper id="1026">
   <title>Facilitating Treebank Annotation Using a Statistical Parser</title>
-  <author><first>F.</first><last>Chiou</last></author>
-  <author><first>D.</first><last>Chiang</last></author>
-  <author><first>M.</first><last>Palmer</last></author>
+  <author><first>Fu-Dong</first><last>Chiou</last></author>
+  <author><first>David</first><last>Chiang</last></author>
+  <author><first>Martha</first><last>Palmer</last></author>
 </paper>
 
 <paper id="1027">
   <title>FactBrowser Demonstration</title>
-  <author><first>S.</first><last>Miller</last></author>
-  <author><first>S.</first><last>Bratus</last></author>
-  <author><first>L.</first><last>Ramshaw</last></author>
-  <author><first>R.</first><last>Weischedel</last></author>
-  <author><first>A.</first><last>Zamanian</last></author>
+  <author><first>Scott</first><last>Miller</last></author>
+  <author><first>Sergey</first><last>Bratus</last></author>
+  <author><first>Lance</first><last>Ramshaw</last></author>
+  <author><first>Ralph</first><last>Weischedel</last></author>
+  <author><first>Alex</first><last>Zamanian</last></author>
 </paper>
 
 <paper id="1028">
   <title>Finding Errors Automatically in Semantically Tagged Dialogues</title>
-  <author><first>J.</first><last>Aberdeen</last></author>
-  <author><first>C.</first><last>Doran</last></author>
-  <author><first>L.</first><last>Damianos</last></author>
-  <author><first>S.</first><last>Bayer</last></author>
-  <author><first>L.</first><last>Hirschman</last></author>
+  <author><first>John</first><last>Aberdeen</last></author>
+  <author><first>Christine</first><last>Doran</last></author>
+  <author><first>Laurie</first><last>Damianos</last></author>
+  <author><first>Samuel</first><last>Bayer</last></author>
+  <author><first>Lynette</first><last>Hirschman</last></author>
 </paper>
 
 <paper id="1029">
   <title>Fine-Grained Hidden Markov Modeling for Broadcast-News Story Segmentation</title>
-  <author><first>W.</first><last>Greiff</last></author>
-  <author><first>A.</first><last>Morgan</last></author>
-  <author><first>R.</first><last>Fish</last></author>
-  <author><first>M.</first><last>Richards</last></author>
-  <author><first>A.</first><last>Kundu</last></author>
+  <author><first>Warren</first><last>Greiff</last></author>
+  <author><first>Alex</first><last>Morgan</last></author>
+  <author><first>Randall</first><last>Fish</last></author>
+  <author><first>Marc</first><last>Richards</last></author>
+  <author><first>Amlan</first><last>Kundu</last></author>
 </paper>
 
 <paper id="1030">
   <title>First Story Detection using a Composite Document Representation</title>
-  <author><first>N.</first><last>Stokes</last></author>
-  <author><first>J.</first><last>Carthy</last></author>
+  <author><first>Nicola</first><last>Stokes</last></author>
+  <author><first>Joe</first><last>Carthy</last></author>
 </paper>
 
 <paper id="1031">
   <title>Guidelines for Annotating Temporal Information</title>
-  <author><first>I.</first><last>Mani</last></author>
-  <author><first>G.</first><last>Wilson</last></author>
-  <author><first>L.</first><last>Ferro</last></author>
-  <author><first>B.</first><last>Sundheim</last></author>
+  <author><first>Inderjeet</first><last>Mani</last></author>
+  <author><first>George</first><last>Wilson</last></author>
+  <author><first>Lisa</first><last>Ferro</last></author>
+  <author><first>Beth</first><last>Sundheim</last></author>
 </paper>
 
 <paper id="1032">
   <title>Hypothesis Selection and Resolution in the Mercury Flight Reservation System</title>
-  <author><first>S.</first><last>Seneff</last></author>
-  <author><first>J.</first><last>Polifroni</last></author>
+  <author><first>Stephanie</first><last>Seneff</last></author>
+  <author><first>Joseph</first><last>Polifroni</last></author>
 </paper>
 
 <paper id="1033">
   <title>Improved Cross-Language Retrieval using Backoff Translation</title>
-  <author><first>P.</first><last>Resnik</last></author>
-  <author><first>D.</first><last>Oard</last></author>
-  <author><first>G.</first><last>Levow</last></author>
+  <author><first>Philip</first><last>Resnik</last></author>
+  <author><first>Douglas</first><last>Oard</last></author>
+  <author><first>Gina</first><last>Levow</last></author>
 </paper>
 
 <paper id="1034">
   <title>Improving Information Extraction by Modeling Errors in Speech Recognizer Output</title>
-  <author><first>D.D.</first><last>Palmer</last></author>
-  <author><first>M.</first><last>Ostendorf</last></author>
+  <author><first>David D.</first><last>Palmer</last></author>
+  <author><first>Mari</first><last>Ostendorf</last></author>
 </paper>
 
 <paper id="1035">
   <title>Inducing Multilingual Text Analysis Tools via Robust Projection across Aligned Corpora</title>
-  <author><first>D.</first><last>Yarowsky</last></author>
-  <author><first>G.</first><last>Ngai</last></author>
-  <author><first>R.</first><last>Wicentowski</last></author>
+  <author><first>David</first><last>Yarowsky</last></author>
+  <author><first>Grace</first><last>Ngai</last></author>
+  <author><first>Richard</first><last>Wicentowski</last></author>
 </paper>
 
 <paper id="1036">
   <title>Information Extraction with Term Frequencies</title>
-  <author><first>T.R.</first><last>Lynam</last></author>
-  <author><first>C.L.A.</first><last>Clarke</last></author>
-  <author><first>G.V.</first><last>Cormack</last></author>
+  <author><first>T. R.</first><last>Lynam</last></author>
+  <author><first>C. L. A.</first><last>Clarke</last></author>
+  <author><first>G. V.</first><last>Cormack</last></author>
 </paper>
 
 <paper id="1037">
   <title>The Integrated Feasibility Experiment Process</title>
-  <author><first>A.</first><last>Sears</last></author>
-  <author><first>S.E.</first><last>Cross</last></author>
+  <author><first>J. Allen</first><last>Sears</last></author>
+  <author><first>Stephen E.</first><last>Cross</last></author>
 </paper>
 
 <paper id="1038">
   <title>Integrated Feasibility Experiment for Bio-Security: IFE-Bio, A TIDES Demonstration</title>
-  <author><first>L.</first><last>Hirschman</last></author>
-  <author><first>K.</first><last>Concepcion</last></author>
-  <author><first>L.</first><last>Damianos</last></author>
-  <author><first>D.</first><last>Day</last></author>
-  <author><first>J.</first><last>Delmore</last></author>
-  <author><first>L.</first><last>Ferro</last></author>
-  <author><first>J.</first><last>Griffith</last></author>
-  <author><first>J.</first><last>Henderson</last></author>
-  <author><first>J.</first><last>Kurtz</last></author>
-  <author><first>I.</first><last>Mani</last></author>
-  <author><first>S.</first><last>Mardis</last></author>
-  <author><first>T.</first><last>McEntee</last></author>
-  <author><first>K.</first><last>Miller</last></author>
-  <author><first>B.</first><last>Nunam</last></author>
-  <author><first>J.</first><last>Ponte</last></author>
-  <author><first>F.</first><last>Reeder</last></author>
-  <author><first>B.</first><last>Wellner</last></author>
-  <author><first>G.</first><last>Wilson</last></author>
-  <author><first>A.</first><last>Yeh</last></author>
+  <author><first>Lynette</first><last>Hirschman</last></author>
+  <author><first>Kris</first><last>Concepcion</last></author>
+  <author><first>Laurie</first><last>Damianos</last></author>
+  <author><first>David</first><last>Day</last></author>
+  <author><first>John</first><last>Delmore</last></author>
+  <author><first>Lisa</first><last>Ferro</last></author>
+  <author><first>John</first><last>Griffith</last></author>
+  <author><first>John</first><last>Henderson</last></author>
+  <author><first>Jeff</first><last>Kurtz</last></author>
+  <author><first>Inderjeet</first><last>Mani</last></author>
+  <author><first>Scott</first><last>Mardis</last></author>
+  <author><first>Tom</first><last>McEntee</last></author>
+  <author><first>Keith</first><last>Miller</last></author>
+  <author><first>Beverly</first><last>Nunam</last></author>
+  <author><first>Jay</first><last>Ponte</last></author>
+  <author><first>Florence</first><last>Reeder</last></author>
+  <author><first>Ben</first><last>Wellner</last></author>
+  <author><first>George</first><last>Wilson</last></author>
+  <author><first>Alex</first><last>Yeh</last></author>
 </paper>
 
 <paper id="1039">
   <title>Integrated Information Management: An Interactive, Extensible Architecture for Information Retrieval </title>
-  <author><first>E.</first><last>Nyberg</last></author>
-  <author><first>H.</first><last>Daume</last></author>
+  <author><first>Eric</first><last>Nyberg</last></author>
+  <author><first>Hal</first><last>Daume</last></author>
 </paper>
 
 <paper id="1040">
   <title>Intelligent Access to Text: Integrating Information Extraction Technology into Text Browsers</title>
-  <author><first>R.</first><last>Gaizauskas</last></author>
-  <author><first>P.</first><last>Herring</last></author>
-  <author><first>M.</first><last>Oakes</last></author>
-  <author><first>M.</first><last>Beaulieu</last></author>
-  <author><first>P.</first><last>Willett</last></author>
-  <author><first>H.</first><last>Fowkes</last></author>
-  <author><first>A.</first><last>Jonsson</last></author>
+  <author><first>Robert</first><last>Gaizauskas</last></author>
+  <author><first>Patrick</first><last>Herring</last></author>
+  <author><first>Michael</first><last>Oakes</last></author>
+  <author><first>Michelline</first><last>Beaulieu</last></author>
+  <author><first>Peter</first><last>Willett</last></author>
+  <author><first>Helene</first><last>Fowkes</last></author>
+  <author><first>Anna</first><last>Jonsson</last></author>
 </paper>
 
 <paper id="1041">
   <title>Interlingua-Based Broad-Coverage Korean-to-English Translation in CCLINC</title>
-  <author><first>Y.-S.</first><last>Lee</last></author>
-  <author><first>W.S.</first><last>Yi</last></author>
-  <author><first>S.</first><last>Seneff</last></author>
-  <author><first>C.</first><last>Weinstein</last></author>
+  <author><first>Young-Suk</first><last>Lee</last></author>
+  <author><first>Wu Sok</first><last>Yi</last></author>
+  <author><first>Stephanie</first><last>Seneff</last></author>
+  <author><first>Clifford J.</first><last>Weinstein</last></author>
 </paper>
 
 <paper id="1042">
   <title>Is That Your Final Answer?</title>
-  <author><first>F.</first><last>Reeder</last></author>
+  <author><first>Florence</first><last>Reeder</last></author>
 </paper>
 
 <paper id="1043">
   <title>Japanese Case Frame Construction by Coupling the Verb and its Closest Case Component</title>
-  <author><first>D.</first><last>Kawahara</last></author>
-  <author><first>S.</first><last>Kurohashi</last></author>
+  <author><first>Daisuke</first><last>Kawahara</last></author>
+  <author><first>Sadao</first><last>Kurohashi</last></author>
 </paper>
 
 <paper id="1044">
   <title>Japanese Text Input System With Digits</title>
-  <author><first>K.</first><last>Tanaka-Ishii</last></author>
-  <author><first>Y.</first><last>Inutsuka</last></author>
-  <author><first>M.</first><last>Takeichi</last></author>
+  <author><first>Kumiko</first><last>Tanaka-Ishii</last></author>
+  <author><first>Yusuke</first><last>Inutsuka</last></author>
+  <author><first>Masato</first><last>Takeichi</last></author>
 </paper>
 
 <paper id="1045">
   <title>Large scale testing of a descriptive phrase finder</title>
-  <author><first>H.</first><last>Joho</last></author>
-  <author><first>Y.K.</first><last>Liu</last></author>
-  <author><first>M.</first><last>Sanderson</last></author>
+  <author><first>Hideo</first><last>Joho</last></author>
+  <author><first>Ying Ki</first><last>Liu</last></author>
+  <author><first>Mark</first><last>Sanderson</last></author>
 </paper>
 
 <paper id="1046">
   <title>LaTaT: Language and Text Analysis Tools</title>
-  <author><first>D.</first><last>Lin</last></author>
+  <author><first>Dekang</first><last>Lin</last></author>
 </paper>
 
 <paper id="1047">
   <title>Linguatronic: Product-Level Speech System for Mercedes-Benz Car</title>
-  <author><first>P.</first><last>Heisterkamp</last></author>
+  <author><first>Paul</first><last>Heisterkamp</last></author>
 </paper>
 
 <paper id="1048">
   <title>LingWear: A Mobile Tourist Information System</title>
-  <author><first>C.</first><last>Fügen</last></author>
-  <author><first>M.</first><last>Westphal</last></author>
-  <author><first>M.</first><last>Schneider</last></author>
-  <author><first>T.</first><last>Schultz</last></author>
-  <author><first>A.</first><last>Waibel</last></author>
+  <author><first>Christian</first><last>Fügen</last></author>
+  <author><first>Martin</first><last>Westphal</last></author>
+  <author><first>Mike</first><last>Schneider</last></author>
+  <author><first>Tanja</first><last>Schultz</last></author>
+  <author><first>Alex</first><last>Waibel</last></author>
 </paper>
 
 <paper id="1049">
   <title>Listen-Communicate-Show: Spoken Language Command of Agent-based Remote Information Access</title>
-  <author><first>J.</first><last>Daniels</last></author>
-  <author><first>B.</first><last>Bell</last></author>
+  <author><first>Jody J.</first><last>Daniels</last></author>
+  <author><first>Benjamin</first><last>Bell</last></author>
 </paper>
 
 <paper id="1050">
   <title>Mandarin-English Information: Investigating Translingual Speech Retrieval </title>
-  <author><first>H.</first><last>Meng</last></author>
-  <author><first>W.-K.</first><last>Lo</last></author>
-  <author><first>B.</first><last>Chen</last></author>
-  <author><first>H.-M..</first><last>Wang</last></author>
-  <author><first>S.</first><last>Khudanpur</last></author>
-  <author><first>G.-A.</first><last>Levow</last></author>
-  <author><first>D.W.</first><last>Oard</last></author>
-  <author><first>J.</first><last>Wang</last></author>
+  <author><first>Helen</first><last>Meng</last></author>
+  <author><first>Berlin</first><last>Chen</last></author>
+  <author><first>Sanjeev</first><last>Khudanpur</last></author>
+  <author><first>Gina-Anne</first><last>Levow</last></author>
+  <author><first>Wai-Kit</first><last>Lo</last></author>
+  <author><first>Douglas</first><last>Oard</last></author>
+  <author><first>Patrick</first><last>Shone</last></author>
+  <author><first>Karen</first><last>Tang</last></author>
+  <author><first>Hsin-Min</first><last>Wang</last></author>
+  <author><first>Jianqiang</first><last>Wang</last></author>
 </paper>
 
 <paper id="1051">
   <title>The Meeting Project at ICSI</title>
-  <author><first>N.</first><last>Morgan</last></author>
-  <author><first>D.</first><last>Baron</last></author>
-  <author><first>J.</first><last>Edwards</last></author>
-  <author><first>D.</first><last>Ellis</last></author>
-  <author><first>D.</first><last>Gelbart</last></author>
-  <author><first>A.</first><last>Janin</last></author>
-  <author><first>T.</first><last>Pfau</last></author>
-  <author><first>E.</first><last>Shriberg</last></author>
-  <author><first>A.</first><last>Stolcke</last></author>
+  <author><first>Nelson</first><last>Morgan</last></author>
+  <author><first>Don</first><last>Baron</last></author>
+  <author><first>Jane</first><last>Edwards</last></author>
+  <author><first>Dan</first><last>Ellis</last></author>
+  <author><first>David</first><last>Gelbart</last></author>
+  <author><first>Adam</first><last>Janin</last></author>
+  <author><first>Thilo</first><last>Pfau</last></author>
+  <author><first>Elizabeth</first><last>Shriberg</last></author>
+  <author><first>Andreas</first><last>Stolcke</last></author>
 </paper>
 
 <paper id="1052">
   <title>Mitigating the Paucity-of-Data Problem: Exploring the Effect of Training Corpus Size on Classifier Performance for Natural Language Processing</title>
-  <author><first>M.</first><last>Banko</last></author>
-  <author><first>E.</first><last>Brill</last></author>
+  <author><first>Michele</first><last>Banko</last></author>
+  <author><first>Eric</first><last>Brill</last></author>
 </paper>
 
 <paper id="1053">
   <title>Monitoring the News: a TDT demonstration system</title>
-  <author><first>D.</first><last>Frey</last></author>
-  <author><first>R.</first><last>Gupta</last></author>
-  <author><first>V.</first><last>Khandelwal</last></author>
-  <author><first>V.</first><last>Lavrenko</last></author>
-  <author><first>A.</first><last>Leuski</last></author>
-  <author><first>J.</first><last>Allan</last></author>
+  <author><first>David</first><last>Frey</last></author>
+  <author><first>Rahul</first><last>Gupta</last></author>
+  <author><first>Vikas</first><last>Khandelwal</last></author>
+  <author><first>Victor</first><last>Lavrenko</last></author>
+  <author><first>Anton</first><last>Leuski</last></author>
+  <author><first>James</first><last>Allan</last></author>
 </paper>
 
 <paper id="1054">
   <title>Multidocument Summarization via Information Extraction</title>
-  <author><first>M.</first><last>White</last></author>
-  <author><first>T.</first><last>Korelsky</last></author>
-  <author><first>C.</first><last>Cardie</last></author>
-  <author><first>V.</first><last>Ng</last></author>
-  <author><first>D.</first><last>Pierce</last></author>
-  <author><first>K.</first><last>Wagstaff</last></author>
+  <author><first>Michael</first><last>White</last></author>
+  <author><first>Tanya</first><last>Korelsky</last></author>
+  <author><first>Claire</first><last>Cardie</last></author>
+  <author><first>Vincent</first><last>Ng</last></author>
+  <author><first>David</first><last>Pierce</last></author>
+  <author><first>Kiri</first><last>Wagstaff</last></author>
 </paper>
 
 <paper id="1055">
   <title>Natural Language Generation in Dialog Systems</title>
-  <author><first>O.</first><last>Rambow</last></author>
-  <author><first>S.</first><last>Bangalore</last></author>
-  <author><first>M.</first><last>Walker</last></author>
+  <author><first>Owen</first><last>Rambow</last></author>
+  <author><first>Srinivas</first><last>Bangalore</last></author>
+  <author><first>Marilyn</first><last>Walker</last></author>
 </paper>
 
 <paper id="1056">
   <title>NewsInEssence: A System For Domain-Independent, Real-Time News Clustering and Multi-Document Summarization</title>
-  <author><first>D.R.</first><last>Radev</last></author>
-  <author><first>S.</first><last>Blair-Goldensohn</last></author>
-  <author><first>Z.</first><last>Zhang</last></author>
-  <author><first>R.S.</first><last>Raghavan</last></author>
+  <author><first>Dragomir R.</first><last>Radev</last></author>
+  <author><first>Sasha</first><last>Blair-Goldensohn</last></author>
+  <author><first>Zhu</first><last>Zhang</last></author>
+  <author><first>Revathi Sundara</first><last>Raghavan</last></author>
 </paper>
 
 <paper id="1057">
   <title>Non-Dictionary-Based Thai Word Segmentation Using Decision Trees</title>
-  <author><first>T.</first><last>Theeramunkong</last></author>
-  <author><first>S.</first><last>Usanavasin</last></author>
+  <author><first>Thanaruk</first><last>Theeramunkong</last></author>
+  <author><first>Sasiporn</first><last>Usanavasin</last></author>
 </paper>
 
 <paper id="1058">
   <title>On Combining Language Models: Oracle Approach</title>
-  <author><first>K.</first><last>Hacioglu</last></author>
-  <author><first>W.</first><last>Ward</last></author>
+  <author><first>Kadri</first><last>Hacioglu</last></author>
+  <author><first>Wayne</first><last>Ward</last></author>
 </paper>
 
 <paper id="1059">
   <title>Portability Issues for Speech Recognition Technologies</title>
-  <author><first>L.</first><last>Lamel</last></author>
-  <author><first>F.</first><last>Lefevre</last></author>
-  <author><first>J.-L.</first><last>Gauvain</last></author>
-  <author><first>G.</first><last>Adda</last></author>
+  <author><first>Lori</first><last>Lamel</last></author>
+  <author><first>Fabrice</first><last>Lefevre</last></author>
+  <author><first>Jean-Luc</first><last>Gauvain</last></author>
+  <author><first>Gilles</first><last>Adda</last></author>
 </paper>
 
 <paper id="1060">
   <title>Rapidly Retargetable Interactive Translingual Retrieval</title>
-  <author><first>G.-A.</first><last>Levow</last></author>
-  <author><first>D.W.</first><last>Oard</last></author>
-  <author><first>P.</first><last>Resnik</last></author>
+  <author><first>Gina-Anne</first><last>Levow</last></author>
+  <author><first>Douglas W.</first><last>Oard</last></author>
+  <author><first>Philip</first><last>Resnik</last></author>
 </paper>
 
 <paper id="1061">
@@ -486,7 +489,7 @@
   <author><first>S.</first><last>Khudanpur</last></author>
   <author><first>B.</first><last>Hladká</last></author>
   <author><first>H.</first><last>Ney</last></author>
-  <author><first>F.J.</first><last>Och</last></author>
+  <author><first>F. J.</first><last>Och</last></author>
   <author><first>J.</first><last>Curín</last></author>
   <author><first>J.</first><last>Psutka</last></author>
 </paper>
@@ -494,82 +497,82 @@
 <paper id="1062">
   <title>The RWTH System for Statistical Translation of Spoken Dialogues</title>
   <author><first>H.</first><last>Ney</last></author>
-  <author><first>F.J.</first><last>Och</last></author>
+  <author><first>F. J.</first><last>Och</last></author>
   <author><first>S.</first><last>Vogel</last></author>
 </paper>
 
 <paper id="1063">
   <title>Scalability and Portability of a Belief Network-based Dialog Model for Different Application Domains</title>
-  <author><first>C.</first><last>Wai</last></author>
-  <author><first>H.M.</first><last>Meng</last></author>
-  <author><first>R.</first><last>Pieraccini</last></author>
+  <author><first>Carmen</first><last>Wai</last></author>
+  <author><first>Helen M.</first><last>Meng</last></author>
+  <author><first>Roberto</first><last>Pieraccini</last></author>
 </paper>
 
 <paper id="1064">
   <title>SCANMail: Audio Navigation in the Voicemail Domain</title>
-  <author><first>M.</first><last>Bacchiani</last></author>
-  <author><first>J.</first><last>Hirschberg</last></author>
-  <author><first>A.</first><last>Rosenberg</last></author>
-  <author><first>S.</first><last>Whittaker</last></author>
-  <author><first>D.</first><last>Hindle</last></author>
-  <author><first>P.</first><last>Isenhour</last></author>
-  <author><first>M.</first><last>Jones</last></author>
-  <author><first>L.</first><last>Stark</last></author>
-  <author><first>G.</first><last>Zamchick</last></author>
+  <author><first>Michiel</first><last>Bacchiani</last></author>
+  <author><first>Julia</first><last>Hirschberg</last></author>
+  <author><first>Aaron</first><last>Rosenberg</last></author>
+  <author><first>Steve</first><last>Whittaker</last></author>
+  <author><first>Donald</first><last>Hindle</last></author>
+  <author><first>Phil</first><last>Isenhour</last></author>
+  <author><first>Mark</first><last>Jones</last></author>
+  <author><first>Litza</first><last>Stark</last></author>
+  <author><first>Gary</first><last>Zamchick</last></author>
 </paper>
 
 <paper id="1065">
   <title>Sentence Ordering in Multidocument Summarization</title>
-  <author><first>R.</first><last>Barzilay</last></author>
-  <author><first>N.</first><last>Elhadad</last></author>
-  <author><first>K.</first><last>McKeown</last></author>
+  <author><first>Regina</first><last>Barzilay</last></author>
+  <author><first>Noemie</first><last>Elhadad</last></author>
+  <author><first>Kathleen R.</first><last>McKeown</last></author>
 </paper>
 
 <paper id="1066">
   <title>A Server for Real-Time Event Tracking in News</title>
-  <author><first>R.D.</first><last>Brown</last></author>
+  <author><first>Ralf D.</first><last>Brown</last></author>
 </paper>
 
 <paper id="1067">
   <title>The SynDiKATe Text Knowledge Base Generator</title>
-  <author><first>U.</first><last>Hahn</last></author>
-  <author><first>M.</first><last>Romacker</last></author>
+  <author><first>Udo</first><last>Hahn</last></author>
+  <author><first>Martin</first><last>Romacker</last></author>
 </paper>
 
 <paper id="1068">
   <title>A Three-Tiered Evaluation Approach for Interactive Spoken Dialogue Systems</title>
-  <author><first>K.</first><last>Stibler</last></author>
-  <author><first>J.</first><last>Denny</last></author>
+  <author><first>Kathleen</first><last>Stibler</last></author>
+  <author><first>James</first><last>Denny</last></author>
 </paper>
 
 <paper id="1069">
   <title>Toward Semantics-Based Answer Pinpointing</title>
-  <author><first>E.</first><last>Hovy</last></author>
-  <author><first>L.</first><last>Gerber</last></author>
-  <author><first>U.</first><last>Hermjakob</last></author>
-  <author><first>C.-Y.</first><last>Lin</last></author>
-  <author><first>D.</first><last>Ravichandran</last></author>
+  <author><first>Eduard</first><last>Hovy</last></author>
+  <author><first>Laurie</first><last>Gerber</last></author>
+  <author><first>Ulf</first><last>Hermjakob</last></author>
+  <author><first>Chin-Yew</first><last>Lin</last></author>
+  <author><first>Deepak</first><last>Ravichandran</last></author>
 </paper>
 
 <paper id="1070">
   <title>Towards an Intelligent Multilingual Keyboard System</title>
-  <author><first>T.</first><last>Potipiti</last></author>
-  <author><first>V.</first><last>Sornlertlamvanich</last></author>
-  <author><first>K.</first><last>Thanadkran</last></author>
+  <author><first>Tanapong</first><last>Potipiti</last></author>
+  <author><first>Virach</first><last>Sornlertlamvanich</last></author>
+  <author><first>Kanokwut</first><last>Thanadkran</last></author>
 </paper>
 
 <paper id="1071">
   <title>Towards Automatic Sign Translation</title>
-  <author><first>J.</first><last>Yang</last></author>
-  <author><first>J.</first><last>Gao</last></author>
-  <author><first>Y.</first><last>Zhang</last></author>
-  <author><first>A.</first><last>Waibel</last></author>
+  <author><first>Jie</first><last>Yang</last></author>
+  <author><first>Jiang</first><last>Gao</last></author>
+  <author><first>Ying</first><last>Zhang</last></author>
+  <author><first>Alex</first><last>Waibel</last></author>
 </paper>
 
 <paper id="1072">
   <title>TüSBL: A Similarity-Based Chunk Parser for Robust Syntactic Processing</title>
-  <author><first>S.</first><last>Kübler</last></author>
-  <author><first>E.W.</first><last>Hinrichs</last></author>
+  <author><first>Sandra</first><last>Kübler</last></author>
+  <author><first>Erhard W.</first><last>Hinrichs</last></author>
 </paper>
 
 <paper id="1073">
@@ -586,14 +589,14 @@
 
 <paper id="1074">
   <title>The Use of Dynamic Segment Scoring for Language-Independent Question Answering </title>
-  <author><first>D.</first><last>Pack</last></author>
-  <author><first>C.</first><last>Weinstein</last></author>
+  <author><first>Daniel</first><last>Pack</last></author>
+  <author><first>Clifford</first><last>Weinstein</last></author>
 </paper>
 
 <paper id="1075">
   <title>Using Speech and Language Technology to Coach Reading</title>
-  <author><first>P.</first><last>Price</last></author>
-  <author><first>L.</first><last>Julia</last></author>
+  <author><first>Patti</first><last>Price</last></author>
+  <author><first>Luc</first><last>Julia</last></author>
 </paper>
 
 </volume>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <volume id="L06">
   <paper id="1000">
     <title>Proceedings of the Fifth International Conference on Language Resources and Evaluation (LREC’06)</title>
@@ -16,7 +17,7 @@
     <bibkey>2006:lrec2006</bibkey>
   </paper>
   <paper id="1001" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/4_pdf.pdf">
-    <author><first>N.</first><last>Grønnum</last></author>
+    <author><first>Nina</first><last>Grønnum</last></author>
     <title>DanPASS - A Danish Phonetically Annotated Spontaneous Speech Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -26,8 +27,8 @@
     <bibkey>grønnum:4:2006:lrec2006</bibkey>
   </paper>
   <paper id="1002" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/6_pdf.pdf">
-    <author><first>A.</first><last>Wu</last></author>
-    <author><first>K.</first><last>Lowery</last></author>
+    <author><first>Andi</first><last>Wu</last></author>
+    <author><first>Kirk</first><last>Lowery</last></author>
     <title>A Hebrew Tree Bank Based on Cantillation Marks</title>
     <month>May</month>
     <year>2006</year>
@@ -37,8 +38,8 @@
     <bibkey>wu:6:2006:lrec2006</bibkey>
   </paper>
   <paper id="1003" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/8_pdf.pdf">
-    <author><first>S.</first><last>Chaudiron</last></author>
-    <author><first>J.</first><last>Mariani</last></author>
+    <author><first>Stéphane</first><last>Chaudiron</last></author>
+    <author><first>Joseph</first><last>Mariani</last></author>
     <title>Techno-langue: The French National Initiative for Human Language Technologies (HLT)</title>
     <month>May</month>
     <year>2006</year>
@@ -48,10 +49,10 @@
     <bibkey>chaudiron:8:2006:lrec2006</bibkey>
   </paper>
   <paper id="1004" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/9_pdf.pdf">
-    <author><first>M.</first><last>Rayner</last></author>
-    <author><first>P.</first><last>Bouillon</last></author>
-    <author><first>B.</first><last>Hockey</last></author>
-    <author><first>N.</first><last>Chatzichrisafis</last></author>
+    <author><first>Manny</first><last>Rayner</last></author>
+    <author><first>Pierrette</first><last>Bouillon</last></author>
+    <author><first>Beth Ann</first><last>Hockey</last></author>
+    <author><first>Nikos</first><last>Chatzichrisafis</last></author>
     <title>REGULUS: A Generic Multilingual Open Source Platform for Grammar-Based Speech Applications</title>
     <month>May</month>
     <year>2006</year>
@@ -61,9 +62,9 @@
     <bibkey>rayner:9:2006:lrec2006</bibkey>
   </paper>
   <paper id="1005" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/10_pdf.pdf">
-    <author><first>A.</first><last>Berglund</last></author>
-    <author><first>R.</first><last>Johansson</last></author>
-    <author><first>P.</first><last>Nugues</last></author>
+    <author><first>Anders</first><last>Berglund</last></author>
+    <author><first>Richard</first><last>Johansson</last></author>
+    <author><first>Pierre</first><last>Nugues</last></author>
     <title>Extraction of Temporal Information from Texts in Swedish</title>
     <month>May</month>
     <year>2006</year>
@@ -73,7 +74,7 @@
     <bibkey>berglund:10:2006:lrec2006</bibkey>
   </paper>
   <paper id="1006" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/11_pdf.pdf">
-    <author><first>J.</first><last>Hlaváèová</last></author>
+    <author><first>Jaroslava</first><last>Hlaváčová</last></author>
     <title>New Approach to Frequency Dictionaries - Czech Example</title>
     <month>May</month>
     <year>2006</year>
@@ -83,9 +84,9 @@
     <bibkey>hlaváèová:11:2006:lrec2006</bibkey>
   </paper>
   <paper id="1007" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/12_pdf.pdf">
-    <author><first>F.</first><last>Bustamante</last></author>
-    <author><first>A.</first><last>Arnaiz</last></author>
-    <author><first>M.</first><last>Ginés</last></author>
+    <author><first>Flora Ramírez</first><last>Bustamante</last></author>
+    <author><first>Alfredo</first><last>Arnaiz</last></author>
+    <author><first>Mar</first><last>Ginés</last></author>
     <title>A Spell Checker for a World Language: The New Microsoft’s Spanish Spell Checker</title>
     <month>May</month>
     <year>2006</year>
@@ -95,7 +96,7 @@
     <bibkey>bustamante:12:2006:lrec2006</bibkey>
   </paper>
   <paper id="1008" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/14_pdf.pdf">
-    <author><first>E.</first><last>Macklovitch</last></author>
+    <author><first>Elliott</first><last>Macklovitch</last></author>
     <title>TransType2 : The Last Word</title>
     <month>May</month>
     <year>2006</year>
@@ -105,10 +106,10 @@
     <bibkey>macklovitch:14:2006:lrec2006</bibkey>
   </paper>
   <paper id="1009" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/19_pdf.pdf">
-    <author><first>I.</first><last>Saratxaga</last></author>
-    <author><first>E.</first><last>Navas</last></author>
-    <author><first>I.</first><last>Hernáez</last></author>
-    <author><first>I.</first><last>Aholab</last></author>
+    <author><first>Ibon</first><last>Saratxaga</last></author>
+    <author><first>Eva</first><last>Navas</last></author>
+    <author><first>Inmaculada</first><last>Hernáez</last></author>
+    <author><first>Iker</first><last>Aholab</last></author>
     <title>Designing and Recording an Emotional Speech Database for Corpus Based Synthesis in Basque</title>
     <month>May</month>
     <year>2006</year>
@@ -118,7 +119,7 @@
     <bibkey>saratxaga:19:2006:lrec2006</bibkey>
   </paper>
   <paper id="1010" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/23_pdf.pdf">
-    <author><first>D.</first><last>Kokkinakis</last></author>
+    <author><first>Dimitrios</first><last>Kokkinakis</last></author>
     <title>Collection, Encoding and Linguistic Processing of a Swedish Medical Corpus - The MEDLEX Experience</title>
     <month>May</month>
     <year>2006</year>
@@ -128,10 +129,10 @@
     <bibkey>kokkinakis:23:2006:lrec2006</bibkey>
   </paper>
   <paper id="1011" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/29_pdf.pdf">
-    <author><first>N.</first><last>Masaki</last></author>
-    <author><first>I.</first><last>Hiroshi</last></author>
-    <author><first>H.</first><last>Taiichi</last></author>
-    <author><first>T.</first><last>Takenobu</last></author>
+    <author><first>Noguchi</first><last>Masaki</last></author>
+    <author><first>Ichikawa</first><last>Hiroshi</last></author>
+    <author><first>Hashimoto</first><last>Taiichi</last></author>
+    <author><first>Tokunaga</first><last>Takenobu</last></author>
     <title>A new approach to syntactic annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -141,8 +142,8 @@
     <bibkey>masaki:29:2006:lrec2006</bibkey>
   </paper>
   <paper id="1012" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/33_pdf.pdf">
-    <author><first>T.</first><last>Tan</last></author>
-    <author><first>L.</first><last>Besacier</last></author>
+    <author><first>Tien-Ping</first><last>Tan</last></author>
+    <author><first>Laurent</first><last>Besacier</last></author>
     <title>A French Non-Native Corpus for Automatic Speech Recognition</title>
     <month>May</month>
     <year>2006</year>
@@ -152,7 +153,7 @@
     <bibkey>tan:33:2006:lrec2006</bibkey>
   </paper>
   <paper id="1013" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/35_pdf.pdf">
-    <author><first>A.</first><last>Sansò</last></author>
+    <author><first>Andrea</first><last>Sansò</last></author>
     <title>Documenting variation across Europe and the Mediterranean: the Pavia Typological Database</title>
     <month>May</month>
     <year>2006</year>
@@ -165,7 +166,7 @@
     <author><first>M.</first><last>Bahrani</last></author>
     <author><first>H.</first><last>Sameti</last></author>
     <author><first>N.</first><last>Hafezi</last></author>
-    <author><first>H.</first><last>Movassagh</last></author>
+    <author><first>H.</first><last>Movasagh</last></author>
     <title>Building and Incorporating Language Models for Persian Continuous Speech Recognition Systems</title>
     <month>May</month>
     <year>2006</year>
@@ -175,10 +176,10 @@
     <bibkey>bahrani:36:2006:lrec2006</bibkey>
   </paper>
   <paper id="1015" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/37_pdf.pdf">
-    <author><first>S.</first><last>Tongchim</last></author>
-    <author><first>P.</first><last>Srichaivattana</last></author>
-    <author><first>V.</first><last>Sornlertlamvanich</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Shisanu</first><last>Tongchim</last></author>
+    <author><first>Prapass</first><last>Srichaivattana</last></author>
+    <author><first>Virach</first><last>Sornlertlamvanich</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Blind Evaluation for Thai Search Engines</title>
     <month>May</month>
     <year>2006</year>
@@ -188,12 +189,12 @@
     <bibkey>tongchim:37:2006:lrec2006</bibkey>
   </paper>
   <paper id="1016" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/39_pdf.pdf">
-    <author><first>Y.</first><last>Matsumoto</last></author>
-    <author><first>M.</first><last>Asahara</last></author>
-    <author><first>K.</first><last>Hashimoto</last></author>
-    <author><first>Y.</first><last>Tono</last></author>
-    <author><first>A.</first><last>Ohtani</last></author>
-    <author><first>T.</first><last>Morita</last></author>
+    <author><first>Yuji</first><last>Matsumoto</last></author>
+    <author><first>Masayuki</first><last>Asahara</last></author>
+    <author><first>Kiyota</first><last>Hashimoto</last></author>
+    <author><first>Yukio</first><last>Tono</last></author>
+    <author><first>Akira</first><last>Ohtani</last></author>
+    <author><first>Toshio</first><last>Morita</last></author>
     <title>An Annotated Corpus Management Tool: ChaKi</title>
     <month>May</month>
     <year>2006</year>
@@ -203,7 +204,7 @@
     <bibkey>matsumoto:39:2006:lrec2006</bibkey>
   </paper>
   <paper id="1017" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/43_pdf.pdf">
-    <author><first>C.</first><last>Jouis</last></author>
+    <author><first>Christophe</first><last>Jouis</last></author>
     <title>Hierarchical Relationships “is-a”: Distinguishing Belonging, Inclusion and Part/of Relationships.</title>
     <month>May</month>
     <year>2006</year>
@@ -213,10 +214,10 @@
     <bibkey>jouis:43:2006:lrec2006</bibkey>
   </paper>
   <paper id="1018" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/44_pdf.pdf">
-    <author><first>I.</first><last>Berlocher</last></author>
-    <author><first>K.</first><last>Huh</last></author>
-    <author><first>E.</first><last>Laporte</last></author>
-    <author><first>J.</first><last>Nam</last></author>
+    <author><first>Ivan</first><last>Berlocher</last></author>
+    <author><first>Hyun-gue</first><last>Huh</last></author>
+    <author><first>Eric</first><last>Laporte</last></author>
+    <author><first>Jee-sun</first><last>Nam</last></author>
     <title>Morphological annotation of Korean with Directly Maintainable Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -226,7 +227,7 @@
     <bibkey>berlocher:44:2006:lrec2006</bibkey>
   </paper>
   <paper id="1019" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/45_pdf.pdf">
-    <author><first>P.</first><last>Saint-dizier</last></author>
+    <author><first>Patrick</first><last>Saint-Dizier</last></author>
     <title>PrepNet: a Multilingual Lexical Description of Prepositions</title>
     <month>May</month>
     <year>2006</year>
@@ -236,8 +237,8 @@
     <bibkey>saint-dizier:45:2006:lrec2006</bibkey>
   </paper>
   <paper id="1020" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/48_pdf.pdf">
-    <author><first>M.</first><last>L’homme</last></author>
-    <author><first>H.</first><last>Bae </last></author>
+    <author><first>Marie-Claude</first><last>L’Homme</last></author>
+    <author><first>Hee Sook</first><last>Bae</last></author>
     <title>A Methodology for Developing Multilingual Resources for Terminology</title>
     <month>May</month>
     <year>2006</year>
@@ -247,9 +248,9 @@
     <bibkey>l’homme:48:2006:lrec2006</bibkey>
   </paper>
   <paper id="1021" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/49_pdf.pdf">
-    <author><first>S.</first><last>Raidt</last></author>
-    <author><first>G.</first><last>Bailly</last></author>
-    <author><first>F.</first><last>Elisei</last></author>
+    <author><first>Stephan</first><last>Raidt</last></author>
+    <author><first>Gérard</first><last>Bailly</last></author>
+    <author><first>Frederic</first><last>Elisei</last></author>
     <title>Does a Virtual Talking Face Generate Proper Multimodal Cues to Draw User’s Attention to Points of Interest?</title>
     <month>May</month>
     <year>2006</year>
@@ -259,7 +260,7 @@
     <bibkey>raidt:49:2006:lrec2006</bibkey>
   </paper>
   <paper id="1022" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/50_pdf.pdf">
-    <author><first>M.</first><last>Wong</last></author>
+    <author><first>May Lai-Yin</first><last>Wong</last></author>
     <title>Skeleton Parsing in Chinese: Annotation Scheme and Guidelines</title>
     <month>May</month>
     <year>2006</year>
@@ -269,8 +270,8 @@
     <bibkey>wong:50:2006:lrec2006</bibkey>
   </paper>
   <paper id="1023" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/52_pdf.pdf">
-    <author><first>C.</first><last>Orasan</last></author>
-    <author><first>L.</first><last>Hasler</last></author>
+    <author><first>Constantin</first><last>Orăsan</last></author>
+    <author><first>Laura</first><last>Hasler</last></author>
     <title>Computer-aided summarisation – what the user really wants</title>
     <month>May</month>
     <year>2006</year>
@@ -280,7 +281,7 @@
     <bibkey>orasan:52:2006:lrec2006</bibkey>
   </paper>
   <paper id="1024" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/54_pdf.pdf">
-    <author><first>N.</first><last>Xue</last></author>
+    <author><first>Nianwen</first><last>Xue</last></author>
     <title>Annotating the Predicate-Argument Structure of Chinese Nominalizations</title>
     <month>May</month>
     <year>2006</year>
@@ -290,8 +291,8 @@
     <bibkey>xue:54:2006:lrec2006</bibkey>
   </paper>
   <paper id="1025" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/55_pdf.pdf">
-    <author><first>K.</first><last>Kageura</last></author>
-    <author><first>G.</first><last>Kikui</last></author>
+    <author><first>Kyo</first><last>Kageura</last></author>
+    <author><first>Genichiro</first><last>Kikui</last></author>
     <title>A Self-Referring Quantitative Evaluation of the ATR Basic Travel Expression Corpus (BTEC)</title>
     <month>May</month>
     <year>2006</year>
@@ -301,11 +302,11 @@
     <bibkey>kageura:55:2006:lrec2006</bibkey>
   </paper>
   <paper id="1026" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/58_pdf.pdf">
-    <author><first>H.</first><last>Ozaku</last></author>
-    <author><first>A.</first><last>Abe</last></author>
-    <author><first>K.</first><last>Sagara</last></author>
-    <author><first>N.</first><last>Kuwahara</last></author>
-    <author><first>K.</first><last>Kogure</last></author>
+    <author><first>Hiromi itoh</first><last>Ozaku</last></author>
+    <author><first>Akinori</first><last>Abe</last></author>
+    <author><first>Kaoru</first><last>Sagara</last></author>
+    <author><first>Noriaki</first><last>Kuwahara</last></author>
+    <author><first>Kiyoshi</first><last>Kogure</last></author>
     <title>Features of Terms in Actual Nursing Activities</title>
     <month>May</month>
     <year>2006</year>
@@ -315,10 +316,10 @@
     <bibkey>ozaku:58:2006:lrec2006</bibkey>
   </paper>
   <paper id="1027" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/59_pdf.pdf">
-    <author><first>D.</first><last>Santos</last></author>
-    <author><first>N.</first><last>Seco</last></author>
-    <author><first>N.</first><last>Cardoso</last></author>
-    <author><first>R.</first><last>Vilela</last></author>
+    <author><first>Diana</first><last>Santos</last></author>
+    <author><first>Nuno</first><last>Seco</last></author>
+    <author><first>Nuno</first><last>Cardoso</last></author>
+    <author><first>Rui</first><last>Vilela</last></author>
     <title>HAREM: An Advanced NER Evaluation Contest for Portuguese</title>
     <month>May</month>
     <year>2006</year>
@@ -328,9 +329,9 @@
     <bibkey>santos:59:2006:lrec2006</bibkey>
   </paper>
   <paper id="1028" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/60_pdf.pdf">
-    <author><first>R.</first><last>Banchs</last></author>
-    <author><first>A.</first><last>Bonafonte</last></author>
-    <author><first>J.</first><last>Pérez</last></author>
+    <author><first>Rafael</first><last>Banchs</last></author>
+    <author><first>Antonio</first><last>Bonafonte</last></author>
+    <author><first>Javier</first><last>Pérez</last></author>
     <title>Acceptance Testing of a Spoken Language Translation System</title>
     <month>May</month>
     <year>2006</year>
@@ -340,10 +341,10 @@
     <bibkey>banchs:60:2006:lrec2006</bibkey>
   </paper>
   <paper id="1029" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/64_pdf.pdf">
-    <author><first>V.</first><last>Tablan</last></author>
-    <author><first>W.</first><last>Peters</last></author>
-    <author><first>D.</first><last>Maynard</last></author>
-    <author><first>H.</first><last>Cunningham</last></author>
+    <author><first>Valentin</first><last>Tablan</last></author>
+    <author><first>Wim</first><last>Peters</last></author>
+    <author><first>Diana</first><last>Maynard</last></author>
+    <author><first>Hamish</first><last>Cunningham</last></author>
     <title>Creating Tools for Morphological Analysis of Sumerian</title>
     <month>May</month>
     <year>2006</year>
@@ -353,8 +354,8 @@
     <bibkey>tablan:64:2006:lrec2006</bibkey>
   </paper>
   <paper id="1030" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/66_pdf.pdf">
-    <author><first>I.</first><last>Amdal</last></author>
-    <author><first>T.</first><last>Svendsen</last></author>
+    <author><first>Ingunn</first><last>Amdal</last></author>
+    <author><first>Torbjørn</first><last>Svendsen</last></author>
     <title>FonDat1: A Speech Synthesis Corpus for Norwegian</title>
     <month>May</month>
     <year>2006</year>
@@ -364,9 +365,9 @@
     <bibkey>amdal:66:2006:lrec2006</bibkey>
   </paper>
   <paper id="1031" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/67_pdf.pdf">
-    <author><first>A.</first><last>Itai</last></author>
-    <author><first>S.</first><last>Wintner</last></author>
-    <author><first>S.</first><last>Yona</last></author>
+    <author><first>Alon</first><last>Itai</last></author>
+    <author><first>Shuly</first><last>Wintner</last></author>
+    <author><first>Shlomo</first><last>Yona</last></author>
     <title>A Computational Lexicon of Contemporary Hebrew</title>
     <month>May</month>
     <year>2006</year>
@@ -376,7 +377,7 @@
     <bibkey>itai:67:2006:lrec2006</bibkey>
   </paper>
   <paper id="1032" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/68_pdf.pdf">
-    <author><first>R.</first><last>Ivanovska-naskova</last></author>
+    <author><first>Ruska</first><last>Ivanovska-Naskova</last></author>
     <title>Development of the First LRs for Macedonian: Current Projects</title>
     <month>May</month>
     <year>2006</year>
@@ -386,8 +387,8 @@
     <bibkey>ivanovska-naskova:68:2006:lrec2006</bibkey>
   </paper>
   <paper id="1033" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/74_pdf.pdf">
-    <author><first>R.</first><last>Rapp</last></author>
-    <author><first>C.</first><last>Vide</last></author>
+    <author><first>Reinhard</first><last>Rapp</last></author>
+    <author><first>Carlos Martin</first><last>Vide</last></author>
     <title>Example-Based Machine Translation Using a Dictionary of Word Pairs</title>
     <month>May</month>
     <year>2006</year>
@@ -397,12 +398,12 @@
     <bibkey>rapp:74:2006:lrec2006</bibkey>
   </paper>
   <paper id="1034" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/75_pdf.pdf">
-    <author><first>W. Mustafa</first><last>el Hadi</last></author>
-    <author><first>I.</first><last>Timimi</last></author>
-    <author><first>M.</first><last>Dabbadie</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
-    <author><first>O.</first><last>Hamon</last></author>
-    <author><first>Y.</first><last>Chiao</last></author>
+    <author><first>Widad Mustafa</first><last>El Hadi</last></author>
+    <author><first>Ismail</first><last>Timimi</last></author>
+    <author><first>Marianne</first><last>Dabbadie</last></author>
+    <author><first>Khalid</first><last>Choukri</last></author>
+    <author><first>Olivier</first><last>Hamon</last></author>
+    <author><first>Yun-Chuang</first><last>Chiao</last></author>
     <title>Terminological Resources Acquisition Tools: Toward a User-oriented Evaluation Model</title>
     <month>May</month>
     <year>2006</year>
@@ -412,9 +413,9 @@
     <bibkey>hadi:75:2006:lrec2006</bibkey>
   </paper>
   <paper id="1035" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/76_pdf.pdf">
-    <author><first>N.</first><last>Bel</last></author>
-    <author><first>S.</first><last>Espeja</last></author>
-    <author><first>M.</first><last>Marimon</last></author>
+    <author><first>Núria</first><last>Bel</last></author>
+    <author><first>Sergio</first><last>Espeja</last></author>
+    <author><first>Montserrat</first><last>Marimon</last></author>
     <title>New tools for the encoding of lexical data extracted from corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -424,10 +425,10 @@
     <bibkey>bel:76:2006:lrec2006</bibkey>
   </paper>
   <paper id="1036" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/77_pdf.pdf">
-    <author><first>D.</first><last>Braga</last></author>
-    <author><first>L.</first><last>Coelho</last></author>
-    <author><first>J.</first><last>Teixeira</last></author>
-    <author><first>D.</first><last>Freitas</last></author>
+    <author><first>Daniela</first><last>Braga</last></author>
+    <author><first>Luís</first><last>Coelho</last></author>
+    <author><first>João P.</first><last>Teixeira</last></author>
+    <author><first>Diamantino</first><last>Freitas</last></author>
     <title>Progmatica: A Prosodic Database for European Portuguese</title>
     <month>May</month>
     <year>2006</year>
@@ -437,8 +438,8 @@
     <bibkey>braga:77:2006:lrec2006</bibkey>
   </paper>
   <paper id="1037" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/79_pdf.pdf">
-    <author><first>J.</first><last>Giménez</last></author>
-    <author><first>E.</first><last>Amigó</last></author>
+    <author><first>Jesús</first><last>Giménez</last></author>
+    <author><first>Enrique</first><last>Amigó</last></author>
     <title>Iqmt: A Framework for Automatic Machine Translation Evaluation</title>
     <month>May</month>
     <year>2006</year>
@@ -448,8 +449,8 @@
     <bibkey>giménez:79:2006:lrec2006</bibkey>
   </paper>
   <paper id="1038" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/80_pdf.pdf">
-    <author><first>T.</first><last>Caselli</last></author>
-    <author><first>I.</first><last>Prodanof</last></author>
+    <author><first>Tommaso</first><last>Caselli</last></author>
+    <author><first>Irina</first><last>Prodanof</last></author>
     <title>Annotating Bridging Anaphors in Italian: in Search of Reliability</title>
     <month>May</month>
     <year>2006</year>
@@ -459,11 +460,11 @@
     <bibkey>caselli:80:2006:lrec2006</bibkey>
   </paper>
   <paper id="1039" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/81_pdf.pdf">
-    <author><first>H.</first><last>Heuvel</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
-    <author><first>C.</first><last>Gollan</last></author>
-    <author><first>A.</first><last>Moreno</last></author>
-    <author><first>D.</first><last>Mostefa</last></author>
+    <author><first>Henk van den</first><last>Heuvel</last></author>
+    <author><first>Khalid</first><last>Choukri</last></author>
+    <author><first>Christian</first><last>Gollan</last></author>
+    <author><first>Asuncion</first><last>Moreno</last></author>
+    <author><first>Djamel</first><last>Mostefa</last></author>
     <title>TC-STAR: New language resources for ASR and SLT purposes</title>
     <month>May</month>
     <year>2006</year>
@@ -473,9 +474,9 @@
     <bibkey>heuvel:81:2006:lrec2006</bibkey>
   </paper>
   <paper id="1040" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/86_pdf.pdf">
-    <author><first>Y.</first><last>Xia</last></author>
-    <author><first>K.</first><last>Wong.</last></author>
-    <author><first>Wen.</first><last>Li</last></author>
+    <author><first>Yunqing</first><last>Xia</last></author>
+    <author><first>Kam-Fai</first><last>Wong</last></author>
+    <author><first>Wenjie</first><last>Li</last></author>
     <title>Constructing A Chinese Chat Language Corpus with A Two-Stage Incremental Annotation Approach</title>
     <month>May</month>
     <year>2006</year>
@@ -485,7 +486,7 @@
     <bibkey>xia:86:2006:lrec2006</bibkey>
   </paper>
   <paper id="1041" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/87_pdf.pdf">
-    <author><first>B.</first><last>Hughes</last></author>
+    <author><first>Baden</first><last>Hughes</last></author>
     <title>Searching for Language Resources on the Web: User Behaviour in the Open Language Archives Community</title>
     <month>May</month>
     <year>2006</year>
@@ -495,10 +496,10 @@
     <bibkey>hughes:87:2006:lrec2006</bibkey>
   </paper>
   <paper id="1042" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/88_pdf.pdf">
-    <author><first>Y.</first><last>Ohishi</last></author>
-    <author><first>K.</first><last>Itou</last></author>
-    <author><first>K.</first><last>Takeda</last></author>
-    <author><first>A.</first><last>Fujii</last></author>
+    <author><first>Yasunori</first><last>Ohishi</last></author>
+    <author><first>Katunobu</first><last>Itou</last></author>
+    <author><first>Kazuya</first><last>Takeda</last></author>
+    <author><first>Atsushi</first><last>Fujii</last></author>
     <title>Statistical Analysis for Thesaurus Construction using an Encyclopedic Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -508,9 +509,9 @@
     <bibkey>ohishi:88:2006:lrec2006</bibkey>
   </paper>
   <paper id="1043" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/89_pdf.pdf">
-    <author><first>C.</first><last>Havasi</last></author>
-    <author><first>J.</first><last>Pustejovsky</last></author>
-    <author><first>M.</first><last>Verhagen</last></author>
+    <author><first>Catherine</first><last>Havasi</last></author>
+    <author><first>James</first><last>Pustejovsky</last></author>
+    <author><first>Marc</first><last>Verhagen</last></author>
     <title>BULB: A Unified Lexical Browser</title>
     <month>May</month>
     <year>2006</year>
@@ -520,8 +521,8 @@
     <bibkey>havasi:89:2006:lrec2006</bibkey>
   </paper>
   <paper id="1044" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/91_pdf.pdf">
-    <author><first>U.</first><last>Schäfer</last></author>
-    <author><first>D.</first><last>Beck</last></author>
+    <author><first>Ulrich</first><last>Schäfer</last></author>
+    <author><first>Daniel</first><last>Beck</last></author>
     <title>Automatic Testing and Evaluation of Multilingual Language Technology Resources and Components</title>
     <month>May</month>
     <year>2006</year>
@@ -531,7 +532,7 @@
     <bibkey>schäfer:91:2006:lrec2006</bibkey>
   </paper>
   <paper id="1045" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/92_pdf.pdf">
-    <author><first>E.</first><last>Grishina</last></author>
+    <author><first>Elena</first><last>Grishina</last></author>
     <title>Spoken Russian in the Russian National Corpus (RNC)</title>
     <month>May</month>
     <year>2006</year>
@@ -541,10 +542,10 @@
     <bibkey>grishina:92:2006:lrec2006</bibkey>
   </paper>
   <paper id="1046" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/93_pdf.pdf">
-    <author><first>P.</first><last>Buitelaar</last></author>
-    <author><first>P.</first><last>Cimiano</last></author>
-    <author><first>S.</first><last>Racioppa</last></author>
-    <author><first>M.</first><last>Siegel</last></author>
+    <author><first>Paul</first><last>Buitelaar</last></author>
+    <author><first>Philipp</first><last>Cimiano</last></author>
+    <author><first>Stefania</first><last>Racioppa</last></author>
+    <author><first>Melanie</first><last>Siegel</last></author>
     <title>Ontology-based Information Extraction with SOBA</title>
     <month>May</month>
     <year>2006</year>
@@ -554,7 +555,7 @@
     <bibkey>buitelaar:93:2006:lrec2006</bibkey>
   </paper>
   <paper id="1047" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/94_pdf.pdf">
-    <author><first>D.</first><last>Dutoit</last></author>
+    <author><first>Dominique</first><last>Dutoit</last></author>
     <title>Alexandria: A Powerful Multilingual Resource for Web</title>
     <month>May</month>
     <year>2006</year>
@@ -564,8 +565,8 @@
     <bibkey>dutoit:94:2006:lrec2006</bibkey>
   </paper>
   <paper id="1048" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/96_pdf.pdf">
-    <author><first>J.</first><last>Maas</last></author>
-    <author><first>B.</first><last>Wrede</last></author>
+    <author><first>Jan Frederik</first><last>Maas</last></author>
+    <author><first>Britta</first><last>Wrede</last></author>
     <title>BITT: A Corpus for Topic Tracking Evaluation on Multimodal Human-Robot-Interaction</title>
     <month>May</month>
     <year>2006</year>
@@ -575,8 +576,8 @@
     <bibkey>maas:96:2006:lrec2006</bibkey>
   </paper>
   <paper id="1049" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/97_pdf.pdf">
-    <author><first>H.</first><last>Dalianis</last></author>
-    <author><first>B.</first><last>Jongejan</last></author>
+    <author><first>Hercules</first><last>Dalianis</last></author>
+    <author><first>Bart</first><last>Jongejan</last></author>
     <title>Hand-crafted versus Machine-learned Inflectional Rules: The Euroling-SiteSeeker Stemmer and CST’s Lemmatiser</title>
     <month>May</month>
     <year>2006</year>
@@ -586,8 +587,8 @@
     <bibkey>dalianis:97:2006:lrec2006</bibkey>
   </paper>
   <paper id="1050" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/99_pdf.pdf">
-    <author><first>C.</first><last>Rohrer</last></author>
-    <author><first>M.</first><last>Forst</last></author>
+    <author><first>Christian</first><last>Rohrer</last></author>
+    <author><first>Martin</first><last>Forst</last></author>
     <title>Improving coverage and parsing quality of a large-scale LFG for German</title>
     <month>May</month>
     <year>2006</year>
@@ -597,7 +598,7 @@
     <bibkey>rohrer:99:2006:lrec2006</bibkey>
   </paper>
   <paper id="1051" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/100_pdf.pdf">
-    <author><first>B.</first><last>Schrader</last></author>
+    <author><first>Bettina</first><last>Schrader</last></author>
     <title>Non-probabilistic alignment of rare German and English nominal expressions</title>
     <month>May</month>
     <year>2006</year>
@@ -607,8 +608,8 @@
     <bibkey>schrader:100:2006:lrec2006</bibkey>
   </paper>
   <paper id="1052" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/101_pdf.pdf">
-    <author><first>P.</first><last>Chesley</last></author>
-    <author><first>S.</first><last>Salmon-alt</last></author>
+    <author><first>Paula</first><last>Chesley</last></author>
+    <author><first>Susanne</first><last>Salmon-Alt</last></author>
     <title>Automatic extraction of subcategorization frames for French</title>
     <month>May</month>
     <year>2006</year>
@@ -618,11 +619,11 @@
     <bibkey>chesley:101:2006:lrec2006</bibkey>
   </paper>
   <paper id="1053" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/103_pdf.pdf">
-    <author><first>Y.</first><last>Irie</last></author>
-    <author><first>S.</first><last>Matsubara</last></author>
-    <author><first>N.</first><last>Kawaguchi</last></author>
-    <author><first>Y.</first><last>Yamaguchi</last></author>
-    <author><first>Y.</first><last>Inagaki</last></author>
+    <author><first>Yuki</first><last>Irie</last></author>
+    <author><first>Shigeki</first><last>Matsubara</last></author>
+    <author><first>Nobuo</first><last>Kawaguchi</last></author>
+    <author><first>Yukiko</first><last>Yamaguchi</last></author>
+    <author><first>Yasuyoshi</first><last>Inagaki</last></author>
     <title>Layered Speech-Act Annotation for Spoken Dialogue Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -632,9 +633,9 @@
     <bibkey>irie:103:2006:lrec2006</bibkey>
   </paper>
   <paper id="1054" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/104_pdf.pdf">
-    <author><first>K.</first><last>Ahmad</last></author>
-    <author><first>C.</first><last>Bennett</last></author>
-    <author><first>T.</first><last>Oliver</last></author>
+    <author><first>Khurshid</first><last>Ahmad</last></author>
+    <author><first>Craig</first><last>Bennett</last></author>
+    <author><first>Tim</first><last>Oliver</last></author>
     <title>Visual Surveillance and Video Annotation and Description</title>
     <month>May</month>
     <year>2006</year>
@@ -644,8 +645,8 @@
     <bibkey>ahmad:104:2006:lrec2006</bibkey>
   </paper>
   <paper id="1055" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/105_pdf.pdf">
-    <author><first>M.</first><last>Mangeot</last></author>
-    <author><first>A.</first><last>Chalvin</last></author>
+    <author><first>Mathieu</first><last>Mangeot</last></author>
+    <author><first>Antoine</first><last>Chalvin</last></author>
     <title>Dictionary Building with the Jibiki Platform: the GDEF case</title>
     <month>May</month>
     <year>2006</year>
@@ -655,11 +656,11 @@
     <bibkey>mangeot:105:2006:lrec2006</bibkey>
   </paper>
   <paper id="1056" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/106_pdf.pdf">
-    <author><first>T.</first><last>Ohno</last></author>
-    <author><first>S.</first><last>Matsubara</last></author>
-    <author><first>H.</first><last>Kashioka</last></author>
-    <author><first>N.</first><last>Kato</last></author>
-    <author><first>Y.</first><last>Inagaki</last></author>
+    <author><first>Tomohiro</first><last>Ohno</last></author>
+    <author><first>Shigeki</first><last>Matsubara</last></author>
+    <author><first>Hideki</first><last>Kashioka</last></author>
+    <author><first>Naoto</first><last>Kato</last></author>
+    <author><first>Yasuyoshi</first><last>Inagaki</last></author>
     <title>A Syntactically Annotated Corpus of Japanese Spoken Monologue</title>
     <month>May</month>
     <year>2006</year>
@@ -669,10 +670,10 @@
     <bibkey>ohno:106:2006:lrec2006</bibkey>
   </paper>
   <paper id="1057" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/111_pdf.pdf">
-    <author><first>J.</first><last>Gros</last></author>
-    <author><first>V.</first><last>Cvetko-orešnik</last></author>
-    <author><first>P.</first><last>Jakopin</last></author>
-    <author><first>A.</first><last>Mihelic</last></author>
+    <author><first>Jerneja Žganec</first><last>Gros</last></author>
+    <author><first>Varja</first><last>Cvetko-Orešnik</last></author>
+    <author><first>Primož</first><last>Jakopin</last></author>
+    <author><first>Aleš</first><last>Mihelic</last></author>
     <title>SI-PRON: A Pronunciation Lexicon for Slovenian</title>
     <month>May</month>
     <year>2006</year>
@@ -682,7 +683,7 @@
     <bibkey>gros:111:2006:lrec2006</bibkey>
   </paper>
   <paper id="1058" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/112_pdf.pdf">
-    <author><first>S.</first><last>Cinková</last></author>
+    <author><first>Silvie</first><last>Cinková</last></author>
     <title>From PropBank to EngValLex: Adapting the PropBank-Lexicon to the Valency Theory of the Functional Generative Description</title>
     <month>May</month>
     <year>2006</year>
@@ -692,8 +693,8 @@
     <bibkey>cinková:112:2006:lrec2006</bibkey>
   </paper>
   <paper id="1059" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/113_pdf.pdf">
-    <author><first>T.</first><last>Wandmacher</last></author>
-    <author><first>J.</first><last>Antoine</last></author>
+    <author><first>Tonio</first><last>Wandmacher</last></author>
+    <author><first>Jean-Yves</first><last>Antoine</last></author>
     <title>Training Language Models without Appropriate Language Resources: Experiments with an AAC System for Disabled People</title>
     <month>May</month>
     <year>2006</year>
@@ -703,21 +704,21 @@
     <bibkey>wandmacher:113:2006:lrec2006</bibkey>
   </paper>
   <paper id="1060" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/116_pdf.pdf">
-    <author><first>B.</first><last>Roark</last></author>
-    <author><first>M.</first><last>Harper</last></author>
-    <author><first>E.</first><last>Charniak</last></author>
-    <author><first>B.</first><last>Dorr</last></author>
-    <author><first>M.</first><last>Johnson</last></author>
-    <author><first>J.</first><last>Kahn</last></author>
-    <author><first>Y.</first><last>Liu</last></author>
-    <author><first>M.</first><last>Ostendorf</last></author>
-    <author><first>J.</first><last>Hale</last></author>
-    <author><first>A.</first><last>Krasnyanskaya</last></author>
-    <author><first>M.</first><last>Lease</last></author>
-    <author><first>I.</first><last>Shafran</last></author>
-    <author><first>M.</first><last>Snover</last></author>
-    <author><first>R.</first><last>Stewart</last></author>
-    <author><first>L.</first><last>Yung</last></author>
+    <author><first>Brian</first><last>Roark</last></author>
+    <author><first>Mary</first><last>Harper</last></author>
+    <author><first>Eugene</first><last>Charniak</last></author>
+    <author><first>Bonnie</first><last>Dorr</last></author>
+    <author><first>Mark</first><last>Johnson</last></author>
+    <author><first>Jeremy</first><last>Kahn</last></author>
+    <author><first>Yang</first><last>Liu</last></author>
+    <author><first>Mari</first><last>Ostendorf</last></author>
+    <author><first>John</first><last>Hale</last></author>
+    <author><first>Anna</first><last>Krasnyanskaya</last></author>
+    <author><first>Matthew</first><last>Lease</last></author>
+    <author><first>Izhak</first><last>Shafran</last></author>
+    <author><first>Matthew</first><last>Snover</last></author>
+    <author><first>Robin</first><last>Stewart</last></author>
+    <author><first>Lisa</first><last>Yung</last></author>
     <title>SParseval: Evaluation Metrics for Parsing Speech</title>
     <month>May</month>
     <year>2006</year>
@@ -727,8 +728,8 @@
     <bibkey>roark:116:2006:lrec2006</bibkey>
   </paper>
   <paper id="1061" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/118_pdf.pdf">
-    <author><first>M.</first><last>Lin</last></author>
-    <author><first>H.</first><last>Chen</last></author>
+    <author><first>Ming-Shun</first><last>Lin</last></author>
+    <author><first>Hsin-Hsi</first><last>Chen</last></author>
     <title>Constructing a Named Entity Ontology from Web Corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -738,8 +739,8 @@
     <bibkey>lin:118:2006:lrec2006</bibkey>
   </paper>
   <paper id="1062" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/119_pdf.pdf">
-    <author><first>F.</first><last>Bustamante</last></author>
-    <author><first>E.</first><last>Díaz</last></author>
+    <author><first>Flora Ramírez</first><last>Bustamante</last></author>
+    <author><first>Enrique López</first><last>Díaz</last></author>
     <title>Spelling Error Patterns in Spanish for Word Processing Applications</title>
     <month>May</month>
     <year>2006</year>
@@ -749,9 +750,9 @@
     <bibkey>bustamante:119:2006:lrec2006</bibkey>
   </paper>
   <paper id="1063" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/124_pdf.pdf">
-    <author><first>A.</first><last>Nøklestad</last></author>
-    <author><first>Ø.</first><last>Reigem</last></author>
-    <author><first>C.</first><last>Johansson</last></author>
+    <author><first>Anders</first><last>Nøklestad</last></author>
+    <author><first>Øystein</first><last>Reigem</last></author>
+    <author><first>Christer</first><last>Johansson</last></author>
     <title>Developing a re-usable web-demonstrator for automatic anaphora resolution with support for manual editing of coreference chains</title>
     <month>May</month>
     <year>2006</year>
@@ -761,8 +762,8 @@
     <bibkey>nøklestad:124:2006:lrec2006</bibkey>
   </paper>
   <paper id="1064" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/125_pdf.pdf">
-    <author><first>H.</first><last>Tohyama</last></author>
-    <author><first>S.</first><last>Matsubara</last></author>
+    <author><first>Hitomi</first><last>Tohyama</last></author>
+    <author><first>Shigeki</first><last>Matsubara</last></author>
     <title>Collection of Simultaneous Interpreting Patterns by Using Bilingual Spoken Monologue Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -772,9 +773,9 @@
     <bibkey>tohyama:125:2006:lrec2006</bibkey>
   </paper>
   <paper id="1065" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/127_pdf.pdf">
-    <author><first>S.</first><last>Itahashi</last></author>
-    <author><first>C.</first><last>Tseng</last></author>
-    <author><first>S.</first><last>Nakamura</last></author>
+    <author><first>Shuichi</first><last>Itahashi</last></author>
+    <author><first>Chiu-yu</first><last>Tseng</last></author>
+    <author><first>Satoshi</first><last>Nakamura</last></author>
     <title>Oriental COCOSDA: Past, Present and Future</title>
     <month>May</month>
     <year>2006</year>
@@ -784,8 +785,8 @@
     <bibkey>itahashi:127:2006:lrec2006</bibkey>
   </paper>
   <paper id="1066" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/128_pdf.pdf">
-    <author><first>A.</first><last>Storrer</last></author>
-    <author><first>S.</first><last>Wellinghoff</last></author>
+    <author><first>Angelika</first><last>Storrer</last></author>
+    <author><first>Sandra</first><last>Wellinghoff</last></author>
     <title>Automated detection and annotation of term definitions in German text corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -808,7 +809,7 @@
     <author><first>B.</first><last>Haddad</last></author>
     <author><first>C.</first><last>Mukbel</last></author>
     <author><first>A.</first><last>Mouradi</last></author>
-    <author><first>A.</first><last>Al-kufaishi</last></author>
+    <author><first>A.</first><last>Al-Kufaishi</last></author>
     <author><first>M.</first><last>Shahin</last></author>
     <author><first>N.</first><last>Chenfour</last></author>
     <author><first>A.</first><last>Ragheb</last></author>
@@ -821,12 +822,12 @@
     <bibkey>yaseen:131:2006:lrec2006</bibkey>
   </paper>
   <paper id="1068" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/133_pdf.pdf">
-    <author><first>S.</first><last>Džeroski</last></author>
-    <author><first>T.</first><last>Erjavec</last></author>
-    <author><first>N.</first><last>Ledinek</last></author>
-    <author><first>P.</first><last>Pajas</last></author>
-    <author><first>Z.</first><last>Žabokrtsky</last></author>
-    <author><first>A.</first><last>Žele</last></author>
+    <author><first>Sašo</first><last>Džeroski</last></author>
+    <author><first>Tomaž</first><last>Erjavec</last></author>
+    <author><first>Nina</first><last>Ledinek</last></author>
+    <author><first>Petr</first><last>Pajas</last></author>
+    <author><first>Zdenek</first><last>Žabokrtsky</last></author>
+    <author><first>Andreja</first><last>Žele</last></author>
     <title>Towards a Slovene Dependency Treebank</title>
     <month>May</month>
     <year>2006</year>
@@ -836,9 +837,9 @@
     <bibkey>džeroski:133:2006:lrec2006</bibkey>
   </paper>
   <paper id="1069" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/137_pdf.pdf">
-    <author><first>C.</first><last>Kruengkrai</last></author>
-    <author><first>V.</first><last>Sornlertlamvanich</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Canasai</first><last>Kruengkrai</last></author>
+    <author><first>Virach</first><last>Sornlertlamvanich</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>A Conditional Random Field Framework for Thai Morphological Analysis</title>
     <month>May</month>
     <year>2006</year>
@@ -848,9 +849,9 @@
     <bibkey>kruengkrai:137:2006:lrec2006</bibkey>
   </paper>
   <paper id="1070" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/138_pdf.pdf">
-    <author><first>Y.</first><last>Kato</last></author>
-    <author><first>S.</first><last>Matsubara</last></author>
-    <author><first>Y.</first><last>Inagaki</last></author>
+    <author><first>Yoshihide</first><last>Kato</last></author>
+    <author><first>Shigeki</first><last>Matsubara</last></author>
+    <author><first>Yasuyoshi</first><last>Inagaki</last></author>
     <title>A Corpus Search System Utilizing Lexical Dependency Structure</title>
     <month>May</month>
     <year>2006</year>
@@ -860,8 +861,8 @@
     <bibkey>kato:138:2006:lrec2006</bibkey>
   </paper>
   <paper id="1071" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/139_pdf.pdf">
-    <author><first>P.</first><last>Berck</last></author>
-    <author><first>A.</first><last>Russel</last></author>
+    <author><first>Peter</first><last>Berck</last></author>
+    <author><first>Albert</first><last>Russel</last></author>
     <title>ANNEX - a web-based Framework for Exploiting Annotated Media Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -871,7 +872,7 @@
     <bibkey>berck:139:2006:lrec2006</bibkey>
   </paper>
   <paper id="1072" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/140_pdf.pdf">
-    <author><first>T.</first><last>Erjavec</last></author>
+    <author><first>Tomaž</first><last>Erjavec</last></author>
     <title>The English-Slovene ACQUIS corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -881,12 +882,12 @@
     <bibkey>erjavec:140:2006:lrec2006</bibkey>
   </paper>
   <paper id="1073" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/141_pdf.pdf">
-    <author><first>D.</first><last>Broeder</last></author>
-    <author><first>A.</first><last>Claus</last></author>
-    <author><first>F.</first><last>Offenga</last></author>
-    <author><first>R.</first><last>Skiba</last></author>
-    <author><first>P.</first><last>Trilsbeek</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
+    <author><first>Daan</first><last>Broeder</last></author>
+    <author><first>Andreas</first><last>Claus</last></author>
+    <author><first>Freddy</first><last>Offenga</last></author>
+    <author><first>Romuald</first><last>Skiba</last></author>
+    <author><first>Paul</first><last>Trilsbeek</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
     <title>LAMUS: the Language Archive Management and Upload System</title>
     <month>May</month>
     <year>2006</year>
@@ -896,12 +897,12 @@
     <bibkey>broeder:141:2006:lrec2006</bibkey>
   </paper>
   <paper id="1074" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/142_pdf.pdf">
-    <author><first>D.</first><last>Broeder</last></author>
-    <author><first>F.</first><last>Offenga</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>P.</first><last>Kamp</last></author>
-    <author><first>D.</first><last>Nathan</last></author>
-    <author><first>S.</first><last>Strömqvist</last></author>
+    <author><first>Daan</first><last>Broeder</last></author>
+    <author><first>Freddy</first><last>Offenga</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
+    <author><first>Peter van der</first><last>Kamp</last></author>
+    <author><first>David</first><last>Nathan</last></author>
+    <author><first>Sven</first><last>Strömqvist</last></author>
     <title>Technologies for a Federation of Language Resource Archives</title>
     <month>May</month>
     <year>2006</year>
@@ -911,10 +912,10 @@
     <bibkey>broeder:142:2006:lrec2006</bibkey>
   </paper>
   <paper id="1075" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/146_pdf.pdf">
-    <author><first>M.</first><last>Kemps-snijders</last></author>
-    <author><first>J.</first><last>Ducret</last></author>
-    <author><first>L.</first><last>Romary</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
+    <author><first>Marc</first><last>Kemps-Snijders</last></author>
+    <author><first>Julien</first><last>Ducret</last></author>
+    <author><first>Laurent</first><last>Romary</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
     <title>An API for accessing the Data Category Registry</title>
     <month>May</month>
     <year>2006</year>
@@ -924,11 +925,11 @@
     <bibkey>kemps-snijders:146:2006:lrec2006</bibkey>
   </paper>
   <paper id="1076" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/147_pdf.pdf">
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>D.</first><last>Broeder</last></author>
-    <author><first>W.</first><last>Klein</last></author>
-    <author><first>S.</first><last>Levinson</last></author>
-    <author><first>L.</first><last>Romary</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
+    <author><first>Daan</first><last>Broeder</last></author>
+    <author><first>Wolfgang</first><last>Klein</last></author>
+    <author><first>Stephen</first><last>Levinson</last></author>
+    <author><first>Laurent</first><last>Romary</last></author>
     <title>Foundations of Modern Language Resource Archives</title>
     <month>May</month>
     <year>2006</year>
@@ -938,11 +939,11 @@
     <bibkey>wittenburg:147:2006:lrec2006</bibkey>
   </paper>
   <paper id="1077" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/148_pdf.pdf">
-    <author><first>F.</first><last>Offenga</last></author>
-    <author><first>D.</first><last>Broeder</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>J.</first><last>Ducret</last></author>
-    <author><first>L.</first><last>Romary</last></author>
+    <author><first>Freddy</first><last>Offenga</last></author>
+    <author><first>Daan</first><last>Broeder</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
+    <author><first>Julien</first><last>Ducret</last></author>
+    <author><first>Laurent</first><last>Romary</last></author>
     <title>Metadata Profile in the ISO Data Category Registry</title>
     <month>May</month>
     <year>2006</year>
@@ -952,9 +953,9 @@
     <bibkey>offenga:148:2006:lrec2006</bibkey>
   </paper>
   <paper id="1078" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/149_pdf.pdf">
-    <author><first>M.</first><last>Kemps-snijders</last></author>
-    <author><first>M.</first><last>Nederhof</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
+    <author><first>Marc</first><last>Kemps-Snijders</last></author>
+    <author><first>Mark-Jan</first><last>Nederhof</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
     <title>LEXUS, a web-based tool for manipulating lexical resources lexicon</title>
     <month>May</month>
     <year>2006</year>
@@ -964,8 +965,8 @@
     <bibkey>kemps-snijders:149:2006:lrec2006</bibkey>
   </paper>
   <paper id="1079" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/150_pdf.pdf">
-    <author><first>T.</first><last>Erjavec</last></author>
-    <author><first>T.</first><last>Fišer</last></author>
+    <author><first>Tomaž</first><last>Erjavec</last></author>
+    <author><first>Darja</first><last>Fišer</last></author>
     <title>Building Slovene WordNet</title>
     <month>May</month>
     <year>2006</year>
@@ -975,8 +976,8 @@
     <bibkey>erjavec:150:2006:lrec2006</bibkey>
   </paper>
   <paper id="1080" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/151_pdf.pdf">
-    <author><first>L.</first><last>Bordoni</last></author>
-    <author><first>T.</first><last>Mazzoli</last></author>
+    <author><first>Luciana</first><last>Bordoni</last></author>
+    <author><first>Tiziana</first><last>Mazzoli</last></author>
     <title>Towards an Ontology for Art and Colours</title>
     <month>May</month>
     <year>2006</year>
@@ -986,8 +987,8 @@
     <bibkey>bordoni:151:2006:lrec2006</bibkey>
   </paper>
   <paper id="1081" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/152_pdf.pdf">
-    <author><first>R.</first><last>Johansson</last></author>
-    <author><first>P.</first><last>Nugues</last></author>
+    <author><first>Richard</first><last>Johansson</last></author>
+    <author><first>Pierre</first><last>Nugues</last></author>
     <title>Construction of a FrameNet Labeler for Swedish Text</title>
     <month>May</month>
     <year>2006</year>
@@ -997,11 +998,11 @@
     <bibkey>johansson:152:2006:lrec2006</bibkey>
   </paper>
   <paper id="1082" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/153_pdf.pdf">
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>H.</first><last>Brugman</last></author>
-    <author><first>A.</first><last>Russel</last></author>
-    <author><first>A.</first><last>Klassmann</last></author>
-    <author><first>H.</first><last>Sloetjes</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
+    <author><first>Hennie</first><last>Brugman</last></author>
+    <author><first>Albert</first><last>Russel</last></author>
+    <author><first>Alex</first><last>Klassmann</last></author>
+    <author><first>Han</first><last>Sloetjes</last></author>
     <title>ELAN: a Professional Framework for Multimodality Research</title>
     <month>May</month>
     <year>2006</year>
@@ -1011,11 +1012,11 @@
     <bibkey>wittenburg:153:2006:lrec2006</bibkey>
   </paper>
   <paper id="1083" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/154_pdf.pdf">
-    <author><first>P.</first><last>Berck</last></author>
-    <author><first>H.</first><last>Bibiko</last></author>
-    <author><first>M.</first><last>Kemps-snijders</last></author>
-    <author><first>A.</first><last>Russel</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
+    <author><first>Peter</first><last>Berck</last></author>
+    <author><first>Hans-Jörg</first><last>Bibiko</last></author>
+    <author><first>Marc</first><last>Kemps-Snijders</last></author>
+    <author><first>Albert</first><last>Russel</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
     <title>Ontology-based Language Archive Utilization</title>
     <month>May</month>
     <year>2006</year>
@@ -1025,9 +1026,9 @@
     <bibkey>berck:154:2006:lrec2006</bibkey>
   </paper>
   <paper id="1084" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/162_pdf.pdf">
-    <author><first>J.</first><last>Nivre</last></author>
-    <author><first>J.</first><last>Hall</last></author>
-    <author><first>J.</first><last>Nilsson</last></author>
+    <author><first>Joakim</first><last>Nivre</last></author>
+    <author><first>Johan</first><last>Hall</last></author>
+    <author><first>Jens</first><last>Nilsson</last></author>
     <title>MaltParser: A Data-Driven Parser-Generator for Dependency Parsing</title>
     <month>May</month>
     <year>2006</year>
@@ -1037,10 +1038,10 @@
     <bibkey>nivre:162:2006:lrec2006</bibkey>
   </paper>
   <paper id="1085" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/163_pdf.pdf">
-    <author><first>A.</first><last>Zgank</last></author>
-    <author><first>D.</first><last>Verdonik</last></author>
-    <author><first>A.</first><last>Markus</last></author>
-    <author><first>Z.</first><last>Kacic</last></author>
+    <author><first>Andrej</first><last>Zgank</last></author>
+    <author><first>Darinka</first><last>Verdonik</last></author>
+    <author><first>Aleksandra Zögling</first><last>Markuš</last></author>
+    <author><first>Zdravko</first><last>Kačič</last></author>
     <title>SINOD - Slovenian non-native speech database</title>
     <month>May</month>
     <year>2006</year>
@@ -1050,9 +1051,9 @@
     <bibkey>zgank:163:2006:lrec2006</bibkey>
   </paper>
   <paper id="1086" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/165_pdf.pdf">
-    <author><first>M.</first><last>Assem</last></author>
-    <author><first>A.</first><last>Gangemi</last></author>
-    <author><first>G.</first><last>Schreiber</last></author>
+    <author><first>Mark van</first><last>Assem</last></author>
+    <author><first>Aldo</first><last>Gangemi</last></author>
+    <author><first>Guus</first><last>Schreiber</last></author>
     <title>Conversion of WordNet to a standard RDF/OWL representation</title>
     <month>May</month>
     <year>2006</year>
@@ -1062,9 +1063,9 @@
     <bibkey>assem:165:2006:lrec2006</bibkey>
   </paper>
   <paper id="1087" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/167_pdf.pdf">
-    <author><first>A.</first><last>Bosch</last></author>
-    <author><first>I.</first><last>Schuurman</last></author>
-    <author><first>V.</first><last>Vandeghinste</last></author>
+    <author><first>Antal van den</first><last>Bosch</last></author>
+    <author><first>Ineke</first><last>Schuurman</last></author>
+    <author><first>Vincent</first><last>Vandeghinste</last></author>
     <title>Transferring PoS-tagging and lemmatization tools from spoken to written Dutch corpus development</title>
     <month>May</month>
     <year>2006</year>
@@ -1074,9 +1075,9 @@
     <bibkey>bosch:167:2006:lrec2006</bibkey>
   </paper>
   <paper id="1088" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/168_pdf.pdf">
-    <author><first>M.</first><last>Przybocki</last></author>
-    <author><first>G.</first><last>Sanders</last></author>
-    <author><first>A.</first><last>Le</last></author>
+    <author><first>Mark</first><last>Przybocki</last></author>
+    <author><first>Gregory</first><last>Sanders</last></author>
+    <author><first>Audrey</first><last>Le</last></author>
     <title>Edit Distance: A Metric for Machine Translation Evaluation</title>
     <month>May</month>
     <year>2006</year>
@@ -1086,9 +1087,9 @@
     <bibkey>przybocki:168:2006:lrec2006</bibkey>
   </paper>
   <paper id="1089" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/169_pdf.pdf">
-    <author><first>N.</first><last>Bernsen</last></author>
-    <author><first>L.</first><last>Dybkjær</last></author>
-    <author><first>S.</first><last>Kiilerich</last></author>
+    <author><first>Niels Ole</first><last>Bernsen</last></author>
+    <author><first>Laila</first><last>Dybkjær</last></author>
+    <author><first>Svend</first><last>Kiilerich</last></author>
     <title>H. C. Andersen Conversation Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -1098,7 +1099,7 @@
     <bibkey>bernsen:169:2006:lrec2006</bibkey>
   </paper>
   <paper id="1090" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/170_pdf.pdf">
-    <author><first>M.</first><last>Sahlgren</last></author>
+    <author><first>Magnus</first><last>Sahlgren</last></author>
     <title>Towards pertinent evaluation methodologies for word-space models</title>
     <month>May</month>
     <year>2006</year>
@@ -1108,10 +1109,10 @@
     <bibkey>sahlgren:170:2006:lrec2006</bibkey>
   </paper>
   <paper id="1091" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/171_pdf.pdf">
-    <author><first>A.</first><last>Popescu-belis</last></author>
-    <author><first>P.</first><last>Estrella</last></author>
-    <author><first>M.</first><last>King</last></author>
-    <author><first>N.</first><last>Underwood</last></author>
+    <author><first>Andrei</first><last>Popescu-Belis</last></author>
+    <author><first>Paula</first><last>Estrella</last></author>
+    <author><first>Margaret</first><last>King</last></author>
+    <author><first>Nancy</first><last>Underwood</last></author>
     <title>A Model for Context-Based Evaluation of Language Processing Systems and its Application to Machine Translation Evaluation</title>
     <month>May</month>
     <year>2006</year>
@@ -1121,8 +1122,8 @@
     <bibkey>popescu-belis:171:2006:lrec2006</bibkey>
   </paper>
   <paper id="1092" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/172_pdf.pdf">
-    <author><first>M.</first><last>Forst</last></author>
-    <author><first>R.</first><last>Kaplan</last></author>
+    <author><first>Martin</first><last>Forst</last></author>
+    <author><first>Ronald M.</first><last>Kaplan</last></author>
     <title>The importance of precise tokenizing for deep grammars</title>
     <month>May</month>
     <year>2006</year>
@@ -1132,8 +1133,8 @@
     <bibkey>forst:172:2006:lrec2006</bibkey>
   </paper>
   <paper id="1093" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/174_pdf.pdf">
-    <author><first>A.</first><last>Sandrelli</last></author>
-    <author><first>C.</first><last>Bendazzoli</last></author>
+    <author><first>Annalisa</first><last>Sandrelli</last></author>
+    <author><first>Claudio</first><last>Bendazzoli</last></author>
     <title>Tagging a Corpus of Interpreted Speeches: the European Parliament Interpreting Corpus (EPIC)</title>
     <month>May</month>
     <year>2006</year>
@@ -1143,8 +1144,8 @@
     <bibkey>sandrelli:174:2006:lrec2006</bibkey>
   </paper>
   <paper id="1094" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/178_pdf.pdf">
-    <author><first>H.</first><last>Suzuki</last></author>
-    <author><first>G.</first><last>Kacmarcik</last></author>
+    <author><first>Hisami</first><last>Suzuki</last></author>
+    <author><first>Gary</first><last>Kacmarcik</last></author>
     <title>RefRef: A Tool for Viewing and Exploring Coreference Space</title>
     <month>May</month>
     <year>2006</year>
@@ -1154,8 +1155,8 @@
     <bibkey>suzuki:178:2006:lrec2006</bibkey>
   </paper>
   <paper id="1095" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/179_pdf.pdf">
-    <author><first>B.</first><last>Andrassy</last></author>
-    <author><first>H.</first><last>Hoege</last></author>
+    <author><first>Bernt</first><last>Andrassy</last></author>
+    <author><first>Harald</first><last>Hoege</last></author>
     <title>Human and machine recognition as a function of SNR</title>
     <month>May</month>
     <year>2006</year>
@@ -1179,7 +1180,7 @@
     <bibkey>manurung:180:2006:lrec2006</bibkey>
   </paper>
   <paper id="1097" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/182_pdf.pdf">
-    <author><first>B.</first><last>Cartoni</last></author>
+    <author><first>Bruno</first><last>Cartoni</last></author>
     <title>Dealing with unknown words by simple decomposition: feasibility studies with Italian prefixes.</title>
     <month>May</month>
     <year>2006</year>
@@ -1189,7 +1190,7 @@
     <bibkey>cartoni:182:2006:lrec2006</bibkey>
   </paper>
   <paper id="1098" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/184_pdf.pdf">
-    <author><first>S.</first><last>Sharoff</last></author>
+    <author><first>Serge</first><last>Sharoff</last></author>
     <title>A Uniform Interface to Large-Scale Linguistic Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -1199,9 +1200,9 @@
     <bibkey>sharoff:184:2006:lrec2006</bibkey>
   </paper>
   <paper id="1099" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/186_pdf.pdf">
-    <author><first>C.</first><last>Strapparava</last></author>
-    <author><first>A.</first><last>Valitutti</last></author>
-    <author><first>O.</first><last>Stock</last></author>
+    <author><first>Carlo</first><last>Strapparava</last></author>
+    <author><first>Alessandro</first><last>Valitutti</last></author>
+    <author><first>Oliviero</first><last>Stock</last></author>
     <title>The Affective Weight of Lexicon</title>
     <month>May</month>
     <year>2006</year>
@@ -1211,8 +1212,8 @@
     <bibkey>strapparava:186:2006:lrec2006</bibkey>
   </paper>
   <paper id="1100" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/187_pdf.pdf">
-    <author><first>A.</first><last>Lisowska</last></author>
-    <author><first>N.</first><last>Underwood</last></author>
+    <author><first>Agnes</first><last>Lisowska</last></author>
+    <author><first>Nancy L.</first><last>Underwood</last></author>
     <title>ROTE: A Tool to Support Users in Defining the Relative Importance of Quality Characteristics</title>
     <month>May</month>
     <year>2006</year>
@@ -1222,9 +1223,9 @@
     <bibkey>lisowska:187:2006:lrec2006</bibkey>
   </paper>
   <paper id="1101" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/190_pdf.pdf">
-    <author><first>S.</first><last>Sharoff</last></author>
-    <author><first>B.</first><last>Babych</last></author>
-    <author><first>A.</first><last>Hartley</last></author>
+    <author><first>Serge</first><last>Sharoff</last></author>
+    <author><first>Bogdan</first><last>Babych</last></author>
+    <author><first>Anthony</first><last>Hartley</last></author>
     <title>Using collocations from comparable corpora to find translation equivalents</title>
     <month>May</month>
     <year>2006</year>
@@ -1234,12 +1235,12 @@
     <bibkey>sharoff:190:2006:lrec2006</bibkey>
   </paper>
   <paper id="1102" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/192_pdf.pdf">
-    <author><first>F.</first><last>Vriend</last></author>
-    <author><first>L.</first><last>Boves</last></author>
-    <author><first>H.</first><last>Heuvel</last></author>
-    <author><first>R.</first><last>Hout</last></author>
-    <author><first>J.</first><last>Kruijsen</last></author>
-    <author><first>J.</first><last>Swanenberg</last></author>
+    <author><first>Folkert de</first><last>Vriend</last></author>
+    <author><first>Lou</first><last>Boves</last></author>
+    <author><first>Henk van den</first><last>Heuvel</last></author>
+    <author><first>Roeland van</first><last>Hout</last></author>
+    <author><first>Joep</first><last>Kruijsen</last></author>
+    <author><first>Jos</first><last>Swanenberg</last></author>
     <title>A Unified Structure for Dutch Dialect Dictionary Data</title>
     <month>May</month>
     <year>2006</year>
@@ -1249,8 +1250,8 @@
     <bibkey>vriend:192:2006:lrec2006</bibkey>
   </paper>
   <paper id="1103" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/193_pdf.pdf">
-    <author><first>E.</first><last>Dhonnchadha</last></author>
-    <author><first>J.</first><last>Genabith</last></author>
+    <author><first>E. Uí</first><last>Dhonnchadha</last></author>
+    <author><first>J. Van</first><last>Genabith</last></author>
     <title>A Part-of-speech tagger for Irish using Finite-State Morphology and Constraint Grammar Disambiguation</title>
     <month>May</month>
     <year>2006</year>
@@ -1260,7 +1261,7 @@
     <bibkey>dhonnchadha:193:2006:lrec2006</bibkey>
   </paper>
   <paper id="1104" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/194_pdf.pdf">
-    <author><first>V.</first><last>Moriceau</last></author>
+    <author><first>Véronique</first><last>Moriceau</last></author>
     <title>Language Challenges for Data Fusion in Question-Answering</title>
     <month>May</month>
     <year>2006</year>
@@ -1270,7 +1271,7 @@
     <bibkey>moriceau:194:2006:lrec2006</bibkey>
   </paper>
   <paper id="1105" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/195_pdf.pdf">
-    <author><first>L.</first><last>Sarmento</last></author>
+    <author><first>Luís</first><last>Sarmento</last></author>
     <title>BACO - A large database of text and co-occurrences</title>
     <month>May</month>
     <year>2006</year>
@@ -1280,7 +1281,7 @@
     <bibkey>sarmento:195:2006:lrec2006</bibkey>
   </paper>
   <paper id="1106" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/196_pdf.pdf">
-    <author><first>U.</first><last>Schäfer</last></author>
+    <author><first>Ulrich</first><last>Schäfer</last></author>
     <title>OntoNERdIE – Mapping and Linking Ontologies to Named Entity Recognition and Information Extraction Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -1290,10 +1291,10 @@
     <bibkey>schäfer:196:2006:lrec2006</bibkey>
   </paper>
   <paper id="1107" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/197_pdf.pdf">
-    <author><first>J.</first><last>Fiscus</last></author>
-    <author><first>J.</first><last>Ajot</last></author>
-    <author><first>N.</first><last>Radde</last></author>
-    <author><first>C.</first><last>Laprun</last></author>
+    <author><first>Jonathan G.</first><last>Fiscus</last></author>
+    <author><first>Jerome</first><last>Ajot</last></author>
+    <author><first>Nicolas</first><last>Radde</last></author>
+    <author><first>Christophe</first><last>Laprun</last></author>
     <title>Multiple Dimension Levenshtein Edit Distance Calculations for Evaluating Automatic Speech Recognition Systems During Simultaneous Speech</title>
     <month>May</month>
     <year>2006</year>
@@ -1318,7 +1319,7 @@
     <bibkey>atserias:198:2006:lrec2006</bibkey>
   </paper>
   <paper id="1109" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/199_pdf.pdf">
-    <author><first>J.</first><last>Semecký</last></author>
+    <author><first>Jiří</first><last>Semecký</last></author>
     <title>On Automatic Assignment of Verb Valency Frames in Czech</title>
     <month>May</month>
     <year>2006</year>
@@ -1328,7 +1329,7 @@
     <bibkey>semecký:199:2006:lrec2006</bibkey>
   </paper>
   <paper id="1110" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/200_pdf.pdf">
-    <author><first>B.</first><last>Medlock</last></author>
+    <author><first>Ben</first><last>Medlock</last></author>
     <title>An Introduction to NLP-based Textual Anonymisation</title>
     <month>May</month>
     <year>2006</year>
@@ -1338,9 +1339,9 @@
     <bibkey>medlock:200:2006:lrec2006</bibkey>
   </paper>
   <paper id="1111" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/201_pdf.pdf">
-    <author><first>H.</first><last>Brugman</last></author>
-    <author><first>V.</first><last>Malaisé</last></author>
-    <author><first>L.</first><last>Gazendam</last></author>
+    <author><first>Hennie</first><last>Brugman</last></author>
+    <author><first>Véronique</first><last>Malaisé</last></author>
+    <author><first>Luit</first><last>Gazendam</last></author>
     <title>A Web Based General Thesaurus Browser to Support Indexing of Television and Radio Programs</title>
     <month>May</month>
     <year>2006</year>
@@ -1350,9 +1351,9 @@
     <bibkey>brugman:201:2006:lrec2006</bibkey>
   </paper>
   <paper id="1112" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/203_pdf.pdf">
-    <author><first>J.</first><last>Feliu</last></author>
-    <author><first>J.</first><last>Vivaldi</last></author>
-    <author><first>M.</first><last>Cabré</last></author>
+    <author><first>Judit</first><last>Feliu</last></author>
+    <author><first>Jorge</first><last>Vivaldi</last></author>
+    <author><first>M. Teresa</first><last>Cabré</last></author>
     <title>SKELETON: Specialised knowledge retrieval on the basis of terms and conceptual relations</title>
     <month>May</month>
     <year>2006</year>
@@ -1362,9 +1363,9 @@
     <bibkey>feliu:203:2006:lrec2006</bibkey>
   </paper>
   <paper id="1113" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/206_pdf.pdf">
-    <author><first>I.</first><last>Cramer</last></author>
-    <author><first>J.</first><last>Leidner</last></author>
-    <author><first>D.</first><last>Klakow</last></author>
+    <author><first>Irene</first><last>Cramer</last></author>
+    <author><first>Jochen L.</first><last>Leidner</last></author>
+    <author><first>Dietrich</first><last>Klakow</last></author>
     <title>Building an Evaluation Corpus for German Question Answering by Harvesting Wikipedia</title>
     <month>May</month>
     <year>2006</year>
@@ -1374,7 +1375,7 @@
     <bibkey>cramer:206:2006:lrec2006</bibkey>
   </paper>
   <paper id="1114" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/210_pdf.pdf">
-    <author><first>G.</first><last>Fliedner</last></author>
+    <author><first>Gerhard</first><last>Fliedner</last></author>
     <title>Towards Natural Interactive Question Answering</title>
     <month>May</month>
     <year>2006</year>
@@ -1384,10 +1385,10 @@
     <bibkey>fliedner:210:2006:lrec2006</bibkey>
   </paper>
   <paper id="1115" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/214_pdf.pdf">
-    <author><first>B.</first><last>Waldron</last></author>
-    <author><first>A.</first><last>Copestake</last></author>
-    <author><first>U.</first><last>Schäfer</last></author>
-    <author><first>B.</first><last>Kiefer</last></author>
+    <author><first>Benjamin</first><last>Waldron</last></author>
+    <author><first>Ann</first><last>Copestake</last></author>
+    <author><first>Ulrich</first><last>Schäfer</last></author>
+    <author><first>Bernd</first><last>Kiefer</last></author>
     <title>Preprocessing and Tokenisation Standards in DELPH-IN Tools</title>
     <month>May</month>
     <year>2006</year>
@@ -1397,12 +1398,12 @@
     <bibkey>waldron:214:2006:lrec2006</bibkey>
   </paper>
   <paper id="1116" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/216_pdf.pdf">
-    <author><first>J.</first><last>Apresjan</last></author>
-    <author><first>I.</first><last>Boguslavsky</last></author>
-    <author><first>B.</first><last>Iomdin</last></author>
-    <author><first>L.</first><last>Iomdin</last></author>
-    <author><first>A.</first><last>Sannikov</last></author>
-    <author><first>V.</first><last>Sizov</last></author>
+    <author><first>Juri</first><last>Apresjan</last></author>
+    <author><first>Igor</first><last>Boguslavsky</last></author>
+    <author><first>Boris</first><last>Iomdin</last></author>
+    <author><first>Leonid</first><last>Iomdin</last></author>
+    <author><first>Andrei</first><last>Sannikov</last></author>
+    <author><first>Victor</first><last>Sizov</last></author>
     <title>A Syntactically and Semantically Tagged Corpus of Russian: State of the Art and Prospects</title>
     <month>May</month>
     <year>2006</year>
@@ -1412,8 +1413,8 @@
     <bibkey>apresjan:216:2006:lrec2006</bibkey>
   </paper>
   <paper id="1117" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/218_pdf.pdf">
-    <author><first>M.</first><last>Hassel</last></author>
-    <author><first>J.</first><last>Sjöbergh</last></author>
+    <author><first>Martin</first><last>Hassel</last></author>
+    <author><first>Jonas</first><last>Sjöbergh</last></author>
     <title>Towards Holistic Summarization – Selecting Summaries, Not Sentences</title>
     <month>May</month>
     <year>2006</year>
@@ -1423,8 +1424,8 @@
     <bibkey>hassel:218:2006:lrec2006</bibkey>
   </paper>
   <paper id="1118" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/219_pdf.pdf">
-    <author><first>S.</first><last>Schaden</last></author>
-    <author><first>U.</first><last>Jekosch</last></author>
+    <author><first>Stefan</first><last>Schaden</last></author>
+    <author><first>Ute</first><last>Jekosch</last></author>
     <title>“Casselberveetovallarga” and other Unpronounceable Places: The CrossTowns Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -1434,8 +1435,8 @@
     <bibkey>schaden:219:2006:lrec2006</bibkey>
   </paper>
   <paper id="1119" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/220_pdf.pdf">
-    <author><first>D.</first><last>Kokkinakis</last></author>
-    <author><first>D.</first><last>Dannélls</last></author>
+    <author><first>Dimitrios</first><last>Kokkinakis</last></author>
+    <author><first>Dana</first><last>Dannélls</last></author>
     <title>Recognizing Acronyms and their Definitions in Swedish Medical Texts</title>
     <month>May</month>
     <year>2006</year>
@@ -1445,9 +1446,9 @@
     <bibkey>kokkinakis:220:2006:lrec2006</bibkey>
   </paper>
   <paper id="1120" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/222_pdf.pdf">
-    <author><first>L.</first><last>Ku</last></author>
-    <author><first>Y.</first><last>Liang</last></author>
-    <author><first>H.</first><last>Chen</last></author>
+    <author><first>Lun-Wei</first><last>Ku</last></author>
+    <author><first>Yu-Ting</first><last>Liang</last></author>
+    <author><first>Hsin-Hsi</first><last>Chen</last></author>
     <title>Tagging Heterogeneous Evaluation Corpora for Opinionated Tasks</title>
     <month>May</month>
     <year>2006</year>
@@ -1457,9 +1458,9 @@
     <bibkey>ku:222:2006:lrec2006</bibkey>
   </paper>
   <paper id="1121" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/223_pdf.pdf">
-    <author><first>J.</first><last>Nivre</last></author>
-    <author><first>J.</first><last>Nilsson</last></author>
-    <author><first>J.</first><last>Hall</last></author>
+    <author><first>Joakim</first><last>Nivre</last></author>
+    <author><first>Jens</first><last>Nilsson</last></author>
+    <author><first>Johan</first><last>Hall</last></author>
     <title>Talbanken05: A Swedish Treebank with Phrase Structure and Dependency Annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -1469,9 +1470,9 @@
     <bibkey>nivre:223:2006:lrec2006</bibkey>
   </paper>
   <paper id="1122" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/224_pdf.pdf">
-    <author><first>O.</first><last>Postolache</last></author>
-    <author><first>D.</first><last>Cristea</last></author>
-    <author><first>C.</first><last>Orasan</last></author>
+    <author><first>Oana</first><last>Postolache</last></author>
+    <author><first>Dan</first><last>Cristea</last></author>
+    <author><first>Constantin</first><last>Orasan</last></author>
     <title>Transferring Coreference Chains through Word Alignment</title>
     <month>May</month>
     <year>2006</year>
@@ -1495,11 +1496,11 @@
     <bibkey>tummarello:225:2006:lrec2006</bibkey>
   </paper>
   <paper id="1124" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/227_pdf.pdf">
-    <author><first>A.</first><last>Bogacka</last></author>
-    <author><first>K.</first><last>Dziubalska-kołaczyk</last></author>
-    <author><first>G.</first><last>Krynicki</last></author>
-    <author><first>D.</first><last>Pietrala</last></author>
-    <author><first>M.</first><last>Wypych</last></author>
+    <author><first>Anna</first><last>Bogacka</last></author>
+    <author><first>Katarzyna</first><last>Dziubalska-Kołaczyk</last></author>
+    <author><first>Grzegorz</first><last>Krynicki</last></author>
+    <author><first>Dawid</first><last>Pietrala</last></author>
+    <author><first>Mikołaj</first><last>Wypych</last></author>
     <title>General and Task-Specific Corpus Resources for Polish Adult Learners of English</title>
     <month>May</month>
     <year>2006</year>
@@ -1509,11 +1510,11 @@
     <bibkey>bogacka:227:2006:lrec2006</bibkey>
   </paper>
   <paper id="1125" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/228_pdf.pdf">
-    <author><first>O.</first><last>Medelyan</last></author>
-    <author><first>S.</first><last>Schulz</last></author>
-    <author><first>J.</first><last>Paetzold</last></author>
-    <author><first>M.</first><last>Poprat</last></author>
-    <author><first>K.</first><last>Markó</last></author>
+    <author><first>Olena</first><last>Medelyan</last></author>
+    <author><first>Stefan</first><last>Schulz</last></author>
+    <author><first>Jan</first><last>Paetzold</last></author>
+    <author><first>Michael</first><last>Poprat</last></author>
+    <author><first>Kornél</first><last>Markó</last></author>
     <title>Language Specific and Topic Focused Web Crawling</title>
     <month>May</month>
     <year>2006</year>
@@ -1523,7 +1524,7 @@
     <bibkey>medelyan:228:2006:lrec2006</bibkey>
   </paper>
   <paper id="1126" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/229_pdf.pdf">
-    <author><first>M.</first><last>Reynaert</last></author>
+    <author><first>Martin</first><last>Reynaert</last></author>
     <title>Corpus-Induced Corpus Clean-up</title>
     <month>May</month>
     <year>2006</year>
@@ -1533,8 +1534,8 @@
     <bibkey>reynaert:229:2006:lrec2006</bibkey>
   </paper>
   <paper id="1127" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/233_pdf.pdf">
-    <author><first>A.</first><last>Popescu-belis</last></author>
-    <author><first>M.</first><last>Georgescul</last></author>
+    <author><first>Andrei</first><last>Popescu-Belis</last></author>
+    <author><first>Maria</first><last>Georgescul</last></author>
     <title>TQB: Accessing Multimodal Data Using a Transcript-based Query and Browsing Interface</title>
     <month>May</month>
     <year>2006</year>
@@ -1544,9 +1545,9 @@
     <bibkey>popescu-belis:233:2006:lrec2006</bibkey>
   </paper>
   <paper id="1128" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/234_pdf.pdf">
-    <author><first>F.</first><last>Pan</last></author>
-    <author><first>R.</first><last>Mulkar</last></author>
-    <author><first>J.</first><last>Hobbs</last></author>
+    <author><first>Feng</first><last>Pan</last></author>
+    <author><first>Rutu</first><last>Mulkar</last></author>
+    <author><first>Jerry R.</first><last>Hobbs</last></author>
     <title>An Annotated Corpus of Typical Durations of Events</title>
     <month>May</month>
     <year>2006</year>
@@ -1556,8 +1557,8 @@
     <bibkey>pan:234:2006:lrec2006</bibkey>
   </paper>
   <paper id="1129" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/235_pdf.pdf">
-    <author><first>A.</first><last>Patel</last></author>
-    <author><first>D.</first><last>Radev</last></author>
+    <author><first>Agam</first><last>Patel</last></author>
+    <author><first>Dragomir R.</first><last>Radev</last></author>
     <title>Lexical similarity can distinguish between automatic and manual translations</title>
     <month>May</month>
     <year>2006</year>
@@ -1567,12 +1568,12 @@
     <bibkey>patel:235:2006:lrec2006</bibkey>
   </paper>
   <paper id="1130" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/236_pdf.pdf">
-    <author><first>N.</first><last>Campbell</last></author>
-    <author><first>T.</first><last>Sadanobu</last></author>
-    <author><first>M.</first><last>Imura</last></author>
-    <author><first>N.</first><last>Iwahashi</last></author>
-    <author><first>S.</first><last>Noriko</last></author>
-    <author><first>D.</first><last>Douxchamps</last></author>
+    <author><first>Nick</first><last>Campbell</last></author>
+    <author><first>Toshiyuki</first><last>Sadanobu</last></author>
+    <author><first>Masataka</first><last>Imura</last></author>
+    <author><first>Naoto</first><last>Iwahashi</last></author>
+    <author><first>Suzuki</first><last>Noriko</last></author>
+    <author><first>Damien</first><last>Douxchamps</last></author>
     <title>Multimedia Database of Meetings and Informal Interactions for Tracking Participant Involvement and Discourse Flow</title>
     <month>May</month>
     <year>2006</year>
@@ -1582,9 +1583,9 @@
     <bibkey>campbell:236:2006:lrec2006</bibkey>
   </paper>
   <paper id="1131" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/237_pdf.pdf">
-    <author><first>F.</first><last>Wang</last></author>
-    <author><first>X.</first><last>Deng</last></author>
-    <author><first>F.</first><last>Zou</last></author>
+    <author><first>Fu Lee</first><last>Wang</last></author>
+    <author><first>Xiaotie</first><last>Deng</last></author>
+    <author><first>Feng</first><last>Zou</last></author>
     <title>Towards Unified Chinese Segmentation Algorithm</title>
     <month>May</month>
     <year>2006</year>
@@ -1594,10 +1595,10 @@
     <bibkey>wang:237:2006:lrec2006</bibkey>
   </paper>
   <paper id="1132" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/238_pdf.pdf">
-    <author><first>D.</first><last>Samy</last></author>
-    <author><first>A.</first><last>Sandoval</last></author>
-    <author><first>J.</first><last>Guirao</last></author>
-    <author><first>E.</first><last>Alfonseca</last></author>
+    <author><first>Doaa</first><last>Samy</last></author>
+    <author><first>Antonio Moreno</first><last>Sandoval</last></author>
+    <author><first>José M.</first><last>Guirao</last></author>
+    <author><first>Enrique</first><last>Alfonseca</last></author>
     <title>Building a Parallel Multilingual Corpus (Arabic-Spanish-English)</title>
     <month>May</month>
     <year>2006</year>
@@ -1607,8 +1608,8 @@
     <bibkey>samy:238:2006:lrec2006</bibkey>
   </paper>
   <paper id="1133" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/241_pdf.pdf">
-    <author><first>D.</first><last>Byron</last></author>
-    <author><first>E.</first><last>Fosler-lussier</last></author>
+    <author><first>Donna K.</first><last>Byron</last></author>
+    <author><first>Eric</first><last>Fosler-Lussier</last></author>
     <title>The OSU Quake 2004 corpus of two-party situated problem-solving dialogs</title>
     <month>May</month>
     <year>2006</year>
@@ -1618,8 +1619,8 @@
     <bibkey>byron:241:2006:lrec2006</bibkey>
   </paper>
   <paper id="1134" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/242_pdf.pdf">
-    <author><first>M.</first><last>Islam</last></author>
-    <author><first>D.</first><last>Inkpen</last></author>
+    <author><first>Md. Aminul</first><last>Islam</last></author>
+    <author><first>Diana</first><last>Inkpen</last></author>
     <title>Second Order Co-occurrence PMI for Determining the Semantic Similarity of Words</title>
     <month>May</month>
     <year>2006</year>
@@ -1629,8 +1630,8 @@
     <bibkey>islam:242:2006:lrec2006</bibkey>
   </paper>
   <paper id="1135" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/243_pdf.pdf">
-    <author><first>Y.</first><last>Kiyota</last></author>
-    <author><first>H.</first><last>Nakagawa</last></author>
+    <author><first>Yoji</first><last>Kiyota</last></author>
+    <author><first>Hiroshi</first><last>Nakagawa</last></author>
     <title>A Domain Ontology Production Tool Kit Based on Automatically Constructed Case Frames</title>
     <month>May</month>
     <year>2006</year>
@@ -1640,8 +1641,8 @@
     <bibkey>kiyota:243:2006:lrec2006</bibkey>
   </paper>
   <paper id="1136" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/244_pdf.pdf">
-    <author><first>R.</first><last>Taib</last></author>
-    <author><first>N.</first><last>Ruiz</last></author>
+    <author><first>Ronnie</first><last>Taib</last></author>
+    <author><first>Natalie</first><last>Ruiz</last></author>
     <title>Tangible Objects for the Acquisition of Multimodal Interaction Patterns</title>
     <month>May</month>
     <year>2006</year>
@@ -1651,8 +1652,8 @@
     <bibkey>taib:244:2006:lrec2006</bibkey>
   </paper>
   <paper id="1137" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/245_pdf.pdf">
-    <author><first>V.</first><last>Novak</last></author>
-    <author><first>J.</first><last>Hajic</last></author>
+    <author><first>Václav</first><last>Novák</last></author>
+    <author><first>Jan</first><last>Hajič</last></author>
     <title>Perspectives of Turning Prague Dependency Treebank into a Knowledge Base</title>
     <month>May</month>
     <year>2006</year>
@@ -1662,12 +1663,12 @@
     <bibkey>novak:245:2006:lrec2006</bibkey>
   </paper>
   <paper id="1138" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/246_pdf.pdf">
-    <author><first>J.</first><last>Granfeldt</last></author>
-    <author><first>P.</first><last>Nugues</last></author>
-    <author><first>M.</first><last>Ågren</last></author>
-    <author><first>J.</first><last>Thulin</last></author>
-    <author><first>E.</first><last>Persson</last></author>
-    <author><first>S.</first><last>Schlyter</last></author>
+    <author><first>Jonas</first><last>Granfeldt</last></author>
+    <author><first>Pierre</first><last>Nugues</last></author>
+    <author><first>Malin</first><last>Ågren</last></author>
+    <author><first>Jonas</first><last>Thulin</last></author>
+    <author><first>Emil</first><last>Persson</last></author>
+    <author><first>Suzanne</first><last>Schlyter</last></author>
     <title>CEFLE and Direkt Profil: a New Computer Learner Corpus in French L2 and a System for Grammatical Profiling</title>
     <month>May</month>
     <year>2006</year>
@@ -1677,10 +1678,10 @@
     <bibkey>granfeldt:246:2006:lrec2006</bibkey>
   </paper>
   <paper id="1139" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/248_pdf.pdf">
-    <author><first>Q.</first><last>Yang</last></author>
-    <author><first>J.</first><last>Martens</last></author>
-    <author><first>N.</first><last>Konings</last></author>
-    <author><first>H.</first><last>Heuvel</last></author>
+    <author><first>Qian</first><last>Yang</last></author>
+    <author><first>Jean-Pierre</first><last>Martens</last></author>
+    <author><first>Nanneke</first><last>Konings</last></author>
+    <author><first>Henk van den</first><last>Heuvel</last></author>
     <title>Development of a phoneme-to-phoneme (p2p) converter to improve the grapheme-to-phoneme (g2p) conversion of names</title>
     <month>May</month>
     <year>2006</year>
@@ -1690,9 +1691,9 @@
     <bibkey>yang:248:2006:lrec2006</bibkey>
   </paper>
   <paper id="1140" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/249_pdf.pdf">
-    <author><first>J.</first><last>Jung</last></author>
-    <author><first>M.</first><last>Miyake</last></author>
-    <author><first>H.</first><last>Akam</last></author>
+    <author><first>Jaeyoung</first><last>Jung</last></author>
+    <author><first>Maki</first><last>Miyake</last></author>
+    <author><first>Hiroyuki</first><last>Akam</last></author>
     <title>Recurrent Markov Cluster (RMCL) Algorithm for the Refinement of the Semantic Network</title>
     <month>May</month>
     <year>2006</year>
@@ -1702,10 +1703,10 @@
     <bibkey>jung:249:2006:lrec2006</bibkey>
   </paper>
   <paper id="1141" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/254_pdf.pdf">
-    <author><first>C.</first><last>Cucchiarini</last></author>
-    <author><first>H.</first><last>Hamme</last></author>
-    <author><first>O.</first><last>Herwijnen</last></author>
-    <author><first>F.</first><last>Smits</last></author>
+    <author><first>Catia</first><last>Cucchiarini</last></author>
+    <author><first>Hugo Van</first><last>Hamme</last></author>
+    <author><first>Olga van</first><last>Herwijnen</last></author>
+    <author><first>Felix</first><last>Smits</last></author>
     <title>JASMIN-CGN: Extension of the Spoken Dutch Corpus with Speech of Elderly People, Children and Non-natives in the Human-Machine Interaction Modality</title>
     <month>May</month>
     <year>2006</year>
@@ -1715,8 +1716,8 @@
     <bibkey>cucchiarini:254:2006:lrec2006</bibkey>
   </paper>
   <paper id="1142" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/255_pdf.pdf">
-    <author><first>C.</first><last>Fairon</last></author>
-    <author><first>S.</first><last>Paumier</last></author>
+    <author><first>Cédrick</first><last>Fairon</last></author>
+    <author><first>Sébastien</first><last>Paumier</last></author>
     <title>A framework for real-time dictionary updating</title>
     <month>May</month>
     <year>2006</year>
@@ -1726,8 +1727,8 @@
     <bibkey>fairon:255:2006:lrec2006</bibkey>
   </paper>
   <paper id="1143" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/256_pdf.pdf">
-    <author><first>V.</first><last>Alabau</last></author>
-    <author><first>C.</first><last>Martinez</last></author>
+    <author><first>Vicente</first><last>Alabau</last></author>
+    <author><first>Carlos D.</first><last>Martínez</last></author>
     <title>Bilingual speech corpus in two phonetically similar languages</title>
     <month>May</month>
     <year>2006</year>
@@ -1737,11 +1738,11 @@
     <bibkey>alabau:256:2006:lrec2006</bibkey>
   </paper>
   <paper id="1144" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/258_pdf.pdf">
-    <author><first>V.</first><last>Vandeghinste</last></author>
-    <author><first>I.</first><last>Schuurman</last></author>
-    <author><first>M.</first><last>Carl</last></author>
-    <author><first>S.</first><last>Markantonatou</last></author>
-    <author><first>T.</first><last>Badia</last></author>
+    <author><first>Vincent</first><last>Vandeghinste</last></author>
+    <author><first>Ineke</first><last>Schuurman</last></author>
+    <author><first>Michael</first><last>Carl</last></author>
+    <author><first>Stella</first><last>Markantonatou</last></author>
+    <author><first>Toni</first><last>Badia</last></author>
     <title>METIS-II: Machine Translation for Low Resource Languages</title>
     <month>May</month>
     <year>2006</year>
@@ -1751,10 +1752,10 @@
     <bibkey>vandeghinste:258:2006:lrec2006</bibkey>
   </paper>
   <paper id="1145" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/259_pdf.pdf">
-    <author><first>E.</first><last>D’halleweyn</last></author>
-    <author><first>J.</first><last>Odijk</last></author>
-    <author><first>L.</first><last>Teunissen</last></author>
-    <author><first>C.</first><last>Cucchiarini</last></author>
+    <author><first>Elisabeth</first><last>D’Halleweyn</last></author>
+    <author><first>Jan</first><last>Odijk</last></author>
+    <author><first>Lisanne</first><last>Teunissen</last></author>
+    <author><first>Catia</first><last>Cucchiarini</last></author>
     <title>The Dutch-Flemish HLT Programme STEVIN: Essential Speech and Language Technology Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -1764,9 +1765,9 @@
     <bibkey>d'halleweyn:259:2006:lrec2006</bibkey>
   </paper>
   <paper id="1146" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/262_pdf.pdf">
-    <author><first>E.</first><last>Suzuki</last></author>
-    <author><first>T.</first><last>Suzuki</last></author>
-    <author><first>K.</first><last>Kakihana</last></author>
+    <author><first>Emiko</first><last>Suzuki</last></author>
+    <author><first>Tomomi</first><last>Suzuki</last></author>
+    <author><first>Kyoko</first><last>Kakihana</last></author>
     <title>On the Web Trilingual Sign Language Dictionary to Learn the foreign Sign Language without Learning a Target Spoken Language</title>
     <month>May</month>
     <year>2006</year>
@@ -1776,8 +1777,8 @@
     <bibkey>suzuki:262:2006:lrec2006</bibkey>
   </paper>
   <paper id="1147" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/266_pdf.pdf">
-    <author><first>D.</first><last>Goecke</last></author>
-    <author><first>A.</first><last>Witt</last></author>
+    <author><first>Daniela</first><last>Goecke</last></author>
+    <author><first>Andreas</first><last>Witt</last></author>
     <title>Exploiting logical document structure for anaphora resolution</title>
     <month>May</month>
     <year>2006</year>
@@ -1787,8 +1788,8 @@
     <bibkey>goecke:266:2006:lrec2006</bibkey>
   </paper>
   <paper id="1148" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/270_pdf.pdf">
-    <author><first>C.</first><last>Fairon</last></author>
-    <author><first>S.</first><last>Paumier</last></author>
+    <author><first>Cédrick</first><last>Fairon</last></author>
+    <author><first>Sébastien</first><last>Paumier</last></author>
     <title>A translated corpus of 30,000 French SMS</title>
     <month>May</month>
     <year>2006</year>
@@ -1798,10 +1799,10 @@
     <bibkey>fairon:270:2006:lrec2006</bibkey>
   </paper>
   <paper id="1149" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/273_pdf.pdf">
-    <author><first>F.</first><last>Zou</last></author>
-    <author><first>F.</first><last>Wang</last></author>
-    <author><first>X.</first><last>Deng</last></author>
-    <author><first>S.</first><last>Han</last></author>
+    <author><first>Feng</first><last>Zou</last></author>
+    <author><first>Fu Lee</first><last>Wang</last></author>
+    <author><first>Xiaotie</first><last>Deng</last></author>
+    <author><first>Song</first><last>Han</last></author>
     <title>Evaluation of Stop Word Lists in Chinese Language</title>
     <month>May</month>
     <year>2006</year>
@@ -1811,8 +1812,8 @@
     <bibkey>zou:273:2006:lrec2006</bibkey>
   </paper>
   <paper id="1150" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/275_pdf.pdf">
-    <author><first>A.</first><last>Sinopalnikova</last></author>
-    <author><first>P.</first><last>Smrž</last></author>
+    <author><first>Anna</first><last>Sinopalnikova</last></author>
+    <author><first>Pavel</first><last>Smrž</last></author>
     <title>Intelligent Dictionary Interfaces: Usability Evaluation of Access-Supporting Enhancements</title>
     <month>May</month>
     <year>2006</year>
@@ -1822,9 +1823,9 @@
     <bibkey>sinopalnikova:275:2006:lrec2006</bibkey>
   </paper>
   <paper id="1151" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/277_pdf.pdf">
-    <author><first>H.</first><last>Mögele</last></author>
-    <author><first>M.</first><last>Kaiser</last></author>
-    <author><first>F.</first><last>Schiel</last></author>
+    <author><first>Hannes</first><last>Mögele</last></author>
+    <author><first>Moritz</first><last>Kaiser</last></author>
+    <author><first>Florian</first><last>Schiel</last></author>
     <title>SmartWeb UMTS Speech Data Collection: The SmartWeb Handheld Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -1834,9 +1835,9 @@
     <bibkey>mögele:277:2006:lrec2006</bibkey>
   </paper>
   <paper id="1152" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/278_pdf.pdf">
-    <author><first>M.</first><last>Lopatkova</last></author>
-    <author><first>Z.</first><last>Zabokrtsky</last></author>
-    <author><first>K.</first><last>Skwarska</last></author>
+    <author><first>Markéta</first><last>Lopatková</last></author>
+    <author><first>Zdeněk</first><last>Žabokrtský</last></author>
+    <author><first>Karolina</first><last>Skwarska</last></author>
     <title>Valency Lexicon of Czech Verbs: Alternation-Based Model</title>
     <month>May</month>
     <year>2006</year>
@@ -1846,8 +1847,8 @@
     <bibkey>lopatkova:278:2006:lrec2006</bibkey>
   </paper>
   <paper id="1153" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/279_pdf.pdf">
-    <author><first>D.</first><last>Verdonik</last></author>
-    <author><first>M.</first><last>Rojc</last></author>
+    <author><first>Darinka</first><last>Verdonik</last></author>
+    <author><first>Matej</first><last>Rojc</last></author>
     <title>Are you ready for a call? - Spontaneous conversations in tourism for speech-to-speech translation systems</title>
     <month>May</month>
     <year>2006</year>
@@ -1857,9 +1858,9 @@
     <bibkey>verdonik:279:2006:lrec2006</bibkey>
   </paper>
   <paper id="1154" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/280_pdf.pdf">
-    <author><first>M.</first><last>Kaiser</last></author>
-    <author><first>H.</first><last>Mögele</last></author>
-    <author><first>F.</first><last>Schiel</last></author>
+    <author><first>Moritz</first><last>Kaiser</last></author>
+    <author><first>Hannes</first><last>Mögele</last></author>
+    <author><first>Florian</first><last>Schiel</last></author>
     <title>Bikers Accessing the Web: The SmartWeb Motorbike Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -1869,13 +1870,13 @@
     <bibkey>kaiser:280:2006:lrec2006</bibkey>
   </paper>
   <paper id="1155" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/281_pdf.pdf">
-    <author><first>A.</first><last>Kawtrakul</last></author>
-    <author><first>C.</first><last>Pechsiri</last></author>
-    <author><first>T.</first><last>Permpool</last></author>
-    <author><first>D.</first><last>Thamvijit</last></author>
-    <author><first>P.</first><last>Sornprasert</last></author>
-    <author><first>C.</first><last>Yingsaeree</last></author>
-    <author><first>M.</first><last>Suktarachan</last></author>
+    <author><first>Asanee</first><last>Kawtrakul</last></author>
+    <author><first>Chaveevan</first><last>Pechsiri</last></author>
+    <author><first>Trakul</first><last>Permpool</last></author>
+    <author><first>Dussadee</first><last>Thamvijit</last></author>
+    <author><first>Phukao</first><last>Sornprasert</last></author>
+    <author><first>Chaiyakorn</first><last>Yingsaeree</last></author>
+    <author><first>Mukda</first><last>Suktarachan</last></author>
     <title>Ontology Driven K-Portal Construction and K-Service Provision</title>
     <month>May</month>
     <year>2006</year>
@@ -1885,9 +1886,9 @@
     <bibkey>kawtrakul:281:2006:lrec2006</bibkey>
   </paper>
   <paper id="1156" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/282_pdf.pdf">
-    <author><first>C.</first><last>Forăscu</last></author>
-    <author><first>I.</first><last>Pistol</last></author>
-    <author><first>D.</first><last>Cristea</last></author>
+    <author><first>Corina</first><last>Forăscu</last></author>
+    <author><first>Ionuț Cristian</first><last>Pistol</last></author>
+    <author><first>Dan</first><last>Cristea</last></author>
     <title>Temporality in relation with discourse structure</title>
     <month>May</month>
     <year>2006</year>
@@ -1897,8 +1898,8 @@
     <bibkey>forăscu:282:2006:lrec2006</bibkey>
   </paper>
   <paper id="1157" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/283_pdf.pdf">
-    <author><first>E.</first><last>Hajicova</last></author>
-    <author><first>P.</first><last>Sgall</last></author>
+    <author><first>Eva</first><last>Hajičová</last></author>
+    <author><first>Petr</first><last>Sgall</last></author>
     <title>Corpus Annotation as a Test of a Linguistic Theory</title>
     <month>May</month>
     <year>2006</year>
@@ -1908,8 +1909,8 @@
     <bibkey>hajicova:283:2006:lrec2006</bibkey>
   </paper>
   <paper id="1158" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/285_pdf.pdf">
-    <author><first>O.</first><last>Bojar</last></author>
-    <author><first>M.</first><last>Prokopova</last></author>
+    <author><first>Ondřej</first><last>Bojar</last></author>
+    <author><first>Magdelena</first><last>Prokopova</last></author>
     <title>Czech-English Word Alignment</title>
     <month>May</month>
     <year>2006</year>
@@ -1919,10 +1920,10 @@
     <bibkey>bojar:285:2006:lrec2006</bibkey>
   </paper>
   <paper id="1159" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/286_pdf.pdf">
-    <author><first>E.</first><last>Guevara</last></author>
-    <author><first>S.</first><last>Scalise</last></author>
-    <author><first>A.</first><last>Bisetto</last></author>
-    <author><first>C.</first><last>Melloni</last></author>
+    <author><first>Emiliano</first><last>Guevara</last></author>
+    <author><first>Sergio</first><last>Scalise</last></author>
+    <author><first>Antonietta</first><last>Bisetto</last></author>
+    <author><first>Chiara</first><last>Melloni</last></author>
     <title>MORBO/COMP: a multilingual database of compound words</title>
     <month>May</month>
     <year>2006</year>
@@ -1932,8 +1933,8 @@
     <bibkey>guevara:286:2006:lrec2006</bibkey>
   </paper>
   <paper id="1160" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/288_pdf.pdf">
-    <author><first>D.</first><last>Sonntag</last></author>
-    <author><first>M.</first><last>Romanelli</last></author>
+    <author><first>Daniel</first><last>Sonntag</last></author>
+    <author><first>Massimo</first><last>Romanelli</last></author>
     <title>A Multimodal Result Ontology for Integrated Semantic Web Dialogue Applications</title>
     <month>May</month>
     <year>2006</year>
@@ -1943,7 +1944,7 @@
     <bibkey>sonntag:288:2006:lrec2006</bibkey>
   </paper>
   <paper id="1161" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/292_pdf.pdf">
-    <author><first>N.</first><last>Grégoire</last></author>
+    <author><first>Nicole</first><last>Grégoire</last></author>
     <title>Elaborating the parameterized Equivalence Class Method for Dutch</title>
     <month>May</month>
     <year>2006</year>
@@ -1953,10 +1954,10 @@
     <bibkey>grégoire:292:2006:lrec2006</bibkey>
   </paper>
   <paper id="1162" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/293_pdf.pdf">
-    <author><first>A.</first><last>Green</last></author>
-    <author><first>H.</first><last>Hüttenrauch</last></author>
-    <author><first>E.</first><last>Topp</last></author>
-    <author><first>K.</first><last>Severinson</last></author>
+    <author><first>Anders</first><last>Green</last></author>
+    <author><first>Helge</first><last>Hüttenrauch</last></author>
+    <author><first>Elin Anna</first><last>Topp</last></author>
+    <author><first>Kerstin</first><last>Severinson</last></author>
     <title>Developing a ContextualizedMultimodal Corpus for Human-Robot Interaction</title>
     <month>May</month>
     <year>2006</year>
@@ -1966,8 +1967,8 @@
     <bibkey>green:293:2006:lrec2006</bibkey>
   </paper>
   <paper id="1163" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/294_pdf.pdf">
-    <author><first>W.</first><last>Ma</last></author>
-    <author><first>C.</first><last>Huang</last></author>
+    <author><first>Wei-Yun</first><last>Ma</last></author>
+    <author><first>Chu-Ren</first><last>Huang</last></author>
     <title>Uniform and Effective Tagging of a Heterogeneous Giga-word Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -1977,9 +1978,9 @@
     <bibkey>ma:294:2006:lrec2006</bibkey>
   </paper>
   <paper id="1164" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/295_pdf.pdf">
-    <author><first>A.</first><last>Barbu</last></author>
-    <author><first>E.</first><last>Ionescu</last></author>
-    <author><first>V.</first><last>Mititelu</last></author>
+    <author><first>Ana-Maria</first><last>Barbu</last></author>
+    <author><first>Emil</first><last>Ionescu</last></author>
+    <author><first>Verginica Barbu</first><last>Mititelu</last></author>
     <title>Romanian Valence Dictionary in XML Format</title>
     <month>May</month>
     <year>2006</year>
@@ -1989,10 +1990,10 @@
     <bibkey>barbu:295:2006:lrec2006</bibkey>
   </paper>
   <paper id="1165" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/296_pdf.pdf">
-    <author><first>N.</first><last>Bernsen</last></author>
-    <author><first>T.</first><last>Hansen</last></author>
-    <author><first>S.</first><last>Kiilerich</last></author>
-    <author><first>T.</first><last>Madsen</last></author>
+    <author><first>Niels Ole</first><last>Bernsen</last></author>
+    <author><first>Thomas K.</first><last>Hansen</last></author>
+    <author><first>Svend</first><last>Kiilerich</last></author>
+    <author><first>Torben Kruchov</first><last>Madsen</last></author>
     <title>Field Evaluation of a Single-Word Pronunciation Training System</title>
     <month>May</month>
     <year>2006</year>
@@ -2002,9 +2003,9 @@
     <bibkey>bernsen:296:2006:lrec2006</bibkey>
   </paper>
   <paper id="1166" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/297_pdf.pdf">
-    <author><first>Wei.</first><last>Li</last></author>
-    <author><first>Wen.</first><last>Li</last></author>
-    <author><first>Q.</first><last>Lu</last></author>
+    <author><first>Wei</first><last>Li</last></author>
+    <author><first>Wenjie</first><last>Li</last></author>
+    <author><first>Qin</first><last>Lu</last></author>
     <title>Mining Implicit Entities in Queries</title>
     <month>May</month>
     <year>2006</year>
@@ -2014,12 +2015,12 @@
     <bibkey>li:297:2006:lrec2006</bibkey>
   </paper>
   <paper id="1167" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/298_pdf.pdf">
-    <author><first>K.</first><last>Uchimoto</last></author>
-    <author><first>R.</first><last>Hamabe</last></author>
-    <author><first>T.</first><last>Maruyama</last></author>
-    <author><first>K.</first><last>Takanashi</last></author>
-    <author><first>T.</first><last>Kawahara</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Kiyotaka</first><last>Uchimoto</last></author>
+    <author><first>Ryoji</first><last>Hamabe</last></author>
+    <author><first>Takehiko</first><last>Maruyama</last></author>
+    <author><first>Katsuya</first><last>Takanashi</last></author>
+    <author><first>Tatsuya</first><last>Kawahara</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Dependency-structure Annotation to Corpus of Spontaneous Japanese</title>
     <month>May</month>
     <year>2006</year>
@@ -2036,7 +2037,7 @@
     <author><first>R.</first><last>Saiz</last></author>
     <author><first>I.</first><last>Alegria</last></author>
     <author><first>X.</first><last>Artola</last></author>
-    <author><first>A. Diaz</first><last>de Ilarraza</last></author>
+    <author><first>A.</first><last>Diaz de Ilarraza</last></author>
     <author><first>N.</first><last>Ezeiza</last></author>
     <author><first>A.</first><last>Sologaistoa</last></author>
     <author><first>A.</first><last>Soroa</last></author>
@@ -2050,8 +2051,8 @@
     <bibkey>areta:299:2006:lrec2006</bibkey>
   </paper>
   <paper id="1169" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/301_pdf.pdf">
-    <author><first>J.</first><last>Polifroni</last></author>
-    <author><first>M.</first><last>Walker</last></author>
+    <author><first>Joseph</first><last>Polifroni</last></author>
+    <author><first>Marilyn</first><last>Walker</last></author>
     <title>Learning Database Content for Spoken Dialogue System Design</title>
     <month>May</month>
     <year>2006</year>
@@ -2061,8 +2062,8 @@
     <bibkey>polifroni:301:2006:lrec2006</bibkey>
   </paper>
   <paper id="1170" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/304_pdf.pdf">
-    <author><first>J.</first><last>Civera</last></author>
-    <author><first>A.</first><last>Juan</last></author>
+    <author><first>Jorge</first><last>Civera</last></author>
+    <author><first>Alfons</first><last>Juan</last></author>
     <title>Bilingual Machine-Aided Indexing</title>
     <month>May</month>
     <year>2006</year>
@@ -2072,9 +2073,9 @@
     <bibkey>civera:304:2006:lrec2006</bibkey>
   </paper>
   <paper id="1171" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/305_pdf.pdf">
-    <author><first>P.</first><last>Alessandro</last></author>
-    <author><first>F.</first><last>Marco</last></author>
-    <author><first>M.</first><last>Massimo</last></author>
+    <author><first>Panunzi</first><last>Alessandro</last></author>
+    <author><first>Fabbri</first><last>Marco</last></author>
+    <author><first>Moneglia</first><last>Massimo</last></author>
     <title>Integrating Methods and LRs for Automatic Keyword Extraction from Open Domain Texts</title>
     <month>May</month>
     <year>2006</year>
@@ -2084,8 +2085,8 @@
     <bibkey>alessandro:305:2006:lrec2006</bibkey>
   </paper>
   <paper id="1172" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/306_pdf.pdf">
-    <author><first>L.</first><last>Costa</last></author>
-    <author><first>L.</first><last>Sarmento</last></author>
+    <author><first>Luís Fernando</first><last>Costa</last></author>
+    <author><first>Luís</first><last>Sarmento</last></author>
     <title>Component Evaluation in a Question Answering System</title>
     <month>May</month>
     <year>2006</year>
@@ -2095,10 +2096,10 @@
     <bibkey>costa:306:2006:lrec2006</bibkey>
   </paper>
   <paper id="1173" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/307_pdf.pdf">
-    <author><first>S.</first><last>Breuer</last></author>
-    <author><first>S.</first><last>Bergmann</last></author>
-    <author><first>R.</first><last>Dragon</last></author>
-    <author><first>S.</first><last>Möller</last></author>
+    <author><first>Stefan</first><last>Breuer</last></author>
+    <author><first>Sven</first><last>Bergmann</last></author>
+    <author><first>Ralf</first><last>Dragon</last></author>
+    <author><first>Sebastian</first><last>Möller</last></author>
     <title>Set-up of a Unit-Selection Synthesis with a Prominent Voice</title>
     <month>May</month>
     <year>2006</year>
@@ -2108,9 +2109,9 @@
     <bibkey>breuer:307:2006:lrec2006</bibkey>
   </paper>
   <paper id="1174" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/308_pdf.pdf">
-    <author><first>N.</first><last>Semmar</last></author>
-    <author><first>M.</first><last>Laib</last></author>
-    <author><first>C.</first><last>Fluhr</last></author>
+    <author><first>Nasredine</first><last>Semmar</last></author>
+    <author><first>Meriama</first><last>Laib</last></author>
+    <author><first>Christian</first><last>Fluhr</last></author>
     <title>A Deep Linguistic Analysis for Cross-language Information Retrieval</title>
     <month>May</month>
     <year>2006</year>
@@ -2120,8 +2121,8 @@
     <bibkey>semmar:308:2006:lrec2006</bibkey>
   </paper>
   <paper id="1175" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/309_pdf.pdf">
-    <author><first>D.</first><last>Santos</last></author>
-    <author><first>S.</first><last>Inácio</last></author>
+    <author><first>Diana</first><last>Santos</last></author>
+    <author><first>Susana</first><last>Inácio</last></author>
     <title>Annotating COMPARA, a Grammar-aware Parallel Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -2131,9 +2132,9 @@
     <bibkey>santos:309:2006:lrec2006</bibkey>
   </paper>
   <paper id="1176" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/310_pdf.pdf">
-    <author><first>L.</first><last>Henriksen</last></author>
-    <author><first>C.</first><last>Povlsen</last></author>
-    <author><first>A.</first><last>Vasiljevs</last></author>
+    <author><first>Lina</first><last>Henriksen</last></author>
+    <author><first>Claus</first><last>Povlsen</last></author>
+    <author><first>Andrejs</first><last>Vasiljevs</last></author>
     <title>EuroTermBank - a Terminology Resource based on Best Practice</title>
     <month>May</month>
     <year>2006</year>
@@ -2143,13 +2144,13 @@
     <bibkey>henriksen:310:2006:lrec2006</bibkey>
   </paper>
   <paper id="1177" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/311_pdf.pdf">
-    <author><first>F.</first><last>Barreto</last></author>
-    <author><first>A.</first><last>Branco</last></author>
-    <author><first>E.</first><last>Ferreira</last></author>
-    <author><first>A.</first><last>Mendes</last></author>
-    <author><first>M.</first><last>Nascimento</last></author>
-    <author><first>F.</first><last>Nunes</last></author>
-    <author><first>J.</first><last>Silva</last></author>
+    <author><first>Florbela</first><last>Barreto</last></author>
+    <author><first>António</first><last>Branco</last></author>
+    <author><first>Eduardo</first><last>Ferreira</last></author>
+    <author><first>Amália</first><last>Mendes</last></author>
+    <author><first>Maria Fernanda Bacelar do</first><last>Nascimento</last></author>
+    <author><first>Filipe</first><last>Nunes</last></author>
+    <author><first>João Ricardo</first><last>Silva</last></author>
     <title>Open Resources and Tools for the Shallow Processing of Portuguese: The TagShare Project</title>
     <month>May</month>
     <year>2006</year>
@@ -2159,11 +2160,11 @@
     <bibkey>barreto:311:2006:lrec2006</bibkey>
   </paper>
   <paper id="1178" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/312_pdf.pdf">
-    <author><first>L.</first><last>Sarmento</last></author>
-    <author><first>B.</first><last>Maia</last></author>
-    <author><first>D.</first><last>Santos</last></author>
-    <author><first>A.</first><last>Pinto</last></author>
-    <author><first>L.</first><last>Cabral</last></author>
+    <author><first>Luís</first><last>Sarmento</last></author>
+    <author><first>Belinda</first><last>Maia</last></author>
+    <author><first>Diana</first><last>Santos</last></author>
+    <author><first>Ana</first><last>Pinto</last></author>
+    <author><first>Luís</first><last>Cabral</last></author>
     <title>Corpógrafo V3 - From Terminological Aid to Semi-automatic Knowledge Engineering</title>
     <month>May</month>
     <year>2006</year>
@@ -2173,8 +2174,8 @@
     <bibkey>sarmento:312:2006:lrec2006</bibkey>
   </paper>
   <paper id="1179" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/313_pdf.pdf">
-    <author><first>L.</first><last>Dinu</last></author>
-    <author><first>A.</first><last>Dinu</last></author>
+    <author><first>Liviu</first><last>Dinu</last></author>
+    <author><first>Anca</first><last>Dinu</last></author>
     <title>On the data base of Romanian syllables and some of its quantitative and cryptographic aspects</title>
     <month>May</month>
     <year>2006</year>
@@ -2184,8 +2185,8 @@
     <bibkey>dinu:313:2006:lrec2006</bibkey>
   </paper>
   <paper id="1180" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/314_pdf.pdf">
-    <author><first>A.</first><last>Shehata</last></author>
-    <author><first>F.</first><last>Zanzotto</last></author>
+    <author><first>Alessandro Bahgat</first><last>Shehata</last></author>
+    <author><first>Fabio Massimo</first><last>Zanzotto</last></author>
     <title>A Dependency-based Algorithm for Grammar Conversion</title>
     <month>May</month>
     <year>2006</year>
@@ -2195,9 +2196,9 @@
     <bibkey>shehata:314:2006:lrec2006</bibkey>
   </paper>
   <paper id="1181" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/315_pdf.pdf">
-    <author><first>K.</first><last>Ahmad</last></author>
-    <author><first>M.</first><last>Musacchio</last></author>
-    <author><first>G.</first><last>Palumbo</last></author>
+    <author><first>Khurshid</first><last>Ahmad</last></author>
+    <author><first>Maria Teresa</first><last>Musacchio</last></author>
+    <author><first>Giuseppe</first><last>Palumbo</last></author>
     <title>Ontological and Terminological Commitments and the Discourse of Specialist Communities</title>
     <month>May</month>
     <year>2006</year>
@@ -2207,7 +2208,7 @@
     <bibkey>ahmad:315:2006:lrec2006</bibkey>
   </paper>
   <paper id="1182" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/318_pdf.pdf">
-    <author><first>A.</first><last>Oltramari</last></author>
+    <author><first>Alessandro</first><last>Oltramari</last></author>
     <title>LexiPass methodology: a conceptual path from frames to senses and back</title>
     <month>May</month>
     <year>2006</year>
@@ -2217,11 +2218,11 @@
     <bibkey>oltramari:318:2006:lrec2006</bibkey>
   </paper>
   <paper id="1183" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/319_pdf.pdf">
-    <author><first>C.</first><last>Clavel</last></author>
-    <author><first>I.</first><last>Vasilescu</last></author>
-    <author><first>L.</first><last>Devillers</last></author>
-    <author><first>T.</first><last>Ehrette</last></author>
-    <author><first>G.</first><last>Richard</last></author>
+    <author><first>Chloé</first><last>Clavel</last></author>
+    <author><first>Ioana</first><last>Vasilescu</last></author>
+    <author><first>Laurence</first><last>Devillers</last></author>
+    <author><first>Thibaut</first><last>Ehrette</last></author>
+    <author><first>Gaël</first><last>Richard</last></author>
     <title>Fear-type emotions of the SAFE Corpus: annotation issues</title>
     <month>May</month>
     <year>2006</year>
@@ -2231,9 +2232,9 @@
     <bibkey>clavel:319:2006:lrec2006</bibkey>
   </paper>
   <paper id="1184" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/320_pdf.pdf">
-    <author><first>A.</first><last>Mauser</last></author>
-    <author><first>E.</first><last>Matusov</last></author>
-    <author><first>H.</first><last>Ney</last></author>
+    <author><first>Arne</first><last>Mauser</last></author>
+    <author><first>Evgeny</first><last>Matusov</last></author>
+    <author><first>Hermann</first><last>Ney</last></author>
     <title>Training a Statistical Machine Translation System without GIZA++</title>
     <month>May</month>
     <year>2006</year>
@@ -2243,8 +2244,8 @@
     <bibkey>mauser:320:2006:lrec2006</bibkey>
   </paper>
   <paper id="1185" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/323_pdf.pdf">
-    <author><first>E.</first><last>Coussé</last></author>
-    <author><first>S.</first><last>Gillis</last></author>
+    <author><first>Evie</first><last>Coussé</last></author>
+    <author><first>Steven</first><last>Gillis</last></author>
     <title>Regional Bias in the Broad Phonetic Transcriptions of the Spoken Dutch Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -2254,9 +2255,9 @@
     <bibkey>coussé:323:2006:lrec2006</bibkey>
   </paper>
   <paper id="1187" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/324_pdf.pdf">
-    <author><first>A.</first><last>Fujii</last></author>
-    <author><first>M.</first><last>Iwayama</last></author>
-    <author><first>N.</first><last>Kando</last></author>
+    <author><first>Atsushi</first><last>Fujii</last></author>
+    <author><first>Makoto</first><last>Iwayama</last></author>
+    <author><first>Noriko</first><last>Kando</last></author>
     <title>Test Collections for Patent Retrieval and Patent Classification in the Fifth NTCIR Workshop</title>
     <month>May</month>
     <year>2006</year>
@@ -2266,8 +2267,8 @@
     <bibkey>kando:324:2006:lrec2006</bibkey>
   </paper>
   <paper id="1188" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/326_pdf.pdf">
-    <author><first>Ž.</first><last>Agić</last></author>
-    <author><first>M.</first><last>Tadić</last></author>
+    <author><first>Željko</first><last>Agić</last></author>
+    <author><first>Marko</first><last>Tadić</last></author>
     <title>Evaluating Morphosyntactic Tagging of Croatian Texts</title>
     <month>May</month>
     <year>2006</year>
@@ -2277,11 +2278,11 @@
     <bibkey>agić:326:2006:lrec2006</bibkey>
   </paper>
   <paper id="1189" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/328_pdf.pdf">
-    <author><first>M.</first><last>Rajman</last></author>
-    <author><first>M.</first><last>Ailomaa</last></author>
-    <author><first>A.</first><last>Lisowska</last></author>
-    <author><first>M.</first><last>Melichar</last></author>
-    <author><first>S.</first><last>Armstrong</last></author>
+    <author><first>Martin</first><last>Rajman</last></author>
+    <author><first>Marita</first><last>Ailomaa</last></author>
+    <author><first>Agnes</first><last>Lisowska</last></author>
+    <author><first>Miroslav</first><last>Melichar</last></author>
+    <author><first>Susan</first><last>Armstrong</last></author>
     <title>Extending the Wizard of Oz Methodologie for Multimodal Language-enabled Systems</title>
     <month>May</month>
     <year>2006</year>
@@ -2291,9 +2292,9 @@
     <bibkey>rajman:328:2006:lrec2006</bibkey>
   </paper>
   <paper id="1190" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/329_pdf.pdf">
-    <author><first>G.</first><last>Noord</last></author>
-    <author><first>I.</first><last>Schuurman</last></author>
-    <author><first>V.</first><last>Vandeghinste</last></author>
+    <author><first>Gertjan van</first><last>Noord</last></author>
+    <author><first>Ineke</first><last>Schuurman</last></author>
+    <author><first>Vincent</first><last>Vandeghinste</last></author>
     <title>Syntactic Annotation of Large Corpora in STEVIN</title>
     <month>May</month>
     <year>2006</year>
@@ -2303,8 +2304,8 @@
     <bibkey>noord:329:2006:lrec2006</bibkey>
   </paper>
   <paper id="1191" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/332_pdf.pdf">
-    <author><first>D.</first><last>Buscaldi</last></author>
-    <author><first>P.</first><last>Rosso</last></author>
+    <author><first>Davide</first><last>Buscaldi</last></author>
+    <author><first>Paolo</first><last>Rosso</last></author>
     <title>Mining Knowledge fromWikipedia for the Question Answering task</title>
     <month>May</month>
     <year>2006</year>
@@ -2314,7 +2315,7 @@
     <bibkey>buscaldi:332:2006:lrec2006</bibkey>
   </paper>
   <paper id="1192" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/333_pdf.pdf">
-    <author><first>S.</first><last>Schulte</last></author>
+    <author><first>Sabine</first><last>Schulte im Walde</last></author>
     <title>Human Verb Associations as the Basis for Gold Standard Verb Classes: Validation against GermaNet and FrameNet</title>
     <month>May</month>
     <year>2006</year>
@@ -2324,9 +2325,9 @@
     <bibkey>schulte:333:2006:lrec2006</bibkey>
   </paper>
   <paper id="1193" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/336_pdf.pdf">
-    <author><first>P.</first><last>Wagacha</last></author>
-    <author><first>G.</first><last>Pauw</last></author>
-    <author><first>P.</first><last>Githinji</last></author>
+    <author><first>Peter W.</first><last>Wagacha</last></author>
+    <author><first>Guy De</first><last>Pauw</last></author>
+    <author><first>Pauline W.</first><last>Githinji</last></author>
     <title>A Grapheme-Based Approach for Accent Restoration in Gikuyu</title>
     <month>May</month>
     <year>2006</year>
@@ -2336,10 +2337,10 @@
     <bibkey>wagacha:336:2006:lrec2006</bibkey>
   </paper>
   <paper id="1194" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/338_pdf.pdf">
-    <author><first>J.</first><last>Soler</last></author>
-    <author><first>P.</first><last>Cerezo</last></author>
-    <author><first>D.</first><last>Merino</last></author>
-    <author><first>A.</first><last>Sánchez</last></author>
+    <author><first>Juan José Rodríguez</first><last>Soler</last></author>
+    <author><first>Pedro Concejero</first><last>Cerezo</last></author>
+    <author><first>Daniel Tapias</first><last>Merino</last></author>
+    <author><first>José</first><last>Sánchez</last></author>
     <title>MEDUSA: User-Centred Design and usability evaluation of Automatic Speech Recognition telephone services in Telefónica Móviles España</title>
     <month>May</month>
     <year>2006</year>
@@ -2349,11 +2350,12 @@
     <bibkey>soler:338:2006:lrec2006</bibkey>
   </paper>
   <paper id="1195" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/339_pdf.pdf">
-    <author><first>A.</first><last>Burchardt</last></author>
-    <author><first>K.</first><last>Erk</last></author>
-    <author><first>A.</first><last>Frank</last></author>
-    <author><first>A.</first><last>Kowalski</last></author>
-    <author><first>S.</first><last>Pado</last></author>
+    <author><first>Aljoscha</first><last>Burchardt</last></author>
+    <author><first>Katrin</first><last>Erk</last></author>
+    <author><first>Anette</first><last>Frank</last></author>
+    <author><first>Andrea</first><last>Kowalski</last></author>
+    <author><first>Sebastian</first><last>Padó</last></author>
+    <author><first>Manfred</first><last>Pinkal</last></author>
     <title>The SALSA Corpus: a German Corpus Resource for Lexical Semantics</title>
     <month>May</month>
     <year>2006</year>
@@ -2363,13 +2365,13 @@
     <bibkey>burchardt:339:2006:lrec2006</bibkey>
   </paper>
   <paper id="1196" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/340_pdf.pdf">
-    <author><first>R.</first><last>Steinberger</last></author>
-    <author><first>B.</first><last>Pouliquen</last></author>
-    <author><first>A.</first><last>Widiger</last></author>
-    <author><first>C.</first><last>Ignat</last></author>
-    <author><first>T.</first><last>Erjavec</last></author>
-    <author><first>D.</first><last>Tufiş</last></author>
-    <author><first>D.</first><last>Varga</last></author>
+    <author><first>Ralf</first><last>Steinberger</last></author>
+    <author><first>Bruno</first><last>Pouliquen</last></author>
+    <author><first>Anna</first><last>Widiger</last></author>
+    <author><first>Camelia</first><last>Ignat</last></author>
+    <author><first>Tomaž</first><last>Erjavec</last></author>
+    <author><first>Dan</first><last>Tufiş</last></author>
+    <author><first>Dániel</first><last>Varga</last></author>
     <title>The JRC-Acquis: A Multilingual Aligned Parallel Corpus with 20+ Languages</title>
     <month>May</month>
     <year>2006</year>
@@ -2379,11 +2381,11 @@
     <bibkey>steinberger:340:2006:lrec2006</bibkey>
   </paper>
   <paper id="1197" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/341_pdf.pdf">
-    <author><first>A.</first><last>Burchardt</last></author>
-    <author><first>K.</first><last>Erk</last></author>
-    <author><first>A.</first><last>Frank</last></author>
-    <author><first>A.</first><last>Kowalski</last></author>
-    <author><first>S.</first><last>Pado</last></author>
+    <author><first>Aljoscha</first><last>Burchardt</last></author>
+    <author><first>Katrin</first><last>Erk</last></author>
+    <author><first>Anette</first><last>Frank</last></author>
+    <author><first>Andrea</first><last>Kowalski</last></author>
+    <author><first>Sebastian</first><last>Pado</last></author>
     <title>SALTO - A Versatile Multi-Level Annotation Tool</title>
     <month>May</month>
     <year>2006</year>
@@ -2393,8 +2395,8 @@
     <bibkey>burchardt:341:2006:lrec2006</bibkey>
   </paper>
   <paper id="1198" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/342_pdf.pdf">
-    <author><first>V.</first><last>Hoste</last></author>
-    <author><first>G.</first><last>Pauw</last></author>
+    <author><first>Véronique</first><last>Hoste</last></author>
+    <author><first>Guy De</first><last>Pauw</last></author>
     <title>KNACK-2002: a Richly Annotated Corpus of Dutch Written Text</title>
     <month>May</month>
     <year>2006</year>
@@ -2416,10 +2418,10 @@
     <bibkey>cimiano:343:2006:lrec2006</bibkey>
   </paper>
   <paper id="1200" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/344_pdf.pdf">
-    <author><first>T.</first><last>Kato</last></author>
-    <author><first>T.</first><last>Toda</last></author>
-    <author><first>H.</first><last>Saruwatari</last></author>
-    <author><first>K.</first><last>Shikano</last></author>
+    <author><first>Tomoyuki</first><last>Kato</last></author>
+    <author><first>Tomiki</first><last>Toda</last></author>
+    <author><first>Hiroshi</first><last>Saruwatari</last></author>
+    <author><first>Kiyohiro</first><last>Shikano</last></author>
     <title>Transcription Cost Reduction for Constructing Acoustic Models Using Acoustic Likelihood Selection Criteria</title>
     <month>May</month>
     <year>2006</year>
@@ -2429,8 +2431,8 @@
     <bibkey>kato:344:2006:lrec2006</bibkey>
   </paper>
   <paper id="1201" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/345_pdf.pdf">
-    <author><first>M.</first><last>Mieskes</last></author>
-    <author><first>M.</first><last>Strube</last></author>
+    <author><first>Margot</first><last>Mieskes</last></author>
+    <author><first>Michael</first><last>Strube</last></author>
     <title>Part-of-Speech Tagging of Transcribed Speech</title>
     <month>May</month>
     <year>2006</year>
@@ -2440,8 +2442,8 @@
     <bibkey>mieskes:345:2006:lrec2006</bibkey>
   </paper>
   <paper id="1202" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/346_pdf.pdf">
-    <author><first>B.</first><last>Boguraev</last></author>
-    <author><first>R.</first><last>Ando</last></author>
+    <author><first>Branimir</first><last>Boguraev</last></author>
+    <author><first>Rie Kubota</first><last>Ando</last></author>
     <title>Analysis of TimeBank as a Resource for TimeML Parsing</title>
     <month>May</month>
     <year>2006</year>
@@ -2451,8 +2453,8 @@
     <bibkey>boguraev:346:2006:lrec2006</bibkey>
   </paper>
   <paper id="1203" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/347_pdf.pdf">
-    <author><first>D.</first><last>Kawahara</last></author>
-    <author><first>S.</first><last>Kurohashi</last></author>
+    <author><first>Daisuke</first><last>Kawahara</last></author>
+    <author><first>Sadao</first><last>Kurohashi</last></author>
     <title>Case Frame Compilation from the Web using High-Performance Computing</title>
     <month>May</month>
     <year>2006</year>
@@ -2462,10 +2464,10 @@
     <bibkey>kawahara:347:2006:lrec2006</bibkey>
   </paper>
   <paper id="1204" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/348_pdf.pdf">
-    <author><first>P.</first><last>Paroubek</last></author>
-    <author><first>I.</first><last>Robba</last></author>
-    <author><first>A.</first><last>Vilnat</last></author>
-    <author><first>C.</first><last>Ayache</last></author>
+    <author><first>Patrick</first><last>Paroubek</last></author>
+    <author><first>Isabelle</first><last>Robba</last></author>
+    <author><first>Anne</first><last>Vilnat</last></author>
+    <author><first>Christelle</first><last>Ayache</last></author>
     <title>Data, Annotations and Measures in EASY the Evaluation Campaign for Parsers of French.</title>
     <month>May</month>
     <year>2006</year>
@@ -2475,9 +2477,9 @@
     <bibkey>paroubek:348:2006:lrec2006</bibkey>
   </paper>
   <paper id="1205" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/349_pdf.pdf">
-    <author><first>T.</first><last>Kanamaru</last></author>
-    <author><first>M.</first><last>Murata</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Toshiyuki</first><last>Kanamaru</last></author>
+    <author><first>Masaki</first><last>Murata</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Creation of a Japanese Adverb Dictionary that Includes Information on the Speaker’s Communicative Intention Using Machine Learning</title>
     <month>May</month>
     <year>2006</year>
@@ -2487,10 +2489,10 @@
     <bibkey>kanamaru:349:2006:lrec2006</bibkey>
   </paper>
   <paper id="1206" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/350_pdf.pdf">
-    <author><first>G.</first><last>Grefenstette</last></author>
-    <author><first>F.</first><last>Debili</last></author>
-    <author><first>C.</first><last>Fluhr</last></author>
-    <author><first>S.</first><last>Zinger</last></author>
+    <author><first>Gregory</first><last>Grefenstette</last></author>
+    <author><first>Fathi</first><last>Debili</last></author>
+    <author><first>Christian</first><last>Fluhr</last></author>
+    <author><first>Svitlana</first><last>Zinger</last></author>
     <title>Exploiting text for extracting image processing resources</title>
     <month>May</month>
     <year>2006</year>
@@ -2500,8 +2502,8 @@
     <bibkey>grefenstette:350:2006:lrec2006</bibkey>
   </paper>
   <paper id="1207" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/351_pdf.pdf">
-    <author><first>N.</first><last>Okazaki</last></author>
-    <author><first>S.</first><last>Ananiadou</last></author>
+    <author><first>Naoaki</first><last>Okazaki</last></author>
+    <author><first>Sophia</first><last>Ananiadou</last></author>
     <title>Clustering acronyms in biomedical text for disambiguation</title>
     <month>May</month>
     <year>2006</year>
@@ -2511,9 +2513,9 @@
     <bibkey>okazaki:351:2006:lrec2006</bibkey>
   </paper>
   <paper id="1208" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/352_pdf.pdf">
-    <author><first>G.</first><last>Nenadic</last></author>
-    <author><first>N.</first><last>Okazaki</last></author>
-    <author><first>S.</first><last>Ananiadou</last></author>
+    <author><first>Goran</first><last>Nenadic</last></author>
+    <author><first>Naoki</first><last>Okazaki</last></author>
+    <author><first>Sophia</first><last>Ananiadou</last></author>
     <title>Towards a terminological resource for biomedical text mining</title>
     <month>May</month>
     <year>2006</year>
@@ -2523,7 +2525,7 @@
     <bibkey>nenadic:352:2006:lrec2006</bibkey>
   </paper>
   <paper id="1209" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/356_pdf.pdf">
-    <author><first>H.</first><last>Hjelm</last></author>
+    <author><first>Hans</first><last>Hjelm</last></author>
     <title>Extraction of Cross Language Term Correspondences</title>
     <month>May</month>
     <year>2006</year>
@@ -2533,11 +2535,11 @@
     <bibkey>hjelm:356:2006:lrec2006</bibkey>
   </paper>
   <paper id="1210" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/357_pdf.pdf">
-    <author><first>D.</first><last>Guthrie</last></author>
-    <author><first>B.</first><last>Allison</last></author>
-    <author><first>W.</first><last>Liu</last></author>
-    <author><first>L.</first><last>Guthrie</last></author>
-    <author><first>Y.</first><last>Wilks</last></author>
+    <author><first>David</first><last>Guthrie</last></author>
+    <author><first>Ben</first><last>Allison</last></author>
+    <author><first>Wei</first><last>Liu</last></author>
+    <author><first>Louise</first><last>Guthrie</last></author>
+    <author><first>Yorick</first><last>Wilks</last></author>
     <title>A Closer Look at Skip-gram Modelling</title>
     <month>May</month>
     <year>2006</year>
@@ -2547,8 +2549,8 @@
     <bibkey>guthrie:357:2006:lrec2006</bibkey>
   </paper>
   <paper id="1211" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/359_pdf.pdf">
-    <author><first>B.</first><last>Dobrov</last></author>
-    <author><first>N.</first><last>Loukachevitch</last></author>
+    <author><last>Dobrov</last><first>B.</first></author>
+    <author><last>Loukachevitch</last><first>N.</first></author>
     <title>Development of Linguistic Ontology on Natural Sciences and Technology</title>
     <month>May</month>
     <year>2006</year>
@@ -2558,8 +2560,8 @@
     <bibkey>dobrov:359:2006:lrec2006</bibkey>
   </paper>
   <paper id="1212" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/360_pdf.pdf">
-    <author><first>M.</first><last>Bilotti</last></author>
-    <author><first>E.</first><last>Nyberg</last></author>
+    <author><first>Matthew W.</first><last>Bilotti</last></author>
+    <author><first>Eric</first><last>Nyberg</last></author>
     <title>Evaluation for Scenario Question Answering Systems</title>
     <month>May</month>
     <year>2006</year>
@@ -2569,8 +2571,8 @@
     <bibkey>bilotti:360:2006:lrec2006</bibkey>
   </paper>
   <paper id="1213" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/363_pdf.pdf">
-    <author><first>D.</first><last>Buehler</last></author>
-    <author><first>W.</first><last>Minker</last></author>
+    <author><first>Dirk</first><last>Bühler</last></author>
+    <author><first>Wolfgang</first><last>Minker</last></author>
     <title>Stochastic Spoken Natural Language Parsing in the Framework of the French MEDIA Evaluation Campaign</title>
     <month>May</month>
     <year>2006</year>
@@ -2580,8 +2582,8 @@
     <bibkey>buehler:363:2006:lrec2006</bibkey>
   </paper>
   <paper id="1214" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/364_pdf.pdf">
-    <author><first>S.</first><last>Oepen</last></author>
-    <author><first>J.</first><last>Lønning</last></author>
+    <author><first>Stephan</first><last>Oepen</last></author>
+    <author><first>Jan Tore</first><last>Lønning</last></author>
     <title>Discriminant-Based MRS Banking</title>
     <month>May</month>
     <year>2006</year>
@@ -2591,11 +2593,11 @@
     <bibkey>oepen:364:2006:lrec2006</bibkey>
   </paper>
   <paper id="1215" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/365_pdf.pdf">
-    <author><first>G.</first><last>Szarvas</last></author>
-    <author><first>R.</first><last>Farkas</last></author>
-    <author><first>L.</first><last>Felföldi</last></author>
-    <author><first>A.</first><last>Kocsor</last></author>
-    <author><first>J.</first><last>Csirik</last></author>
+    <author><first>György</first><last>Szarvas</last></author>
+    <author><first>Richárd</first><last>Farkas</last></author>
+    <author><first>László</first><last>Felföldi</last></author>
+    <author><first>András</first><last>Kocsor</last></author>
+    <author><first>János</first><last>Csirik</last></author>
     <title>A highly accurate Named Entity corpus for Hungarian</title>
     <month>May</month>
     <year>2006</year>
@@ -2605,8 +2607,8 @@
     <bibkey>szarvas:365:2006:lrec2006</bibkey>
   </paper>
   <paper id="1216" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/366_pdf.pdf">
-    <author><first>T.</first><last>Declerck</last></author>
-    <author><first>M.</first><last>Vela</last></author>
+    <author><first>Thierry</first><last>Declerck</last></author>
+    <author><first>Mihaela</first><last>Vela</last></author>
     <title>Generic NLP Tools for Supporting Shallow Ontology Building</title>
     <month>May</month>
     <year>2006</year>
@@ -2616,8 +2618,8 @@
     <bibkey>declerck:366:2006:lrec2006</bibkey>
   </paper>
   <paper id="1217" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/367_pdf.pdf">
-    <author><first>J.</first><last>Ritz</last></author>
-    <author><first>U.</first><last>Heid</last></author>
+    <author><first>Julia</first><last>Ritz</last></author>
+    <author><first>Ulrich</first><last>Heid</last></author>
     <title>Extraction tools for collocations and their morphosyntactic specificities</title>
     <month>May</month>
     <year>2006</year>
@@ -2627,10 +2629,10 @@
     <bibkey>ritz:367:2006:lrec2006</bibkey>
   </paper>
   <paper id="1218" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/368_pdf.pdf">
-    <author><first>L.</first><last>Nezda</last></author>
-    <author><first>A.</first><last>Hickl</last></author>
-    <author><first>J.</first><last>Lehmann</last></author>
-    <author><first>S.</first><last>Fayyaz</last></author>
+    <author><first>Luke</first><last>Nezda</last></author>
+    <author><first>Andrew</first><last>Hickl</last></author>
+    <author><first>John</first><last>Lehmann</last></author>
+    <author><first>Sarmad</first><last>Fayyaz</last></author>
     <title>What in the world is a Shahab?: Wide Coverage Named Entity Recognition for Arabic</title>
     <month>May</month>
     <year>2006</year>
@@ -2641,7 +2643,7 @@
   </paper>
   <paper id="1219" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/372_pdf.pdf">
     <author><first>M.</first><last>Poesio</last></author>
-    <author><first>M.</first><last>Kabadjov</last></author>
+    <author><first>M. A.</first><last>Kabadjov</last></author>
     <author><first>P.</first><last>Goux</last></author>
     <author><first>U.</first><last>Kruschwitz</last></author>
     <author><first>E.</first><last>Bishop</last></author>
@@ -2655,8 +2657,8 @@
     <bibkey>poesio:372:2006:lrec2006</bibkey>
   </paper>
   <paper id="1220" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/375_pdf.pdf">
-    <author><first>M.</first><last>Sailer</last></author>
-    <author><first>B.</first><last>Trawinski</last></author>
+    <author><first>Manfred</first><last>Sailer</last></author>
+    <author><first>Beata</first><last>Trawiński</last></author>
     <title>The Collection of Distributionally Idiosyncratic Items: A Multilingual Resource for Linguistic Research</title>
     <month>May</month>
     <year>2006</year>
@@ -2666,9 +2668,9 @@
     <bibkey>sailer:375:2006:lrec2006</bibkey>
   </paper>
   <paper id="1221" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/376_pdf.pdf">
-    <author><first>U.</first><last>Heid</last></author>
-    <author><first>E.</first><last>Taljard</last></author>
-    <author><first>D.</first><last>Prinsloo</last></author>
+    <author><first>Ulrich</first><last>Heid</last></author>
+    <author><first>Elsabé</first><last>Taljard</last></author>
+    <author><first>Danie J.</first><last>Prinsloo</last></author>
     <title>Grammar-based tools for the creation of tagging resources for an unresourced language: the case of Northern Sotho</title>
     <month>May</month>
     <year>2006</year>
@@ -2678,8 +2680,8 @@
     <bibkey>heid:376:2006:lrec2006</bibkey>
   </paper>
   <paper id="1222" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/378_pdf.pdf">
-    <author><first>M.</first><last>Sousa</last></author>
-    <author><first>T.</first><last>Trippel</last></author>
+    <author><first>Maria Clara Paixão de</first><last>Sousa</last></author>
+    <author><first>Thorsten</first><last>Trippel</last></author>
     <title>Building a historical corpus for Classical Portuguese: some technological aspects</title>
     <month>May</month>
     <year>2006</year>
@@ -2689,9 +2691,9 @@
     <bibkey>sousa:378:2006:lrec2006</bibkey>
   </paper>
   <paper id="1223" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/379_pdf.pdf">
-    <author><first>M.</first><last>Pazienza</last></author>
-    <author><first>M.</first><last>Pennacchiotti</last></author>
-    <author><first>F.</first><last>Zanzotto</last></author>
+    <author><first>Maria Teresa</first><last>Pazienza</last></author>
+    <author><first>Marco</first><last>Pennacchiotti</last></author>
+    <author><first>Fabio Massimo</first><last>Zanzotto</last></author>
     <title>Mixing WordNet, VerbNet and PropBank for studying verb relations</title>
     <month>May</month>
     <year>2006</year>
@@ -2701,8 +2703,8 @@
     <bibkey>pazienza:379:2006:lrec2006</bibkey>
   </paper>
   <paper id="1224" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/381_pdf.pdf">
-    <author><first>L.</first><last>Wanner</last></author>
-    <author><first>M.</first><last>Ramos</last></author>
+    <author><first>Leo</first><last>Wanner</last></author>
+    <author><first>Margarita Alonso</first><last>Ramos</last></author>
     <title>Local Document Relevance Clustering in IR Using Collocation Information</title>
     <month>May</month>
     <year>2006</year>
@@ -2712,8 +2714,8 @@
     <bibkey>wanner:381:2006:lrec2006</bibkey>
   </paper>
   <paper id="1225" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/384_pdf.pdf">
-    <author><first>A.</first><last>Esuli</last></author>
-    <author><first>F.</first><last>Sebastiani</last></author>
+    <author><first>Andrea</first><last>Esuli</last></author>
+    <author><first>Fabrizio</first><last>Sebastiani</last></author>
     <title>SENTIWORDNET: A Publicly Available Lexical Resource for Opinion Mining</title>
     <month>May</month>
     <year>2006</year>
@@ -2723,9 +2725,9 @@
     <bibkey>esuli:384:2006:lrec2006</bibkey>
   </paper>
   <paper id="1226" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/386_pdf.pdf">
-    <author><first>A.</first><last>Denis</last></author>
-    <author><first>M.</first><last>Quignard</last></author>
-    <author><first>G.</first><last>Pitel</last></author>
+    <author><first>Alexandre</first><last>Denis</last></author>
+    <author><first>Matthieu</first><last>Quignard</last></author>
+    <author><first>Guillaume</first><last>Pitel</last></author>
     <title>A Deep-Parsing Approach to Natural Language Understanding in Dialogue System: Results of a Corpus-Based Evaluation</title>
     <month>May</month>
     <year>2006</year>
@@ -2735,7 +2737,7 @@
     <bibkey>denis:386:2006:lrec2006</bibkey>
   </paper>
   <paper id="1227" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/388_pdf.pdf">
-    <author><first>F.</first><last>Sasaki</last></author>
+    <author><first>Felix</first><last>Sasaki</last></author>
     <title>Work within the W3C Internationalization Activity and its Benefit for the Creation and Manipulation of Language Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -2745,8 +2747,8 @@
     <bibkey>sasaki:388:2006:lrec2006</bibkey>
   </paper>
   <paper id="1228" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/389_pdf.pdf">
-    <author><first>M.</first><last>King</last></author>
-    <author><first>N.</first><last>Underwood</last></author>
+    <author><first>Margaret</first><last>King</last></author>
+    <author><first>Nancy</first><last>Underwood</last></author>
     <title>Evaluating Symbiotic Systems: the challenge</title>
     <month>May</month>
     <year>2006</year>
@@ -2756,10 +2758,10 @@
     <bibkey>king:389:2006:lrec2006</bibkey>
   </paper>
   <paper id="1229" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/390_pdf.pdf">
-    <author><first>A.</first><last>Chalamandaris</last></author>
-    <author><first>A.</first><last>Protopapas</last></author>
-    <author><first>P.</first><last>Tsiakoulis</last></author>
-    <author><first>S.</first><last>Rapti</last></author>
+    <author><first>Aimilios</first><last>Chalamandaris</last></author>
+    <author><first>Athanassios</first><last>Protopapas</last></author>
+    <author><first>Pirros</first><last>Tsiakoulis</last></author>
+    <author><first>Spyros</first><last>Raptis</last></author>
     <title>All Greek to me! An automatic Greeklish to Greek transliteration system</title>
     <month>May</month>
     <year>2006</year>
@@ -2769,8 +2771,8 @@
     <bibkey>chalamandaris:390:2006:lrec2006</bibkey>
   </paper>
   <paper id="1230" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/392_pdf.pdf">
-    <author><first>T.</first><last>Vogt</last></author>
-    <author><first>E.</first><last>Andre</last></author>
+    <author><first>Thurid</first><last>Vogt</last></author>
+    <author><first>Elisabeth</first><last>Andre</last></author>
     <title>Improving Automatic Emotion Recognition from Speech via Gender Differentiaion</title>
     <month>May</month>
     <year>2006</year>
@@ -2780,9 +2782,9 @@
     <bibkey>vogt:392:2006:lrec2006</bibkey>
   </paper>
   <paper id="1231" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/394_pdf.pdf">
-    <author><first>K.</first><last>Ahmad</last></author>
-    <author><first>L.</first><last>Gillam</last></author>
-    <author><first>D.</first><last>Cheng</last></author>
+    <author><first>Khurshid</first><last>Ahmad</last></author>
+    <author><first>Lee</first><last>Gillam</last></author>
+    <author><first>David</first><last>Cheng</last></author>
     <title>Sentiments on a Grid: Analysis of Streaming News and Views</title>
     <month>May</month>
     <year>2006</year>
@@ -2792,9 +2794,9 @@
     <bibkey>ahmad:394:2006:lrec2006</bibkey>
   </paper>
   <paper id="1232" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/395_pdf.pdf">
-    <author><first>B.</first><last>Williams</last></author>
-    <author><first>R.</first><last>Jones</last></author>
-    <author><first>I.</first><last>Uemlianin</last></author>
+    <author><first>Briony</first><last>Williams</last></author>
+    <author><first>Rhys James</first><last>Jones</last></author>
+    <author><first>Ivan</first><last>Uemlianin</last></author>
     <title>Tools and resources for speech synthesis arising from a Welsh TTS project</title>
     <month>May</month>
     <year>2006</year>
@@ -2804,11 +2806,11 @@
     <bibkey>williams:395:2006:lrec2006</bibkey>
   </paper>
   <paper id="1233" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/397_pdf.pdf">
-    <author><first>T.</first><last>Declerck</last></author>
-    <author><first>A.</first><last>Pérez</last></author>
-    <author><first>O.</first><last>Vela</last></author>
-    <author><first>Z.</first><last>Gantner</last></author>
-    <author><first>D.</first><last>Manzano-macho</last></author>
+    <author><first>Thierry</first><last>Declerck</last></author>
+    <author><first>Asunción Gómez</first><last>Pérez</last></author>
+    <author><first>Ovidiu</first><last>Vela</last></author>
+    <author><first>Zeno</first><last>Gantner</last></author>
+    <author><first>David</first><last>Manzano-Macho</last></author>
     <title>Multilingual Lexical Semantic Resources for Ontology Translation</title>
     <month>May</month>
     <year>2006</year>
@@ -2818,9 +2820,9 @@
     <bibkey>declerck:397:2006:lrec2006</bibkey>
   </paper>
   <paper id="1235" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/398_pdf.pdf">
-    <author><first>B.</first><last>Alex</last></author>
-    <author><first>M.</first><last>Nissim</last></author>
-    <author><first>C.</first><last>Grover</last></author>
+    <author><first>Beatrice</first><last>Alex</last></author>
+    <author><first>Malvina</first><last>Nissim</last></author>
+    <author><first>Claire</first><last>Grover</last></author>
     <title>The Impact of Annotation on the Performance of Protein Tagging in Biomedical Text</title>
     <month>May</month>
     <year>2006</year>
@@ -2830,8 +2832,8 @@
     <bibkey>alex:398:2006:lrec2006</bibkey>
   </paper>
   <paper id="1236" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/404_pdf.pdf">
-    <author><first>B.</first><last>Wellner</last></author>
-    <author><first>M.</first><last>Vilain</last></author>
+    <author><first>Ben</first><last>Wellner</last></author>
+    <author><first>Marc</first><last>Vilain</last></author>
     <title>Leveraging Machine Readable Dictionaries in Discriminative Sequence Models</title>
     <month>May</month>
     <year>2006</year>
@@ -2841,9 +2843,9 @@
     <bibkey>wellner:404:2006:lrec2006</bibkey>
   </paper>
   <paper id="1237" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/405_pdf.pdf">
-    <author><first>S.</first><last>Hasan</last></author>
-    <author><first>A.</first><last>Isbihani</last></author>
-    <author><first>H.</first><last>Ney</last></author>
+    <author><first>Saša</first><last>Hasan</last></author>
+    <author><first>Anas El</first><last>Isbihani</last></author>
+    <author><first>Hermann</first><last>Ney</last></author>
     <title>Creating a Large-Scale Arabic to French Statistical MachineTranslation System</title>
     <month>May</month>
     <year>2006</year>
@@ -2853,11 +2855,11 @@
     <bibkey>hasan:405:2006:lrec2006</bibkey>
   </paper>
   <paper id="1238" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/407_pdf.pdf">
-    <author><first>C.</first><last>Yirong</last></author>
-    <author><first>L.</first><last>Qin</last></author>
-    <author><first>L.</first><last>Wenjie</last></author>
-    <author><first>S.</first><last>Zhifang</last></author>
-    <author><first>J.</first><last>Luning</last></author>
+    <author><first>Chen</first><last>Yirong</last></author>
+    <author><first>Lu</first><last>Qin</last></author>
+    <author><first>Li</first><last>Wenjie</last></author>
+    <author><first>Sui</first><last>Zhifang</last></author>
+    <author><first>Ji</first><last>Luning</last></author>
     <title>A Study on Terminology Extraction Based on Classified Corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -2867,9 +2869,9 @@
     <bibkey>yirong:407:2006:lrec2006</bibkey>
   </paper>
   <paper id="1239" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/408_pdf.pdf">
-    <author><first>A.</first><last>Estellés</last></author>
-    <author><first>A.</first><last>Alcina</last></author>
-    <author><first>V.</first><last>Soler</last></author>
+    <author><first>Anna</first><last>Estellés</last></author>
+    <author><first>Amparo</first><last>Alcina</last></author>
+    <author><first>Victoria</first><last>Soler</last></author>
     <title>Retrieving Terminological Data from the TxtCeram Tagged Domain Corpus: A First Step towards a Terminological Ontology</title>
     <month>May</month>
     <year>2006</year>
@@ -2879,8 +2881,8 @@
     <bibkey>estellés:408:2006:lrec2006</bibkey>
   </paper>
   <paper id="1240" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/409_pdf.pdf">
-    <author><first>V.</first><last>Cavalli-sforza</last></author>
-    <author><first>A.</first><last>Soudi</last></author>
+    <author><first>Violetta</first><last>Cavalli-Sforza</last></author>
+    <author><first>Abdelhadi</first><last>Soudi</last></author>
     <title>IMORPHĒ: An Inheritance and Equivalence Based Morphology Description Compiler</title>
     <month>May</month>
     <year>2006</year>
@@ -2890,8 +2892,8 @@
     <bibkey>cavalli-sforza:409:2006:lrec2006</bibkey>
   </paper>
   <paper id="1241" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/410_pdf.pdf">
-    <author><first>L.</first><last>Sitbon</last></author>
-    <author><first>P.</first><last>Bellot</last></author>
+    <author><first>Laurianne</first><last>Sitbon</last></author>
+    <author><first>Patrice</first><last>Bellot</last></author>
     <title>Tools and methods for objective or contextual evaluation of topic segmentation</title>
     <month>May</month>
     <year>2006</year>
@@ -2903,8 +2905,8 @@
   <paper id="1242" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/411_pdf.pdf">
     <author><first>L.</first><last>Devillers</last></author>
     <author><first>R.</first><last>Cowie</last></author>
-    <author><first>J.</first><last>Martin</last></author>
-    <author><first>E.</first><last>Douglas-cowie</last></author>
+    <author><first>J-C.</first><last>Martin</last></author>
+    <author><first>E.</first><last>Douglas-Cowie</last></author>
     <author><first>S.</first><last>Abrilian</last></author>
     <author><first>M.</first><last>Mcrorie</last></author>
     <title>Real life emotions in French and English TV video clips: an integrated annotation protocol combining continuous and discrete approaches</title>
@@ -2916,8 +2918,8 @@
     <bibkey>devillers:411:2006:lrec2006</bibkey>
   </paper>
   <paper id="1243" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/412_pdf.pdf">
-    <author><first>M.</first><last>Popovic</last></author>
-    <author><first>H.</first><last>Ney</last></author>
+    <author><first>Maja</first><last>Popović</last></author>
+    <author><first>Hermann</first><last>Ney</last></author>
     <title>POS-based Word Reorderings for Statistical Machine Translation</title>
     <month>May</month>
     <year>2006</year>
@@ -2927,10 +2929,10 @@
     <bibkey>popovic:412:2006:lrec2006</bibkey>
   </paper>
   <paper id="1244" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/413_pdf.pdf">
-    <author><first>D.</first><last>Vilar</last></author>
-    <author><first>J.</first><last>Xu</last></author>
-    <author><first>L.</first><last>D’haro</last></author>
-    <author><first>H.</first><last>Ney</last></author>
+    <author><first>David</first><last>Vilar</last></author>
+    <author><first>Jia</first><last>Xu</last></author>
+    <author><first>Luis Fernando</first><last>D’haro</last></author>
+    <author><first>Hermann</first><last>Ney</last></author>
     <title>Error Analysis of Statistical Machine Translation Output</title>
     <month>May</month>
     <year>2006</year>
@@ -2940,11 +2942,11 @@
     <bibkey>vilar:413:2006:lrec2006</bibkey>
   </paper>
   <paper id="1245" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/414_pdf.pdf">
-    <author><first>I.</first><last>Castellón</last></author>
-    <author><first>A.</first><last>Fernández-montraveta</last></author>
-    <author><first>G.</first><last>Vázquez</last></author>
-    <author><first>L.</first><last>Alonso</last></author>
-    <author><first>J.</first><last>Capilla</last></author>
+    <author><first>Irene</first><last>Castellón</last></author>
+    <author><first>Ana</first><last>Fernández-Montraveta</last></author>
+    <author><first>Gloria</first><last>Vázquez</last></author>
+    <author><first>Laura</first><last>Alonso Alemany</last></author>
+    <author><first>Joan Antoni</first><last>Capilla</last></author>
     <title>The Sensem Corpus: a Corpus Annotated at the Syntactic and Semantic Level</title>
     <month>May</month>
     <year>2006</year>
@@ -2954,8 +2956,8 @@
     <bibkey>castellón:414:2006:lrec2006</bibkey>
   </paper>
   <paper id="1246" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/415_pdf.pdf">
-    <author><first>J.</first><last>Pérez</last></author>
-    <author><first>A.</first><last>Bonafonte</last></author>
+    <author><first>Javier</first><last>Pérez</last></author>
+    <author><first>Antonio</first><last>Bonafonte</last></author>
     <title>GAIA: Common Framework for the Development of Speech Translation Technologies</title>
     <month>May</month>
     <year>2006</year>
@@ -2965,7 +2967,7 @@
     <bibkey>pérez:415:2006:lrec2006</bibkey>
   </paper>
   <paper id="1247" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/416_pdf.pdf">
-    <author><first>A.</first><last>Novák</last></author>
+    <author><first>Attila</first><last>Novák</last></author>
     <title>Morphological Tools for Six Small Uralic Languages</title>
     <month>May</month>
     <year>2006</year>
@@ -2975,12 +2977,12 @@
     <bibkey>novák:416:2006:lrec2006</bibkey>
   </paper>
   <paper id="1248" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/417_pdf.pdf">
-    <author><first>J.</first><last>Pérez</last></author>
-    <author><first>A.</first><last>Bonafonte</last></author>
-    <author><first>H.</first><last>Hain</last></author>
-    <author><first>E.</first><last>Keller</last></author>
-    <author><first>S.</first><last>Breuer</last></author>
-    <author><first>J.</first><last>Tian</last></author>
+    <author><first>Javier</first><last>Pérez</last></author>
+    <author><first>Antonio</first><last>Bonafonte</last></author>
+    <author><first>Horst-Udo</first><last>Hain</last></author>
+    <author><first>Eric</first><last>Keller</last></author>
+    <author><first>Stefan</first><last>Breuer</last></author>
+    <author><first>Jilei</first><last>Tian</last></author>
     <title>ECESS Inter-Module Interface Specification for Speech Synthesis</title>
     <month>May</month>
     <year>2006</year>
@@ -2990,7 +2992,7 @@
     <bibkey>pérez:417:2006:lrec2006</bibkey>
   </paper>
   <paper id="1249" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/418_pdf.pdf">
-    <author><first>P.</first><last>Nemec</last></author>
+    <author><first>Petr</first><last>Němec</last></author>
     <title>Tree Searching/Rewriting Formalism</title>
     <month>May</month>
     <year>2006</year>
@@ -3000,9 +3002,9 @@
     <bibkey>nemec:418:2006:lrec2006</bibkey>
   </paper>
   <paper id="1250" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/420_pdf.pdf">
-    <author><first>M.</first><last>Taboada</last></author>
-    <author><first>C.</first><last>Anthony</last></author>
-    <author><first>K.</first><last>Voll</last></author>
+    <author><first>Maite</first><last>Taboada</last></author>
+    <author><first>Caroline</first><last>Anthony</last></author>
+    <author><first>Kimberly</first><last>Voll</last></author>
     <title>Methods for Creating Semantic Orientation Dictionaries</title>
     <month>May</month>
     <year>2006</year>
@@ -3012,9 +3014,9 @@
     <bibkey>taboada:420:2006:lrec2006</bibkey>
   </paper>
   <paper id="1251" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/423_pdf.pdf">
-    <author><first>M.</first><last>Itagaki</last></author>
-    <author><first>A.</first><last>Aue</last></author>
-    <author><first>T.</first><last>Aikawa</last></author>
+    <author><first>Masaki</first><last>Itagaki</last></author>
+    <author><first>Anthony</first><last>Aue</last></author>
+    <author><first>Takako</first><last>Aikawa</last></author>
     <title>Detecting Inter-domain Semantic Shift using Syntactic Similarity</title>
     <month>May</month>
     <year>2006</year>
@@ -3024,9 +3026,9 @@
     <bibkey>itagaki:423:2006:lrec2006</bibkey>
   </paper>
   <paper id="1252" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/427_pdf.pdf">
-    <author><first>H.</first><last>Boril</last></author>
-    <author><first>T.</first><last>Boril</last></author>
-    <author><first>P.</first><last>Pollák</last></author>
+    <author><first>Hynek</first><last>Bořil</last></author>
+    <author><first>Tomáš</first><last>Bořil</last></author>
+    <author><first>Petr</first><last>Pollák</last></author>
     <title>Methodology of Lombard Speech Database Acquisition: Experiences with CLSD</title>
     <month>May</month>
     <year>2006</year>
@@ -3036,7 +3038,7 @@
     <bibkey>boril:427:2006:lrec2006</bibkey>
   </paper>
   <paper id="1253" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/428_pdf.pdf">
-    <author><first>H.</first><last>Bunt</last></author>
+    <author><first>Harry</first><last>Bunt</last></author>
     <title>Dimensions in Dialogue Act Annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -3046,10 +3048,10 @@
     <bibkey>bunt:428:2006:lrec2006</bibkey>
   </paper>
   <paper id="1254" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/430_pdf.pdf">
-    <author><first>O.</first><last>Baude</last></author>
-    <author><first>M.</first><last>Jacobson</last></author>
-    <author><first>A.</first><last>Tchobanov</last></author>
-    <author><first>R.</first><last>Walter</last></author>
+    <author><first>Olivier</first><last>Baude</last></author>
+    <author><first>Michel</first><last>Jacobson</last></author>
+    <author><first>Atanas</first><last>Tchobanov</last></author>
+    <author><first>Richard</first><last>Walter</last></author>
     <title>Interoperability of audio corpora : the case of the French corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -3062,7 +3064,7 @@
     <author><first>R.</first><last>Bernardi</last></author>
     <author><first>D.</first><last>Calvanese</last></author>
     <author><first>L.</first><last>Dini</last></author>
-    <author><first>V.</first><last>Tomaso</last></author>
+    <author><first>V. Di</first><last>Tomaso</last></author>
     <author><first>E.</first><last>Frasnelli</last></author>
     <author><first>U.</first><last>Kugler</last></author>
     <author><first>B.</first><last>Plank</last></author>
@@ -3075,8 +3077,8 @@
     <bibkey>bernardi:433:2006:lrec2006</bibkey>
   </paper>
   <paper id="1256" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/435_pdf.pdf">
-    <author><first>I.</first><last>Langkilde-geary</last></author>
-    <author><first>J.</first><last>Betteridge</last></author>
+    <author><first>Irene</first><last>Langkilde-Geary</last></author>
+    <author><first>Justin</first><last>Betteridge</last></author>
     <title>A Factored Functional Dependency Transformation of the English Penn Treebank for Probabilistic Surface Generation</title>
     <month>May</month>
     <year>2006</year>
@@ -3086,7 +3088,7 @@
     <bibkey>langkilde-geary:435:2006:lrec2006</bibkey>
   </paper>
   <paper id="1257" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/436_pdf.pdf">
-    <author><first>J.</first><last>Talley</last></author>
+    <author><first>Jim</first><last>Talley</last></author>
     <title>Bootstrapping New Language ASR Capabilities: Achieving Best Letter-to-Sound Performance under Resource Constraints</title>
     <month>May</month>
     <year>2006</year>
@@ -3096,10 +3098,10 @@
     <bibkey>talley:436:2006:lrec2006</bibkey>
   </paper>
   <paper id="1258" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/438_pdf.pdf">
-    <author><first>E.</first><last>Hovy</last></author>
-    <author><first>C.</first><last>Lin</last></author>
-    <author><first>L.</first><last>Zhou</last></author>
-    <author><first>J.</first><last>Fukumoto</last></author>
+    <author><first>Eduard</first><last>Hovy</last></author>
+    <author><first>Chin-Yew</first><last>Lin</last></author>
+    <author><first>Liang</first><last>Zhou</last></author>
+    <author><first>Junichi</first><last>Fukumoto</last></author>
     <title>Automated Summarization Evaluation with Basic Elements.</title>
     <month>May</month>
     <year>2006</year>
@@ -3109,8 +3111,8 @@
     <bibkey>hovy:438:2006:lrec2006</bibkey>
   </paper>
   <paper id="1259" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/439_pdf.pdf">
-    <author><first>H.</first><last>Kaji</last></author>
-    <author><first>M.</first><last>Watanabe</last></author>
+    <author><first>Hiroyuki</first><last>Kaji</last></author>
+    <author><first>Mariko</first><last>Watanabe</last></author>
     <title>Automatic Construction of Japanese WordNet</title>
     <month>May</month>
     <year>2006</year>
@@ -3120,9 +3122,9 @@
     <bibkey>kaji:439:2006:lrec2006</bibkey>
   </paper>
   <paper id="1260" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/440_pdf.pdf">
-    <author><first>M.</first><last>Marneffe</last></author>
-    <author><first>B.</first><last>Maccartney</last></author>
-    <author><first>C.</first><last>Manning</last></author>
+    <author><first>Marie-Catherine de</first><last>Marneffe</last></author>
+    <author><first>Bill</first><last>Maccartney</last></author>
+    <author><first>Christopher D.</first><last>Manning</last></author>
     <title>Generating Typed Dependency Parses from Phrase Structure Parses</title>
     <month>May</month>
     <year>2006</year>
@@ -3134,7 +3136,7 @@
   <paper id="1261" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/441_pdf.pdf">
     <author><first>S.</first><last>Frota</last></author>
     <author><first>M.</first><last>Vigário</last></author>
-    <author><first>F.</first><last>Martin</last></author>
+    <author><first>F.</first><last>Martins</last></author>
     <title>FreP: An electronic tool for extracting frequency information of phonological units from Portuguese written text</title>
     <month>May</month>
     <year>2006</year>
@@ -3144,7 +3146,7 @@
     <bibkey>frota:441:2006:lrec2006</bibkey>
   </paper>
   <paper id="1262" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/442_pdf.pdf">
-    <author><first>U.</first><last>Petersen</last></author>
+    <author><first>Ulrik</first><last>Petersen</last></author>
     <title>Querying Both Parallel And Treebank Corpora: Evaluation Of A Corpus Query System</title>
     <month>May</month>
     <year>2006</year>
@@ -3154,9 +3156,9 @@
     <bibkey>petersen:442:2006:lrec2006</bibkey>
   </paper>
   <paper id="1263" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/443_pdf.pdf">
-    <author><first>L.</first><last>Zhou</last></author>
-    <author><first>C.</first><last>Lin</last></author>
-    <author><first>E.</first><last>Hovy</last></author>
+    <author><first>Liang</first><last>Zhou</last></author>
+    <author><first>Chin-Yew</first><last>Lin</last></author>
+    <author><first>Eduard</first><last>Hovy</last></author>
     <title>Summarizing Answers for Complicated Questions</title>
     <month>May</month>
     <year>2006</year>
@@ -3166,14 +3168,14 @@
     <bibkey>zhou:443:2006:lrec2006</bibkey>
   </paper>
   <paper id="1265" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/445_pdf.pdf">
-    <author><first>M.</first><last>Monachini</last></author>
-    <author><first>N.</first><last>Calzolari</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
-    <author><first>J.</first><last>Friedrich</last></author>
-    <author><first>G.</first><last>Maltese</last></author>
-    <author><first>M.</first><last>Mammini</last></author>
-    <author><first>J.</first><last>Odijk</last></author>
-    <author><first>M.</first><last>Ulivieri</last></author>
+    <author><first>Monica</first><last>Monachini</last></author>
+    <author><first>Nicoletta</first><last>Calzolari</last></author>
+    <author><first>Khalid</first><last>Choukri</last></author>
+    <author><first>Jochen</first><last>Friedrich</last></author>
+    <author><first>Giulio</first><last>Maltese</last></author>
+    <author><first>Michele</first><last>Mammini</last></author>
+    <author><first>Jan</first><last>Odijk</last></author>
+    <author><first>Marisa</first><last>Ulivieri</last></author>
     <title>Unified Lexicon and Unified Morphosyntactic Specifications for Written and Spoken Italian</title>
     <month>May</month>
     <year>2006</year>
@@ -3183,9 +3185,9 @@
     <bibkey>monachini:445:2006:lrec2006</bibkey>
   </paper>
   <paper id="1266" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/446_pdf.pdf">
-    <author><first>R.</first><last>Melz</last></author>
-    <author><first>P.</first><last>Ryu</last></author>
-    <author><first>K.</first><last>Choi</last></author>
+    <author><first>Ronny</first><last>Melz</last></author>
+    <author><first>Pum-Mo</first><last>Ryu</last></author>
+    <author><first>Key-Sun</first><last>Choi</last></author>
     <title>Compiling large language resources using lexical similarity metrics for domain taxonomy learning</title>
     <month>May</month>
     <year>2006</year>
@@ -3195,8 +3197,8 @@
     <bibkey>melz:446:2006:lrec2006</bibkey>
   </paper>
   <paper id="1267" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/448_pdf.pdf">
-    <author><first>F.</first><last>Pîrvan</last></author>
-    <author><first>D.</first><last>Tufi</last></author>
+    <author><first>Felix</first><last>Pîrvan</last></author>
+    <author><first>Dan</first><last>Tufiş</last></author>
     <title>Tagset Mapping and Statistical Training Data Cleaning-up</title>
     <month>May</month>
     <year>2006</year>
@@ -3206,8 +3208,8 @@
     <bibkey>pîrvan:448:2006:lrec2006</bibkey>
   </paper>
   <paper id="1268" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/451_pdf.pdf">
-    <author><first>D.</first><last>Tufis</last></author>
-    <author><first>E.</first><last>Irimia</last></author>
+    <author><first>Dan</first><last>Tufiş</last></author>
+    <author><first>Elena</first><last>Irimia</last></author>
     <title>RoCo-News: A Hand Validated Journalistic Corpus of Romanian</title>
     <month>May</month>
     <year>2006</year>
@@ -3217,7 +3219,7 @@
     <bibkey>tufis:451:2006:lrec2006</bibkey>
   </paper>
   <paper id="1269" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/452_pdf.pdf">
-    <author><first>E.</first><last>Bick</last></author>
+    <author><first>Eckhard</first><last>Bick</last></author>
     <title>Turning a Dependency Treebank into a PSG-style Constituent Treebank</title>
     <month>May</month>
     <year>2006</year>
@@ -3227,8 +3229,8 @@
     <bibkey>bick:452:2006:lrec2006</bibkey>
   </paper>
   <paper id="1270" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/453_pdf.pdf">
-    <author><first>D.</first><last>Ştefãnescu</last></author>
-    <author><first>D.</first><last>Tufi</last></author>
+    <author><first>Dan</first><last>Ştefãnescu</last></author>
+    <author><first>Dan</first><last>Tufiş</last></author>
     <title>Aligning Multilingual Thesauri</title>
     <month>May</month>
     <year>2006</year>
@@ -3238,9 +3240,9 @@
     <bibkey>Ştefãnescu:453:2006:lrec2006</bibkey>
   </paper>
   <paper id="1271" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/454_pdf.pdf">
-    <author><first>R.</first><last>Ion</last></author>
-    <author><first>A.</first><last>Ceauşu</last></author>
-    <author><first>D.</first><last>Tufiş</last></author>
+    <author><first>Radu</first><last>Ion</last></author>
+    <author><first>Alexandru</first><last>Ceauşu</last></author>
+    <author><first>Dan</first><last>Tufiş</last></author>
     <title>Dependency-Based Phrase Alignment</title>
     <month>May</month>
     <year>2006</year>
@@ -3250,9 +3252,9 @@
     <bibkey>ion:454:2006:lrec2006</bibkey>
   </paper>
   <paper id="1272" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/456_pdf.pdf">
-    <author><first>A.</first><last>Ceauşu</last></author>
-    <author><first>D.</first><last>Ştefănescu</last></author>
-    <author><first>D.</first><last>Tufiş</last></author>
+    <author><first>Alexandru</first><last>Ceauşu</last></author>
+    <author><first>Dan</first><last>Ştefănescu</last></author>
+    <author><first>Dan</first><last>Tufiş</last></author>
     <title>Acquis Communautaire Sentence Alignment using Support Vector Machines</title>
     <month>May</month>
     <year>2006</year>
@@ -3262,8 +3264,8 @@
     <bibkey>ceauşu:456:2006:lrec2006</bibkey>
   </paper>
   <paper id="1273" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/457_pdf.pdf">
-    <author><first>C.</first><last>Grover</last></author>
-    <author><first>R.</first><last>Tobin</last></author>
+    <author><first>Claire</first><last>Grover</last></author>
+    <author><first>Richard</first><last>Tobin</last></author>
     <title>Rule-Based Chunking and Reusability</title>
     <month>May</month>
     <year>2006</year>
@@ -3273,11 +3275,11 @@
     <bibkey>grover:457:2006:lrec2006</bibkey>
   </paper>
   <paper id="1274" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/459_pdf.pdf">
-    <author><first>B.</first><last>Hughes</last></author>
-    <author><first>T.</first><last>Baldwin</last></author>
-    <author><first>S.</first><last>Bird</last></author>
-    <author><first>J.</first><last>Nicholson</last></author>
-    <author><first>A.</first><last>Mackinlay</last></author>
+    <author><first>Baden</first><last>Hughes</last></author>
+    <author><first>Timothy</first><last>Baldwin</last></author>
+    <author><first>Steven</first><last>Bird</last></author>
+    <author><first>Jeremy</first><last>Nicholson</last></author>
+    <author><first>Andrew</first><last>Mackinlay</last></author>
     <title>Reconsidering Language Identification for Written Language Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -3287,9 +3289,9 @@
     <bibkey>hughes:459:2006:lrec2006</bibkey>
   </paper>
   <paper id="1275" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/461_pdf.pdf">
-    <author><first>Y.</first><last>Senda</last></author>
-    <author><first>Y.</first><last>Sinohara</last></author>
-    <author><first>M.</first><last>Okumura</last></author>
+    <author><first>Yasuko</first><last>Senda</last></author>
+    <author><first>Yasusi</first><last>Sinohara</last></author>
+    <author><first>Manabu</first><last>Okumura</last></author>
     <title>Automatic Terminology Intelligibility Estimation for Readership-oriented Technical Writing</title>
     <month>May</month>
     <year>2006</year>
@@ -3299,10 +3301,10 @@
     <bibkey>senda:461:2006:lrec2006</bibkey>
   </paper>
   <paper id="1276" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/463_pdf.pdf">
-    <author><first>M.</first><last>Lundälv</last></author>
-    <author><first>K.</first><last>Mühlenbock</last></author>
-    <author><first>B.</first><last>Farre</last></author>
-    <author><first>A.</first><last>Brännström</last></author>
+    <author><first>Mats</first><last>Lundälv</last></author>
+    <author><first>Katarina</first><last>Mühlenbock</last></author>
+    <author><first>Bengt</first><last>Farre</last></author>
+    <author><first>Annika</first><last>Brännström</last></author>
     <title>SYMBERED - a Symbol-Concept Editing Tool</title>
     <month>May</month>
     <year>2006</year>
@@ -3312,8 +3314,8 @@
     <bibkey>lundälv:463:2006:lrec2006</bibkey>
   </paper>
   <paper id="1277" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/464_pdf.pdf">
-    <author><first>Y.</first><last>Zhang</last></author>
-    <author><first>V.</first><last>Kordoni</last></author>
+    <author><first>Yi</first><last>Zhang</last></author>
+    <author><first>Valia</first><last>Kordoni</last></author>
     <title>Automated Deep Lexical Acquisition for Robust Open Texts Processing</title>
     <month>May</month>
     <year>2006</year>
@@ -3323,7 +3325,7 @@
     <bibkey>zhang:464:2006:lrec2006</bibkey>
   </paper>
   <paper id="1278" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/465_pdf.pdf">
-    <author><first>J.</first><last>Martin</last></author>
+    <author><first>J.-C.</first><last>Martin</last></author>
     <author><first>G.</first><last>Caridakis</last></author>
     <author><first>L.</first><last>Devillers</last></author>
     <author><first>K.</first><last>Karpouzis</last></author>
@@ -3337,10 +3339,10 @@
     <bibkey>martin:465:2006:lrec2006</bibkey>
   </paper>
   <paper id="1279" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/467_pdf.pdf">
-    <author><first>C.</first><last>Krstev</last></author>
-    <author><first>R.</first><last>Stanković</last></author>
-    <author><first>D.</first><last>Vitas</last></author>
-    <author><first>I.</first><last>Obradović</last></author>
+    <author><first>Cvetana</first><last>Krstev</last></author>
+    <author><first>Ranka</first><last>Stanković</last></author>
+    <author><first>Duško</first><last>Vitas</last></author>
+    <author><first>Ivan</first><last>Obradović</last></author>
     <title>WS4LR: A Workstation for Lexical Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -3350,10 +3352,10 @@
     <bibkey>krstev:467:2006:lrec2006</bibkey>
   </paper>
   <paper id="1280" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/468_pdf.pdf">
-    <author><first>K.</first><last>Kipper</last></author>
-    <author><first>A.</first><last>Korhonen</last></author>
-    <author><first>N.</first><last>Ryant</last></author>
-    <author><first>M.</first><last>Palmer</last></author>
+    <author><first>Karin</first><last>Kipper</last></author>
+    <author><first>Anna</first><last>Korhonen</last></author>
+    <author><first>Neville</first><last>Ryant</last></author>
+    <author><first>Martha</first><last>Palmer</last></author>
     <title>Extending VerbNet with Novel Verb Classes</title>
     <month>May</month>
     <year>2006</year>
@@ -3363,11 +3365,11 @@
     <bibkey>kipper:468:2006:lrec2006</bibkey>
   </paper>
   <paper id="1281" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/469_pdf.pdf">
-    <author><first>J.</first><last>Pustejovsky</last></author>
-    <author><first>C.</first><last>Havasi</last></author>
-    <author><first>J.</first><last>Littman</last></author>
-    <author><first>A.</first><last>Rumshisky</last></author>
-    <author><first>M.</first><last>Verhagen</last></author>
+    <author><first>James</first><last>Pustejovsky</last></author>
+    <author><first>Catherine</first><last>Havasi</last></author>
+    <author><first>Jessica</first><last>Littman</last></author>
+    <author><first>Anna</first><last>Rumshisky</last></author>
+    <author><first>Marc</first><last>Verhagen</last></author>
     <title>Towards a Generative Lexical Resource: The Brandeis Semantic Ontology</title>
     <month>May</month>
     <year>2006</year>
@@ -3377,8 +3379,8 @@
     <bibkey>pustejovsky:469:2006:lrec2006</bibkey>
   </paper>
   <paper id="1282" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/471_pdf.pdf">
-    <author><first>H.</first><last>Dybkjær</last></author>
-    <author><first>L.</first><last>Dybkjær</last></author>
+    <author><first>Hans</first><last>Dybkjær</last></author>
+    <author><first>Laila</first><last>Dybkjær</last></author>
     <title>Act-Topic Patterns for Automatically Checking Dialogue Models</title>
     <month>May</month>
     <year>2006</year>
@@ -3388,8 +3390,8 @@
     <bibkey>dybkjær:471:2006:lrec2006</bibkey>
   </paper>
   <paper id="1283" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/472_pdf.pdf">
-    <author><first>D.</first><last>Rojas</last></author>
-    <author><first>T.</first><last>Aikawa</last></author>
+    <author><first>David M.</first><last>Rojas</last></author>
+    <author><first>Takako</first><last>Aikawa</last></author>
     <title>Predicting MT Quality as a Function of the Source Language</title>
     <month>May</month>
     <year>2006</year>
@@ -3399,8 +3401,8 @@
     <bibkey>rojas:472:2006:lrec2006</bibkey>
   </paper>
   <paper id="1284" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/473_pdf.pdf">
-    <author><first>P.</first><last>Mazur</last></author>
-    <author><first>R.</first><last>Dale</last></author>
+    <author><first>Paweł</first><last>Mazur</last></author>
+    <author><first>Robert</first><last>Dale</last></author>
     <title>Named Entity Extraction with Conjunction Disambiguation</title>
     <month>May</month>
     <year>2006</year>
@@ -3410,9 +3412,9 @@
     <bibkey>mazur:473:2006:lrec2006</bibkey>
   </paper>
   <paper id="1285" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/478_pdf.pdf">
-    <author><first>M.</first><last>Boekestein</last></author>
-    <author><first>G.</first><last>Depoorter</last></author>
-    <author><first>R.</first><last>Veenendaal</last></author>
+    <author><first>Michel</first><last>Boekestein</last></author>
+    <author><first>Griet</first><last>Depoorter</last></author>
+    <author><first>Remco van</first><last>Veenendaal</last></author>
     <title>Functioning of the Centre for Dutch Language and Speech Technology</title>
     <month>May</month>
     <year>2006</year>
@@ -3422,13 +3424,13 @@
     <bibkey>boekestein:478:2006:lrec2006</bibkey>
   </paper>
   <paper id="1286" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/480_pdf.pdf">
-    <author><first>B.</first><last>Maegaard</last></author>
-    <author><first>L.</first><last>Offersgaard</last></author>
-    <author><first>L.</first><last>Henriksen</last></author>
-    <author><first>H.</first><last>Jansen</last></author>
-    <author><first>X.</first><last>Lepetit</last></author>
-    <author><first>C.</first><last>Navarretta</last></author>
-    <author><first>C.</first><last>Povlsen</last></author>
+    <author><first>Bente</first><last>Maegaard</last></author>
+    <author><first>Lene</first><last>Offersgaard</last></author>
+    <author><first>Lina</first><last>Henriksen</last></author>
+    <author><first>Hanne</first><last>Jansen</last></author>
+    <author><first>Xavier</first><last>Lepetit</last></author>
+    <author><first>Costanza</first><last>Navarretta</last></author>
+    <author><first>Claus</first><last>Povlsen</last></author>
     <title>The MULINCO corpus and corpus platform</title>
     <month>May</month>
     <year>2006</year>
@@ -3438,12 +3440,12 @@
     <bibkey>maegaard:480:2006:lrec2006</bibkey>
   </paper>
   <paper id="1287" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/481_pdf.pdf">
-    <author><first>C.</first><last>Soria</last></author>
-    <author><first>M.</first><last>Tesconi</last></author>
-    <author><first>F.</first><last>Bertagna</last></author>
-    <author><first>N.</first><last>Calzolari</last></author>
-    <author><first>A.</first><last>Marchetti</last></author>
-    <author><first>M.</first><last>Monachini</last></author>
+    <author><first>Claudia</first><last>Soria</last></author>
+    <author><first>Maurizio</first><last>Tesconi</last></author>
+    <author><first>Francesca</first><last>Bertagna</last></author>
+    <author><first>Nicoletta</first><last>Calzolari</last></author>
+    <author><first>Andrea</first><last>Marchetti</last></author>
+    <author><first>Monica</first><last>Monachini</last></author>
     <title>Moving to dynamic computational lexicons with LeXFlow</title>
     <month>May</month>
     <year>2006</year>
@@ -3453,11 +3455,11 @@
     <bibkey>soria:481:2006:lrec2006</bibkey>
   </paper>
   <paper id="1288" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/482_pdf.pdf">
-    <author><first>C.</first><last>Sporleder</last></author>
-    <author><first>M.</first><last>Erp</last></author>
-    <author><first>T.</first><last>Porcelijn</last></author>
-    <author><first>A.</first><last>Bosch</last></author>
-    <author><first>P.</first><last>Arntzen</last></author>
+    <author><first>Caroline</first><last>Sporleder</last></author>
+    <author><first>Marieke van</first><last>Erp</last></author>
+    <author><first>Tijn</first><last>Porcelijn</last></author>
+    <author><first>Antal van den</first><last>Bosch</last></author>
+    <author><first>Pim</first><last>Arntzen</last></author>
     <title>Identifying Named Entities in Text Databases from the Natural History Domain</title>
     <month>May</month>
     <year>2006</year>
@@ -3467,9 +3469,9 @@
     <bibkey>sporleder:482:2006:lrec2006</bibkey>
   </paper>
   <paper id="1289" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/483_pdf.pdf">
-    <author><first>H.</first><last>Somers</last></author>
-    <author><first>G.</first><last>Evans</last></author>
-    <author><first>Z.</first><last>Mohamed</last></author>
+    <author><first>Harold</first><last>Somers</last></author>
+    <author><first>Gareth</first><last>Evans</last></author>
+    <author><first>Zeinab</first><last>Mohamed</last></author>
     <title>Developing Speech Synthesis for Under-Resourced Languages by “Faking it”: An Experiment with Somali</title>
     <month>May</month>
     <year>2006</year>
@@ -3479,9 +3481,9 @@
     <bibkey>somers:483:2006:lrec2006</bibkey>
   </paper>
   <paper id="1290" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/484_pdf.pdf">
-    <author><first>D.</first><last>Ciobanu</last></author>
-    <author><first>T.</first><last>Hartley</last></author>
-    <author><first>S.</first><last>Sharoff</last></author>
+    <author><first>Dragoş</first><last>Ciobanu</last></author>
+    <author><first>Tony</first><last>Hartley</last></author>
+    <author><first>Serge</first><last>Sharoff</last></author>
     <title>Using Richly Annotated Trilingual Language Resources for Acquiring Reading Skills in a Foreign Language</title>
     <month>May</month>
     <year>2006</year>
@@ -3495,7 +3497,8 @@
     <author><first>G.</first><last>Boella</last></author>
     <author><first>L.</first><last>Lesmo</last></author>
     <author><first>M.</first><last>Martin</last></author>
-    <author><first>A.</first><last>Mazze</last></author>
+    <author><first>A.</first><last>Mazzei</last></author>
+    <author><first>P.</first><last>Rossi</last></author>
     <title>A Development Tool For Multilingual Ontology-based Conceptual</title>
     <month>May</month>
     <year>2006</year>
@@ -3505,12 +3508,12 @@
     <bibkey>ajani:485:2006:lrec2006</bibkey>
   </paper>
   <paper id="1292" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/487_pdf.pdf">
-    <author><first>B.</first><last>Maegaard</last></author>
-    <author><first>J.</first><last>Fenstad</last></author>
-    <author><first>L.</first><last>Ahrenberg</last></author>
-    <author><first>K.</first><last>Kvale</last></author>
-    <author><first>K.</first><last>Mühlenbock</last></author>
-    <author><first>B.</first><last>Heid</last></author>
+    <author><first>Bente</first><last>Maegaard</last></author>
+    <author><first>Jens-Erik</first><last>Fenstad</last></author>
+    <author><first>Lars</first><last>Ahrenberg</last></author>
+    <author><first>Knut</first><last>Kvale</last></author>
+    <author><first>Katarina</first><last>Mühlenbock</last></author>
+    <author><first>Bernt-Erik</first><last>Heid</last></author>
     <title>KUNSTI - Knowledge Generation for Norwegian Language Technology</title>
     <month>May</month>
     <year>2006</year>
@@ -3520,11 +3523,11 @@
     <bibkey>maegaard:487:2006:lrec2006</bibkey>
   </paper>
   <paper id="1293" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/488_pdf.pdf">
-    <author><first>P.</first><last>Halácsy</last></author>
-    <author><first>A.</first><last>Kornai</last></author>
-    <author><first>C.</first><last>Oravecz</last></author>
-    <author><first>V.</first><last>Trón</last></author>
-    <author><first>D.</first><last>Varga</last></author>
+    <author><first>Péter</first><last>Halácsy</last></author>
+    <author><first>András</first><last>Kornai</last></author>
+    <author><first>Csaba</first><last>Oravecz</last></author>
+    <author><first>Viktor</first><last>Trón</last></author>
+    <author><first>Dániel</first><last>Varga</last></author>
     <title>Using a morphological analyzer in high precision POS tagging of Hungarian</title>
     <month>May</month>
     <year>2006</year>
@@ -3534,10 +3537,10 @@
     <bibkey>halácsy:488:2006:lrec2006</bibkey>
   </paper>
   <paper id="1294" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/489_pdf.pdf">
-    <author><first>D.</first><last>Widdows</last></author>
-    <author><first>A.</first><last>Toumouh</last></author>
-    <author><first>B.</first><last>Dorow</last></author>
-    <author><first>A.</first><last>Lehireche</last></author>
+    <author><first>Dominic</first><last>Widdows</last></author>
+    <author><first>Adil</first><last>Toumouh</last></author>
+    <author><first>Beate</first><last>Dorow</last></author>
+    <author><first>Ahmed</first><last>Lehireche</last></author>
     <title>Ongoing Developments in Automatically Adapting Lexical Resources to the Biomedical Domain</title>
     <month>May</month>
     <year>2006</year>
@@ -3547,9 +3550,9 @@
     <bibkey>widdows:489:2006:lrec2006</bibkey>
   </paper>
   <paper id="1295" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/492_pdf.pdf">
-    <author><first>R.</first><last>Savy</last></author>
-    <author><first>F.</first><last>Cutugno</last></author>
-    <author><first>C.</first><last>Crocco</last></author>
+    <author><first>Renata</first><last>Savy</last></author>
+    <author><first>Francesco</first><last>Cutugno</last></author>
+    <author><first>Claudia</first><last>Crocco</last></author>
     <title>Multilevel corpus analysis: generating and querying an AGset of spoken Italian (SpIt-MDb).</title>
     <month>May</month>
     <year>2006</year>
@@ -3559,9 +3562,9 @@
     <bibkey>savy:492:2006:lrec2006</bibkey>
   </paper>
   <paper id="1296" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/493_pdf.pdf">
-    <author><first>B.</first><last>Hughes</last></author>
-    <author><first>D.</first><last>Gibbon</last></author>
-    <author><first>T.</first><last>Trippel</last></author>
+    <author><first>Baden</first><last>Hughes</last></author>
+    <author><first>Dafydd</first><last>Gibbon</last></author>
+    <author><first>Thorsten</first><last>Trippel</last></author>
     <title>Feature-based Encoding and Querying Language Resources with Character Semantics</title>
     <month>May</month>
     <year>2006</year>
@@ -3571,9 +3574,9 @@
     <bibkey>hughes:493:2006:lrec2006</bibkey>
   </paper>
   <paper id="1297" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/495_pdf.pdf">
-    <author><first>R.</first><last>Subba</last></author>
-    <author><first>B.</first><last>Eugenio</last></author>
-    <author><first>E.</first><last>Terenzi</last></author>
+    <author><first>Rajen</first><last>Subba</last></author>
+    <author><first>Barbara Di</first><last>Eugenio</last></author>
+    <author><first>Elena</first><last>Terenzi</last></author>
     <title>Building lexical resources for PrincPar, a large coverage parser that generates principled semantic representations</title>
     <month>May</month>
     <year>2006</year>
@@ -3583,10 +3586,10 @@
     <bibkey>subba:495:2006:lrec2006</bibkey>
   </paper>
   <paper id="1298" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/496_pdf.pdf">
-    <author><first>K.</first><last>Uchimoto</last></author>
-    <author><first>N.</first><last>Hayashida</last></author>
-    <author><first>T.</first><last>Ishida</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Kiyotaka</first><last>Uchimoto</last></author>
+    <author><first>Naoko</first><last>Hayashida</last></author>
+    <author><first>Toru</first><last>Ishida</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Automatic Detection and Semi-Automatic Revision of Non-Machine-Translatable Parts of a Sentence</title>
     <month>May</month>
     <year>2006</year>
@@ -3596,8 +3599,8 @@
     <bibkey>uchimoto:496:2006:lrec2006</bibkey>
   </paper>
   <paper id="1299" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/497_pdf.pdf">
-    <author><first>I.</first><last>Maks</last></author>
-    <author><first>B.</first><last>Boelhouwer</last></author>
+    <author><first>Isa</first><last>Maks</last></author>
+    <author><first>Bob</first><last>Boelhouwer</last></author>
     <title>Exploring opportunities for Comparability and Enrichment by Linking lexical databases</title>
     <month>May</month>
     <year>2006</year>
@@ -3607,7 +3610,7 @@
     <bibkey>maks:497:2006:lrec2006</bibkey>
   </paper>
   <paper id="1300" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/498_pdf.pdf">
-    <author><first>H.</first><last>Saggion</last></author>
+    <author><first>Horacio</first><last>Saggion</last></author>
     <title>Multilingual Multidocument Summarization Tools and Evaluation</title>
     <month>May</month>
     <year>2006</year>
@@ -3617,7 +3620,7 @@
     <bibkey>saggion:498:2006:lrec2006</bibkey>
   </paper>
   <paper id="1301" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/500_pdf.pdf">
-    <author><first>O.</first><last>Ferret</last></author>
+    <author><first>Olivier</first><last>Ferret</last></author>
     <title>Building a network of topical relations from a corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -3639,10 +3642,10 @@
     <bibkey>bouquet:501:2006:lrec2006</bibkey>
   </paper>
   <paper id="1303" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/503_pdf.pdf">
-    <author><first>M.</first><last>Maragoudakis</last></author>
-    <author><first>K.</first><last>Kermanidis</last></author>
-    <author><first>A.</first><last>Garbis</last></author>
-    <author><first>N.</first><last>Fakotakis</last></author>
+    <author><first>Manolis</first><last>Maragoudakis</last></author>
+    <author><first>Katia</first><last>Kermanidis</last></author>
+    <author><first>Aristogiannis</first><last>Garbis</last></author>
+    <author><first>Nikos</first><last>Fakotakis</last></author>
     <title>Dealing with Imbalanced Data using Bayesian Techniques</title>
     <month>May</month>
     <year>2006</year>
@@ -3652,14 +3655,14 @@
     <bibkey>maragoudakis:503:2006:lrec2006</bibkey>
   </paper>
   <paper id="1304" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/504_pdf.pdf">
-    <author><first>J.</first><last>Benedí</last></author>
-    <author><first>E.</first><last>Lleida</last></author>
-    <author><first>A.</first><last>Varona</last></author>
-    <author><first>M.</first><last>Castro</last></author>
-    <author><first>I.</first><last>Galiano</last></author>
-    <author><first>R.</first><last>Justo</last></author>
-    <author><first>I. López</first><last>de Letona</last></author>
-    <author><first>A.</first><last>Miguel</last></author>
+    <author><first>José-Miguel</first><last>Benedí</last></author>
+    <author><first>Eduardo</first><last>Lleida</last></author>
+    <author><first>Amparo</first><last>Varona</last></author>
+    <author><first>Marı́a-José</first><last>Castro</last></author>
+    <author><first>Isabel</first><last>Galiano</last></author>
+    <author><first>Raquel</first><last>Justo</last></author>
+    <author><first>Iñigo</first><last>López de Letona</last></author>
+    <author><first>Antonio</first><last>Miguel</last></author>
     <title>Design and acquisition of a telephone spontaneous speech dialogue corpus in Spanish: DIHANA</title>
     <month>May</month>
     <year>2006</year>
@@ -3669,9 +3672,9 @@
     <bibkey>benedí:504:2006:lrec2006</bibkey>
   </paper>
   <paper id="1305" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/505_pdf.pdf">
-    <author><first>R.</first><last>Osswald</last></author>
-    <author><first>H.</first><last>Helbig</last></author>
-    <author><first>S.</first><last>Hartrumpf</last></author>
+    <author><first>Rainer</first><last>Osswald</last></author>
+    <author><first>Hermann</first><last>Helbig</last></author>
+    <author><first>Sven</first><last>Hartrumpf</last></author>
     <title>The Representation of German Prepositional Verbs in a Semantically Based Computer Lexicon</title>
     <month>May</month>
     <year>2006</year>
@@ -3681,14 +3684,14 @@
     <bibkey>osswald:505:2006:lrec2006</bibkey>
   </paper>
   <paper id="1306" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/506_pdf.pdf">
-    <author><first>Y.</first><last>Chiao</last></author>
-    <author><first>O.</first><last>Kraif</last></author>
-    <author><first>D.</first><last>Laurent</last></author>
-    <author><first>T.</first><last>Nguyen</last></author>
-    <author><first>N.</first><last>Semmar</last></author>
-    <author><first>F.</first><last>Stuck</last></author>
-    <author><first>J.</first><last>Véronis</last></author>
-    <author><first>W.</first><last>Zaghouani</last></author>
+    <author><first>Yun-Chuang</first><last>Chiao</last></author>
+    <author><first>Olivier</first><last>Kraif</last></author>
+    <author><first>Dominique</first><last>Laurent</last></author>
+    <author><first>Thi Minh Huyen</first><last>Nguyen</last></author>
+    <author><first>Nasredine</first><last>Semmar</last></author>
+    <author><first>François</first><last>Stuck</last></author>
+    <author><first>Jean</first><last>Véronis</last></author>
+    <author><first>Wajdi</first><last>Zaghouani</last></author>
     <title>Evaluation of multilingual text alignment systems: the ARCADE II project</title>
     <month>May</month>
     <year>2006</year>
@@ -3698,7 +3701,7 @@
     <bibkey>chiao:506:2006:lrec2006</bibkey>
   </paper>
   <paper id="1307" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/508_pdf.pdf">
-    <author><first>F.</first><last>Bertagna</last></author>
+    <author><first>Francesca</first><last>Bertagna</last></author>
     <title>Representation and Inference for Open-Domain QA: Strength and Limits of two Italian Semantic Lexicons</title>
     <month>May</month>
     <year>2006</year>
@@ -3708,12 +3711,12 @@
     <bibkey>bertagna:508:2006:lrec2006</bibkey>
   </paper>
   <paper id="1308" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/509_pdf.pdf">
-    <author><first>A.</first><last>Abdelsapor</last></author>
-    <author><first>N.</first><last>Adly</last></author>
-    <author><first>K.</first><last>Darwish</last></author>
-    <author><first>O.</first><last>Emam</last></author>
-    <author><first>W.</first><last>Magdy</last></author>
-    <author><first>M.</first><last>Nagi</last></author>
+    <author><first>Abdelrahim</first><last>Abdelsapor</last></author>
+    <author><first>Noha</first><last>Adly</last></author>
+    <author><first>Kareem</first><last>Darwish</last></author>
+    <author><first>Ossama</first><last>Emam</last></author>
+    <author><first>Walid</first><last>Magdy</last></author>
+    <author><first>Magdi</first><last>Nagi</last></author>
     <title>Building a Heterogeneous Information Retrieval Collection of Printed Arabic Documents</title>
     <month>May</month>
     <year>2006</year>
@@ -3723,9 +3726,9 @@
     <bibkey>abdelsapor:509:2006:lrec2006</bibkey>
   </paper>
   <paper id="1309" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/510_pdf.pdf">
-    <author><first>S.</first><last>Luz</last></author>
-    <author><first>M.</first><last>Bouamrane</last></author>
-    <author><first>M.</first><last>Masoodian</last></author>
+    <author><first>Saturnino</first><last>Luz</last></author>
+    <author><first>Matt-Mouley</first><last>Bouamrane</last></author>
+    <author><first>Masood</first><last>Masoodian</last></author>
     <title>Gathering a corpus of multimodal computer-mediated meetings</title>
     <month>May</month>
     <year>2006</year>
@@ -3735,8 +3738,8 @@
     <bibkey>luz:510:2006:lrec2006</bibkey>
   </paper>
   <paper id="1310" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/511_pdf.pdf">
-    <author><first>D.</first><last>Athanassia-lida</last></author>
-    <author><first>A.</first><last>Chalamandaris</last></author>
+    <author><first>Dimou</first><last>Athanassia-Lida</last></author>
+    <author><first>Chalamandaris</first><last>Aimilios</last></author>
     <title>Language identification from suprasegmental cues: Speech synthesis of Greek utterances from different dialectal variations.</title>
     <month>May</month>
     <year>2006</year>
@@ -3746,8 +3749,8 @@
     <bibkey>athanassia-lida:511:2006:lrec2006</bibkey>
   </paper>
   <paper id="1311" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/513_pdf.pdf">
-    <author><first>R.</first><last>Levy</last></author>
-    <author><first>G.</first><last>Andrew</last></author>
+    <author><first>Roger</first><last>Levy</last></author>
+    <author><first>Galen</first><last>Andrew</last></author>
     <title>Tregex and Tsurgeon: tools for querying and manipulating tree data structures</title>
     <month>May</month>
     <year>2006</year>
@@ -3759,7 +3762,7 @@
   <paper id="1312" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/515_pdf.pdf">
     <author><first>L.</first><last>Gillard</last></author>
     <author><first>P.</first><last>Bellot</last></author>
-    <author><first>M.</first><last>El-bèze</last></author>
+    <author><first>M.</first><last>El-Bèze</last></author>
     <title>Question Answering Evaluation Survey</title>
     <month>May</month>
     <year>2006</year>
@@ -3775,7 +3778,7 @@
     <author><first>M.</first><last>Negri</last></author>
     <author><first>L.</first><last>Romano</last></author>
     <author><first>M.</first><last>Speranza</last></author>
-    <author><first>V.</first><last>Lenzi</last></author>
+    <author><first>V. Bartalesi</first><last>Lenzi</last></author>
     <author><first>R.</first><last>Sprugnoli</last></author>
     <title>I-CAB: the Italian Content Annotation Bank</title>
     <month>May</month>
@@ -3786,10 +3789,10 @@
     <bibkey>magnini:518:2006:lrec2006</bibkey>
   </paper>
   <paper id="1314" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/521_pdf.pdf">
-    <author><first>B.</first><last>Maegaard</last></author>
-    <author><first>S.</first><last>Krauwer</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
-    <author><first>L.</first><last>Jørgensen</last></author>
+    <author><first>Bente</first><last>Maegaard</last></author>
+    <author><first>Steven</first><last>Krauwer</last></author>
+    <author><first>Khalid</first><last>Choukri</last></author>
+    <author><first>Lise Damsgaard</first><last>Jørgensen</last></author>
     <title>The BLARK concept and BLARK for Arabic</title>
     <month>May</month>
     <year>2006</year>
@@ -3799,10 +3802,10 @@
     <bibkey>maegaard:521:2006:lrec2006</bibkey>
   </paper>
   <paper id="1315" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/524_pdf.pdf">
-    <author><first>G.</first><last>Pardelli</last></author>
-    <author><first>M.</first><last>Sassi</last></author>
-    <author><first>S.</first><last>Goggi</last></author>
-    <author><first>P.</first><last>Orsolini</last></author>
+    <author><first>Gabriella</first><last>Pardelli</last></author>
+    <author><first>Manuela</first><last>Sassi</last></author>
+    <author><first>Sara</first><last>Goggi</last></author>
+    <author><first>Paola</first><last>Orsolini</last></author>
     <title>Natural Language Processing: A Terminological and Statistical Approach</title>
     <month>May</month>
     <year>2006</year>
@@ -3812,10 +3815,10 @@
     <bibkey>pardelli:524:2006:lrec2006</bibkey>
   </paper>
   <paper id="1316" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/525_pdf.pdf">
-    <author><first>S.</first><last>Verberne</last></author>
-    <author><first>L.</first><last>Boves</last></author>
-    <author><first>N.</first><last>Oostdijk</last></author>
-    <author><first>P.</first><last>Coppen</last></author>
+    <author><first>Suzan</first><last>Verberne</last></author>
+    <author><first>Lou</first><last>Boves</last></author>
+    <author><first>Nelleke</first><last>Oostdijk</last></author>
+    <author><first>Peter-Arno</first><last>Coppen</last></author>
     <title>Data for question answering: The case of why</title>
     <month>May</month>
     <year>2006</year>
@@ -3825,8 +3828,8 @@
     <bibkey>verberne:525:2006:lrec2006</bibkey>
   </paper>
   <paper id="1317" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/527_pdf.pdf">
-    <author><first>K.</first><last>Simov</last></author>
-    <author><first>P.</first><last>Osenova</last></author>
+    <author><first>Kiril</first><last>Simov</last></author>
+    <author><first>Petya</first><last>Osenova</last></author>
     <title>Shallow Semantic Annotation of Bulgarian</title>
     <month>May</month>
     <year>2006</year>
@@ -3836,17 +3839,17 @@
     <bibkey>simov:527:2006:lrec2006</bibkey>
   </paper>
   <paper id="1318" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/530_pdf.pdf">
-    <author><first>C.</first><last>Cieri</last></author>
-    <author><first>W.</first><last>Andrews</last></author>
-    <author><first>J.</first><last>Campbell</last></author>
-    <author><first>G.</first><last>Doddington</last></author>
-    <author><first>J.</first><last>Godfrey</last></author>
-    <author><first>S.</first><last>Huang</last></author>
-    <author><first>M.</first><last>Liberman</last></author>
-    <author><first>A.</first><last>Martin</last></author>
-    <author><first>H.</first><last>Nakasone</last></author>
-    <author><first>M.</first><last>Przybocki</last></author>
-    <author><first>K.</first><last>Walker</last></author>
+    <author><first>Christopher</first><last>Cieri</last></author>
+    <author><first>Walt</first><last>Andrews</last></author>
+    <author><first>Joseph P.</first><last>Campbell</last></author>
+    <author><first>George</first><last>Doddington</last></author>
+    <author><first>Jack</first><last>Godfrey</last></author>
+    <author><first>Shudong</first><last>Huang</last></author>
+    <author><first>Mark</first><last>Liberman</last></author>
+    <author><first>Alvin</first><last>Martin</last></author>
+    <author><first>Hirotaka</first><last>Nakasone</last></author>
+    <author><first>Mark</first><last>Przybocki</last></author>
+    <author><first>Kevin</first><last>Walker</last></author>
     <title>The Mixer and Transcript Reading Corpora: Resources for Multilingual, Crosschannel Speaker Recognition Research</title>
     <month>May</month>
     <year>2006</year>
@@ -3858,7 +3861,7 @@
   <paper id="1319" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/531_pdf.pdf">
     <author><first>S.</first><last>Abrilian</last></author>
     <author><first>L.</first><last>Devillers</last></author>
-    <author><first>J.</first><last>Martin</last></author>
+    <author><first>J-C.</first><last>Martin</last></author>
     <title>Annotation of Emotions in Real-Life Video Interviews: Variability between Coders</title>
     <month>May</month>
     <year>2006</year>
@@ -3868,8 +3871,8 @@
     <bibkey>abrilian:531:2006:lrec2006</bibkey>
   </paper>
   <paper id="1320" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/532_pdf.pdf">
-    <author><first>Y.</first><last>Chou</last></author>
-    <author><first>C.</first><last>Huang</last></author>
+    <author><first>Ya-Min</first><last>Chou</last></author>
+    <author><first>Chu-Ren</first><last>Huang</last></author>
     <title>Hantology-A Linguistic Resource for Chinese Language Processing and Studying</title>
     <month>May</month>
     <year>2006</year>
@@ -3879,14 +3882,14 @@
     <bibkey>chou:532:2006:lrec2006</bibkey>
   </paper>
   <paper id="1321" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/534_pdf.pdf">
-    <author><first>M.</first><last>Gavrilidou</last></author>
-    <author><first>P.</first><last>Labropoulou</last></author>
-    <author><first>S.</first><last>Piperidis</last></author>
-    <author><first>V.</first><last>Giouli</last></author>
-    <author><first>N.</first><last>Calzolari</last></author>
-    <author><first>M.</first><last>Monachini</last></author>
-    <author><first>C.</first><last>Soria</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
+    <author><first>Maria</first><last>Gavrilidou</last></author>
+    <author><first>Penny</first><last>Labropoulou</last></author>
+    <author><first>Stelios</first><last>Piperidis</last></author>
+    <author><first>Voula</first><last>Giouli</last></author>
+    <author><first>Nicoletta</first><last>Calzolari</last></author>
+    <author><first>Monica</first><last>Monachini</last></author>
+    <author><first>Claudia</first><last>Soria</last></author>
+    <author><first>Khalid</first><last>Choukri</last></author>
     <title>Language Resources Production Models: the Case of the INTERA Multilingual Corpus and Terminology</title>
     <month>May</month>
     <year>2006</year>
@@ -3896,10 +3899,10 @@
     <bibkey>gavrilidou:534:2006:lrec2006</bibkey>
   </paper>
   <paper id="1322" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/535_pdf.pdf">
-    <author><first>K.</first><last>Kanzaki</last></author>
-    <author><first>Q.</first><last>Ma</last></author>
-    <author><first>E.</first><last>Yamamoto</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Kyoko</first><last>Kanzaki</last></author>
+    <author><first>Qing</first><last>Ma</last></author>
+    <author><first>Eiko</first><last>Yamamoto</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Semantic Analysis of Abstract Nouns to Compile a Thesaurus of Adjectives</title>
     <month>May</month>
     <year>2006</year>
@@ -3909,8 +3912,8 @@
     <bibkey>kanzaki:535:2006:lrec2006</bibkey>
   </paper>
   <paper id="1323" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/537_pdf.pdf">
-    <author><first>K.</first><last>Erk</last></author>
-    <author><first>S.</first><last>Pado</last></author>
+    <author><first>Katrin</first><last>Erk</last></author>
+    <author><first>Sebastian</first><last>Padó</last></author>
     <title>Shalmaneser - A Toolchain For Shallow Semantic Parsing</title>
     <month>May</month>
     <year>2006</year>
@@ -3920,10 +3923,10 @@
     <bibkey>erk:537:2006:lrec2006</bibkey>
   </paper>
   <paper id="1324" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/538_pdf.pdf">
-    <author><first>V.</first><last>Tablan</last></author>
-    <author><first>T.</first><last>Polajnar</last></author>
-    <author><first>H.</first><last>Cunningham</last></author>
-    <author><first>K.</first><last>Bontcheva</last></author>
+    <author><first>Valentin</first><last>Tablan</last></author>
+    <author><first>Tamara</first><last>Polajnar</last></author>
+    <author><first>Hamish</first><last>Cunningham</last></author>
+    <author><first>Kalina</first><last>Bontcheva</last></author>
     <title>User-friendly ontology authoring using a controlled language</title>
     <month>May</month>
     <year>2006</year>
@@ -3933,9 +3936,9 @@
     <bibkey>tablan:538:2006:lrec2006</bibkey>
   </paper>
   <paper id="1325" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/539_pdf.pdf">
-    <author><first>L.</first><last>Hasler</last></author>
-    <author><first>C.</first><last>Orasan</last></author>
-    <author><first>K.</first><last>Naumann</last></author>
+    <author><first>Laura</first><last>Hasler</last></author>
+    <author><first>Constantin</first><last>Orasan</last></author>
+    <author><first>Karin</first><last>Naumann</last></author>
     <title>NPs for Events: Experiments in Coreference Annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -3945,12 +3948,12 @@
     <bibkey>hasler:539:2006:lrec2006</bibkey>
   </paper>
   <paper id="1326" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/540_pdf.pdf">
-    <author><first>A.</first><last>Mendes</last></author>
-    <author><first>S.</first><last>Antunes</last></author>
-    <author><first>M.</first><last>Nascimento</last></author>
-    <author><first>J.</first><last>Casteleiro</last></author>
-    <author><first>L.</first><last>Pereira</last></author>
-    <author><first>T.</first><last>Sá</last></author>
+    <author><first>Amália</first><last>Mendes</last></author>
+    <author><first>Sandra</first><last>Antunes</last></author>
+    <author><first>Maria Fernanda Bacelar do</first><last>Nascimento</last></author>
+    <author><first>João Miguel</first><last>Casteleiro</last></author>
+    <author><first>Luísa</first><last>Pereira</last></author>
+    <author><first>Tiago</first><last>Sá</last></author>
     <title>COMBINA-PT: A Large Corpus-extracted and Hand-checked Lexical Database of Portuguese Multiword Expressions</title>
     <month>May</month>
     <year>2006</year>
@@ -3960,10 +3963,10 @@
     <bibkey>mendes:540:2006:lrec2006</bibkey>
   </paper>
   <paper id="1327" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/541_pdf.pdf">
-    <author><first>D.</first><last>Graff</last></author>
-    <author><first>T.</first><last>Buckwalter</last></author>
-    <author><first>M.</first><last>Maamouri</last></author>
-    <author><first>H.</first><last>Jin</last></author>
+    <author><first>David</first><last>Graff</last></author>
+    <author><first>Tim</first><last>Buckwalter</last></author>
+    <author><first>Mohamed</first><last>Maamouri</last></author>
+    <author><first>Hubert</first><last>Jin</last></author>
     <title>Lexicon Development for Varieties of Spoken Colloquial Arabic</title>
     <month>May</month>
     <year>2006</year>
@@ -3973,9 +3976,9 @@
     <bibkey>graff:541:2006:lrec2006</bibkey>
   </paper>
   <paper id="1328" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/542_pdf.pdf">
-    <author><first>A.</first><last>Patry</last></author>
-    <author><first>F.</first><last>Gotti</last></author>
-    <author><first>P.</first><last>Langlais</last></author>
+    <author><first>Alexandre</first><last>Patry</last></author>
+    <author><first>Fabrizio</first><last>Gotti</last></author>
+    <author><first>Philippe</first><last>Langlais</last></author>
     <title>MOOD: A Modular Object-Oriented Decoder for Statistical Machine Translation</title>
     <month>May</month>
     <year>2006</year>
@@ -3985,13 +3988,13 @@
     <bibkey>patry:542:2006:lrec2006</bibkey>
   </paper>
   <paper id="1329" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/543_pdf.pdf">
-    <author><first>M.</first><last>Maamouri</last></author>
-    <author><first>A.</first><last>Bies</last></author>
-    <author><first>T.</first><last>Buckwalter</last></author>
-    <author><first>M.</first><last>Diab</last></author>
-    <author><first>N.</first><last>Habash</last></author>
-    <author><first>O.</first><last>Rambow</last></author>
-    <author><first>D.</first><last>Tabessi</last></author>
+    <author><first>Mohamed</first><last>Maamouri</last></author>
+    <author><first>Ann</first><last>Bies</last></author>
+    <author><first>Tim</first><last>Buckwalter</last></author>
+    <author><first>Mona</first><last>Diab</last></author>
+    <author><first>Nizar</first><last>Habash</last></author>
+    <author><first>Owen</first><last>Rambow</last></author>
+    <author><first>Dalila</first><last>Tabessi</last></author>
     <title>Developing and Using a Pilot Dialectal Arabic Treebank</title>
     <month>May</month>
     <year>2006</year>
@@ -4001,9 +4004,9 @@
     <bibkey>maamouri:543:2006:lrec2006</bibkey>
   </paper>
   <paper id="1330" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/544_pdf.pdf">
-    <author><first>B.</first><last>Megyesi</last></author>
-    <author><first>A.</first><last>Hein</last></author>
-    <author><first>É.</first><last>Johanson</last></author>
+    <author><first>Beáta Bandmann</first><last>Megyesi</last></author>
+    <author><first>Anna Sågvall</first><last>Hein</last></author>
+    <author><first>Éva Csató</first><last>Johanson</last></author>
     <title>Building a Swedish-Turkish Parallel Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -4013,8 +4016,8 @@
     <bibkey>megyesi:544:2006:lrec2006</bibkey>
   </paper>
   <paper id="1331" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/545_pdf.pdf">
-    <author><first>H.</first><last>Saggion</last></author>
-    <author><first>R.</first><last>Gaizauskas</last></author>
+    <author><first>Horacio</first><last>Saggion</last></author>
+    <author><first>Robert</first><last>Gaizauskas</last></author>
     <title>Language Resources for Background Gathering</title>
     <month>May</month>
     <year>2006</year>
@@ -4024,10 +4027,10 @@
     <bibkey>saggion:545:2006:lrec2006</bibkey>
   </paper>
   <paper id="1332" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/550_pdf.pdf">
-    <author><first>J.</first><last>Medero</last></author>
-    <author><first>K.</first><last>Maeda</last></author>
-    <author><first>S.</first><last>Strassel</last></author>
-    <author><first>C.</first><last>Walker</last></author>
+    <author><first>Julie</first><last>Medero</last></author>
+    <author><first>Kazuaki</first><last>Maeda</last></author>
+    <author><first>Stephanie</first><last>Strassel</last></author>
+    <author><first>Christopher</first><last>Walker</last></author>
     <title>An Efficient Approach to Gold-Standard Annotation: Decision Points for Complex Tasks</title>
     <month>May</month>
     <year>2006</year>
@@ -4037,7 +4040,7 @@
     <bibkey>medero:550:2006:lrec2006</bibkey>
   </paper>
   <paper id="1333" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/552_pdf.pdf">
-    <author><first>S.</first><last>Klatt</last></author>
+    <author><first>Stefan</first><last>Klatt</last></author>
     <title>A Corpus-based Approach to the Interpretation of Unknown Words with an Application to German</title>
     <month>May</month>
     <year>2006</year>
@@ -4047,8 +4050,8 @@
     <bibkey>klatt:552:2006:lrec2006</bibkey>
   </paper>
   <paper id="1334" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/553_pdf.pdf">
-    <author><first>S.</first><last>Rosset</last></author>
-    <author><first>S.</first><last>Petel</last></author>
+    <author><first>Sophie</first><last>Rosset</last></author>
+    <author><first>Sandra</first><last>Petel</last></author>
     <title>The Ritel Corpus - An annotated Human-Machine open-domain question answering spoken dialog corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -4058,9 +4061,9 @@
     <bibkey>rosset:553:2006:lrec2006</bibkey>
   </paper>
   <paper id="1335" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/554_pdf.pdf">
-    <author><first>A.</first><last>Feldman</last></author>
-    <author><first>J.</first><last>Hana</last></author>
-    <author><first>C.</first><last>Brew</last></author>
+    <author><first>Anna</first><last>Feldman</last></author>
+    <author><first>Jirka</first><last>Hana</last></author>
+    <author><first>Chris</first><last>Brew</last></author>
     <title>A Cross-language Approach to Rapid Creation of New Morpho-syntactically Annotated Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -4070,10 +4073,10 @@
     <bibkey>feldman:554:2006:lrec2006</bibkey>
   </paper>
   <paper id="1336" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/557_pdf.pdf">
-    <author><first>I.</first><last>Michailidis</last></author>
-    <author><first>K.</first><last>Diamantaras</last></author>
-    <author><first>S.</first><last>Vasileiadis</last></author>
-    <author><first>Y.</first><last>Frère</last></author>
+    <author><first>Ionas</first><last>Michailidis</last></author>
+    <author><first>Konstantinos</first><last>Diamantaras</last></author>
+    <author><first>Spiros</first><last>Vasileiadis</last></author>
+    <author><first>Yannick</first><last>Frère</last></author>
     <title>Greek Named Entity Recognition using Support Vector Machines, Maximum Entropy and Onetime</title>
     <month>May</month>
     <year>2006</year>
@@ -4083,9 +4086,9 @@
     <bibkey>michailidis:557:2006:lrec2006</bibkey>
   </paper>
   <paper id="1337" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/558_pdf.pdf">
-    <author><first>A.</first><last>Korhonen</last></author>
-    <author><first>Y.</first><last>Krymolowski</last></author>
-    <author><first>T.</first><last>Briscoe</last></author>
+    <author><first>Anna</first><last>Korhonen</last></author>
+    <author><first>Yuval</first><last>Krymolowski</last></author>
+    <author><first>Ted</first><last>Briscoe</last></author>
     <title>A Large Subcategorization Lexicon for Natural Language Processing Applications</title>
     <month>May</month>
     <year>2006</year>
@@ -4095,8 +4098,8 @@
     <bibkey>korhonen:558:2006:lrec2006</bibkey>
   </paper>
   <paper id="1338" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/560_pdf.pdf">
-    <author><first>N.</first><last>Ide</last></author>
-    <author><first>K.</first><last>Suderman</last></author>
+    <author><first>Nancy</first><last>Ide</last></author>
+    <author><first>Keith</first><last>Suderman</last></author>
     <title>Integrating Linguistic Resources: The American National Corpus Model</title>
     <month>May</month>
     <year>2006</year>
@@ -4106,8 +4109,8 @@
     <bibkey>ide:560:2006:lrec2006</bibkey>
   </paper>
   <paper id="1339" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/562_pdf.pdf">
-    <author><first>N.</first><last>Ide</last></author>
-    <author><first>L.</first><last>Romary</last></author>
+    <author><first>Nancy</first><last>Ide</last></author>
+    <author><first>Laurent</first><last>Romary</last></author>
     <title>Representing Linguistic Corpora and Their Annotations</title>
     <month>May</month>
     <year>2006</year>
@@ -4117,9 +4120,9 @@
     <bibkey>ide:562:2006:lrec2006</bibkey>
   </paper>
   <paper id="1340" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/565_pdf.pdf">
-    <author><first>Z.</first><last>Huang</last></author>
-    <author><first>L.</first><last>Chen</last></author>
-    <author><first>M.</first><last>Harper</last></author>
+    <author><first>Zhongqiang</first><last>Huang</last></author>
+    <author><first>Lei</first><last>Chen</last></author>
+    <author><first>Mary</first><last>Harper</last></author>
     <title>An Open Source Prosodic Feature Extraction Tool</title>
     <month>May</month>
     <year>2006</year>
@@ -4129,8 +4132,8 @@
     <bibkey>huang:565:2006:lrec2006</bibkey>
   </paper>
   <paper id="1341" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/566_pdf.pdf">
-    <author><first>A.</first><last>Andreevskaia</last></author>
-    <author><first>S.</first><last>Bergler</last></author>
+    <author><first>Alina</first><last>Andreevskaia</last></author>
+    <author><first>Sabine</first><last>Bergler</last></author>
     <title>Semantic Tag Extraction from WordNet Glosses</title>
     <month>May</month>
     <year>2006</year>
@@ -4140,9 +4143,9 @@
     <bibkey>andreevskaia:566:2006:lrec2006</bibkey>
   </paper>
   <paper id="1342" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/567_pdf.pdf">
-    <author><first>K.</first><last>Kuroda</last></author>
-    <author><first>M.</first><last>Utiyama</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Kow</first><last>Kuroda</last></author>
+    <author><first>Masao</first><last>Utiyama</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Getting Deeper Semantics than Berkeley FrameNet with MSFA</title>
     <month>May</month>
     <year>2006</year>
@@ -4152,10 +4155,10 @@
     <bibkey>kuroda:567:2006:lrec2006</bibkey>
   </paper>
   <paper id="1343" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/569_pdf.pdf">
-    <author><first>E.</first><last>Alfonseca</last></author>
-    <author><first>A.</first><last>Moreno-sandoval</last></author>
-    <author><first>J.</first><last>Guirao</last></author>
-    <author><first>M.</first><last>Ruiz-casado</last></author>
+    <author><first>Enrique</first><last>Alfonseca</last></author>
+    <author><first>Antonio</first><last>Moreno-Sandoval</last></author>
+    <author><first>José Marı́a</first><last>Guirao</last></author>
+    <author><first>Maria</first><last>Ruiz-Casado</last></author>
     <title>The wraetlic NLP suite</title>
     <month>May</month>
     <year>2006</year>
@@ -4165,11 +4168,11 @@
     <bibkey>alfonseca:569:2006:lrec2006</bibkey>
   </paper>
   <paper id="1344" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/570_pdf.pdf">
-    <author><first>T.</first><last>Ohta</last></author>
-    <author><first>Y.</first><last>Tateisi</last></author>
-    <author><first>J.</first><last>Kim</last></author>
-    <author><first>A.</first><last>Yakushiji</last></author>
-    <author><first>J.</first><last>Tsujii</last></author>
+    <author><first>Tomoko</first><last>Ohta</last></author>
+    <author><first>Yuka</first><last>Tateisi</last></author>
+    <author><first>Jin-Dong</first><last>Kim</last></author>
+    <author><first>Akane</first><last>Yakushiji</last></author>
+    <author><first>Jun-ichi</first><last>Tsujii</last></author>
     <title>Linguistic and Biological Annotations of Biological Interaction Events</title>
     <month>May</month>
     <year>2006</year>
@@ -4179,9 +4182,9 @@
     <bibkey>ohta:570:2006:lrec2006</bibkey>
   </paper>
   <paper id="1345" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/573_pdf.pdf">
-    <author><first>K.</first><last>Tenfjord</last></author>
-    <author><first>P.</first><last>Meurer</last></author>
-    <author><first>K.</first><last>Hofland</last></author>
+    <author><first>Kari</first><last>Tenfjord</last></author>
+    <author><first>Paul</first><last>Meurer</last></author>
+    <author><first>Knut</first><last>Hofland</last></author>
     <title>The ASK Corpus - a Language Learner Corpus of Norwegian as a Second Language</title>
     <month>May</month>
     <year>2006</year>
@@ -4191,9 +4194,9 @@
     <bibkey>tenfjord:573:2006:lrec2006</bibkey>
   </paper>
   <paper id="1346" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/575_pdf.pdf">
-    <author><first>I.</first><last>Kruijff-korbayová</last></author>
-    <author><first>K.</first><last>Chvatalova</last></author>
-    <author><first>O.</first><last>Postolache</last></author>
+    <author><first>Ivana</first><last>Kruijff-Korbayová</last></author>
+    <author><first>Klára</first><last>Chvatalova</last></author>
+    <author><first>Oana</first><last>Postolache</last></author>
     <title>Annotation Guidelines for Czech-English Word Alignment</title>
     <month>May</month>
     <year>2006</year>
@@ -4203,9 +4206,9 @@
     <bibkey>kruijff-korbayová:575:2006:lrec2006</bibkey>
   </paper>
   <paper id="1347" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/576_pdf.pdf">
-    <author><first>J.</first><last>Segouat</last></author>
-    <author><first>A.</first><last>Braffort</last></author>
-    <author><first>E.</first><last>Martin</last></author>
+    <author><first>Jérémie</first><last>Segouat</last></author>
+    <author><first>Annelies</first><last>Braffort</last></author>
+    <author><first>Emilie</first><last>Martin</last></author>
     <title>Sign Language corpus analysis: Synchronisation of linguistic annotation and numerical data</title>
     <month>May</month>
     <year>2006</year>
@@ -4215,13 +4218,13 @@
     <bibkey>segouat:576:2006:lrec2006</bibkey>
   </paper>
   <paper id="1348" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/577_pdf.pdf">
-    <author><first>G.</first><last>Francopoulo</last></author>
-    <author><first>M.</first><last>George</last></author>
-    <author><first>N.</first><last>Calzolari</last></author>
-    <author><first>M.</first><last>Monachini</last></author>
-    <author><first>N.</first><last>Bel</last></author>
-    <author><first>M.</first><last>Pet</last></author>
-    <author><first>C.</first><last>Soria</last></author>
+    <author><first>Gil</first><last>Francopoulo</last></author>
+    <author><first>Monte</first><last>George</last></author>
+    <author><first>Nicoletta</first><last>Calzolari</last></author>
+    <author><first>Monica</first><last>Monachini</last></author>
+    <author><first>Nuria</first><last>Bel</last></author>
+    <author><first>Mandy</first><last>Pet</last></author>
+    <author><first>Claudia</first><last>Soria</last></author>
     <title>Lexical Markup Framework (LMF)</title>
     <month>May</month>
     <year>2006</year>
@@ -4231,17 +4234,17 @@
     <bibkey>francopoulo:577:2006:lrec2006</bibkey>
   </paper>
   <paper id="1349" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/578_pdf.pdf">
-    <author><first>B.</first><last>Pouliquen</last></author>
-    <author><first>M.</first><last>Kimler</last></author>
-    <author><first>R.</first><last>Steinberger</last></author>
-    <author><first>C.</first><last>Ignat</last></author>
-    <author><first>T.</first><last>Oellinger</last></author>
-    <author><first>K.</first><last>Blackler</last></author>
-    <author><first>F.</first><last>Fluart</last></author>
-    <author><first>W.</first><last>Zaghouani</last></author>
-    <author><first>A.</first><last>Widiger</last></author>
-    <author><first>A.</first><last>Forslund</last></author>
-    <author><first>C.</first><last>Best</last></author>
+    <author><first>Bruno</first><last>Pouliquen</last></author>
+    <author><first>Marco</first><last>Kimler</last></author>
+    <author><first>Ralf</first><last>Steinberger</last></author>
+    <author><first>Camelia</first><last>Ignat</last></author>
+    <author><first>Tamara</first><last>Oellinger</last></author>
+    <author><first>Ken</first><last>Blackler</last></author>
+    <author><first>Flavio</first><last>Fluart</last></author>
+    <author><first>Wajdi</first><last>Zaghouani</last></author>
+    <author><first>Anna</first><last>Widiger</last></author>
+    <author><first>Ann-Charlotte</first><last>Forslund</last></author>
+    <author><first>Clive</first><last>Best</last></author>
     <title>Geocoding Multilingual Texts: Recognition, Disambiguation and Visualisation</title>
     <month>May</month>
     <year>2006</year>
@@ -4251,7 +4254,7 @@
     <bibkey>pouliquen:578:2006:lrec2006</bibkey>
   </paper>
   <paper id="1350" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/580_pdf.pdf">
-    <author><first>B.</first><last>Pedersen</last></author>
+    <author><first>Bolette Sandford</first><last>Pedersen</last></author>
     <title>Query Expansion on Compounds</title>
     <month>May</month>
     <year>2006</year>
@@ -4261,11 +4264,11 @@
     <bibkey>pedersen:580:2006:lrec2006</bibkey>
   </paper>
   <paper id="1351" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/581_pdf.pdf">
-    <author><first>T.</first><last>Charoenporn</last></author>
-    <author><first>C.</first><last>Kruengkrai</last></author>
-    <author><first>T.</first><last>Theeramunkong</last></author>
-    <author><first>V.</first><last>Sornlertlamvanich</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Thatsanee</first><last>Charoenporn</last></author>
+    <author><first>Canasai</first><last>Kruengkrai</last></author>
+    <author><first>Thanaruk</first><last>Theeramunkong</last></author>
+    <author><first>Virach</first><last>Sornlertlamvanich</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Word Knowledge Acquisition for Computational Lexicon Construction</title>
     <month>May</month>
     <year>2006</year>
@@ -4275,10 +4278,10 @@
     <bibkey>charoenporn:581:2006:lrec2006</bibkey>
   </paper>
   <paper id="1352" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/582_pdf.pdf">
-    <author><first>W.</first><last>Peters</last></author>
-    <author><first>M.</first><last>Sagri</last></author>
-    <author><first>D.</first><last>Tiscornia</last></author>
-    <author><first>S.</first><last>Castagnoli</last></author>
+    <author><first>Wim</first><last>Peters</last></author>
+    <author><first>Maria Teresa</first><last>Sagri</last></author>
+    <author><first>Daniela</first><last>Tiscornia</last></author>
+    <author><first>Sara</first><last>Castagnoli</last></author>
     <title>The LOIS Project</title>
     <month>May</month>
     <year>2006</year>
@@ -4288,10 +4291,10 @@
     <bibkey>peters:582:2006:lrec2006</bibkey>
   </paper>
   <paper id="1353" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/583_pdf.pdf">
-    <author><first>J.</first><last>Vaneyghen</last></author>
-    <author><first>G.</first><last>Pauw</last></author>
-    <author><first>D.</first><last>Compernolle</last></author>
-    <author><first>W.</first><last>Daelemans</last></author>
+    <author><first>Joris</first><last>Vaneyghen</last></author>
+    <author><first>Guy De</first><last>Pauw</last></author>
+    <author><first>Dirk Van</first><last>Compernolle</last></author>
+    <author><first>Walter</first><last>Daelemans</last></author>
     <title>A mixed word / morphological approach for extending CELEX for high coverage on contemporary large corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -4301,7 +4304,7 @@
     <bibkey>vaneyghen:583:2006:lrec2006</bibkey>
   </paper>
   <paper id="1354" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/584_pdf.pdf">
-    <author><first>A.</first><last>Roventini</last></author>
+    <author><first>Adriana</first><last>Roventini</last></author>
     <title>Linking Verbal Entries of Different Lexical Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -4312,11 +4315,11 @@
   </paper>
   <paper id="1355" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/586_pdf.pdf">
     <author><first>O.</first><last>Hamon</last></author>
-    <author><first>A.</first><last>Popescu-belis</last></author>
+    <author><first>A.</first><last>Popescu-Belis</last></author>
     <author><first>K.</first><last>Choukri</last></author>
     <author><first>M.</first><last>Dabbadie</last></author>
     <author><first>A.</first><last>Hartley</last></author>
-    <author><first>W. Mustafa El</first><last>Hadi</last></author>
+    <author><first>W.</first><last>Mustafa El Hadi</last></author>
     <author><first>M.</first><last>Rajman</last></author>
     <author><first>I.</first><last>Timimi</last></author>
     <title>CESTA: First Conclusions of the Technolangue MT Evaluation Campaign</title>
@@ -4328,8 +4331,8 @@
     <bibkey>hamon:586:2006:lrec2006</bibkey>
   </paper>
   <paper id="1356" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/589_pdf.pdf">
-    <author><first>A.</first><last>Meur</last></author>
-    <author><first>M.</first><last>Derouin</last></author>
+    <author><first>André Le</first><last>Meur</last></author>
+    <author><first>Marie-Jeanne</first><last>Derouin</last></author>
     <title>Lemma-oriented dictionaries, concept-oriented terminology and translation memories</title>
     <month>May</month>
     <year>2006</year>
@@ -4339,10 +4342,10 @@
     <bibkey>meur:589:2006:lrec2006</bibkey>
   </paper>
   <paper id="1357" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/590_pdf.pdf">
-    <author><first>M.</first><last>Umbert</last></author>
-    <author><first>A.</first><last>Moreno</last></author>
-    <author><first>P.</first><last>Agüero</last></author>
-    <author><first>A.</first><last>Bonafonte</last></author>
+    <author><first>Martí</first><last>Umbert</last></author>
+    <author><first>Asunción</first><last>Moreno</last></author>
+    <author><first>Pablo</first><last>Agüero</last></author>
+    <author><first>Antonio</first><last>Bonafonte</last></author>
     <title>Spanish Synthesis Corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -4352,9 +4355,9 @@
     <bibkey>umbert:590:2006:lrec2006</bibkey>
   </paper>
   <paper id="1358" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/591_pdf.pdf">
-    <author><first>P.</first><last>Ircing</last></author>
-    <author><first>J.</first><last>Hoidekr</last></author>
-    <author><first>J.</first><last>Psutka</last></author>
+    <author><first>Pavel</first><last>Ircing</last></author>
+    <author><first>Jan</first><last>Hoidekr</last></author>
+    <author><first>Josef</first><last>Psutka</last></author>
     <title>Exploiting Linguistic Knowledge in Language Modeling of Czech Spontaneous Speech</title>
     <month>May</month>
     <year>2006</year>
@@ -4364,7 +4367,7 @@
     <bibkey>ircing:591:2006:lrec2006</bibkey>
   </paper>
   <paper id="1359" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/593_pdf.pdf">
-    <author><first>M.</first><last>Slavcheva</last></author>
+    <author><first>Milena</first><last>Slavcheva</last></author>
     <title>Semantic Descriptors: The Case of Reflexive Verbs</title>
     <month>May</month>
     <year>2006</year>
@@ -4374,8 +4377,8 @@
     <bibkey>slavcheva:593:2006:lrec2006</bibkey>
   </paper>
   <paper id="1360" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/595_pdf.pdf">
-    <author><first>G.</first><last>Neumann</last></author>
-    <author><first>B.</first><last>Crysmann</last></author>
+    <author><first>Günter</first><last>Neumann</last></author>
+    <author><first>Berthold</first><last>Crysmann</last></author>
     <title>Exploring HPSG-based Treebanks for Probabilistic Parsing HPSG grammar extraction</title>
     <month>May</month>
     <year>2006</year>
@@ -4385,8 +4388,8 @@
     <bibkey>neumann:595:2006:lrec2006</bibkey>
   </paper>
   <paper id="1361" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/596_pdf.pdf">
-    <author><first>R.</first><last>Marinelli</last></author>
-    <author><first>R.</first><last>Bindi</last></author>
+    <author><first>Rita</first><last>Marinelli</last></author>
+    <author><first>Remo</first><last>Bindi</last></author>
     <title>Proper Names and Linguistic Dynamics</title>
     <month>May</month>
     <year>2006</year>
@@ -4396,9 +4399,9 @@
     <bibkey>marinelli:596:2006:lrec2006</bibkey>
   </paper>
   <paper id="1362" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/597_pdf.pdf">
-    <author><first>S.</first><last>Bosch</last></author>
-    <author><first>L.</first><last>Pretorius</last></author>
-    <author><first>J.</first><last>Jones</last></author>
+    <author><first>Sonja E.</first><last>Bosch</last></author>
+    <author><first>Laurette</first><last>Pretorius</last></author>
+    <author><first>Jackie</first><last>Jones</last></author>
     <title>Towards machine-readable lexicons for South African Bantu languages</title>
     <month>May</month>
     <year>2006</year>
@@ -4408,10 +4411,10 @@
     <bibkey>bosch:597:2006:lrec2006</bibkey>
   </paper>
   <paper id="1363" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/599_pdf.pdf">
-    <author><first>G.</first><last>Lechenadec</last></author>
-    <author><first>V.</first><last>Maffiolo</last></author>
-    <author><first>N.</first><last>Chateau</last></author>
-    <author><first>J.</first><last>Colletta</last></author>
+    <author><last>Lechenadec</last><first>G.</first></author>
+    <author><last>Maffiolo</last><first>V.</first></author>
+    <author><last>Chateau</last><first>N.</first></author>
+    <author><last>Colletta</last><first>J.M.</first></author>
     <title>Creation of a corpus of multimodal spontaneous expressions of emotions in Human-Machine Interaction</title>
     <month>May</month>
     <year>2006</year>
@@ -4421,8 +4424,8 @@
     <bibkey>lechenadec:599:2006:lrec2006</bibkey>
   </paper>
   <paper id="1364" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/600_pdf.pdf">
-    <author><first>Y.</first><last>Hayashi</last></author>
-    <author><first>T.</first><last>Ishida</last></author>
+    <author><first>Yoshihiko</first><last>Hayashi</last></author>
+    <author><first>Toru</first><last>Ishida</last></author>
     <title>A Dictionary Model for Unifying Machine Readable Dictionaries and Computational Concept Lexicons</title>
     <month>May</month>
     <year>2006</year>
@@ -4432,9 +4435,9 @@
     <bibkey>hayashi:600:2006:lrec2006</bibkey>
   </paper>
   <paper id="1365" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/602_pdf.pdf">
-    <author><first>R.</first><last>Marinelli</last></author>
-    <author><first>A.</first><last>Roventini</last></author>
-    <author><first>G.</first><last>Spadoni</last></author>
+    <author><first>Rita</first><last>Marinelli</last></author>
+    <author><first>Adriana</first><last>Roventini</last></author>
+    <author><first>Giovanni</first><last>Spadoni</last></author>
     <title>Using Core Ontology for Domain Lexicon Structuring</title>
     <month>May</month>
     <year>2006</year>
@@ -4444,11 +4447,11 @@
     <bibkey>marinelli:602:2006:lrec2006</bibkey>
   </paper>
   <paper id="1366" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/603_pdf.pdf">
-    <author><first>W.</first><last>Abramowicz</last></author>
-    <author><first>A.</first><last>Filipowska</last></author>
-    <author><first>J.</first><last>Piskorski</last></author>
-    <author><first>K.</first><last>Węcel</last></author>
-    <author><first>K.</first><last>Wieloc</last></author>
+    <author><first>Witold</first><last>Abramowicz</last></author>
+    <author><first>Agata</first><last>Filipowska</last></author>
+    <author><first>Jakub</first><last>Piskorski</last></author>
+    <author><first>Krzysztof</first><last>Węcel</last></author>
+    <author><first>Karol</first><last>Wieloch</last></author>
     <title>Linguistic Suite for Polish Cadastral System</title>
     <month>May</month>
     <year>2006</year>
@@ -4458,9 +4461,9 @@
     <bibkey>abramowicz:603:2006:lrec2006</bibkey>
   </paper>
   <paper id="1367" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/604_pdf.pdf">
-    <author><first>H.</first><last>Kawanami</last></author>
-    <author><first>T.</first><last>Kitamura</last></author>
-    <author><first>K.</first><last>Shikano</last></author>
+    <author><first>Hiromichi</first><last>Kawanami</last></author>
+    <author><first>Takahiro</first><last>Kitamura</last></author>
+    <author><first>Kiyohiro</first><last>Shikano</last></author>
     <title>Long-term Analysis of Prosodic Features of Spoken Guidance System User Speech</title>
     <month>May</month>
     <year>2006</year>
@@ -4470,9 +4473,9 @@
     <bibkey>kawanami:604:2006:lrec2006</bibkey>
   </paper>
   <paper id="1368" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/606_pdf.pdf">
-    <author><first>V.</first><last>Nováček</last></author>
-    <author><first>P.</first><last>Smrž</last></author>
-    <author><first>J.</first><last>Pomikálek</last></author>
+    <author><first>Vít</first><last>Nováček</last></author>
+    <author><first>Pavel</first><last>Smrž</last></author>
+    <author><first>Jan</first><last>Pomikálek</last></author>
     <title>Text Mining for Semantic Relations as a Support Base of a Scientific Portal Generator</title>
     <month>May</month>
     <year>2006</year>
@@ -4482,10 +4485,10 @@
     <bibkey>nováček:606:2006:lrec2006</bibkey>
   </paper>
   <paper id="1369" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/608_pdf.pdf">
-    <author><first>R.</first><last>Bernardi</last></author>
-    <author><first>A.</first><last>Bolognesi</last></author>
-    <author><first>C.</first><last>Seidenari</last></author>
-    <author><first>F.</first><last>Tamburini</last></author>
+    <author><first>Raffaella</first><last>Bernardi</last></author>
+    <author><first>Andrea</first><last>Bolognesi</last></author>
+    <author><first>Corrado</first><last>Seidenari</last></author>
+    <author><first>Fabio</first><last>Tamburini</last></author>
     <title>POS tagset design for Italian</title>
     <month>May</month>
     <year>2006</year>
@@ -4495,11 +4498,11 @@
     <bibkey>bernardi:608:2006:lrec2006</bibkey>
   </paper>
   <paper id="1370" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/610_pdf.pdf">
-    <author><first>K.</first><last>Inui</last></author>
-    <author><first>T.</first><last>Hirano</last></author>
-    <author><first>R.</first><last>Iida</last></author>
-    <author><first>A.</first><last>Fujita</last></author>
-    <author><first>Y.</first><last>Matsumoto</last></author>
+    <author><first>Kentaro</first><last>Inui</last></author>
+    <author><first>Toru</first><last>Hirano</last></author>
+    <author><first>Ryu</first><last>Iida</last></author>
+    <author><first>Atsushi</first><last>Fujita</last></author>
+    <author><first>Yuji</first><last>Matsumoto</last></author>
     <title>Augmenting a Semantic Verb Lexicon with a Large Scale Collection of Example Sentences</title>
     <month>May</month>
     <year>2006</year>
@@ -4510,7 +4513,7 @@
   </paper>
   <paper id="1371" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/611_pdf.pdf">
     <author><first>C.</first><last>Onelli</last></author>
-    <author><first>D.</first><last>Poietti</last></author>
+    <author><first>D.</first><last>Proietti</last></author>
     <author><first>C.</first><last>Seidenari</last></author>
     <author><first>F.</first><last>Tamburini</last></author>
     <title>The DiaCORIS project: a diachronic corpus of written Italian</title>
@@ -4522,10 +4525,10 @@
     <bibkey>onelli:611:2006:lrec2006</bibkey>
   </paper>
   <paper id="1372" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/612_pdf.pdf">
-    <author><first>E.</first><last>Agirre</last></author>
-    <author><first>I.</first><last>Aldezabal</last></author>
-    <author><first>J.</first><last>Etxeberria</last></author>
-    <author><first>E.</first><last>Pociello</last></author>
+    <author><first>Eneko</first><last>Agirre</last></author>
+    <author><first>Izaskun</first><last>Aldezabal</last></author>
+    <author><first>Jone</first><last>Etxeberria</last></author>
+    <author><first>Eli</first><last>Pociello</last></author>
     <title>A Preliminary Study for Building the Basque PropBank</title>
     <month>May</month>
     <year>2006</year>
@@ -4535,9 +4538,9 @@
     <bibkey>agirre:612:2006:lrec2006</bibkey>
   </paper>
   <paper id="1373" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/613_pdf.pdf">
-    <author><first>E.</first><last>Yamamoto</last></author>
-    <author><first>K.</first><last>Kanzaki</last></author>
-    <author><first>H.</first><last>Isahara</last></author>
+    <author><first>Eiko</first><last>Yamamoto</last></author>
+    <author><first>Kyoko</first><last>Kanzaki</last></author>
+    <author><first>Hitoshi</first><last>Isahara</last></author>
     <title>Detection of inconsistencies in concept classifications in a large dictionary — Toward an improvement of the EDR electronic dictionary —</title>
     <month>May</month>
     <year>2006</year>
@@ -4547,13 +4550,13 @@
     <bibkey>yamamoto:613:2006:lrec2006</bibkey>
   </paper>
   <paper id="1374" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/614_pdf.pdf">
-    <author><first>E.</first><last>Agirre</last></author>
-    <author><first>I.</first><last>Aldezabal</last></author>
-    <author><first>J.</first><last>Etxeberria</last></author>
-    <author><first>E.</first><last>Izagirre</last></author>
-    <author><first>K.</first><last>Mendizabal</last></author>
-    <author><first>E.</first><last>Pociello</last></author>
-    <author><first>M.</first><last>Quintian</last></author>
+    <author><first>Eneko</first><last>Agirre</last></author>
+    <author><first>Izaskun</first><last>Aldezabal</last></author>
+    <author><first>Jone</first><last>Etxeberria</last></author>
+    <author><first>Eli</first><last>Izagirre</last></author>
+    <author><first>Karmele</first><last>Mendizabal</last></author>
+    <author><first>Eli</first><last>Pociello</last></author>
+    <author><first>Mikel</first><last>Quintian</last></author>
     <title>A methodology for the joint development of the Basque WordNet and Semcor</title>
     <month>May</month>
     <year>2006</year>
@@ -4563,10 +4566,10 @@
     <bibkey>agirre:614:2006:lrec2006</bibkey>
   </paper>
   <paper id="1375" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/615_pdf.pdf">
-    <author><first>J.</first><last>Hoidekr</last></author>
-    <author><first>J.</first><last>Psutka</last></author>
-    <author><first>A.</first><last>Pražák</last></author>
-    <author><first>J.</first><last>Psutka</last></author>
+    <author><first>Jan</first><last>Hoidekr</last></author>
+    <author><first>J.V.</first><last>Psutka</last></author>
+    <author><first>Aleš</first><last>Pražák</last></author>
+    <author><first>Josef</first><last>Psutka</last></author>
     <title>Benefit of a Class-based Language Model for Real-time Closed-captioning of TV Ice-hockey Commentaries</title>
     <month>May</month>
     <year>2006</year>
@@ -4576,9 +4579,9 @@
     <bibkey>hoidekr:615:2006:lrec2006</bibkey>
   </paper>
   <paper id="1376" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/617_pdf.pdf">
-    <author><first>S.</first><last>Anstein</last></author>
-    <author><first>G.</first><last>Kremer</last></author>
-    <author><first>U.</first><last>Reyle</last></author>
+    <author><first>Stefanie</first><last>Anstein</last></author>
+    <author><first>Gerhard</first><last>Kremer</last></author>
+    <author><first>Uwe</first><last>Reyle</last></author>
     <title>Identifying and Classifying Terms in the Life Sciences: The Case of Chemical Terminology</title>
     <month>May</month>
     <year>2006</year>
@@ -4588,7 +4591,7 @@
     <bibkey>anstein:617:2006:lrec2006</bibkey>
   </paper>
   <paper id="1377" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/618_pdf.pdf">
-    <author><first>M.</first><last>Lafourcade</last></author>
+    <author><first>Mathieu</first><last>Lafourcade</last></author>
     <title>Conceptual Vector Learning - Comparing Bootstrapping from a Thesaurus or Induction by Emergence</title>
     <month>May</month>
     <year>2006</year>
@@ -4598,8 +4601,8 @@
     <bibkey>lafourcade:618:2006:lrec2006</bibkey>
   </paper>
   <paper id="1378" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/620_pdf.pdf">
-    <author><first>E.</first><last>Luca</last></author>
-    <author><first>A.</first><last>Nürnberger</last></author>
+    <author><first>Ernesto William De</first><last>Luca</last></author>
+    <author><first>Andreas</first><last>Nürnberger</last></author>
     <title>Rebuilding Lexical Resources for Information Retrieval using Sense Folder Detection and Merging Methods</title>
     <month>May</month>
     <year>2006</year>
@@ -4609,7 +4612,7 @@
     <bibkey>luca:620:2006:lrec2006</bibkey>
   </paper>
   <paper id="1379" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/621_pdf.pdf">
-    <author><first>P.</first><last>Smrž</last></author>
+    <author><first>Pavel</first><last>Smrž</last></author>
     <title>Automatic Acquisition of Semantics-Extraction Patterns</title>
     <month>May</month>
     <year>2006</year>
@@ -4619,7 +4622,7 @@
     <bibkey>smrž:621:2006:lrec2006</bibkey>
   </paper>
   <paper id="1380" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/622_pdf.pdf">
-    <author><first>L.</first><last>Cyrus</last></author>
+    <author><first>Lea</first><last>Cyrus</last></author>
     <title>Building a resource for studying translation shifts</title>
     <month>May</month>
     <year>2006</year>
@@ -4629,8 +4632,8 @@
     <bibkey>cyrus:622:2006:lrec2006</bibkey>
   </paper>
   <paper id="1381" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/623_pdf.pdf">
-    <author><first>C.</first><last>Draxler</last></author>
-    <author><first>K.</first><last>Jänsch</last></author>
+    <author><first>Christoph</first><last>Draxler</last></author>
+    <author><first>Klaus</first><last>Jänsch</last></author>
     <title>Speech Recordings in Public Schools in Germany - the Perfect Show Case for Web-based Recordings and Annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -4640,10 +4643,10 @@
     <bibkey>draxler:623:2006:lrec2006</bibkey>
   </paper>
   <paper id="1382" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/624_pdf.pdf">
-    <author><first>B.</first><last>Tsou</last></author>
-    <author><first>T.</first><last>Lai</last></author>
-    <author><first>K.</first><last>Sin</last></author>
-    <author><first>L.</first><last>Cheung</last></author>
+    <author><first>Benjamin K.</first><last>Tsou</last></author>
+    <author><first>Tom B.Y.</first><last>Lai</last></author>
+    <author><first>K.K.</first><last>Sin</last></author>
+    <author><first>Lawrence Y.L.</first><last>Cheung</last></author>
     <title>Court Stenography-To-Text (“STT”) in Hong Kong: A Jurilinguistic Engineering Effort</title>
     <month>May</month>
     <year>2006</year>
@@ -4653,8 +4656,8 @@
     <bibkey>tsou:624:2006:lrec2006</bibkey>
   </paper>
   <paper id="1383" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/625_pdf.pdf">
-    <author><first>D.</first><last>Beermann</last></author>
-    <author><first>L.</first><last>Hellan</last></author>
+    <author><first>Dorothee</first><last>Beermann</last></author>
+    <author><first>Lars</first><last>Hellan</last></author>
     <title>Word Sense Disambiguation and Semantic Disambiguation for Construction Types in Deep Processing Grammars</title>
     <month>May</month>
     <year>2006</year>
@@ -4664,9 +4667,9 @@
     <bibkey>beermann:625:2006:lrec2006</bibkey>
   </paper>
   <paper id="1384" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/626_pdf.pdf">
-    <author><first>D.</first><last>Reidsma</last></author>
-    <author><first>D.</first><last>Heylen</last></author>
-    <author><first>R.</first><last>Ordelman</last></author>
+    <author><first>Dennis</first><last>Reidsma</last></author>
+    <author><first>Dirk</first><last>Heylen</last></author>
+    <author><first>Roeland</first><last>Ordelman</last></author>
     <title>Annotating Emotions in Meetings</title>
     <month>May</month>
     <year>2006</year>
@@ -4676,7 +4679,7 @@
     <bibkey>reidsma:626:2006:lrec2006</bibkey>
   </paper>
   <paper id="1385" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/627_pdf.pdf">
-    <author><first>H.</first><last>Bonneau-maynard</last></author>
+    <author><first>H.</first><last>Bonneau-Maynard</last></author>
     <author><first>C.</first><last>Ayache</last></author>
     <author><first>F.</first><last>Bechet</last></author>
     <author><first>A.</first><last>Denis</last></author>
@@ -4696,8 +4699,8 @@
     <bibkey>bonneau-maynard:627:2006:lrec2006</bibkey>
   </paper>
   <paper id="1386" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/629_pdf.pdf">
-    <author><first>J.</first><last>Kuhn</last></author>
-    <author><first>M.</first><last>Jellinghaus</last></author>
+    <author><first>Jonas</first><last>Kuhn</last></author>
+    <author><first>Michael</first><last>Jellinghaus</last></author>
     <title>Multilingual parallel treebanking: a lean and flexible approach</title>
     <month>May</month>
     <year>2006</year>
@@ -4707,10 +4710,10 @@
     <bibkey>kuhn:629:2006:lrec2006</bibkey>
   </paper>
   <paper id="1387" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/630_pdf.pdf">
-    <author><first>J.</first><last>Mauclair</last></author>
-    <author><first>Y.</first><last>Estève</last></author>
-    <author><first>S.</first><last>Petit-renaud</last></author>
-    <author><first>P.</first><last>Deléglise</last></author>
+    <author><first>Julie</first><last>Mauclair</last></author>
+    <author><first>Yannick</first><last>Estève</last></author>
+    <author><first>Simon</first><last>Petit-Renaud</last></author>
+    <author><first>Paul</first><last>Deléglise</last></author>
     <title>Automatic Detection of Well Recognized Words in Automatic Speech Transcriptions</title>
     <month>May</month>
     <year>2006</year>
@@ -4720,16 +4723,16 @@
     <bibkey>mauclair:630:2006:lrec2006</bibkey>
   </paper>
   <paper id="1388" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/631_pdf.pdf">
-    <author><first>F.</first><last>Calzolari</last></author>
-    <author><first>E.</first><last>Sassolini</last></author>
-    <author><first>M.</first><last>Sassi</last></author>
-    <author><first>S.</first><last>Cucurullo</last></author>
-    <author><first>E.</first><last>Picchi</last></author>
-    <author><first>F.</first><last>Bertagna</last></author>
-    <author><first>A.</first><last>Enea</last></author>
-    <author><first>M.</first><last>Monachini</last></author>
-    <author><first>C.</first><last>Soria</last></author>
-    <author><first>N.</first><last>Calzolari</last></author>
+    <author><first>Federico</first><last>Calzolari</last></author>
+    <author><first>Eva</first><last>Sassolini</last></author>
+    <author><first>Manuela</first><last>Sassi</last></author>
+    <author><first>Sebastiana</first><last>Cucurullo</last></author>
+    <author><first>Eugenio</first><last>Picchi</last></author>
+    <author><first>Francesca</first><last>Bertagna</last></author>
+    <author><first>Alessandro</first><last>Enea</last></author>
+    <author><first>Monica</first><last>Monachini</last></author>
+    <author><first>Claudia</first><last>Soria</last></author>
+    <author><first>Nicoletta</first><last>Calzolari</last></author>
     <title>Next Generation Language Resources using Grid</title>
     <month>May</month>
     <year>2006</year>
@@ -4739,7 +4742,7 @@
     <bibkey>calzolari:631:2006:lrec2006</bibkey>
   </paper>
   <paper id="1389" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/632_pdf.pdf">
-    <author><first>S.</first><last>Nimb</last></author>
+    <author><first>Sanni</first><last>Nimb</last></author>
     <title>LEXADV - a multilingual semantic Lexicon for Adverbs</title>
     <month>May</month>
     <year>2006</year>
@@ -4749,10 +4752,10 @@
     <bibkey>nimb:632:2006:lrec2006</bibkey>
   </paper>
   <paper id="1390" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/633_pdf.pdf">
-    <author><first>V.</first><last>Giouli</last></author>
-    <author><first>A.</first><last>Konstandinidis</last></author>
-    <author><first>E.</first><last>Desypri</last></author>
-    <author><first>H.</first><last>Papageorgiou</last></author>
+    <author><first>Voula</first><last>Giouli</last></author>
+    <author><first>Alexis</first><last>Konstandinidis</last></author>
+    <author><first>Elina</first><last>Desypri</last></author>
+    <author><first>Harris</first><last>Papageorgiou</last></author>
     <title>Multi-domain Multi-lingual Named Entity Recognition: Revisiting &amp; Grounding the resources issue</title>
     <month>May</month>
     <year>2006</year>
@@ -4762,9 +4765,9 @@
     <bibkey>giouli:633:2006:lrec2006</bibkey>
   </paper>
   <paper id="1391" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/634_pdf.pdf">
-    <author><first>R.</first><last>Passonneau</last></author>
-    <author><first>N.</first><last>Habash</last></author>
-    <author><first>O.</first><last>Rambow</last></author>
+    <author><first>Rebecca</first><last>Passonneau</last></author>
+    <author><first>Nizar</first><last>Habash</last></author>
+    <author><first>Owen</first><last>Rambow</last></author>
     <title>Inter-annotator Agreement on a Multilingual Semantic Annotation Task</title>
     <month>May</month>
     <year>2006</year>
@@ -4774,7 +4777,7 @@
     <bibkey>passonneau:634:2006:lrec2006</bibkey>
   </paper>
   <paper id="1392" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/636_pdf.pdf">
-    <author><first>R.</first><last>Passonneau</last></author>
+    <author><first>Rebecca</first><last>Passonneau</last></author>
     <title>Measuring Agreement on Set-valued Items (MASI) for Semantic and Pragmatic Annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -4784,7 +4787,7 @@
     <bibkey>passonneau:636:2006:lrec2006</bibkey>
   </paper>
   <paper id="1393" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/637_pdf.pdf">
-    <author><first>T.</first><last>Akiba</last></author>
+    <author><first>Tomoyosi</first><last>Akiba</last></author>
     <title>Exploiting Dynamic Passage Retrieval for Spoken Question Recognition and Context Processing towards Speech-driven Information Access Dialogue</title>
     <month>May</month>
     <year>2006</year>
@@ -4794,10 +4797,10 @@
     <bibkey>akiba:637:2006:lrec2006</bibkey>
   </paper>
   <paper id="1394" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/638_pdf.pdf">
-    <author><first>M.</first><last>Verhagen</last></author>
-    <author><first>R.</first><last>Knippen</last></author>
-    <author><first>I.</first><last>Mani</last></author>
-    <author><first>J.</first><last>Pustejovsky</last></author>
+    <author><first>Marc</first><last>Verhagen</last></author>
+    <author><first>Robert</first><last>Knippen</last></author>
+    <author><first>Inderjeet</first><last>Mani</last></author>
+    <author><first>James</first><last>Pustejovsky</last></author>
     <title>Annotation of Temporal Relations with Tango</title>
     <month>May</month>
     <year>2006</year>
@@ -4807,7 +4810,7 @@
     <bibkey>verhagen:638:2006:lrec2006</bibkey>
   </paper>
   <paper id="1395" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/639_pdf.pdf">
-    <author><first>P.</first><last>Paggio</last></author>
+    <author><first>Patrizia</first><last>Paggio</last></author>
     <title>Annotating Information Structure in a Corpus of Spoken Danish</title>
     <month>May</month>
     <year>2006</year>
@@ -4817,9 +4820,9 @@
     <bibkey>paggio:639:2006:lrec2006</bibkey>
   </paper>
   <paper id="1396" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/641_pdf.pdf">
-    <author><first>U.</first><last>Quasthoff</last></author>
-    <author><first>M.</first><last>Richter</last></author>
-    <author><first>C.</first><last>Biemann</last></author>
+    <author><first>Uwe</first><last>Quasthoff</last></author>
+    <author><first>Matthias</first><last>Richter</last></author>
+    <author><first>Christian</first><last>Biemann</last></author>
     <title>Corpus Portal for Search in Monolingual Corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -4829,9 +4832,9 @@
     <bibkey>quasthoff:641:2006:lrec2006</bibkey>
   </paper>
   <paper id="1397" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/642_pdf.pdf">
-    <author><first>T.</first><last>Vanrullen</last></author>
-    <author><first>P.</first><last>Blache</last></author>
-    <author><first>J.</first><last>Balfourier</last></author>
+    <author><first>Tristan</first><last>Vanrullen</last></author>
+    <author><first>Philippe</first><last>Blache</last></author>
+    <author><first>Jean-Marie</first><last>Balfourier</last></author>
     <title>Constraint-Based Parsing as an Efficient Solution: Results from the Parsing Evaluation Campaign EASy</title>
     <month>May</month>
     <year>2006</year>
@@ -4841,7 +4844,7 @@
     <bibkey>vanrullen:642:2006:lrec2006</bibkey>
   </paper>
   <paper id="1398" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/643_pdf.pdf">
-    <author><first>A.</first><last>Eisele</last></author>
+    <author><first>Andreas</first><last>Eisele</last></author>
     <title>Parallel Corpora and Phrase-Based Statistical Machine Translation for New Language Pairs via Multiple Intermediaries</title>
     <month>May</month>
     <year>2006</year>
@@ -4851,20 +4854,18 @@
     <bibkey>eisele:643:2006:lrec2006</bibkey>
   </paper>
   <paper id="1399" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/645_pdf.pdf">
-    <author><first>K.</first><last>Miller</last></author>
-    <author><first>M.</first><last>Vanni</last></author>
-    <author><first>O.</first><last>Rambow</last></author>
-    <author><first>B.</first><last>Dorr</last></author>
-    <author><first>D.</first><last>Farwell</last></author>
-    <author><first>R.</first><last>Green</last></author>
-    <author><first>N.</first><last>Habash</last></author>
-    <author><first>S.</first><last>Helmreich</last></author>
-    <author><first>E.</first><last>Hovy</last></author>
-    <author><first>L.</first><last>Levin</last></author>
-    <author><first>K.</first><last>Miller</last></author>
-    <author><first>T.</first><last>Mitamura</last></author>
-    <author><first>F.</first><last>Reeder</last></author>
-    <author><first>A.</first><last>Siddharthan</last></author>
+    <author><first>Owen</first><last>Rambow</last></author>
+    <author><first>Bonnie</first><last>Dorr</last></author>
+    <author><first>David</first><last>Farwell</last></author>
+    <author><first>Rebecca</first><last>Green</last></author>
+    <author><first>Nizar</first><last>Habash</last></author>
+    <author><first>Stephen</first><last>Helmreich</last></author>
+    <author><first>Eduard</first><last>Hovy</last></author>
+    <author><first>Lori</first><last>Levin</last></author>
+    <author><first>Keith J.</first><last>Miller</last></author>
+    <author><first>Teruko</first><last>Mitamura</last></author>
+    <author><first>Florence</first><last>Reeder</last></author>
+    <author><first>Advaith</first><last>Siddharthan</last></author>
     <title>Parallel Syntactic Annotation of Multiple Languages</title>
     <month>May</month>
     <year>2006</year>
@@ -4877,7 +4878,7 @@
     <author><first>S.</first><last>Galliano</last></author>
     <author><first>E.</first><last>Geoffrois</last></author>
     <author><first>G.</first><last>Gravier</last></author>
-    <author><first>J.</first><last>Bonastre</last></author>
+    <author><first>J.-F.</first><last>Bonastre</last></author>
     <author><first>D.</first><last>Mostefa</last></author>
     <author><first>K.</first><last>Choukri</last></author>
     <title>Corpus description of the ESTER Evaluation Campaign for the Rich Transcription of French Broadcast News</title>
@@ -4889,10 +4890,10 @@
     <bibkey>galliano:646:2006:lrec2006</bibkey>
   </paper>
   <paper id="1401" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/647_pdf.pdf">
-    <author><first>J.</first><last>Soler</last></author>
-    <author><first>P.</first><last>Cerezo</last></author>
-    <author><first>C.</first><last>Ávila</last></author>
-    <author><first>D.</first><last>Merino</last></author>
+    <author><first>Juan José Rodríguez</first><last>Soler</last></author>
+    <author><first>Pedro Concejero</first><last>Cerezo</last></author>
+    <author><first>Carlos Lázaro</first><last>Ávila</last></author>
+    <author><first>Daniel Tapias</first><last>Merino</last></author>
     <title>Usability evaluation of 3G multimodal services in Telefónica Móviles España</title>
     <month>May</month>
     <year>2006</year>
@@ -4902,8 +4903,8 @@
     <bibkey>soler:647:2006:lrec2006</bibkey>
   </paper>
   <paper id="1402" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/649_pdf.pdf">
-    <author><first>M.</first><last>Miháltz</last></author>
-    <author><first>G.</first><last>Pohl</last></author>
+    <author><first>Márton</first><last>Miháltz</last></author>
+    <author><first>Gábor</first><last>Pohl</last></author>
     <title>Exploiting Parallel Corpora for Supervised Word-Sense Disambiguation in English-Hungarian Machine Translation</title>
     <month>May</month>
     <year>2006</year>
@@ -4913,8 +4914,8 @@
     <bibkey>miháltz:649:2006:lrec2006</bibkey>
   </paper>
   <paper id="1403" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/650_pdf.pdf">
-    <author><first>P.</first><last>Filipe</last></author>
-    <author><first>N.</first><last>Mamede</last></author>
+    <author><first>Porfírio</first><last>Filipe</last></author>
+    <author><first>Nuno</first><last>Mamede</last></author>
     <title>A Framework to Integrate Ubiquitous Knowledge Modeling</title>
     <month>May</month>
     <year>2006</year>
@@ -4924,10 +4925,10 @@
     <bibkey>filipe:650:2006:lrec2006</bibkey>
   </paper>
   <paper id="1404" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/651_pdf.pdf">
-    <author><first>F.</first><last>Dell’orletta</last></author>
-    <author><first>A.</first><last>Lenci</last></author>
-    <author><first>S.</first><last>Montemagni</last></author>
-    <author><first>V.</first><last>Pirrelli</last></author>
+    <author><first>Felice</first><last>Dell’orletta</last></author>
+    <author><first>Alessandro</first><last>Lenci</last></author>
+    <author><first>Simonetta</first><last>Montemagni</last></author>
+    <author><first>Vito</first><last>Pirrelli</last></author>
     <title>Searching treebanks for functional constraints: cross-lingual experiments in grammatical relation assignment</title>
     <month>May</month>
     <year>2006</year>
@@ -4937,7 +4938,7 @@
     <bibkey>dell’orletta:651:2006:lrec2006</bibkey>
   </paper>
   <paper id="1405" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/652_pdf.pdf">
-    <author><first>T.</first><last>Declerck</last></author>
+    <author><first>Thierry</first><last>Declerck</last></author>
     <title>SynAF: Towards a Standard for Syntactic Annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -4947,9 +4948,9 @@
     <bibkey>declerck:652:2006:lrec2006</bibkey>
   </paper>
   <paper id="1406" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/653_pdf.pdf">
-    <author><first>C.</first><last>Ayache</last></author>
-    <author><first>B.</first><last>Grau</last></author>
-    <author><first>A.</first><last>Vilnat</last></author>
+    <author><first>Christelle</first><last>Ayache</last></author>
+    <author><first>Brigitte</first><last>Grau</last></author>
+    <author><first>Anne</first><last>Vilnat</last></author>
     <title>EQueR: the French Evaluation campaign of Question-Answering Systems</title>
     <month>May</month>
     <year>2006</year>
@@ -4959,13 +4960,13 @@
     <bibkey>ayache:653:2006:lrec2006</bibkey>
   </paper>
   <paper id="1407" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/654_pdf.pdf">
-    <author><first>M.</first><last>Nascimento</last></author>
-    <author><first>J.</first><last>Gonçalves</last></author>
-    <author><first>L.</first><last>Pereira</last></author>
-    <author><first>A.</first><last>Estrela</last></author>
-    <author><first>A.</first><last>Pereira</last></author>
-    <author><first>R.</first><last>Santos</last></author>
-    <author><first>S.</first><last>Oliveira</last></author>
+    <author><first>Maria Fernanda Bacelar do</first><last>Nascimento</last></author>
+    <author><first>José Bettencourt</first><last>Gonçalves</last></author>
+    <author><first>Luísa</first><last>Pereira</last></author>
+    <author><first>Antónia</first><last>Estrela</last></author>
+    <author><first>Afonso</first><last>Pereira</last></author>
+    <author><first>Rui</first><last>Santos</last></author>
+    <author><first>Sancho M.</first><last>Oliveira</last></author>
     <title>The African Varieties of Portuguese: Compiling Comparable Corpora and Analyzing Data-Derived Lexicon</title>
     <month>May</month>
     <year>2006</year>
@@ -4975,8 +4976,8 @@
     <bibkey>nascimento:654:2006:lrec2006</bibkey>
   </paper>
   <paper id="1408" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/656_pdf.pdf">
-    <author><first>B.</first><last>Tsou</last></author>
-    <author><first>O.</first><last>Kwong</last></author>
+    <author><first>Benjamin K.</first><last>Tsou</last></author>
+    <author><first>Oi Yee</first><last>Kwong</last></author>
     <title>Toward a Pan-Chinese Thesaurus</title>
     <month>May</month>
     <year>2006</year>
@@ -4986,8 +4987,8 @@
     <bibkey>tsou:656:2006:lrec2006</bibkey>
   </paper>
   <paper id="1409" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/657_pdf.pdf">
-    <author><first>N.</first><last>Oostdijk</last></author>
-    <author><first>L.</first><last>Boves</last></author>
+    <author><first>Nelleke</first><last>Oostdijk</last></author>
+    <author><first>Lou</first><last>Boves</last></author>
     <title>User requirements analysis for the design of a reference corpus of written Dutch</title>
     <month>May</month>
     <year>2006</year>
@@ -4997,11 +4998,11 @@
     <bibkey>oostdijk:657:2006:lrec2006</bibkey>
   </paper>
   <paper id="1410" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/658_pdf.pdf">
-    <author><first>B.</first><last>Grau</last></author>
-    <author><first>A.</first><last>Ligozat</last></author>
-    <author><first>I.</first><last>Robba</last></author>
-    <author><first>A.</first><last>Vilnat</last></author>
-    <author><first>L.</first><last>Monceau</last></author>
+    <author><first>Brigitte</first><last>Grau</last></author>
+    <author><first>Anne-Laure</first><last>Ligozat</last></author>
+    <author><first>Isabelle</first><last>Robba</last></author>
+    <author><first>Anne</first><last>Vilnat</last></author>
+    <author><first>Laura</first><last>Monceaux</last></author>
     <title>FRASQUES: A Question Answering system in the EQueR evaluation campaign</title>
     <month>May</month>
     <year>2006</year>
@@ -5011,7 +5012,7 @@
     <bibkey>grau:658:2006:lrec2006</bibkey>
   </paper>
   <paper id="1411" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/661_pdf.pdf">
-    <author><first>G.</first><last>Hodász</last></author>
+    <author><first>Gábor</first><last>Hodász</last></author>
     <title>Evaluation Methods of a Linguistically Enriched Translation Memory System</title>
     <month>May</month>
     <year>2006</year>
@@ -5021,8 +5022,8 @@
     <bibkey>hodász:661:2006:lrec2006</bibkey>
   </paper>
   <paper id="1412" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/664_pdf.pdf">
-    <author><first>A.</first><last>Simões</last></author>
-    <author><first>J.</first><last>Almeida</last></author>
+    <author><first>Alberto</first><last>Simões</last></author>
+    <author><first>José João</first><last>Almeida</last></author>
     <title>T2O - Recycling Thesauri into a Multilingual Ontology</title>
     <month>May</month>
     <year>2006</year>
@@ -5032,7 +5033,7 @@
     <bibkey>simões:664:2006:lrec2006</bibkey>
   </paper>
   <paper id="1413" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/666_pdf.pdf">
-    <author><first>S.</first><last>Amsalu</last></author>
+    <author><first>Saba</first><last>Amsalu</last></author>
     <title>Data-driven Amharic-English Bilingual Lexicon Acquisition</title>
     <month>May</month>
     <year>2006</year>
@@ -5042,7 +5043,7 @@
     <bibkey>amsalu:666:2006:lrec2006</bibkey>
   </paper>
   <paper id="1414" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/667_pdf.pdf">
-    <author><first>J.</first><last>Tiedemann</last></author>
+    <author><first>Jörg</first><last>Tiedemann</last></author>
     <title>ISA &amp; ICA - Two Web Interfaces for Interactive Alignment of Bitexts alignment of parallel texts</title>
     <month>May</month>
     <year>2006</year>
@@ -5052,16 +5053,16 @@
     <bibkey>tiedemann:667:2006:lrec2006</bibkey>
   </paper>
   <paper id="1415" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/669_pdf.pdf">
-    <author><first>P.</first><last>Strauß</last></author>
-    <author><first>H.</first><last>Hoffman</last></author>
-    <author><first>W.</first><last>Minker</last></author>
-    <author><first>H.</first><last>Neumann</last></author>
-    <author><first>G.</first><last>Palm</last></author>
-    <author><first>S.</first><last>Scherer</last></author>
-    <author><first>F.</first><last>Schwenker</last></author>
-    <author><first>H.</first><last>Traue</last></author>
-    <author><first>W.</first><last>Walter</last></author>
-    <author><first>U.</first><last>Weidenbacher</last></author>
+    <author><first>Petra-Maria</first><last>Strauß</last></author>
+    <author><first>Holger</first><last>Hoffman</last></author>
+    <author><first>Wolfgang</first><last>Minker</last></author>
+    <author><first>Heiko</first><last>Neumann</last></author>
+    <author><first>Günther</first><last>Palm</last></author>
+    <author><first>Stefan</first><last>Scherer</last></author>
+    <author><first>Friedhelm</first><last>Schwenker</last></author>
+    <author><first>Harald</first><last>Traue</last></author>
+    <author><first>Welf</first><last>Walter</last></author>
+    <author><first>Ulrich</first><last>Weidenbacher</last></author>
     <title>Wizard-of-Oz Data Collection for Perception and Interaction in Multi-User Environments</title>
     <month>May</month>
     <year>2006</year>
@@ -5071,8 +5072,8 @@
     <bibkey>strauß:669:2006:lrec2006</bibkey>
   </paper>
   <paper id="1416" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/670_pdf.pdf">
-    <author><first>N.</first><last>Underwood</last></author>
-    <author><first>A.</first><last>Lisowska</last></author>
+    <author><first>Nancy L.</first><last>Underwood</last></author>
+    <author><first>Agnes</first><last>Lisowska</last></author>
     <title>The Evolution of an Evaluation Framework for a Text Mining System</title>
     <month>May</month>
     <year>2006</year>
@@ -5082,8 +5083,8 @@
     <bibkey>underwood:670:2006:lrec2006</bibkey>
   </paper>
   <paper id="1417" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/672_pdf.pdf">
-    <author><first>E.</first><last>Westerhout</last></author>
-    <author><first>P.</first><last>Monachesi</last></author>
+    <author><first>Eline</first><last>Westerhout</last></author>
+    <author><first>Paola</first><last>Monachesi</last></author>
     <title>A pilot study for a Corpus of Dutch Aphasic Speech (CoDAS)</title>
     <month>May</month>
     <year>2006</year>
@@ -5093,11 +5094,11 @@
     <bibkey>westerhout:672:2006:lrec2006</bibkey>
   </paper>
   <paper id="1418" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/673_pdf.pdf">
-    <author><first>J.</first><last>Bungeroth</last></author>
-    <author><first>D.</first><last>Stein</last></author>
-    <author><first>P.</first><last>Dreuw</last></author>
-    <author><first>M.</first><last>Zahedi</last></author>
-    <author><first>H.</first><last>Ney</last></author>
+    <author><first>Jan</first><last>Bungeroth</last></author>
+    <author><first>Daniel</first><last>Stein</last></author>
+    <author><first>Philippe</first><last>Dreuw</last></author>
+    <author><first>Morteza</first><last>Zahedi</last></author>
+    <author><first>Hermann</first><last>Ney</last></author>
     <title>A German Sign Language Corpus of the Domain Weather Report</title>
     <month>May</month>
     <year>2006</year>
@@ -5107,14 +5108,14 @@
     <bibkey>bungeroth:673:2006:lrec2006</bibkey>
   </paper>
   <paper id="1419" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/674_pdf.pdf">
-    <author><first>R.</first><last>Bartolini</last></author>
-    <author><first>C.</first><last>Caracciolo</last></author>
-    <author><first>E.</first><last>Giovannetti</last></author>
-    <author><first>A.</first><last>Lenci</last></author>
-    <author><first>S.</first><last>Marchi</last></author>
-    <author><first>V.</first><last>Pirrelli</last></author>
-    <author><first>C.</first><last>Renso</last></author>
-    <author><first>L.</first><last>Spinsanti</last></author>
+    <author><first>Roberto</first><last>Bartolini</last></author>
+    <author><first>Caterina</first><last>Caracciolo</last></author>
+    <author><first>Emiliano</first><last>Giovanetti</last></author>
+    <author><first>Alessandro</first><last>Lenci</last></author>
+    <author><first>Simone</first><last>Marchi</last></author>
+    <author><first>Vito</first><last>Pirrelli</last></author>
+    <author><first>Chiara</first><last>Renso</last></author>
+    <author><first>Laura</first><last>Spinsanti</last></author>
     <title>Creation and Use of Lexicons and Ontologies for NL Interfaces to Databases</title>
     <month>May</month>
     <year>2006</year>
@@ -5124,8 +5125,8 @@
     <bibkey>bartolini:674:2006:lrec2006</bibkey>
   </paper>
   <paper id="1420" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/676_pdf.pdf">
-    <author><first>A.</first><last>Mulloni</last></author>
-    <author><first>V.</first><last>Pekar</last></author>
+    <author><first>Andrea</first><last>Mulloni</last></author>
+    <author><first>Viktor</first><last>Pekar</last></author>
     <title>Automatic Detection of Orthographics Cues for Cognate Recognition</title>
     <month>May</month>
     <year>2006</year>
@@ -5135,8 +5136,8 @@
     <bibkey>mulloni:676:2006:lrec2006</bibkey>
   </paper>
   <paper id="1421" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/677_pdf.pdf">
-    <author><first>T.</first><last>Baldwin</last></author>
-    <author><first>S.</first><last>Awab</last></author>
+    <author><first>Timothy</first><last>Baldwin</last></author>
+    <author><first>Su’ad</first><last>Awab</last></author>
     <title>Open Source Corpus Analysis Tools for Malay</title>
     <month>May</month>
     <year>2006</year>
@@ -5146,7 +5147,7 @@
     <bibkey>baldwin:677:2006:lrec2006</bibkey>
   </paper>
   <paper id="1422" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/678_pdf.pdf">
-    <author><first>F.</first><last>Ibekwe-sanjuan</last></author>
+    <author><first>Fidelia</first><last>Ibekwe-Sanjuan</last></author>
     <title>A task-oriented framework for evaluating theme detection systems: A discussion paper</title>
     <month>May</month>
     <year>2006</year>
@@ -5157,8 +5158,8 @@
   </paper>
   <paper id="1423" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/679_pdf.pdf">
     <author><first>A.</first><last>Moreno</last></author>
-    <author><first>A.</first><last>Febrer</last></author>
-    <author><first>L.</first><last>Márquez</last></author>
+    <author><first>Albert</first><last>Febrer</last></author>
+    <author><first>Lluis</first><last>Márquez</last></author>
     <title>Generation of Language Resources for the Development of Speech Technologies in Catalan</title>
     <month>May</month>
     <year>2006</year>
@@ -5168,8 +5169,8 @@
     <bibkey>moreno:679:2006:lrec2006</bibkey>
   </paper>
   <paper id="1424" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/680_pdf.pdf">
-    <author><first>G.</first><last>Puscasu</last></author>
-    <author><first>R.</first><last>Mitkov</last></author>
+    <author><first>Georgiana</first><last>Puşcaşu</last></author>
+    <author><first>Ruslan</first><last>Mitkov</last></author>
     <title>If “it” were “then”, then when was “it”? Establishing the anaphoric role of “then”</title>
     <month>May</month>
     <year>2006</year>
@@ -5179,12 +5180,12 @@
     <bibkey>puscasu:680:2006:lrec2006</bibkey>
   </paper>
   <paper id="1425" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/683_pdf.pdf">
-    <author><first>V.</first><last>Trón</last></author>
-    <author><first>P.</first><last>Halácsy</last></author>
-    <author><first>P.</first><last>Rebrus</last></author>
-    <author><first>A.</first><last>Rung</last></author>
-    <author><first>P.</first><last>Vajda</last></author>
-    <author><first>E.</first><last>Simon</last></author>
+    <author><first>Viktor</first><last>Trón</last></author>
+    <author><first>Péter</first><last>Halácsy</last></author>
+    <author><first>Péter</first><last>Rebrus</last></author>
+    <author><first>András</first><last>Rung</last></author>
+    <author><first>Péter</first><last>Vajda</last></author>
+    <author><first>Eszter</first><last>Simon</last></author>
     <title>Morphdb.hu: Hungarian lexical database and morphological grammar</title>
     <month>May</month>
     <year>2006</year>
@@ -5194,10 +5195,10 @@
     <bibkey>trón:683:2006:lrec2006</bibkey>
   </paper>
   <paper id="1426" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/685_pdf.pdf">
-    <author><first>P.</first><last>Le</last></author>
-    <author><first>T.</first><last>Nguyen</last></author>
-    <author><first>L.</first><last>Romary</last></author>
-    <author><first>A.</first><last>Roussanaly</last></author>
+    <author><last>Le</last><first>H. Phuong</first></author>
+    <author><last>Nguyen</last><first>T. M. Huyen</first></author>
+    <author><last>Romary</last><first>Laurent</first></author>
+    <author><last>Roussanaly</last><first>Azim</first></author>
     <title>A Lexicalized Tree-Adjoining Grammar for Vietnamese</title>
     <month>May</month>
     <year>2006</year>
@@ -5207,10 +5208,10 @@
     <bibkey>le:685:2006:lrec2006</bibkey>
   </paper>
   <paper id="1427" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/687_pdf.pdf">
-    <author><first>S.</first><last>Cinkova</last></author>
-    <author><first>P.</first><last>Pecina</last></author>
-    <author><first>P.</first><last>Podvesky</last></author>
-    <author><first>P.</first><last>Schlesinger</last></author>
+    <author><first>Silvie</first><last>Cinkova</last></author>
+    <author><first>Pavel</first><last>Pecina</last></author>
+    <author><first>Petr</first><last>Podvesky</last></author>
+    <author><first>Pavel</first><last>Schlesinger</last></author>
     <title>Semi-automatic Building of Swedish Collocation Lexicon</title>
     <month>May</month>
     <year>2006</year>
@@ -5220,8 +5221,8 @@
     <bibkey>cinkova:687:2006:lrec2006</bibkey>
   </paper>
   <paper id="1428" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/688_pdf.pdf">
-    <author><first>D.</first><last>Oliver</last></author>
-    <author><first>K.</first><last>Szklanny</last></author>
+    <author><first>Dominika</first><last>Oliver</last></author>
+    <author><first>Krzysztof</first><last>Szklanny</last></author>
     <title>Creation and analysis of a Polish speech database for use in unit selection synthesis</title>
     <month>May</month>
     <year>2006</year>
@@ -5231,9 +5232,9 @@
     <bibkey>oliver:688:2006:lrec2006</bibkey>
   </paper>
   <paper id="1429" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/689_pdf.pdf">
-    <author><first>J.</first><last>Kinoshita</last></author>
-    <author><first>L.</first><last>Salvador</last></author>
-    <author><first>C.</first><last>Menezes</last></author>
+    <author><first>Jorge</first><last>Kinoshita</last></author>
+    <author><first>Laís do Nascimento</first><last>Salvador</last></author>
+    <author><first>Carlos Eduardo Dantas de</first><last>Menezes</last></author>
     <title>CoGrOO: a Brazilian-Portuguese Grammar Checker based on the CETENFOLHA Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -5243,7 +5244,7 @@
     <bibkey>kinoshita:689:2006:lrec2006</bibkey>
   </paper>
   <paper id="1430" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/691_pdf.pdf">
-    <author><first>S.</first><last>Schaden</last></author>
+    <author><first>Stefan</first><last>Schaden</last></author>
     <title>Evaluation of Automatically Generated Transcriptions of Non-Native Pronunciations using a Phonetic Distance Measure</title>
     <month>May</month>
     <year>2006</year>
@@ -5253,7 +5254,7 @@
     <bibkey>schaden:691:2006:lrec2006</bibkey>
   </paper>
   <paper id="1431" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/692_pdf.pdf">
-    <author><first>I.</first><last>Chiari</last></author>
+    <author><first>Isabella</first><last>Chiari</last></author>
     <title>Slips and errors in spoken data transcription</title>
     <month>May</month>
     <year>2006</year>
@@ -5263,7 +5264,7 @@
     <bibkey>chiari:692:2006:lrec2006</bibkey>
   </paper>
   <paper id="1432" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/697_pdf.pdf">
-    <author><first>M.</first><last>Ueyama</last></author>
+    <author><first>Motoko</first><last>Ueyama</last></author>
     <title>Evaluation of Web-based Corpora: Effects of Seed Selection and Time Interval</title>
     <month>May</month>
     <year>2006</year>
@@ -5273,10 +5274,10 @@
     <bibkey>ueyama:697:2006:lrec2006</bibkey>
   </paper>
   <paper id="1433" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/700_pdf.pdf">
-    <author><first>J.</first><last>Iria</last></author>
-    <author><first>C.</first><last>Brewster</last></author>
-    <author><first>F.</first><last>Ciravegna</last></author>
-    <author><first>Y.</first><last>Wilks</last></author>
+    <author><first>José</first><last>Iria</last></author>
+    <author><first>Christopher</first><last>Brewster</last></author>
+    <author><first>Fabio</first><last>Ciravegna</last></author>
+    <author><first>Yorick</first><last>Wilks</last></author>
     <title>An Incremental Tri-Partite Approach To Ontology Learning</title>
     <month>May</month>
     <year>2006</year>
@@ -5286,8 +5287,8 @@
     <bibkey>iria:700:2006:lrec2006</bibkey>
   </paper>
   <paper id="1434" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/701_pdf.pdf">
-    <author><first>T.</first><last>Pellegrini</last></author>
-    <author><first>L.</first><last>Lamel</last></author>
+    <author><first>Thomas</first><last>Pellegrini</last></author>
+    <author><first>Lori</first><last>Lamel</last></author>
     <title>Experimental detection of vowel pronunciation variants in Amharic</title>
     <month>May</month>
     <year>2006</year>
@@ -5297,9 +5298,9 @@
     <bibkey>pellegrini:701:2006:lrec2006</bibkey>
   </paper>
   <paper id="1435" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/702_pdf.pdf">
-    <author><first>R.</first><last>Catizone</last></author>
-    <author><first>A.</first><last>Dalli</last></author>
-    <author><first>Y.</first><last>Wilks</last></author>
+    <author><first>Roberta</first><last>Catizone</last></author>
+    <author><first>Angelo</first><last>Dalli</last></author>
+    <author><first>Yorick</first><last>Wilks</last></author>
     <title>Evaluating Automatically Generated Timelines from the Web</title>
     <month>May</month>
     <year>2006</year>
@@ -5309,14 +5310,14 @@
     <bibkey>catizone:702:2006:lrec2006</bibkey>
   </paper>
   <paper id="1436" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/704_pdf.pdf">
-    <author><first>I.</first><last>Kruijff-korbayova</last></author>
-    <author><first>T.</first><last>Becker</last></author>
-    <author><first>N.</first><last>Blaylock</last></author>
-    <author><first>C.</first><last>Gerstenberger</last></author>
-    <author><first>M.</first><last>Kaisser</last></author>
-    <author><first>P.</first><last>Poller</last></author>
-    <author><first>V.</first><last>Rieser</last></author>
-    <author><first>J.</first><last>Schehl</last></author>
+    <author><first>Ivana</first><last>Kruijff-Korbayová</last></author>
+    <author><first>Tilman</first><last>Becker</last></author>
+    <author><first>Nate</first><last>Blaylock</last></author>
+    <author><first>Ciprian</first><last>Gerstenberger</last></author>
+    <author><first>Michael</first><last>Kaißer</last></author>
+    <author><first>Peter</first><last>Poller</last></author>
+    <author><first>Verena</first><last>Rieser</last></author>
+    <author><first>Jan</first><last>Schehl</last></author>
     <title>The SAMMIE Corpus of Multimodal Dialogues with an MP3 Player</title>
     <month>May</month>
     <year>2006</year>
@@ -5326,11 +5327,11 @@
     <bibkey>kruijff-korbayova:704:2006:lrec2006</bibkey>
   </paper>
   <paper id="1437" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/705_pdf.pdf">
-    <author><first>R.</first><last>Passonneau</last></author>
-    <author><first>R.</first><last>Blitz</last></author>
-    <author><first>D.</first><last>Elson</last></author>
-    <author><first>A.</first><last>Giral</last></author>
-    <author><first>J.</first><last>Klavans</last></author>
+    <author><first>Rebecca</first><last>Passonneau</last></author>
+    <author><first>Roberta</first><last>Blitz</last></author>
+    <author><first>David</first><last>Elson</last></author>
+    <author><first>Angela</first><last>Giral</last></author>
+    <author><first>Judith</first><last>Klavans</last></author>
     <title>CLiMB ToolKit: A Case Study of Iterative Evaluation in a Multidisciplinary Project</title>
     <month>May</month>
     <year>2006</year>
@@ -5340,8 +5341,8 @@
     <bibkey>passonneau:705:2006:lrec2006</bibkey>
   </paper>
   <paper id="1438" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/706_pdf.pdf">
-    <author><first>A.</first><last>Rumshisky</last></author>
-    <author><first>J.</first><last>Pustejovsky</last></author>
+    <author><first>Anna</first><last>Rumshisky</last></author>
+    <author><first>James</first><last>Pustejovsky</last></author>
     <title>Inducing Sense-Discriminating Context Patterns from Sense-Tagged Corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -5351,8 +5352,8 @@
     <bibkey>rumshisky:706:2006:lrec2006</bibkey>
   </paper>
   <paper id="1439" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/707_pdf.pdf">
-    <author><first>M.</first><last>Kouylekov</last></author>
-    <author><first>B.</first><last>Magnini</last></author>
+    <author><first>Milen</first><last>Kouylekov</last></author>
+    <author><first>Bernardo</first><last>Magnini</last></author>
     <title>Building a Large-Scale Repository of Textual Entailment Rules</title>
     <month>May</month>
     <year>2006</year>
@@ -5362,8 +5363,8 @@
     <bibkey>kouylekov:707:2006:lrec2006</bibkey>
   </paper>
   <paper id="1440" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/708_pdf.pdf">
-    <author><first>A.</first><last>Moschitti</last></author>
-    <author><first>R.</first><last>Basili</last></author>
+    <author><first>Alessandro</first><last>Moschitti</last></author>
+    <author><first>Roberto</first><last>Basili</last></author>
     <title>A Tree Kernel approach to Question and Answer Classification in Question Answering Systems</title>
     <month>May</month>
     <year>2006</year>
@@ -5373,12 +5374,12 @@
     <bibkey>moschitti:708:2006:lrec2006</bibkey>
   </paper>
   <paper id="1441" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/709_pdf.pdf">
-    <author><first>P.</first><last>Mareüil</last></author>
-    <author><first>C.</first><last>D’alessandro</last></author>
-    <author><first>A.</first><last>Raake</last></author>
-    <author><first>G.</first><last>Bailly</last></author>
-    <author><first>M.</first><last>Garcia</last></author>
-    <author><first>M.</first><last>Morel</last></author>
+    <author><first>Philippe Boula de</first><last>Mareüil</last></author>
+    <author><first>Christophe</first><last>D’alessandro</last></author>
+    <author><first>Alexander</first><last>Raake</last></author>
+    <author><first>Gérard</first><last>Bailly</last></author>
+    <author><first>Marie-Neige</first><last>Garcia</last></author>
+    <author><first>Michel</first><last>Morel</last></author>
     <title>A joint intelligibility evaluation of French text-to-speech synthesis systems: the EvaSy SUS/ACR campaign</title>
     <month>May</month>
     <year>2006</year>
@@ -5388,8 +5389,8 @@
     <bibkey>mareüil:709:2006:lrec2006</bibkey>
   </paper>
   <paper id="1442" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/710_pdf.pdf">
-    <author><first>W.</first><last>Anderson</last></author>
-    <author><first>P.</first><last>Kotzé</last></author>
+    <author><first>Winston N</first><last>Anderson</last></author>
+    <author><first>Petronella M</first><last>Kotzé</last></author>
     <title>Finite state tokenisation of an orthographical disjunctive agglutinative language: The verbal segment of Northern Sotho</title>
     <month>May</month>
     <year>2006</year>
@@ -5399,9 +5400,9 @@
     <bibkey>anderson:710:2006:lrec2006</bibkey>
   </paper>
   <paper id="1443" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/711_pdf.pdf">
-    <author><first>J.</first><last>Couturier</last></author>
-    <author><first>S.</first><last>Neuvel</last></author>
-    <author><first>P.</first><last>Drouin</last></author>
+    <author><first>Jean-François</first><last>Couturier</last></author>
+    <author><first>Sylvain</first><last>Neuvel</last></author>
+    <author><first>Patrick</first><last>Drouin</last></author>
     <title>Applying Lexical Constraints on Morpho-Syntactic Patterns for the Identification of Conceptual-Relational Content in Specialized Texts</title>
     <month>May</month>
     <year>2006</year>
@@ -5411,7 +5412,7 @@
     <bibkey>couturier:711:2006:lrec2006</bibkey>
   </paper>
   <paper id="1444" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/712_pdf.pdf">
-    <author><first>K.</first><last>Pastra</last></author>
+    <author><first>Katerina</first><last>Pastra</last></author>
     <title>Beyond Multimedia Integration: corpora and annotations for cross-media decision mechanisms</title>
     <month>May</month>
     <year>2006</year>
@@ -5421,9 +5422,9 @@
     <bibkey>pastra:712:2006:lrec2006</bibkey>
   </paper>
   <paper id="1445" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/715_pdf.pdf">
-    <author><first>Y.</first><last>Nitta</last></author>
-    <author><first>M.</first><last>Saraki</last></author>
-    <author><first>S.</first><last>Ikehara</last></author>
+    <author><first>Yoshihiko</first><last>Nitta</last></author>
+    <author><first>Masashi</first><last>Saraki</last></author>
+    <author><first>Satoru</first><last>Ikehara</last></author>
     <title>Building Carefully Tagged Bilingual Corpora to Cope with Linguistic Idiosyncrasy</title>
     <month>May</month>
     <year>2006</year>
@@ -5433,9 +5434,9 @@
     <bibkey>nitta:715:2006:lrec2006</bibkey>
   </paper>
   <paper id="1446" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/716_pdf.pdf">
-    <author><first>R.</first><last>Sauri</last></author>
-    <author><first>M.</first><last>Verhagen</last></author>
-    <author><first>J.</first><last>Pustejovsk</last></author>
+    <author><first>Roser</first><last>Saurí</last></author>
+    <author><first>Marc</first><last>Verhagen</last></author>
+    <author><first>James</first><last>Pustejovsky</last></author>
     <title>SlinkET: A Partial Modal Parser for Events</title>
     <month>May</month>
     <year>2006</year>
@@ -5445,8 +5446,8 @@
     <bibkey>sauri:716:2006:lrec2006</bibkey>
   </paper>
   <paper id="1447" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/717_pdf.pdf">
-    <author><first>C.</first><last>Cieri</last></author>
-    <author><first>M.</first><last>Liberman</last></author>
+    <author><first>Christopher</first><last>Cieri</last></author>
+    <author><first>Mark</first><last>Liberman</last></author>
     <title>More Data and Tools for More Languages and Research Areas: A Progress Report on LDC Activities</title>
     <month>May</month>
     <year>2006</year>
@@ -5461,9 +5462,9 @@
     <author><first>I.</first><last>Kiss</last></author>
     <author><first>A.</first><last>Moreno</last></author>
     <author><first>U.</first><last>Ziegenhain</last></author>
-    <author><first>H.</first><last>Heuvel</last></author>
-    <author><first>H.</first><last>Hain</last></author>
-    <author><first>X.</first><last>Wang</last></author>
+    <author><first>H.</first><last>van den Heuvel</last></author>
+    <author><first>H.-U.</first><last>Hain</last></author>
+    <author><first>X. S.</first><last>Wang</last></author>
     <author><first>M.</first><last>Garcia</last></author>
     <title>TC-STAR:Specifications of Language Resources and Evaluation for Speech Synthesis</title>
     <month>May</month>
@@ -5474,8 +5475,8 @@
     <bibkey>bonafonte:719:2006:lrec2006</bibkey>
   </paper>
   <paper id="1449" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/720_pdf.pdf">
-    <author><first>M.</first><last>Voghera</last></author>
-    <author><first>F.</first><last>Cutugno</last></author>
+    <author><first>Miriam</first><last>Voghera</last></author>
+    <author><first>Francesco</first><last>Cutugno</last></author>
     <title>An observatory on Spoken Italian linguistic resources and descriptive standards.</title>
     <month>May</month>
     <year>2006</year>
@@ -5485,9 +5486,9 @@
     <bibkey>voghera:720:2006:lrec2006</bibkey>
   </paper>
   <paper id="1450" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/721_pdf.pdf">
-    <author><first>K.</first><last>Smaïli</last></author>
-    <author><first>C.</first><last>Lavecchia</last></author>
-    <author><first>J.</first><last>Haton</last></author>
+    <author><first>Kamel</first><last>Smaïli</last></author>
+    <author><first>Caroline</first><last>Lavecchia</last></author>
+    <author><first>Jean-Paul</first><last>Haton</last></author>
     <title>Linguistic features modeling based on Partial New Cache</title>
     <month>May</month>
     <year>2006</year>
@@ -5497,15 +5498,15 @@
     <bibkey>smaïli:721:2006:lrec2006</bibkey>
   </paper>
   <paper id="1451" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/724_pdf.pdf">
-    <author><first>S.</first><last>Schulz</last></author>
-    <author><first>K.</first><last>Markó</last></author>
-    <author><first>P.</first><last>Daumke</last></author>
-    <author><first>U.</first><last>Hahn</last></author>
-    <author><first>S.</first><last>Hanser</last></author>
-    <author><first>P.</first><last>Nohama</last></author>
-    <author><first>R.</first><last>Andrade</last></author>
-    <author><first>E.</first><last>Pacheco</last></author>
-    <author><first>M.</first><last>Romacker</last></author>
+    <author><first>Stefan</first><last>Schulz</last></author>
+    <author><first>Kornél</first><last>Markó</last></author>
+    <author><first>Philipp</first><last>Daumke</last></author>
+    <author><first>Udo</first><last>Hahn</last></author>
+    <author><first>Susanne</first><last>Hanser</last></author>
+    <author><first>Percy</first><last>Nohama</last></author>
+    <author><first>Roosewelt Leite de</first><last>Andrade</last></author>
+    <author><first>Edson</first><last>Pacheco</last></author>
+    <author><first>Martin</first><last>Romacker</last></author>
     <title>Semantic Atomicity and Multilinguality in the Medical Domain: Design Considerations for the MorphoSaurus Subword Lexicon</title>
     <month>May</month>
     <year>2006</year>
@@ -5515,7 +5516,7 @@
     <bibkey>schulz:724:2006:lrec2006</bibkey>
   </paper>
   <paper id="1452" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/725_pdf.pdf">
-    <author><first>M.</first><last>Salmenkivi</last></author>
+    <author><first>Marko</first><last>Salmenkivi</last></author>
     <title>Finding representative sets of dialect words for geographical regions</title>
     <month>May</month>
     <year>2006</year>
@@ -5525,7 +5526,7 @@
     <bibkey>salmenkivi:725:2006:lrec2006</bibkey>
   </paper>
   <paper id="1453" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/726_pdf.pdf">
-    <author><first>O.</first><last>Uryupina</last></author>
+    <author><first>Olga</first><last>Uryupina</last></author>
     <title>Coreference Resolution with and without Linguistic Knowledge</title>
     <month>May</month>
     <year>2006</year>
@@ -5535,8 +5536,8 @@
     <bibkey>uryupina:726:2006:lrec2006</bibkey>
   </paper>
   <paper id="1454" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/727_pdf.pdf">
-    <author><first>K.</first><last>Miller</last></author>
-    <author><first>M.</first><last>Vanni</last></author>
+    <author><first>Keith J.</first><last>Miller</last></author>
+    <author><first>Michelle</first><last>Vanni</last></author>
     <title>Formal v. Informal: Register-Differentiated Arabic MT Evaluation in the PLATO Paradigm</title>
     <month>May</month>
     <year>2006</year>
@@ -5557,7 +5558,7 @@
     <bibkey>hamon:729:2006:lrec2006</bibkey>
   </paper>
   <paper id="1456" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/733_pdf.pdf">
-    <author><first>R.</first><last>Navigli</last></author>
+    <author><first>Roberto</first><last>Navigli</last></author>
     <title>Reducing the Granularity of a Computational Lexicon via an Automatic Mapping to a Coarse-Grained Sense Inventory</title>
     <month>May</month>
     <year>2006</year>
@@ -5567,9 +5568,9 @@
     <bibkey>navigli:733:2006:lrec2006</bibkey>
   </paper>
   <paper id="1457" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/735_pdf.pdf">
-    <author><first>D.</first><last>Gibbon</last></author>
-    <author><first>F.</first><last>Fernandes</last></author>
-    <author><first>T.</first><last>Trippel</last></author>
+    <author><first>Dafydd</first><last>Gibbon</last></author>
+    <author><first>Flaviane Romani</first><last>Fernandes</last></author>
+    <author><first>Thorsten</first><last>Trippel</last></author>
     <title>A BLARK extension for temporal annotation mining</title>
     <month>May</month>
     <year>2006</year>
@@ -5579,8 +5580,8 @@
     <bibkey>gibbon:735:2006:lrec2006</bibkey>
   </paper>
   <paper id="1458" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/736_pdf.pdf">
-    <author><first>M.</first><last>Schiehlen</last></author>
-    <author><first>K.</first><last>Spranger</last></author>
+    <author><first>Michael</first><last>Schiehlen</last></author>
+    <author><first>Kristina</first><last>Spranger</last></author>
     <title>The Mass-Count Distinction: Acquisition and Disambiguation</title>
     <month>May</month>
     <year>2006</year>
@@ -5590,7 +5591,7 @@
     <bibkey>schiehlen:736:2006:lrec2006</bibkey>
   </paper>
   <paper id="1459" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/738_pdf.pdf">
-    <author><first>A.</first><last>Cole</last></author>
+    <author><first>Andrew W.</first><last>Cole</last></author>
     <title>Corpus Development and Publication</title>
     <month>May</month>
     <year>2006</year>
@@ -5600,8 +5601,8 @@
     <bibkey>cole:738:2006:lrec2006</bibkey>
   </paper>
   <paper id="1460" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/739_pdf.pdf">
-    <author><first>D.</first><last>Gibbon</last></author>
-    <author><first>S.</first><last>Tseng</last></author>
+    <author><first>Dafydd</first><last>Gibbon</last></author>
+    <author><first>Shu-Chuan</first><last>Tseng</last></author>
     <title>Discourse functions of duration in Mandarin: resource design and implementation</title>
     <month>May</month>
     <year>2006</year>
@@ -5611,8 +5612,8 @@
     <bibkey>gibbon:739:2006:lrec2006</bibkey>
   </paper>
   <paper id="1461" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/740_pdf.pdf">
-    <author><first>L.</first><last>Lesmo</last></author>
-    <author><first>L.</first><last>Robaldo</last></author>
+    <author><first>Leonardo</first><last>Lesmo</last></author>
+    <author><first>Livio</first><last>Robaldo</last></author>
     <title>From Natural Language to Databases via Ontologies</title>
     <month>May</month>
     <year>2006</year>
@@ -5637,8 +5638,8 @@
     <bibkey>nazarenko:742:2006:lrec2006</bibkey>
   </paper>
   <paper id="1463" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/744_pdf.pdf">
-    <author><first>A.</first><last>Raake</last></author>
-    <author><first>B.</first><last>Katz</last></author>
+    <author><first>Alexander</first><last>Raake</last></author>
+    <author><first>Brian FG</first><last>Katz</last></author>
     <title>US-based Method for Speech Reception Threshold Measurement in French</title>
     <month>May</month>
     <year>2006</year>
@@ -5648,14 +5649,14 @@
     <bibkey>raake:744:2006:lrec2006</bibkey>
   </paper>
   <paper id="1464" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/745_pdf.pdf">
-    <author><first>S.</first><last>Strassel</last></author>
-    <author><first>C.</first><last>Cieri</last></author>
-    <author><first>A.</first><last>Cole</last></author>
-    <author><first>D.</first><last>Dipersio</last></author>
-    <author><first>M.</first><last>Liberman</last></author>
-    <author><first>X.</first><last>Ma</last></author>
-    <author><first>M.</first><last>Maamouri</last></author>
-    <author><first>K.</first><last>Maeda</last></author>
+    <author><first>Stephanie</first><last>Strassel</last></author>
+    <author><first>Christopher</first><last>Cieri</last></author>
+    <author><first>Andrew</first><last>Cole</last></author>
+    <author><first>Denise</first><last>Dipersio</last></author>
+    <author><first>Mark</first><last>Liberman</last></author>
+    <author><first>Xiaoyi</first><last>Ma</last></author>
+    <author><first>Mohamed</first><last>Maamouri</last></author>
+    <author><first>Kazuaki</first><last>Maeda</last></author>
     <title>Integrated Linguistic Resources for Language Exploitation Technologies</title>
     <month>May</month>
     <year>2006</year>
@@ -5665,7 +5666,7 @@
     <bibkey>strassel:745:2006:lrec2006</bibkey>
   </paper>
   <paper id="1465" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/746_pdf.pdf">
-    <author><first>X.</first><last>Ma</last></author>
+    <author><first>Xiaoyi</first><last>Ma</last></author>
     <title>Champollion: A Robust Parallel Text Sentence Aligner</title>
     <month>May</month>
     <year>2006</year>
@@ -5675,8 +5676,8 @@
     <bibkey>ma:746:2006:lrec2006</bibkey>
   </paper>
   <paper id="1466" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/748_pdf.pdf">
-    <author><first>F.</first><last>Behrens</last></author>
-    <author><first>J.</first><last>Milde</last></author>
+    <author><first>Fabian</first><last>Behrens</last></author>
+    <author><first>Jan-Torsten</first><last>Milde</last></author>
     <title>The Eclipse Annotator: an extensible system for multimodal corpus creation</title>
     <month>May</month>
     <year>2006</year>
@@ -5686,11 +5687,11 @@
     <bibkey>behrens:748:2006:lrec2006</bibkey>
   </paper>
   <paper id="1467" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/749_pdf.pdf">
-    <author><first>H.</first><last>Papageorgiou</last></author>
-    <author><first>E.</first><last>Desipri</last></author>
-    <author><first>M.</first><last>Koutsombogera</last></author>
-    <author><first>K.</first><last>Pouli</last></author>
-    <author><first>P.</first><last>Prokopidis</last></author>
+    <author><first>Harris</first><last>Papageorgiou</last></author>
+    <author><first>Elina</first><last>Desipri</last></author>
+    <author><first>Maria</first><last>Koutsombogera</last></author>
+    <author><first>Kanella</first><last>Pouli</last></author>
+    <author><first>Prokopis</first><last>Prokopidis</last></author>
     <title>Adding multi-layer semantics to the Greek Dependency Treebank</title>
     <month>May</month>
     <year>2006</year>
@@ -5700,8 +5701,8 @@
     <bibkey>papageorgiou:749:2006:lrec2006</bibkey>
   </paper>
   <paper id="1468" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/750_pdf.pdf">
-    <author><first>C.</first><last>Bosco</last></author>
-    <author><first>V.</first><last>Lombardo</last></author>
+    <author><first>Cristina</first><last>Bosco</last></author>
+    <author><first>Vincenzo</first><last>Lombardo</last></author>
     <title>Comparing linguistic information in treebank annotations</title>
     <month>May</month>
     <year>2006</year>
@@ -5711,11 +5712,11 @@
     <bibkey>bosco:750:2006:lrec2006</bibkey>
   </paper>
   <paper id="1469" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/752_pdf.pdf">
-    <author><first>N.</first><last>Cucurullo</last></author>
-    <author><first>S.</first><last>Montemagni</last></author>
-    <author><first>M.</first><last>Paoli</last></author>
-    <author><first>E.</first><last>Picchi</last></author>
-    <author><first>E.</first><last>Sassolini</last></author>
+    <author><first>Nella</first><last>Cucurullo</last></author>
+    <author><first>Simonetta</first><last>Montemagni</last></author>
+    <author><first>Matilde</first><last>Paoli</last></author>
+    <author><first>Eugenio</first><last>Picchi</last></author>
+    <author><first>Eva</first><last>Sassolini</last></author>
     <title>Dialectal resources on-line: the ALT-Web experience</title>
     <month>May</month>
     <year>2006</year>
@@ -5725,8 +5726,8 @@
     <bibkey>cucurullo:752:2006:lrec2006</bibkey>
   </paper>
   <paper id="1470" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/754_pdf.pdf">
-    <author><first>X.</first><last>Ma</last></author>
-    <author><first>C.</first><last>Cieri</last></author>
+    <author><first>Xiaoyi</first><last>Ma</last></author>
+    <author><first>Christopher</first><last>Cieri</last></author>
     <title>Corpus Support for Machine Translation at LDC</title>
     <month>May</month>
     <year>2006</year>
@@ -5736,14 +5737,14 @@
     <bibkey>ma:754:2006:lrec2006</bibkey>
   </paper>
   <paper id="1471" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/755_pdf.pdf">
-    <author><first>A.</first><last>Bies</last></author>
-    <author><first>S.</first><last>Strassel</last></author>
-    <author><first>H.</first><last>Lee</last></author>
-    <author><first>K.</first><last>Maeda</last></author>
-    <author><first>S.</first><last>Kulick</last></author>
-    <author><first>Y.</first><last>Liu</last></author>
-    <author><first>M.</first><last>Harper</last></author>
-    <author><first>M.</first><last>Lease</last></author>
+    <author><first>Ann</first><last>Bies</last></author>
+    <author><first>Stephanie</first><last>Strassel</last></author>
+    <author><first>Haejoong</first><last>Lee</last></author>
+    <author><first>Kazuaki</first><last>Maeda</last></author>
+    <author><first>Seth</first><last>Kulick</last></author>
+    <author><first>Yang</first><last>Liu</last></author>
+    <author><first>Mary</first><last>Harper</last></author>
+    <author><first>Matthew</first><last>Lease</last></author>
     <title>Linguistic Resources for Speech Parsing</title>
     <month>May</month>
     <year>2006</year>
@@ -5753,8 +5754,8 @@
     <bibkey>bies:755:2006:lrec2006</bibkey>
   </paper>
   <paper id="1472" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/756_pdf.pdf">
-    <author><first>T.</first><last>Obrebski</last></author>
-    <author><first>M.</first><last>Stolarski</last></author>
+    <author><first>Tomasz</first><last>Obrȩbski</last></author>
+    <author><first>Michał</first><last>Stolarski</last></author>
     <title>UAM Text Tools - a flexible NLP architecture</title>
     <month>May</month>
     <year>2006</year>
@@ -5764,8 +5765,8 @@
     <bibkey>obrebski:756:2006:lrec2006</bibkey>
   </paper>
   <paper id="1473" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/757_pdf.pdf">
-    <author><first>M.</first><last>Geilfuss</last></author>
-    <author><first>J.</first><last>Milde</last></author>
+    <author><first>Markus</first><last>Geilfuss</last></author>
+    <author><first>Jan-Torsten</first><last>Milde</last></author>
     <title>SAM - an annotation editor for parallel texts</title>
     <month>May</month>
     <year>2006</year>
@@ -5775,10 +5776,10 @@
     <bibkey>geilfuss:757:2006:lrec2006</bibkey>
   </paper>
   <paper id="1474" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/758_pdf.pdf">
-    <author><first>H.</first><last>Uszkoreit</last></author>
-    <author><first>F.</first><last>Xu</last></author>
-    <author><first>J.</first><last>Steffen</last></author>
-    <author><first>I.</first><last>Aslan</last></author>
+    <author><first>Hans</first><last>Uszkoreit</last></author>
+    <author><first>Feiyu</first><last>Xu</last></author>
+    <author><first>Jörg</first><last>Steffen</last></author>
+    <author><first>Ilhan</first><last>Aslan</last></author>
     <title>The pragmatic combination of different crosslingual resources</title>
     <month>May</month>
     <year>2006</year>
@@ -5788,11 +5789,11 @@
     <bibkey>uszkoreit:758:2006:lrec2006</bibkey>
   </paper>
   <paper id="1475" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/759_pdf.pdf">
-    <author><first>N.</first><last>Habash</last></author>
-    <author><first>C.</first><last>Mah</last></author>
-    <author><first>S.</first><last>Imran</last></author>
-    <author><first>R.</first><last>Calistri-yeh</last></author>
-    <author><first>P.</first><last>Sheridan</last></author>
+    <author><first>Nizar</first><last>Habash</last></author>
+    <author><first>Clinton</first><last>Mah</last></author>
+    <author><first>Sabiha</first><last>Imran</last></author>
+    <author><first>Randy</first><last>Calistri-Yeh</last></author>
+    <author><first>Páraic</first><last>Sheridan</last></author>
     <title>Design, Construction and Validation of an Arabic-English Conceptual Interlingua for Cross-lingual Information Retrieval</title>
     <month>May</month>
     <year>2006</year>
@@ -5802,9 +5803,9 @@
     <bibkey>habash:759:2006:lrec2006</bibkey>
   </paper>
   <paper id="1476" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/760_pdf.pdf">
-    <author><first>G.</first><last>Vetulani</last></author>
-    <author><first>Z.</first><last>Vetulani</last></author>
-    <author><first>T.</first><last>Obrębski</last></author>
+    <author><first>Grażyna</first><last>Vetulani</last></author>
+    <author><first>Zygmunt</first><last>Vetulani</last></author>
+    <author><first>Tomasz</first><last>Obrębski</last></author>
     <title>Syntactic Lexicon of Polish Predicative Nouns</title>
     <month>May</month>
     <year>2006</year>
@@ -5814,7 +5815,7 @@
     <bibkey>vetulani:760:2006:lrec2006</bibkey>
   </paper>
   <paper id="1477" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/762_pdf.pdf">
-    <author><first>A.</first><last>Alonge</last></author>
+    <author><first>Antonietta</first><last>Alonge</last></author>
     <title>The Italian Metaphor Database</title>
     <month>May</month>
     <year>2006</year>
@@ -5824,8 +5825,8 @@
     <bibkey>alonge:762:2006:lrec2006</bibkey>
   </paper>
   <paper id="1478" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/765_pdf.pdf">
-    <author><first>J.</first><last>Iria</last></author>
-    <author><first>F.</first><last>Ciravegna</last></author>
+    <author><first>José</first><last>Iria</last></author>
+    <author><first>Fabio</first><last>Ciravegna</last></author>
     <title>A Methodology and Tool for Representing Language Resources for Information Extraction</title>
     <month>May</month>
     <year>2006</year>
@@ -5835,7 +5836,7 @@
     <bibkey>iria:765:2006:lrec2006</bibkey>
   </paper>
   <paper id="1479" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/767_pdf.pdf">
-    <author><first>H.</first><last>Halpin</last></author>
+    <author><first>Harry</first><last>Halpin</last></author>
     <title>Automatic Evaluation and Composition of NLP Pipelines with Web Services</title>
     <month>May</month>
     <year>2006</year>
@@ -5845,8 +5846,8 @@
     <bibkey>halpin:767:2006:lrec2006</bibkey>
   </paper>
   <paper id="1480" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/769_pdf.pdf">
-    <author><first>H.</first><last>Bunt</last></author>
-    <author><first>A.</first><last>Schiffrin</last></author>
+    <author><first>Harry</first><last>Bunt</last></author>
+    <author><first>Amanda</first><last>Schiffrin</last></author>
     <title>Methodological Aspects of Semantic Annotation</title>
     <month>May</month>
     <year>2006</year>
@@ -5856,8 +5857,8 @@
     <bibkey>bunt:769:2006:lrec2006</bibkey>
   </paper>
   <paper id="1481" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/770_pdf.pdf">
-    <author><first>W.</first><last>Gegg-harrison</last></author>
-    <author><first>D.</first><last>Byron</last></author>
+    <author><first>Whitney</first><last>Gegg-Harrison</last></author>
+    <author><first>Donna K.</first><last>Byron</last></author>
     <title>PYCOT: An Optimality Theory-based Pronoun Resolution Toolkit</title>
     <month>May</month>
     <year>2006</year>
@@ -5867,12 +5868,12 @@
     <bibkey>gegg-harrison:770:2006:lrec2006</bibkey>
   </paper>
   <paper id="1482" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/772_pdf.pdf">
-    <author><first>E.</first><last>Barker</last></author>
-    <author><first>R.</first><last>Higashinaka</last></author>
-    <author><first>F.</first><last>Mairesse</last></author>
-    <author><first>R.</first><last>Gaizauskas</last></author>
-    <author><first>M.</first><last>Walker</last></author>
-    <author><first>J.</first><last>Foster</last></author>
+    <author><first>Emma</first><last>Barker</last></author>
+    <author><first>Ryuichiro</first><last>Higashinaka</last></author>
+    <author><first>François</first><last>Mairesse</last></author>
+    <author><first>Robert</first><last>Gaizauskas</last></author>
+    <author><first>Marilyn</first><last>Walker</last></author>
+    <author><first>Jonathan</first><last>Foster</last></author>
     <title>Simulating Cub Reporter Dialogues: The collection of naturalistic human-human dialogues for information access to text archives</title>
     <month>May</month>
     <year>2006</year>
@@ -5882,9 +5883,9 @@
     <bibkey>barker:772:2006:lrec2006</bibkey>
   </paper>
   <paper id="1483" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/774_pdf.pdf">
-    <author><first>J.</first><last>Ko</last></author>
-    <author><first>L.</first><last>Hiyakumoto</last></author>
-    <author><first>E.</first><last>Nyberg</last></author>
+    <author><first>Jeongwoo</first><last>Ko</last></author>
+    <author><first>Laurie</first><last>Hiyakumoto</last></author>
+    <author><first>Eric</first><last>Nyberg</last></author>
     <title>Exploiting Multiple Semantic Resources for Answer Selection</title>
     <month>May</month>
     <year>2006</year>
@@ -5894,9 +5895,9 @@
     <bibkey>ko:774:2006:lrec2006</bibkey>
   </paper>
   <paper id="1484" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/776_pdf.pdf">
-    <author><first>K.</first><last>Maeda</last></author>
-    <author><first>C.</first><last>Cieri</last></author>
-    <author><first>K.</first><last>Walker</last></author>
+    <author><first>Kazuaki</first><last>Maeda</last></author>
+    <author><first>Christopher</first><last>Cieri</last></author>
+    <author><first>Kevin</first><last>Walker</last></author>
     <title>Low-cost Customized Speech Corpus Creation for Speech Technology Applications</title>
     <month>May</month>
     <year>2006</year>
@@ -5906,8 +5907,8 @@
     <bibkey>maeda:776:2006:lrec2006</bibkey>
   </paper>
   <paper id="1485" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/777_pdf.pdf">
-    <author><first>J.</first><last>Niekrasz</last></author>
-    <author><first>J.</first><last>Gruenstein</last></author>
+    <author><first>John</first><last>Niekrasz</last></author>
+    <author><first>Alexander</first><last>Gruenstein</last></author>
     <title>NOMOS: A Semantic Web Software Framework for Annotation of Multimodal Corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -5917,12 +5918,12 @@
     <bibkey>niekrasz:777:2006:lrec2006</bibkey>
   </paper>
   <paper id="1486" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/778_pdf.pdf">
-    <author><first>C.</first><last>Benzmüller</last></author>
-    <author><first>H.</first><last>Horacek</last></author>
-    <author><first>H.</first><last>Lesourd</last></author>
-    <author><first>I.</first><last>Kruijff-korbayova</last></author>
-    <author><first>M.</first><last>Schiller</last></author>
-    <author><first>M.</first><last>Wolska</last></author>
+    <author><first>Christoph</first><last>Benzmüller</last></author>
+    <author><first>Helmut</first><last>Horacek</last></author>
+    <author><first>Henri</first><last>Lesourd</last></author>
+    <author><first>Ivana</first><last>Kruijff-Korbayova</last></author>
+    <author><first>Marvin</first><last>Schiller</last></author>
+    <author><first>Magdalena</first><last>Wolska</last></author>
     <title>A corpus of tutorial dialogs on theorem proving; the influence of the presentation of the study-material</title>
     <month>May</month>
     <year>2006</year>
@@ -5932,9 +5933,9 @@
     <bibkey>benzmüller:778:2006:lrec2006</bibkey>
   </paper>
   <paper id="1487" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/779_pdf.pdf">
-    <author><first>J.</first><last>Laoudi</last></author>
-    <author><first>C.</first><last>Tate</last></author>
-    <author><first>C.</first><last>Voss</last></author>
+    <author><first>Jamal</first><last>Laoudi</last></author>
+    <author><first>Calandra R.</first><last>Tate</last></author>
+    <author><first>Clare R.</first><last>Voss</last></author>
     <title>Task-based MT Evaluation: From Who/When/Where Extraction to Event Understanding</title>
     <month>May</month>
     <year>2006</year>
@@ -5944,10 +5945,10 @@
     <bibkey>laoudi:779:2006:lrec2006</bibkey>
   </paper>
   <paper id="1488" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/780_pdf.pdf">
-    <author><first>K.</first><last>Maeda</last></author>
-    <author><first>H.</first><last>Lee</last></author>
-    <author><first>J.</first><last>Medero</last></author>
-    <author><first>S.</first><last>Strassel</last></author>
+    <author><first>Kazuaki</first><last>Maeda</last></author>
+    <author><first>Haejoong</first><last>Lee</last></author>
+    <author><first>Julie</first><last>Medero</last></author>
+    <author><first>Stephanie</first><last>Strassel</last></author>
     <title>A New Phase in Annotation Tool Development at the Linguistic Data Consortium: The Evolution of the Annotation Graph Toolkit</title>
     <month>May</month>
     <year>2006</year>
@@ -5957,10 +5958,10 @@
     <bibkey>maeda:780:2006:lrec2006</bibkey>
   </paper>
   <paper id="1489" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/782_pdf.pdf">
-    <author><first>H.</first><last>Shima</last></author>
-    <author><first>M.</first><last>Wang</last></author>
-    <author><first>F.</first><last>Lin</last></author>
-    <author><first>T.</first><last>Mitamura</last></author>
+    <author><first>Hideki</first><last>Shima</last></author>
+    <author><first>Mengqiu</first><last>Wang</last></author>
+    <author><first>Frank</first><last>Lin</last></author>
+    <author><first>Teruko</first><last>Mitamura</last></author>
     <title>Modular Approach to Error Analysis and Evaluation for Multilingual Question Answering</title>
     <month>May</month>
     <year>2006</year>
@@ -5970,12 +5971,12 @@
     <bibkey>shima:782:2006:lrec2006</bibkey>
   </paper>
   <paper id="1490" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/783_pdf.pdf">
-    <author><first>J.</first><last>Ko</last></author>
-    <author><first>F.</first><last>Murase</last></author>
-    <author><first>T.</first><last>Mitamura</last></author>
-    <author><first>E.</first><last>Nyberg</last></author>
-    <author><first>M.</first><last>Tateishi</last></author>
-    <author><first>I.</first><last>Akahori</last></author>
+    <author><first>Jeongwoo</first><last>Ko</last></author>
+    <author><first>Fumihiko</first><last>Murase</last></author>
+    <author><first>Teruko</first><last>Mitamura</last></author>
+    <author><first>Eric</first><last>Nyberg</last></author>
+    <author><first>Masahiko</first><last>Tateishi</last></author>
+    <author><first>Ichiro</first><last>Akahori</last></author>
     <title>Analyzing the Effects of Spoken Dialog Systems on Driving Behavior</title>
     <month>May</month>
     <year>2006</year>
@@ -5985,11 +5986,11 @@
     <bibkey>ko:783:2006:lrec2006</bibkey>
   </paper>
   <paper id="1491" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/787_pdf.pdf">
-    <author><first>M.</first><last>Balasubramanya</last></author>
-    <author><first>M.</first><last>Higgins</last></author>
-    <author><first>P.</first><last>Lucas</last></author>
-    <author><first>J.</first><last>Senn</last></author>
-    <author><first>D.</first><last>Widdows</last></author>
+    <author><first>Magesh</first><last>Balasubramanya</last></author>
+    <author><first>Michael</first><last>Higgins</last></author>
+    <author><first>Peter</first><last>Lucas</last></author>
+    <author><first>Jeff</first><last>Senn</last></author>
+    <author><first>Dominic</first><last>Widdows</last></author>
     <title>Collaborative Annotation that Lasts Forever: Using Peer-to-Peer Technology for Disseminating Corpora and Language Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -5999,8 +6000,8 @@
     <bibkey>balasubramanya:787:2006:lrec2006</bibkey>
   </paper>
   <paper id="1492" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/788_pdf.pdf">
-    <author><first>V.</first><last>Rus</last></author>
-    <author><first>A.</first><last>Graesser</last></author>
+    <author><first>Vasile</first><last>Rus</last></author>
+    <author><first>Art</first><last>Graesser</last></author>
     <title>The Look and Feel of a Confident Entailer</title>
     <month>May</month>
     <year>2006</year>
@@ -6010,8 +6011,8 @@
     <bibkey>rus:788:2006:lrec2006</bibkey>
   </paper>
   <paper id="1493" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/790_pdf.pdf">
-    <author><first>G.</first><last>Marton</last></author>
-    <author><first>B.</first><last>Katz</last></author>
+    <author><first>Gregory</first><last>Marton</last></author>
+    <author><first>Boris</first><last>Katz</last></author>
     <title>Using Semantic Overlap Scoring in Answering TREC Relationship Questions</title>
     <month>May</month>
     <year>2006</year>
@@ -6021,9 +6022,9 @@
     <bibkey>marton:790:2006:lrec2006</bibkey>
   </paper>
   <paper id="1494" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/792_pdf.pdf">
-    <author><first>F.</first><last>Lacatusu</last></author>
-    <author><first>A.</first><last>Hickl</last></author>
-    <author><first>S.</first><last>Harabagiu</last></author>
+    <author><first>Finley</first><last>Lacatusu</last></author>
+    <author><first>Andrew</first><last>Hickl</last></author>
+    <author><first>Sanda</first><last>Harabagiu</last></author>
     <title>Impact of Question Decomposition on the Quality of Answer Summaries</title>
     <month>May</month>
     <year>2006</year>
@@ -6033,8 +6034,8 @@
     <bibkey>lacatusu:792:2006:lrec2006</bibkey>
   </paper>
   <paper id="1495" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/794_pdf.pdf">
-    <author><first>S.</first><last>Harabagiu</last></author>
-    <author><first>C.</first><last>Human</last></author>
+    <author><first>Sanda</first><last>Harabagiu</last></author>
+    <author><first>Cosmin Adrian</first><last>Bejan</last></author>
     <title>An Answer Bank for Temporal Inference</title>
     <month>May</month>
     <year>2006</year>
@@ -6044,7 +6045,7 @@
     <bibkey>harabagiu:794:2006:lrec2006</bibkey>
   </paper>
   <paper id="1496" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/795_pdf.pdf">
-    <author><first>P.</first><last>Morărescu</last></author>
+    <author><first>Paul C.</first><last>Morărescu</last></author>
     <title>Principles for annotating and reasoning with spatial information</title>
     <month>May</month>
     <year>2006</year>
@@ -6054,10 +6055,10 @@
     <bibkey>morărescu:795:2006:lrec2006</bibkey>
   </paper>
   <paper id="1497" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/796_pdf.pdf">
-    <author><first>S.</first><last>Li</last></author>
-    <author><first>Q.</first><last>Lu</last></author>
-    <author><first>W.</first><last>Li</last></author>
-    <author><first>R.</first><last>Xu</last></author>
+    <author><first>Sujian</first><last>Li</last></author>
+    <author><first>Qin</first><last>Lu</last></author>
+    <author><first>Wenjie</first><last>Li</last></author>
+    <author><first>Ruifeng</first><last>Xu</last></author>
     <title>Interaction between Lexical Base and Ontology with Formal Concept Analysis</title>
     <month>May</month>
     <year>2006</year>
@@ -6067,8 +6068,8 @@
     <bibkey>li:796:2006:lrec2006</bibkey>
   </paper>
   <paper id="1498" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/798_pdf.pdf">
-    <author><first>R.</first><last>Kongkachandra</last></author>
-    <author><first>K.</first><last>Chamnongthai</last></author>
+    <author><first>Rachada</first><last>Kongkachandra</last></author>
+    <author><first>Kosin</first><last>Chamnongthai</last></author>
     <title>Semantic-Based Keyword Recovery Function for Keyword Extraction System</title>
     <month>May</month>
     <year>2006</year>
@@ -6078,9 +6079,9 @@
     <bibkey>kongkachandra:798:2006:lrec2006</bibkey>
   </paper>
   <paper id="1499" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/799_pdf.pdf">
-    <author><first>R.</first><last>Xu</last></author>
-    <author><first>Q.</first><last>Lu</last></author>
-    <author><first>S.</first><last>Li</last></author>
+    <author><first>Ruifeng</first><last>Xu</last></author>
+    <author><first>Qin</first><last>Lu</last></author>
+    <author><first>Sujian</first><last>Li</last></author>
     <title>The Design and Construction of A Chinese Collocation Bank</title>
     <month>May</month>
     <year>2006</year>
@@ -6090,7 +6091,7 @@
     <bibkey>xu:799:2006:lrec2006</bibkey>
   </paper>
   <paper id="1500" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/800_pdf.pdf">
-    <author><first>N.</first><last>Ruimy</last></author>
+    <author><first>Nilda</first><last>Ruimy</last></author>
     <title>Merging two Ontology-based Lexical Resources</title>
     <month>May</month>
     <year>2006</year>
@@ -6100,9 +6101,9 @@
     <bibkey>ruimy:800:2006:lrec2006</bibkey>
   </paper>
   <paper id="1501" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/801_pdf.pdf">
-    <author><first>A.</first><last>Nimaan</last></author>
-    <author><first>P.</first><last>Nocera</last></author>
-    <author><first>J.</first><last>Bonastre</last></author>
+    <author><last>Nimaan</last><first>Abdillahi</first></author>
+    <author><last>Nocera</last><first>Pascal</first></author>
+    <author><last>Bonastre</last><first>Jean-François</first></author>
     <title>Towards automatic transcription of Somali language</title>
     <month>May</month>
     <year>2006</year>
@@ -6112,9 +6113,9 @@
     <bibkey>nimaan:801:2006:lrec2006</bibkey>
   </paper>
   <paper id="1502" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/802_pdf.pdf">
-    <author><first>S.</first><last>Burger</last></author>
-    <author><first>Z.</first><last>Sloane</last></author>
-    <author><first>J.</first><last>Yang</last></author>
+    <author><first>Susanne</first><last>Burger</last></author>
+    <author><first>Zachary A.</first><last>Sloane</last></author>
+    <author><first>Jie</first><last>Yang</last></author>
     <title>Competitive Evaluation of Commercially Available Speech Recognizers in Multiple Languages</title>
     <month>May</month>
     <year>2006</year>
@@ -6124,8 +6125,8 @@
     <bibkey>burger:802:2006:lrec2006</bibkey>
   </paper>
   <paper id="1503" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/803_pdf.pdf">
-    <author><first>K.</first><last>Laskowski</last></author>
-    <author><first>S.</first><last>Burger</last></author>
+    <author><first>Kornel</first><last>Laskowski</last></author>
+    <author><first>Susanne</first><last>Burger</last></author>
     <title>Annotation and Analysis of Emotionally Relevant Behavior in the ISL Meeting Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -6135,14 +6136,13 @@
     <bibkey>laskowski:803:2006:lrec2006</bibkey>
   </paper>
   <paper id="1504" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/805_pdf.pdf">
-    <author><first>S.</first><last>Elkateb</last></author>
-    <author><first>W.</first><last>Black</last></author>
-    <author><first>H.</first><last>Rodríguez</last></author>
-    <author><first>M.</first><last>Alkhalifa</last></author>
-    <author><first>E.</first><last>Aribau</last></author>
-    <author><first>P.</first><last>Vossen</last></author>
-    <author><first>A.</first><last>Pease</last></author>
-    <author><first>C.</first><last>Fellbaum</last></author>
+    <author><first>Sabri</first><last>Elkateb</last></author>
+    <author><first>William</first><last>Black</last></author>
+    <author><first>Horacio</first><last>Rodríguez</last></author>
+    <author><first>Musa</first><last>Alkhalifa</last></author>
+    <author><first>Piek</first><last>Vossen</last></author>
+    <author><first>Adam</first><last>Pease</last></author>
+    <author><first>Christiane</first><last>Fellbaum</last></author>
     <title>Building a WordNet for Arabic</title>
     <month>May</month>
     <year>2006</year>
@@ -6152,8 +6152,8 @@
     <bibkey>elkateb:805:2006:lrec2006</bibkey>
   </paper>
   <paper id="1505" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/806_pdf.pdf">
-    <author><first>B.</first><last>Sagot</last></author>
-    <author><first>P.</first><last>Boullier</last></author>
+    <author><first>Benoı̂t</first><last>Sagot</last></author>
+    <author><first>Pierre</first><last>Boullier</last></author>
     <title>Deep non-probabilistic parsing of large corpora</title>
     <month>May</month>
     <year>2006</year>
@@ -6163,10 +6163,10 @@
     <bibkey>sagot:806:2006:lrec2006</bibkey>
   </paper>
   <paper id="1506" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/807_pdf.pdf">
-    <author><first>M.</first><last>Brekke</last></author>
-    <author><first>K.</first><last>Innselset</last></author>
-    <author><first>M.</first><last>Kristiansen</last></author>
-    <author><first>K.</first><last>Øvsthus</last></author>
+    <author><first>Magnar</first><last>Brekke</last></author>
+    <author><first>Kai</first><last>Innselset</last></author>
+    <author><first>Marita</first><last>Kristiansen</last></author>
+    <author><first>Kari</first><last>Øvsthus</last></author>
     <title>Automatic Term Extraction from Knowledge Bank of Economics</title>
     <month>May</month>
     <year>2006</year>
@@ -6176,11 +6176,11 @@
     <bibkey>brekke:807:2006:lrec2006</bibkey>
   </paper>
   <paper id="1507" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/808_pdf.pdf">
-    <author><first>A.</first><last>Klassmann</last></author>
-    <author><first>F.</first><last>Offenga</last></author>
-    <author><first>D.</first><last>Broeder</last></author>
-    <author><first>R.</first><last>Skiba</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
+    <author><first>Alex</first><last>Klassmann</last></author>
+    <author><first>Freddy</first><last>Offenga</last></author>
+    <author><first>Daan</first><last>Broeder</last></author>
+    <author><first>Romuald</first><last>Skiba</last></author>
+    <author><first>Peter</first><last>Wittenburg</last></author>
     <title>Comparison of Resource Discovery Methods</title>
     <month>May</month>
     <year>2006</year>
@@ -6190,10 +6190,10 @@
     <bibkey>klassmann:808:2006:lrec2006</bibkey>
   </paper>
   <paper id="1508" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/809_pdf.pdf">
-    <author><first>P.</first><last>Lucas</last></author>
-    <author><first>M.</first><last>Balasubramanya</last></author>
-    <author><first>D.</first><last>Widdows</last></author>
-    <author><first>M.</first><last>Higgins</last></author>
+    <author><first>Peter</first><last>Lucas</last></author>
+    <author><first>Magesh</first><last>Balasubramanya</last></author>
+    <author><first>Dominic</first><last>Widdows</last></author>
+    <author><first>Michael</first><last>Higgins</last></author>
     <title>The Information Commons Gazetteer</title>
     <month>May</month>
     <year>2006</year>
@@ -6203,10 +6203,10 @@
     <bibkey>lucas:809:2006:lrec2006</bibkey>
   </paper>
   <paper id="1509" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/810_pdf.pdf">
-    <author><first>B.</first><last>Sagot</last></author>
-    <author><first>L.</first><last>Clément</last></author>
-    <author><first>E. Villemonte</first><last>de la Clergerie</last></author>
-    <author><first>P.</first><last>Boullier</last></author>
+    <author><first>Benoı̂t</first><last>Sagot</last></author>
+    <author><first>Lionel</first><last>Clément</last></author>
+    <author><first>Éric Villemonte</first><last>de la Clergerie</last></author>
+    <author><first>Pierre</first><last>Boullier</last></author>
     <title>The Lefff 2 syntactic lexicon for French: architecture, acquisition, use</title>
     <month>May</month>
     <year>2006</year>
@@ -6216,7 +6216,7 @@
     <bibkey>sagot:810:2006:lrec2006</bibkey>
   </paper>
   <paper id="1510" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/811_pdf.pdf">
-    <author><first>N.</first><last>Ruimy</last></author>
+    <author><first>Nilda</first><last>Ruimy</last></author>
     <title>Structuring a Domain Vocabulary in a General Knowledge Environment</title>
     <month>May</month>
     <year>2006</year>
@@ -6226,8 +6226,8 @@
     <bibkey>ruimy:811:2006:lrec2006</bibkey>
   </paper>
   <paper id="1511" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/812_pdf.pdf">
-    <author><first>A.</first><last>Geyken</last></author>
-    <author><first>N.</first><last>Schrader</last></author>
+    <author><first>Alexander</first><last>Geyken</last></author>
+    <author><first>Norbert</first><last>Schrader</last></author>
     <title>LexikoNet - a lexical database based on type and role hierarchies</title>
     <month>May</month>
     <year>2006</year>
@@ -6237,9 +6237,9 @@
     <bibkey>geyken:812:2006:lrec2006</bibkey>
   </paper>
   <paper id="1512" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/813_pdf.pdf">
-    <author><first>D.</first><last>Mostefa</last></author>
-    <author><first>O.</first><last>Hamon</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
+    <author><first>Djamel</first><last>Mostefa</last></author>
+    <author><first>Olivier</first><last>Hamon</last></author>
+    <author><first>Khalid</first><last>Choukri</last></author>
     <title>Evaluation of Automatic Speech Recognition and Speech Language Translation within TC-STAR:Results from the first evaluation campaign</title>
     <month>May</month>
     <year>2006</year>
@@ -6249,9 +6249,9 @@
     <bibkey>mostefa:813:2006:lrec2006</bibkey>
   </paper>
   <paper id="1513" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/814_pdf.pdf">
-    <author><first>D.</first><last>Mostefa</last></author>
-    <author><first>M.</first><last>Garcia</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
+    <author><first>Djamel</first><last>Mostefa</last></author>
+    <author><first>Marie-Neige</first><last>Garcia</last></author>
+    <author><first>Khalid</first><last>Choukri</last></author>
     <title>Evaluation of multimodal components within CHIL: The evaluation packages and results</title>
     <month>May</month>
     <year>2006</year>
@@ -6261,7 +6261,7 @@
     <bibkey>mostefa:814:2006:lrec2006</bibkey>
   </paper>
   <paper id="1514" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/815_pdf.pdf">
-    <author><first>C.</first><last>Peters</last></author>
+    <author><first>Carol</first><last>Peters</last></author>
     <title>The Impact of Evaluation on Multilingual Information Retrieval System Development</title>
     <month>May</month>
     <year>2006</year>
@@ -6271,16 +6271,16 @@
     <bibkey>peters:815:2006:lrec2006</bibkey>
   </paper>
   <paper id="1515" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/816_pdf.pdf">
-    <author><first>B.</first><last>Magnini</last></author>
-    <author><first>D.</first><last>Giampicollo</last></author>
-    <author><first>L.</first><last>Aunimo</last></author>
-    <author><first>C.</first><last>Ayache</last></author>
-    <author><first>P.</first><last>Osenova</last></author>
-    <author><first>A.</first><last>Peñas</last></author>
-    <author><first>M.</first><last>Rijke</last></author>
-    <author><first>B.</first><last>Sacaleanu</last></author>
-    <author><first>D.</first><last>Santos</last></author>
-    <author><first>R.</first><last>Sutcliffe</last></author>
+    <author><first>Bernardo</first><last>Magnini</last></author>
+    <author><first>Danilo</first><last>Giampiccolo</last></author>
+    <author><first>Lili</first><last>Aunimo</last></author>
+    <author><first>Christelle</first><last>Ayache</last></author>
+    <author><first>Petya</first><last>Osenova</last></author>
+    <author><first>Anselmo</first><last>Peñas</last></author>
+    <author><first>Maarten de</first><last>Rijke</last></author>
+    <author><first>Bogdan</first><last>Sacaleanu</last></author>
+    <author><first>Diana</first><last>Santos</last></author>
+    <author><first>Richard</first><last>Sutcliffe</last></author>
     <title>The Multilingual Question Answering Track at CLEF</title>
     <month>May</month>
     <year>2006</year>
@@ -6290,11 +6290,11 @@
     <bibkey>magnini:816:2006:lrec2006</bibkey>
   </paper>
   <paper id="1516" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/817_pdf.pdf">
-    <author><first>M.</first><last>Garcia</last></author>
-    <author><first>C.</first><last>D’alessandro</last></author>
-    <author><first>G.</first><last>Bailly</last></author>
-    <author><first>P.</first><last>Mareüil</last></author>
-    <author><first>M.</first><last>Morel</last></author>
+    <author><first>Marie-Neige</first><last>Garcia</last></author>
+    <author><first>Christophe</first><last>D’alessandro</last></author>
+    <author><first>Gérard</first><last>Bailly</last></author>
+    <author><first>Philippe Boula de</first><last>Mareüil</last></author>
+    <author><first>Michel</first><last>Morel</last></author>
     <title>A joint prosody evaluation of French text-to-speech synthesis systems</title>
     <month>May</month>
     <year>2006</year>

--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -9,7 +9,7 @@ MarkupText = (text | b | i | url | fixed-case | tex-math )+
 
 first = element first { text }
 last = element last { text }
-Person = (first?, last)
+Person = (first? & last)
 
 Paper = element paper {
   attribute id { xsd:integer },

--- a/data/xml/schema.rng
+++ b/data/xml/schema.rng
@@ -49,10 +49,12 @@
     </element>
   </define>
   <define name="Person">
-    <optional>
-      <ref name="first"/>
-    </optional>
-    <ref name="last"/>
+    <interleave>
+      <optional>
+        <ref name="first"/>
+      </optional>
+      <ref name="last"/>
+    </interleave>
   </define>
   <define name="Paper">
     <element name="paper">


### PR DESCRIPTION
For the most part, the first names were scraped from the PDF files, and then manually checked. The scraper is bin/auto_first_names.py.

A few other corrections were made as well.

Closes #224, although there are a few much smaller conferences that have the same problem.

