### PR TITLE
Corrections to author names and name variants

### DIFF
--- a/data/xml/C02.xml
+++ b/data/xml/C02.xml
@@ -90,7 +90,7 @@
 
 <paper id="1014">
     <title>Semiautomatic Labelling of Semantic Features</title>
-    <author><first>Arantza Díaz</first><last>de Ilarraza</last></author>
+    <author><first>Arantza</first><last>Díaz de Ilarraza</last></author>
     <author><first>Aingeru</first><last>Mayor</last></author>
     <author><first>Kepa</first><last>Sarasola</last></author>
 </paper>

--- a/data/xml/C88.xml
+++ b/data/xml/C88.xml
@@ -94,8 +94,8 @@
  <title>A STATISTICAL APPROACH TO LANGUAGE TRANSLATION</title>
  <author><first>P.</first><last>BROWN</last></author>
  <author><first>J.</first><last>COCKE</last></author>
- <author><first>S. DELLA</first><last>PIETRA</last></author>
- <author><first>V. DELLA</first><last>PIETRA</last></author>
+ <author><first>S.</first><last>DELLA PIETRA</last></author>
+ <author><first>V.</first><last>DELLA PIETRA</last></author>
  <author><first>F.</first><last>JELINEK</last></author>
  <author><first>R.</first><last>MERCER</last></author>
  <author><first>P.</first><last>ROOSSIN</last></author>

--- a/data/xml/C90.xml
+++ b/data/xml/C90.xml
@@ -1162,9 +1162,9 @@
 
  <paper id="3102">
  <title>A Mechanism for ellipsis resolution in dialogued systems</title>
- <author><first>A. Diaz</first><last>de Ilarraza Sanchez</last></author>
- <author><first>H. Rodriguez</first><last>Hontoria</last></author>
- <author><first>F. Maillo</first><last>Verdejo</last></author>
+ <author><first>A.</first><last>Diaz de Ilarraza Sanchez</last></author>
+ <author><first>H.</first><last>Rodriguez Hontoria</last></author>
+ <author><first>F.</first><last>Maillo Verdejo</last></author>
 </paper>
 
  <paper id="3103">

--- a/data/xml/C94.xml
+++ b/data/xml/C94.xml
@@ -574,7 +574,7 @@
  <author><first>E.</first><last>Agirre</last></author>
  <author><first>X.</first><last>Arregi</last></author>
  <author><first>X.</first><last>Artola</last></author>
- <author><first>A. Diaz</first><last>de Ilarraza</last></author>
+ <author><first>A.</first><last>Diaz de Ilarraza</last></author>
  <author><first>K.</first><last>Sarasola</last></author>
 </paper>
 

--- a/data/xml/I08.xml
+++ b/data/xml/I08.xml
@@ -991,7 +991,7 @@
 <author><first>I.</first><last>Alegria</last></author>
 <author><first>X.</first><last>Arregi</last></author>
 <author><first>X.</first><last>Artola</last></author>
-<author><first>A. Diaz</first><last>de Ilarraza</last></author>
+<author><first>A.</first><last>Diaz de Ilarraza</last></author>
 <author><first>G.</first><last>Labaka</last></author>
 <author><first>M.</first><last>Lersundi</last></author>
 <author><first>A.</first><last>Mayor</last></author>

--- a/data/xml/L00.xml
+++ b/data/xml/L00.xml
@@ -144,11 +144,11 @@
     <bibkey>jie:15:2000:lrec2000</bibkey>
   </paper>
   <paper id="1012" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/16.pdf">
-    <author><first>Stavroula-Evita</first><last>Fotinea</last></author>
-    <author><first>Ioannis</first><last>Dologlou</last></author>
-    <author><first>Stylianos</first><last>Bakamidis</last></author>
-    <author><first>Gregory</first><last>Stainhaouer</last></author>
-    <author><first>George</first><last>Carayannis</last></author>
+    <author><first>S.-E.</first><last>Fotinea</last></author>
+    <author><first>I.</first><last>Dologlou</last></author>
+    <author><first>S.</first><last>Bakamidis</last></author>
+    <author><first>G.</first><last>Stainhauer</last></author>
+    <author><first>G.</first><last>Carayannis</last></author>
     <title>Perceptual Evaluation of a New Subband Low Bit Rate Speech Compression System based on Waveform Vector Quantization and SVD Postfiltering</title>
     <month>May</month>
     <year>2000</year>
@@ -283,7 +283,7 @@
   </paper>
   <paper id="1024" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/33.pdf">
     <author><first>Marcela</first><last>Charfuelán</last></author>
-    <author><first>José Relaño</first><last>Gil</last></author>
+    <author><first>José</first><last>Relaño Gil</last></author>
     <author><first>M. Carmen Rodríguez</first><last>Gancedo</last></author>
     <author><first>Daniel Tapias</first><last>Merino</last></author>
     <author><first>Luis Hernández</first><last>Gómez</last></author>
@@ -611,7 +611,7 @@
   </paper>
   <paper id="1049" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/68.pdf">
     <author><first>X.</first><last>Artola</last></author>
-    <author><first>A. Díaz</first><last>de Ilarraza</last></author>
+    <author><first>A.</first><last>Díaz de Ilarraza</last></author>
     <author><first>N.</first><last>Ezeiza</last></author>
     <author><first>K.</first><last>Gojenola</last></author>
     <author><first>A.</first><last>Maritxalar</last></author>
@@ -947,7 +947,7 @@
   <paper id="1077" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/101.pdf">
     <author><first>R.</first><last>López-Cózar</last></author>
     <author><first>A.J.</first><last>Rubio</last></author>
-    <author><first>J.E. Díaz</first><last>Verdejo</last></author>
+    <author><first>J.E.</first><last>Díaz Verdejo</last></author>
     <author><first>A. De</first><last>la Torre</last></author>
     <title>Evaluation of a Dialogue System Based on a Generic Model that Combines Robust Speech Understanding and Mixed-initiative Control</title>
     <month>May</month>
@@ -1034,7 +1034,7 @@
     <bibkey>badia:111:2000:lrec2000</bibkey>
   </paper>
   <paper id="1085" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/112.pdf">
-    <author><first>Joan Soler</first><last>i Bou</last></author>
+    <author><first>Joan</first><last>Soler i Bou</last></author>
     <title>Producing LRs in Parallel with Lexicographic Description: the DCC project</title>
     <month>May</month>
     <year>2000</year>

--- a/data/xml/L02.xml
+++ b/data/xml/L02.xml
@@ -2410,7 +2410,7 @@
   </paper>
   <paper id="1200" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/200.pdf">
     <author><first>X.</first><last>Artola</last></author>
-    <author><first>A. Díaz</first><last>de Ilarraza</last></author>
+    <author><first>A.</first><last>Díaz de Ilarraza</last></author>
     <author><first>N.</first><last>Ezeiza</last></author>
     <author><first>K.</first><last>Gojenola</last></author>
     <author><first>G.</first><last>Hernández</last></author>
@@ -3057,7 +3057,7 @@
   </paper>
   <paper id="1252" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/252.pdf">
     <author><first>D.</first><last>Binnenpoorte</last></author>
-    <author><first>F. De</first><last>Vriend</last></author>
+    <author><first>F.</first><last>De Vriend</last></author>
     <author><first>J.</first><last>Sturm</last></author>
     <author><first>W.</first><last>Daelemans</last></author>
     <author><first>H.</first><last>Strik</last></author>

--- a/data/xml/L04.xml
+++ b/data/xml/L04.xml
@@ -2652,7 +2652,7 @@
     <bibkey>garcia-mateo:382:2004:lrec2004</bibkey>
   </paper>
   <paper id="1218" href="http://www.lrec-conf.org/proceedings/lrec2004/pdf/383.pdf">
-    <author><first>Arantza Díaz</first><last>de Ilarraza</last></author>
+    <author><first>Arantza</first><last>Díaz de Ilarraza</last></author>
     <author><first>Aitzpea</first><last>Garmendia</last></author>
     <author><first>Maite</first><last>Oronoz</last></author>
     <title>Abar-Hitz: An Annotation Tool for the Basque Dependency Treebank</title>

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -2109,7 +2109,7 @@
   <paper id="1149" href="http://www.lrec-conf.org/proceedings/lrec2010/pdf/217_Paper.pdf">
     <author><first>Izaskun</first><last>Aldezabal</last></author>
     <author><first>María Jesús</first><last>Aranzabe</last></author>
-    <author><first>Arantza Díaz</first><last>de Ilarraza</last></author>
+    <author><first>Arantza</first><last>Díaz de Ilarraza</last></author>
     <author><first>Ainara</first><last>Estarrona</last></author>
     <title>Building the Basque PropBank</title>
     <month>May</month>

--- a/data/xml/W15.xml
+++ b/data/xml/W15.xml
@@ -24282,7 +24282,7 @@ Exploring the Effects of Redundancy within a Tutorial Dialogue System: Restating
     <title>Exploiting portability to build an RBMT prototype for a new source language</title>
     <author><first>Nora</first><last>Aranberri</last></author>
     <author><first>Gorka</first><last>Labaka</last></author>
-    <author><first>Arantza Díaz</first><last>de Ilarraza</last></author>
+    <author><first>Arantza</first><last>Díaz de Ilarraza</last></author>
     <author><first>Kepa</first><last>Sarasola</last></author>
     <url>http://www.aclweb.org/anthology/W15-4901</url>
     <address>Antalya, Turkey</address>
@@ -27160,7 +27160,7 @@ Using linguistic features longitudinally to predict clinical scores for Alzheime
     <title>Deep-syntax TectoMT for English-Spanish <fixed-case>MT</fixed-case></title>
     <author><first>Gorka</first><last>Labaka</last></author>
     <author><first>Oneka</first><last>Jauregi</last></author>
-    <author><first>Arantza Díaz</first><last>de Ilarraza</last></author>
+    <author><first>Arantza</first><last>Díaz de Ilarraza</last></author>
     <author><first>Michael</first><last>Ustaszewski</last></author>
     <author><first>Nora</first><last>Aranberri</last></author>
     <author><first>Eneko</first><last>Agirre</last></author>

--- a/data/xml/W97.xml
+++ b/data/xml/W97.xml
@@ -1031,7 +1031,7 @@
 <paper id="1007">
  <title>From Psycholinguistic Modelling of Interlanguage in Second Language Acquisition to a Computational Model</title>
  <author><first>Montse</first><last>Maritxalar</last></author>
- <author><first>Arantza Diaz</first><last>de Ilarraza</last></author>
+ <author><first>Arantza</first><last>Diaz de Ilarraza</last></author>
  <author><first>Maite</first><last>Oronoz</last></author>
 </paper>
 

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -2367,7 +2367,7 @@
   - {first: Lance De, last: Vine}
 - canonical: {first: Folkert, last: de Vriend}
   variants:
-  - {first: F. De, last: Vriend}
+  - {first: F., last: De Vriend}
   - {first: F., last: de Vriend}
   - {first: Folkert de, last: Vriend}
   - {first: Folkert De, last: Vriend}
@@ -2728,14 +2728,10 @@
 - canonical: {first: Arantza, last: Díaz de Ilarraza}
   variants:
   - {first: A, last: Diaz de Ilarraza}
-  - {first: A. Diaz, last: de Ilarraza}
-  - {first: A. Díaz, last: de Ilarraza}
   - {first: A., last: Diaz de Ilarraza}
   - {first: A., last: Díaz de Ilarraza}
-  - {first: Arantza Díaz, last: de Ilarraza}
   - {first: Arantza, last: Diaz de Ilarraza}
-  - {first: Arantza Diaz, last: de Ilarraza}
-  - {first: A. Diaz, last: de Ilarraza Sanchez}
+  - {first: A., last: Diaz de Ilarraza Sanchez}
 - canonical: {first: Elisabeth, last: D’Halleweyn}
   variants:
   - {first: Elizabeth, last: D’Halleweyn}
@@ -2903,9 +2899,6 @@
 - canonical: {first: Yannick, last: Estève}
   variants:
   - {first: Yannick, last: Esteve}
-- canonical: {first: Barbara Di, last: Eugenio}
-  variants:
-  - {first: Barbara, last: Di Eugenio}
 - canonical: {first: David A., last: Evans}
   variants:
   - {first: David K., last: Evans}
@@ -4409,7 +4402,7 @@
 - canonical: {first: Jia-Fei, last: Hong}
   variants:
   - {first: Jia-Fei, last: Hung}
-- canonical: {first: H. Rodriguez, last: Hontoria}
+- canonical: {first: H., last: Rodriguez Hontoria}
   variants:
   - {first: H., last: Rodriguez}
 - canonical: {first: Philip, last: Hoole}
@@ -8410,18 +8403,16 @@
 - canonical: {first: Janet, last: Pierrehumbert}
   variants:
   - {first: Janet B., last: Pierrehumbert}
-- canonical: {first: Stephen A. Della, last: Pietra}
+- canonical: {first: Stephen A., last: Della Pietra}
   variants:
-  - {first: S. DELLA, last: PIETRA}
-  - {first: S. Della, last: Pietra}
-  - {first: Stephen Della, last: Pietra}
+  - {first: S., last: DELLA PIETRA}
+  - {first: S., last: Della Pietra}
+  - {first: Stephen, last: Della Pietra}
   - {first: Stephen, last: DellaPietra}
-  - {first: Stephen A., last: Della Pietra}
-- canonical: {first: Vincent J. Della, last: Pietra}
+- canonical: {first: Vincent J., last: Della Pietra}
   variants:
-  - {first: V. DELLA, last: PIETRA}
-  - {first: V. Della, last: Pietra}
-  - {first: Vincent J., last: Della Pietra}
+  - {first: V., last: DELLA PIETRA}
+  - {first: V., last: Della Pietra}
   - {first: Vincent, last: DellaPietra}
 - canonical: {first: Paola, last: Pietrandrea}
   variants:
@@ -8821,7 +8812,6 @@
 - canonical: {first: Jose, last: Relaño-Gil}
   variants:
   - {first: Jose, last: Relano Gil}
-  - {first: José Relaño, last: Gil}
   - {first: José, last: Relaño Gil}
   - {first: José, last: Relaño}
 - canonical: {first: Christian, last: Retoré}
@@ -9851,6 +9841,9 @@
 - canonical: {first: Artem, last: Sokolov}
   variants:
   - {first: Artem, last: Sokokov}
+- canonical: {first: Joan, last: Soler i Bou}
+  variants:
+  - {first: Joan, last: Soler}
 - canonical: {first: Juan José Rodríguez, last: Soler}
   variants:
   - {first: Juan José, last: Rodríguez}
@@ -9960,6 +9953,10 @@
   variants:
   - {first: Edward P., last: 'Stabler, Jr.'}
   - {first: Edward P., last: Stabler}
+- canonical: {first: Gregory, last: Stainhauer}
+  variants:
+  - {first: G., last: Stainhauer}
+  - {first: Gregory, last: Stainhaouer}
 - canonical: {first: Ieva, last: Staliūnaitė}
   variants:
   - {first: Ieva, last: Staliūnaite}


### PR DESCRIPTION
- Corrections from LREC organizers (no full first names yet)
- A couple of further corrections for the Della Pietras (2de24587ea9ed6e6868d3c6224767c286fc9d001), and updated name_variants.yaml
- Updated name_variants.yaml for Di Eugenio (b29ce76b828e7dc81927b4a4a08d0a195359c912)

(Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)