### PR TITLE
Repair URLs in LREC

### DIFF
--- a/bin/repair_url.py
+++ b/bin/repair_url.py
@@ -1,0 +1,60 @@
+"""Repairs URLs in Anthology XML files.
+
+Usage: repair_url.py <infilename> <outfilename>
+
+To do:
+- check URLs of attachments
+- incorporate into a more general XML-fixing script
+
+"""
+
+import lxml.etree as etree
+import requests
+import sys
+
+def test_url(url):
+    #sys.stderr.write("retrieving {}: ".format(url))
+    r = requests.head(url, allow_redirects=True)
+    #sys.stderr.write("{}\n".format(r.status_code))
+    return r.status_code == requests.codes.ok
+
+filename = sys.argv[1]
+outfilename = sys.argv[2]
+tree = etree.parse(filename)
+volume = tree.getroot()
+for paper in volume.findall("paper"):
+    if 'href' in paper.attrib:
+        if not test_url(paper.attrib['href']):
+            sys.stderr.write('{}:{} removing href attribute: {}\n'.format(filename, paper.sourceline, paper.attrib['href']))
+            del paper.attrib['href']
+
+    href = paper.find('href')
+    if href is not None:
+        assert len(href) == 0
+        if not test_url(href.text):
+            sys.stderr.write('{}:{} removing href element: {}\n'.format(filename, href.sourceline, href.text))
+            paper.remove(href)
+    
+    anth_url = 'http://www.aclweb.org/anthology/{}-{:04d}'.format(volume.attrib['id'], int(paper.attrib['id']))
+    anth_url_good = test_url(anth_url)
+    
+    url = paper.find("url")
+    assert url is None or len(url) == 0
+    
+    if url is None:
+        if anth_url_good:
+            url = etree.Element('url')
+            url.text = anth_url
+            sys.stderr.write("{}:{} inserting url element: {}\n".format(filename, paper.sourceline, anth_url))
+            paper.append(url)
+        
+    else:
+        if anth_url_good and url.text != anth_url:
+            sys.stderr.write("{}:{} rewriting url: {} -> {}\n".format(filename, url.sourceline, url.text, anth_url))
+            url.text = anth_url
+
+        else:
+            sys.stderr.write("{}:{} removing url element because {} is bad\n".format(filename, url.sourceline, anth_url))
+            paper.remove(url)
+    
+tree.write(outfilename, encoding='UTF-8', xml_declaration=True, with_tail=True)

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -26,7 +26,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1001</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dalianis:13:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -42,7 +41,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1002</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>padr:14:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -55,7 +53,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1003</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kirschenbaum:16:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -68,7 +65,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1004</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kao:17:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -81,7 +77,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1005</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schmidt:18:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -95,7 +90,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1006</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>navigli:20:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -108,7 +102,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1007</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>khokhlova:21:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -121,7 +114,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1008</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rcostajuss:23:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -133,7 +125,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1009</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>crasborn:25:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -147,7 +138,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1010</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hawayek:27:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -161,7 +151,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1011</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sharoff:28:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -173,7 +162,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1012</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>krieger:29:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -189,7 +177,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1013</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>qian:30:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -205,7 +192,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1014</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cohen:31:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -218,7 +204,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1015</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lefever:34:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -233,7 +218,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1016</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>barrncedeo:35:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -247,7 +231,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1017</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zinn:36:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -262,7 +245,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1018</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>scerri:39:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -275,7 +257,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1019</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tsvetkov:40:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -291,7 +272,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1020</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rentoumi:41:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -303,7 +283,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1021</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bel:45:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -316,7 +295,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1022</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>carlsson:46:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -331,7 +309,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1023</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rcostajuss:47:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -344,7 +321,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1024</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>singh:48:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -357,7 +333,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1025</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pedersen:52:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -370,7 +345,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1026</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>benajiba:54:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -385,7 +359,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1027</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pustejovsky:55:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -399,7 +372,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1028</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>stankovi:57:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -412,7 +384,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1029</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>chambers:58:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -425,7 +396,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1030</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kokkinakis:60:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -438,7 +408,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1031</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>proisl:62:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -451,7 +420,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1032</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>saralegi:63:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -465,7 +433,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1033</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>luxpogodalla:65:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -479,7 +446,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1034</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>krstev:66:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -493,7 +459,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1035</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bhowmick:67:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -506,7 +471,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1036</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tannier:68:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -518,7 +482,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1037</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wrner:69:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -530,7 +493,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1038</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>odijk:70:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -544,7 +506,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1039</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sornlertlamvanich:71:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -558,7 +519,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1040</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>choi:73:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -571,7 +531,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1041</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>handl:76:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -583,7 +542,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1042</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lyashevskaya:77:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -597,7 +555,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1043</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>syed:78:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -612,7 +569,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1044</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kilgarriff:79:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -625,7 +581,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1045</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>johansson:80:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -640,7 +595,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1046</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>galibert:81:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -653,7 +607,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1047</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dini:82:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -669,7 +622,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1048</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang:83:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -685,7 +637,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1049</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ovchinnikova:84:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -702,7 +653,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1050</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>shaikh:85:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -714,7 +664,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1051</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sun:87:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -728,7 +677,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1052</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>simes:90:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -740,7 +688,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1053</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>waltinger:91:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -753,7 +700,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1054</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>parejalora:92:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -766,7 +712,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1055</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zesch:93:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -779,7 +724,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1056</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>campbell:96:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -793,7 +737,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1057</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mendes:97:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -809,7 +752,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1058</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>paggio:98:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -829,7 +771,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1059</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>maekawa:99:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -841,7 +782,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1060</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>macken:100:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -856,7 +796,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1061</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>scherer:101:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -869,7 +808,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1062</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>aker:102:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -886,7 +824,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1063</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>roux:103:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -898,7 +835,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1064</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>jacquemin:104:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -915,7 +851,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1065</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>condon:106:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -928,7 +863,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1066</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mohseni:107:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -943,7 +877,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1067</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>babkomalaya:108:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -955,7 +888,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1068</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ltekin:109:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -972,7 +904,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1069</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>volk:110:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -985,7 +916,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1070</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pareti:111:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1000,7 +930,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1071</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>webb:115:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1015,7 +944,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1072</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>megyesi:116:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1029,7 +957,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1073</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dantuluri:117:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1043,7 +970,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1074</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>teissdre:118:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1058,7 +984,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1075</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>saz:119:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1074,7 +999,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1076</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ananiadou:121:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1087,7 +1011,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1077</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pedler:122:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1103,7 +1026,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1078</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schmitt:123:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1116,7 +1038,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1079</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>stoyanchev:127:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1130,7 +1051,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1080</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kaplan:129:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1144,7 +1064,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1081</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>paci:132:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1158,7 +1077,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1082</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>laurent:133:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1175,7 +1093,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1083</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nakano:135:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1189,7 +1106,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1084</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>silva:136:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1204,7 +1120,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1085</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cardey:137:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1216,7 +1131,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1086</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>erjavec:138:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1231,7 +1145,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1087</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>erjavec:139:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1245,7 +1158,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1088</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>robaldo:140:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1259,7 +1171,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1089</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fier:141:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1272,7 +1183,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1090</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tufi:142:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1284,7 +1194,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1091</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>grishina:143:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1296,7 +1205,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1092</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tiedemann:144:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1308,7 +1216,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1093</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>grivaz:145:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1323,7 +1230,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1094</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>marinelli:147:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1335,7 +1241,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1095</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wawer:149:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1352,7 +1257,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1096</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>alegria:150:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1367,7 +1271,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1097</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>przepirkowski:152:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1386,7 +1289,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1098</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>branco:154:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1400,7 +1302,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1099</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>borin:156:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1413,7 +1314,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1100</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>abeill:157:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1426,7 +1326,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1101</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sekine:158:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1441,7 +1340,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1102</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schmitt:159:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1455,7 +1353,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1103</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>recasens:160:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1469,7 +1366,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1104</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schuurman:162:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1487,7 +1383,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1105</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>broeder:163:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1500,7 +1395,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1106</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>maks:165:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1512,7 +1406,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1107</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>arehart:166:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1525,7 +1418,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1108</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>shinnou:167:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1538,7 +1430,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1109</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>uzzaman:169:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1551,7 +1442,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1110</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>funk:170:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1564,7 +1454,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1111</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>murawaki:171:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1578,7 +1467,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1112</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nir:172:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1590,7 +1478,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1113</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>jokinen:173:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1606,7 +1493,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1114</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>abejn:174:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1618,7 +1504,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1115</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bouma:175:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1631,7 +1516,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1116</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lefebvrealbaret:176:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1644,7 +1528,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1117</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gardent:177:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1657,7 +1540,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1118</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>passarotti:178:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1670,7 +1552,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1119</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schuurman:180:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1684,7 +1565,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1120</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>teraoka:181:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1700,7 +1580,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1121</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vb:182:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1714,7 +1593,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1122</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>balvet:183:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1729,7 +1607,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1123</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tonelli:184:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1742,7 +1619,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1124</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>williams:185:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1762,7 +1638,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1125</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>quintard:186:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1775,7 +1650,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1126</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>quarteroni:188:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1798,7 +1672,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1127</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>galibert:191:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1815,7 +1688,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1128</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tsutsumida:192:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1827,7 +1699,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1129</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ahrenberg:193:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1846,7 +1717,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1130</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>malik:194:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1859,7 +1729,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1131</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>petukhova:195:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1883,7 +1752,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1132</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bosco:196:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1895,7 +1763,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1133</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>federmann:197:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1909,7 +1776,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1134</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhao:199:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1923,7 +1789,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1135</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pedersen:200:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1936,7 +1801,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1136</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tatu:203:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1949,7 +1813,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1137</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>declercq:204:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1962,7 +1825,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1138</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cybulska:205:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1974,7 +1836,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1139</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>scheible:206:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -1986,7 +1847,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1140</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>venant:207:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2000,7 +1860,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1141</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vernier:208:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2014,7 +1873,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1142</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>guerini:209:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2027,7 +1885,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1143</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>desmet:210:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2043,7 +1900,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1144</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>senay:211:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2057,7 +1913,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1145</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ljubei:213:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2071,7 +1926,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1146</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang:214:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2084,7 +1938,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1147</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>strakov:215:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2101,7 +1954,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1148</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>attardi:216:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2116,7 +1968,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1149</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>aldezabal:217:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2131,7 +1982,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1150</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bigi:219:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2146,7 +1996,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1151</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tsourakis:220:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2162,7 +2011,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1152</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>reese:222:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2175,7 +2023,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1153</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dickinson:227:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2191,7 +2038,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1154</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>khalilov:228:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2205,7 +2051,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1155</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sidorov:229:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2221,7 +2066,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1156</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fernndezmartnez:230:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2233,7 +2077,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1157</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hois:231:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2256,7 +2099,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1158</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lin:233:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2275,7 +2117,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1159</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>auer:234:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2290,7 +2131,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1160</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vlaj:235:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2303,7 +2143,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1161</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cartoni:236:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2316,7 +2155,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1162</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>xu:241:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2330,7 +2168,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1163</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ku:242:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2345,7 +2182,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1164</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>abekawa:243:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2359,7 +2195,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1165</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ambati:244:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2372,7 +2207,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1166</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dalianis:245:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2386,7 +2220,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1167</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>anderson:247:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2401,7 +2234,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1168</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhou:248:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2415,7 +2247,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1169</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>saykham:249:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2428,7 +2259,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1170</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>koolen:251:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2443,7 +2273,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1171</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>peris:252:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2457,7 +2286,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1172</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>antonsen:254:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2470,7 +2298,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1173</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>adde:255:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2484,7 +2311,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1174</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>snoeren:258:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2497,7 +2323,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1175</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gowiska:259:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2512,7 +2337,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1176</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kamiya:260:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2528,7 +2352,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1177</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ruiter:261:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2543,7 +2366,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1178</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>burkhardt:262:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2556,7 +2378,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1179</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>marx:263:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2569,7 +2390,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1180</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>henrich:264:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2583,7 +2403,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1181</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hinrichs:266:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2597,7 +2416,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1182</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fritzinger:267:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2610,7 +2428,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1183</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>grg:269:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2624,7 +2441,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1184</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hinrichs:270:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2637,7 +2453,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1185</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>torreira:271:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2661,7 +2476,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1186</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>santos:272:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2677,7 +2491,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1187</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vanuytvanck:273:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2694,7 +2507,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1188</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>skrelin:274:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2709,7 +2521,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1189</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>spiegl:275:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2722,7 +2533,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1190</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dukes:276:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2734,7 +2544,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1191</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schiel:277:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2748,7 +2557,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1192</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dukes:278:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2762,7 +2570,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1193</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vatanen:279:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2776,7 +2583,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1194</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>polifroni:280:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2790,7 +2596,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1195</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rveil:281:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2803,7 +2608,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1196</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sawalha:282:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2816,7 +2620,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1197</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>perinpascual:284:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2830,7 +2633,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1198</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bauer:285:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2844,7 +2646,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1199</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vanoosten:286:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2857,7 +2658,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1200</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sawalha:287:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2877,7 +2677,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1201</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>urbain:289:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2891,7 +2690,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1202</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bouma:291:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2907,7 +2705,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1203</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang:292:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2921,7 +2718,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1204</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lardilleux:293:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2934,7 +2730,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1205</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schraagen:295:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2946,7 +2741,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1206</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>utsumi:296:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2960,7 +2754,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1207</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>leitner:299:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2974,7 +2767,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1208</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>garciafernandez:301:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -2988,7 +2780,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1209</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>martnezhinarejos:303:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3003,7 +2794,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1210</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nawaz:306:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3019,7 +2809,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1211</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kano:307:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3034,7 +2823,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1212</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>johannessen:308:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3047,7 +2835,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1213</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sukkarieh:310:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3060,7 +2847,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1214</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zargayouna:311:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3073,7 +2859,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1215</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>demelo:312:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3087,7 +2872,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1216</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lenci:313:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3104,7 +2888,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1217</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sikveland:314:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3118,7 +2901,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1218</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>koeva:316:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3134,7 +2916,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1219</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lin:317:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3147,7 +2928,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1220</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>haselbach:318:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3162,7 +2942,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1221</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lee:322:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3174,7 +2953,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1222</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>navarretta:325:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3189,7 +2967,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1223</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>thwaites:326:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3208,7 +2985,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1224</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>williams:327:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3224,7 +3000,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1225</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vandenheuvel:328:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3238,7 +3013,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1226</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bernardi:330:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3251,7 +3025,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1227</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>okamoto:331:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3265,7 +3038,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1228</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dione:333:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3277,7 +3049,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1229</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>morante:335:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3291,7 +3062,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1230</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>yao:336:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3305,7 +3075,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1231</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mykowiecka:337:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3318,7 +3087,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1232</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>otrusina:339:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3333,7 +3101,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1233</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>saggion:341:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3347,7 +3114,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1234</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gibbon:342:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3360,7 +3126,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1235</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sato:343:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3373,7 +3138,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1236</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>alsabbagh:344:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3388,7 +3152,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1237</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>heinroth:345:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3406,7 +3169,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1238</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dreuw:346:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3420,7 +3182,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1239</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kubo:347:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3435,7 +3196,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1240</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>seretan:350:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3452,7 +3212,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1241</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>edlund:352:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3467,7 +3226,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1242</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>magdy:353:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3480,7 +3238,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1243</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>saggion:354:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3498,7 +3255,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1244</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>baum:355:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3517,7 +3273,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1245</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>balvet:356:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3533,7 +3288,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1246</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>toms:357:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3547,7 +3301,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1247</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>grishina:358:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3565,7 +3318,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1248</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>felt:360:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3584,7 +3336,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1249</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pucher:361:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3597,7 +3348,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1250</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wiegand:362:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3613,7 +3363,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1251</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>heid:363:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3626,7 +3375,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1252</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>calzolari:369:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3646,7 +3394,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1253</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>calzolari:370:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3668,7 +3415,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1254</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>moreau:372:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3681,7 +3427,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1255</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sanrom:373:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3695,7 +3440,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1256</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zouaq:374:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3710,7 +3454,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1257</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang:377:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3724,7 +3467,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1258</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>oostdijk:378:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3737,7 +3479,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1259</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bedaride:379:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3750,7 +3491,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1260</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tpnek:381:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3764,7 +3504,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1261</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>delmonte:383:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3777,7 +3516,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1262</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mohamed:384:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3790,7 +3528,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1263</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pak:385:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3804,7 +3541,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1264</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nemoto:386:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3818,7 +3554,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1265</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sagot:387:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3831,7 +3566,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1266</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mikulov:388:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3846,7 +3580,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1267</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vanopstal:389:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3864,7 +3597,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1268</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>den:391:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3878,7 +3610,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1269</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>candito:392:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3892,7 +3623,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1270</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ma:393:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3908,7 +3638,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1271</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rodrguezfuentes:394:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3921,7 +3650,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1272</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>panevov:395:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3934,7 +3662,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1273</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hickl:396:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3948,7 +3675,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1274</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang:397:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3961,7 +3687,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1275</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>novielli:399:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3976,7 +3701,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1276</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vivaldi:400:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -3988,7 +3712,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1277</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hamon:402:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4002,7 +3725,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1278</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>brendel:403:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4015,7 +3737,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1279</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>segers:406:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4029,7 +3750,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1280</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>buyko:407:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4042,7 +3762,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1281</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>neubig:408:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4056,7 +3775,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1282</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>faa:409:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4071,7 +3789,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1283</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schwarz:411:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4087,7 +3804,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1284</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>freitas:412:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4102,7 +3818,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1285</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kupietz:414:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4115,7 +3830,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1286</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sassolini:415:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4130,7 +3844,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1287</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>villegas:418:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4143,7 +3856,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1288</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cartoni:420:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4156,7 +3868,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1289</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>duarte:421:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4170,7 +3881,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1290</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>paroubek:422:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4184,7 +3894,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1291</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kouylekov:425:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4197,7 +3906,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1292</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>stymne:426:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4210,7 +3918,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1293</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>weller:428:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4226,7 +3933,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1294</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>paroubek:430:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4242,7 +3948,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1295</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rodrguez:431:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4256,7 +3961,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1296</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>flickinger:432:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4270,7 +3974,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1297</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ruppenhofer:434:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4286,7 +3989,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1298</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>webb:435:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4300,7 +4002,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1299</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gmezgallo:436:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4312,7 +4013,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1300</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>temnikova:437:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4330,7 +4030,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1301</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>allwood:438:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4346,7 +4045,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1302</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>reiter:439:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4371,7 +4069,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1303</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rytting:440:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4384,7 +4081,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1304</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>walker:441:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4399,7 +4095,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1305</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>altantawy:442:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4413,7 +4108,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1306</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kaji:443:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4426,7 +4120,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1307</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>copperman:444:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4439,7 +4132,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1308</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>baird:445:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4456,7 +4148,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1309</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>baker:446:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4470,7 +4161,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1310</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tanenblatt:448:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4484,7 +4174,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1311</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hayashi:449:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4503,7 +4192,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1312</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>carmen:451:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4515,7 +4203,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1313</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>konstantopoulos:452:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4528,7 +4215,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1314</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>davis:453:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4542,7 +4228,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1315</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sharmagrover:454:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4561,7 +4246,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1316</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>poesio:455:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4577,7 +4261,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1317</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sainz:456:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4590,7 +4273,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1318</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>santos:457:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4603,7 +4285,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1319</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>honda:462:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4620,7 +4301,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1320</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>forner:464:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4637,7 +4317,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1321</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vincze:465:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4651,7 +4330,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1322</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fallucchi:466:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4667,7 +4345,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1323</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>oltramari:468:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4680,7 +4357,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1324</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nazar:469:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4693,7 +4369,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1325</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhao:470:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4712,7 +4387,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1326</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>saratxaga:471:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4725,7 +4399,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1327</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>delger:472:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4740,7 +4413,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1328</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ntalampiras:474:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4753,7 +4425,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1329</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dahab:476:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4767,7 +4438,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1330</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>serrano:477:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4784,7 +4454,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1331</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bentivogli:478:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4797,7 +4466,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1332</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>alsaif:479:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4811,7 +4479,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1333</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vasilescu:481:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4826,7 +4493,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1334</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schuller:483:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4839,7 +4505,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1335</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>romano:484:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4853,7 +4518,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1336</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mouton:485:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4867,7 +4531,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1337</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mrovsk:487:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4885,7 +4548,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1338</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>abad:488:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4899,7 +4561,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1339</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>remus:490:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4913,7 +4574,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1340</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>panicheva:491:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4926,7 +4586,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1341</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>goldhahn:492:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4940,7 +4599,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1342</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>jakob:493:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4954,7 +4612,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1343</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bengera:494:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4968,7 +4625,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1344</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gala:497:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4981,7 +4637,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1345</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kordoni:498:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -4997,7 +4652,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1346</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>michelbacher:499:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5012,7 +4666,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1347</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>broscheit:500:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5027,7 +4680,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1348</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>heid:503:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5041,7 +4693,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1349</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>specia:504:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5056,7 +4707,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1350</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>halskov:505:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5073,7 +4723,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1351</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bertrand:506:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5086,7 +4735,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1352</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gleim:507:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5098,7 +4746,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1353</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>holmqvist:508:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5111,7 +4758,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1354</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>goudbeek:511:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5129,7 +4775,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1355</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>stellato:515:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5142,7 +4787,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1356</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pollk:516:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5157,7 +4801,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1357</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bernard:518:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5170,7 +4813,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1358</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>blessing:519:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5184,7 +4826,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1359</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>elayari:520:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5198,7 +4839,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1360</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tatsumi:521:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5212,7 +4852,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1361</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>damljanovic:524:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5232,7 +4871,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1362</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>grappy:529:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5246,7 +4884,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1363</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bernaolabiggio:530:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5261,7 +4898,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1364</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>recski:531:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5276,7 +4912,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1365</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gargett:532:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5292,7 +4927,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1366</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vorwerk:533:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5307,7 +4941,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1367</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>agirre:534:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5322,7 +4955,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1368</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>snchezmarco:535:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5334,7 +4966,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1369</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>raza:536:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5352,7 +4983,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1370</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>besanon:537:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5365,7 +4995,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1371</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>chrupaa:538:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5377,7 +5006,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1372</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rosell:540:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5392,7 +5020,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1373</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gonzlezrubio:541:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5408,7 +5035,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1374</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>apostolova:543:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5421,7 +5047,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1375</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>derczynski:546:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5437,7 +5062,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1376</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>reynaert:549:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5452,7 +5076,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1377</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cruzlara:550:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5466,7 +5089,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1378</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ruppenhofer:552:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5481,7 +5103,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1379</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bonin:553:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5496,7 +5117,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1380</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>blanc:554:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5517,7 +5137,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1381</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>braffort:555:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5532,7 +5151,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1382</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tonelli:556:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5549,7 +5167,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1383</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>maamouri:558:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5561,7 +5178,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1384</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hja:559:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5584,7 +5200,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1385</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bunt:560:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5604,7 +5219,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1386</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bhatia:561:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5618,7 +5232,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1387</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lloberes:562:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5632,7 +5245,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1388</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>duran:564:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5644,7 +5256,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1389</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>grishman:565:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5658,7 +5269,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1390</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kulick:566:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5671,7 +5281,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1391</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zaninello:567:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5684,7 +5293,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1392</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>indlerov:568:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5699,7 +5307,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1393</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>daz:569:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5712,7 +5319,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1394</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>clark:570:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5731,7 +5337,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1395</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>miller:571:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5744,7 +5349,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1396</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>laskowski:576:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5759,7 +5363,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1397</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>viethen:578:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5773,7 +5376,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1398</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hara:579:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5787,7 +5389,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1399</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen:580:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5802,7 +5403,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1400</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>murata:581:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5817,7 +5417,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1401</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>afantenos:582:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5833,7 +5432,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1402</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zhang:583:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5846,7 +5444,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1403</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bohnet:585:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5860,7 +5457,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1404</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kwon:586:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5874,7 +5470,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1405</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ploux:592:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5891,7 +5486,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1406</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>araujo:593:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5905,7 +5499,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1407</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>poggi:596:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5922,7 +5515,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1408</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>altosaar:597:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5939,7 +5531,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1409</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>seljan:599:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5954,7 +5545,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1410</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>orasmaa:600:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5966,7 +5556,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1411</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>marimon:602:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5982,7 +5571,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1412</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vilnat:603:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -5995,7 +5583,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1413</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fishel:604:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6009,7 +5596,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1414</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>strapparava:607:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6023,7 +5609,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1415</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cadic:608:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6037,7 +5622,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1416</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>borg:609:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6055,7 +5639,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1417</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rayner:610:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6071,7 +5654,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1418</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>adolphs:611:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6084,7 +5666,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1419</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>shutova:612:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6098,7 +5679,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1420</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sangati:613:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6114,7 +5694,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1421</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lazaridis:614:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6130,7 +5709,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1422</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nastase:615:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6143,7 +5721,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1423</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>aswani:616:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6157,7 +5734,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1424</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hanaoka:617:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6172,7 +5748,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1425</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sporleder:618:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6192,7 +5767,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1426</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kostoulas:619:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6205,7 +5779,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1427</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lata:620:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6219,7 +5792,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1428</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nicolae:622:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6232,7 +5804,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1429</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>boxwell:623:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6263,7 +5834,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1430</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fougeron:626:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6278,7 +5848,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1431</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>balakrishna:627:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6297,7 +5866,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1432</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>melero:628:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6310,7 +5878,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1433</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lee:631:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6322,7 +5889,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1434</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schulteimwalde:632:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6338,7 +5904,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1435</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mcnamee:634:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6353,7 +5918,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1436</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ferrndez:636:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6367,7 +5931,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1437</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>aliane:638:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6382,7 +5945,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1438</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kempssnijders:639:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6396,7 +5958,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1439</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bojar:642:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6411,7 +5972,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1440</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>liakata:644:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6424,7 +5984,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1441</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tretti:647:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6440,7 +5999,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1442</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>estve:650:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6453,7 +6011,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1443</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tomanek:652:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6467,7 +6024,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1444</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>moore:653:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6485,7 +6041,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1445</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lendvai:654:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6501,7 +6056,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1446</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>savas:655:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6516,7 +6070,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1447</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>atserias:656:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6529,7 +6082,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1448</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cook:657:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6542,7 +6094,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1449</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>leuski:660:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6555,7 +6106,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1450</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>quan:662:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6569,7 +6119,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1451</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zablotskaya:663:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6587,7 +6136,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1452</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>liu:664:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6599,7 +6147,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1453</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>dinu:665:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6613,7 +6160,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1454</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>francom:666:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6627,7 +6173,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1455</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>walker:667:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6652,7 +6197,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1456</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>street:668:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6667,7 +6211,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1457</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>zaghouani:669:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6683,7 +6226,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1458</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>li:670:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6699,7 +6241,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1459</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>eberhard:671:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6713,7 +6254,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1460</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>christensen:672:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6728,7 +6268,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1461</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ambati:673:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6742,7 +6281,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1462</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>robinson:674:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6759,7 +6297,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1463</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>yao:675:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6775,7 +6312,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1464</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ohtake:676:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6788,7 +6324,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1465</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bal:677:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6802,7 +6337,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1466</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>eshkol:678:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6830,7 +6364,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1467</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wittenburg:679:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6842,7 +6375,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1468</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>spina:681:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6859,7 +6391,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1469</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>matsuyoshi:682:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6872,7 +6403,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1470</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>adugna:683:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6884,7 +6414,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1471</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fujii:684:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6897,7 +6426,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1472</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hartung:685:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6910,7 +6438,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1473</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>eisele:686:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6923,7 +6450,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1474</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rakho:687:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6935,7 +6461,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1475</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bick:688:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6949,7 +6474,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1476</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>schulz:689:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6963,7 +6487,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1477</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>broda:690:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6977,7 +6500,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1478</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>trojahn:691:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -6991,7 +6513,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1479</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fritzsch:693:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7004,7 +6525,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1480</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>aswani:694:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7017,7 +6537,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1481</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>agerri:695:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7035,7 +6554,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1482</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nagasaka:696:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7048,7 +6566,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1483</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mille:697:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7060,7 +6577,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1484</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sato:698:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7075,7 +6591,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1485</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nishikawa:699:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7088,7 +6603,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1486</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sagot:700:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7100,7 +6614,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1487</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sagot:701:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7116,7 +6629,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1488</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cuadros:703:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7130,7 +6642,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1489</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rouas:704:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7142,7 +6653,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1490</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>koeva:705:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7155,7 +6665,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1491</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>spyns:707:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7168,7 +6677,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1492</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>jezek:713:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7182,7 +6690,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1493</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>jrg:714:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7196,7 +6703,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1494</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tadeu:715:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7210,7 +6716,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1495</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bramantoro:717:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7223,7 +6728,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1496</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ekbal:718:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7237,7 +6741,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1497</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>belgacem:719:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7251,7 +6754,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1498</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pammi:720:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7265,7 +6767,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1499</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>osenova:721:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7279,7 +6780,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1500</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>spreyer:722:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7292,7 +6792,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1501</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>menke:723:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7305,7 +6804,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1502</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>giordani:724:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7321,7 +6819,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1503</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ishikawa:727:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7335,7 +6832,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1504</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fritzinger:728:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7350,7 +6846,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1505</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cer:730:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7365,7 +6860,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1506</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>reyes:731:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7378,7 +6872,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1507</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kawahara:733:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7390,7 +6883,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1508</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>giovannetti:734:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7402,7 +6894,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1509</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kwong:736:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7416,7 +6907,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1510</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vanopstal:737:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7428,7 +6918,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1511</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>magro:738:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7443,7 +6932,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1512</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gupta:739:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7455,7 +6943,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1513</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>verhagen:740:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7473,7 +6960,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1514</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>luengo:741:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7487,7 +6973,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1515</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ide:745:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7502,7 +6987,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1516</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kozawa:746:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7515,7 +6999,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1517</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rizzolo:747:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7528,7 +7011,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1518</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vivaldi:748:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7541,7 +7023,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1519</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>brierley:749:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7559,7 +7040,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1520</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>alonsoramos:751:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7572,7 +7052,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1521</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lo:752:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7585,7 +7064,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1522</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>chen:754:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7599,7 +7077,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1523</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>poesio:755:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7613,7 +7090,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1524</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bojar:756:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7625,7 +7101,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1525</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vanallemeersch:758:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7640,7 +7115,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1526</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ziknov:762:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7654,7 +7128,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1527</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>fu:763:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7668,7 +7141,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1528</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>riester:764:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7680,7 +7152,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1529</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mousser:766:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7697,7 +7168,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1530</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>spilkov:768:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7711,7 +7181,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1531</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>baccianella:769:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7725,7 +7194,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1532</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tirilly:772:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7739,7 +7207,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1533</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>decao:773:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7751,7 +7218,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1534</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>seddah:775:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7764,7 +7230,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1535</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>caselli:776:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7781,7 +7246,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1536</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>maegaard:777:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7797,7 +7261,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1537</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pastra:778:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7818,7 +7281,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1538</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>blache:781:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7832,7 +7294,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1539</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>jabbari:782:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7846,7 +7307,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1540</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>shamsfard:784:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7859,7 +7319,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1541</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vazlobo:786:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7876,7 +7335,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1542</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>willis:787:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7893,7 +7351,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1543</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>brandschain:789:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7911,7 +7368,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1544</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>campillo:790:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7925,7 +7381,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1545</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lewis:791:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7942,7 +7397,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1546</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>brandschain:792:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7955,7 +7409,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1547</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>egg:796:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7971,7 +7424,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1548</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>attia:797:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7986,7 +7438,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1549</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>song:798:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -7999,7 +7450,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1550</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>laparra:799:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8011,7 +7461,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1551</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>plank:801:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8026,7 +7475,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1552</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ji:802:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8040,7 +7488,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1553</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ramisch:803:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8053,7 +7500,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1554</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rehbein:806:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8066,7 +7512,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1555</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hana:807:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8079,7 +7524,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1556</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>petasis:808:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8093,7 +7537,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1557</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>shamsfard:809:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8107,7 +7550,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1558</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>spoustov:810:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8119,7 +7561,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1559</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vertan:811:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8131,7 +7572,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1560</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>boyd:812:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8143,7 +7583,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1561</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ferret:815:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8155,7 +7594,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1562</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>deluca:816:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8169,7 +7607,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1563</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>catizone:818:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8182,7 +7619,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1564</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>tounsi:819:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8195,7 +7631,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1565</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang:820:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8210,7 +7645,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1566</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>han:821:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8226,7 +7660,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1567</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mcgraw:822:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8240,7 +7673,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1568</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>max:823:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8253,7 +7685,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1569</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>udhonnchadha:824:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8266,7 +7697,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1570</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>monachesi:826:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8279,7 +7709,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1571</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>max:827:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8295,7 +7724,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1572</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rosenthal:828:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8308,7 +7736,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1573</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>lopez:829:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8320,7 +7747,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1574</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>marinelli:830:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8333,7 +7759,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1575</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>declerck:832:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8349,7 +7774,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1576</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>murakami:833:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8363,7 +7787,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1577</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vukovi:834:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8376,7 +7799,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1578</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>elson:835:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8388,7 +7810,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1579</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wong:837:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8401,7 +7822,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1580</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>diasdasilva:838:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8414,7 +7834,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1581</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>karasimos:841:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8427,7 +7846,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1582</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>federmann:842:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8440,7 +7858,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1583</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang:844:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8454,7 +7871,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1584</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kordjamshidi:846:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8466,7 +7882,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1585</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>russo:847:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8479,7 +7894,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1586</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>simov:848:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8496,7 +7910,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1587</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>glenn:849:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8510,7 +7923,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1588</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>mihil:851:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8522,7 +7934,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1589</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>savy:852:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8540,7 +7951,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1590</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>kolachina:854:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8553,7 +7963,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1591</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vasiljevs:855:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8571,7 +7980,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1592</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>maeda:857:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8585,7 +7993,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1593</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>garcamiguel:859:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8599,7 +8006,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1594</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>guthrie:860:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8619,7 +8025,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1595</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>strassel:862:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8634,7 +8039,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1596</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>simpson:864:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8649,7 +8053,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1597</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nouvel:865:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8662,7 +8065,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1598</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>materna:867:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8677,7 +8079,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1599</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>supnithi:868:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8689,7 +8090,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1600</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>blancafort:872:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8703,7 +8103,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1601</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>loukil:873:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8715,7 +8114,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1602</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>jha:874:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8729,7 +8127,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1603</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>agi:876:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8742,7 +8139,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1604</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>ozdowska:878:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8756,7 +8152,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1605</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>savary:879:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8770,7 +8165,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1606</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>stewart:881:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8787,7 +8181,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1607</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>couto:882:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8801,7 +8194,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1608</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>pala:883:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8823,7 +8215,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1609</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>rebholzschuhmann:888:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8835,7 +8226,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1610</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>melli:889:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8850,7 +8240,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1611</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>strau:890:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8864,7 +8253,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1612</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nerima:891:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8877,7 +8265,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1613</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>coppola:893:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8891,7 +8278,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1614</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sowa:894:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8905,7 +8291,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1615</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>reimerink:895:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8919,7 +8304,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1616</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>almeida:898:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8932,7 +8316,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1617</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>javorek:899:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8945,7 +8328,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1618</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>charton:900:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8958,7 +8340,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1619</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bosma:902:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8972,7 +8353,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1620</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>choi:903:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8985,7 +8365,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1621</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>swampillai:905:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -8997,7 +8376,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1622</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nabende:906:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9016,7 +8394,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1623</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>balahur:909:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9029,7 +8406,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1624</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sonntag:911:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9041,7 +8417,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1625</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>strunk:917:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9057,7 +8432,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1626</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>deloupy:919:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9071,7 +8445,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1627</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>xia:921:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9086,7 +8459,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1628</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>passonneau:922:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9098,7 +8470,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1629</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gasser:926:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9112,7 +8483,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1630</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>brown:927:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9125,7 +8495,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1631</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gordon:928:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9139,7 +8508,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1632</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>hickl:930:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9153,7 +8521,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1633</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>witte:932:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9167,7 +8534,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1634</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>prasad:935:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9179,7 +8545,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1635</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>bhattacharyya:939:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9194,7 +8559,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1636</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>roberts:941:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9206,7 +8570,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1637</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>decamp:942:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9222,7 +8585,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1638</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>sassi:945:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9236,7 +8598,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1639</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>vetulani:947:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9249,7 +8610,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1640</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>arranz:948:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9262,7 +8622,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1641</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>atouguengay:949:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9281,7 +8640,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1642</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cieri:951:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9294,7 +8652,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1643</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>nguyen:952:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9308,7 +8665,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1644</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>gishri:953:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>
@@ -9321,7 +8677,6 @@
     <year>2010</year>
     <address>Valletta, Malta</address>
     <publisher>European Languages Resources Association (ELRA)</publisher>
-    <url>http://www.aclweb.org/anthology/L10-1645</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>cieri:954:2010:lrec2010</bibkey>
     <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (LREC’10)</booktitle>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -25,7 +25,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1001</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JOKINEN12.106.L12-1001</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -38,7 +37,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1002</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BURKHARDT12.108.L12-1002</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -51,7 +49,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1003</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BURKHARDT12.110.L12-1003</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -65,7 +62,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1004</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPYNS12.112.L12-1004</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -79,7 +75,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1005</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEIN12.113.L12-1005</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -94,7 +89,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1006</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SARALEGI12.114.L12-1006</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -108,7 +102,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1007</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TANG12.117.L12-1007</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -122,7 +115,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1008</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPOUSTOV12.120.L12-1008</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -135,7 +127,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1009</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LUDER12.121.L12-1009</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -149,7 +140,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1010</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAYNARD12.122.L12-1010</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -163,7 +153,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1011</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHARAF12.123.L12-1011</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -177,7 +166,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1012</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHEIBLE12.124.L12-1012</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -197,7 +185,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1013</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CLEMATIDE12.125.L12-1013</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -216,7 +203,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1014</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAINZ12.126.L12-1014</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -232,7 +218,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1015</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LLORENS12.128.L12-1015</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -246,7 +231,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1016</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BROOKE12.129.L12-1016</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -259,7 +243,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1017</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAINTDIZIER12.130.L12-1017</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -276,7 +259,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1018</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WIEGAND12.136.L12-1018</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -290,7 +272,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1019</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOURSE12.137.L12-1019</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -306,7 +287,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1020</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARCELLINI12.139.L12-1020</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -319,7 +299,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1021</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TANNIER12.148.L12-1021</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -334,7 +313,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1022</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OGRODNICZUK12.149.L12-1022</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -348,7 +326,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1023</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PATEJUK12.150.L12-1023</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -362,7 +339,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1024</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JOKINEN12.151.L12-1024</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -378,7 +354,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1025</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PEREIRA12.152.L12-1025</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -393,7 +368,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1026</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NOVAIS12.153.L12-1026</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -414,7 +388,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1027</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETUKHOVA12.154.L12-1027</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -429,7 +402,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1028</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAMBRIA12.159.L12-1028</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -445,7 +417,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1029</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HERACLEOUS12.160.L12-1029</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -461,7 +432,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1030</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MACKEN12.161.L12-1030</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -475,7 +445,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1031</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HENRICH12.164.L12-1031</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -493,7 +462,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1032</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VARGES12.165.L12-1032</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -507,7 +475,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1033</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HINRICHS12.166.L12-1033</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -521,7 +488,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1034</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JOUBERT12.167.L12-1034</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -538,7 +504,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1035</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEO12.168.L12-1035</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -554,7 +519,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1036</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HEINROTH12.169.L12-1036</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -568,7 +532,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1037</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PASSAROTTI12.170.L12-1037</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -583,7 +546,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1038</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIPPER12.172.L12-1038</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -597,7 +559,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1039</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TATU12.175.L12-1039</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -611,7 +572,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1040</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MOLDOVAN12.176.L12-1040</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -624,7 +584,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1041</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VINCZE12.177.L12-1041</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -638,7 +597,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1042</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FOHR12.178.L12-1042</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -653,7 +611,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1043</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VLKOV12.179.L12-1043</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -667,7 +624,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1044</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETUKHOVA12.180.L12-1044</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -681,7 +637,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1045</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHLAF12.181.L12-1045</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -696,7 +651,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1046</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BANK12.182.L12-1046</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -710,7 +664,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1047</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BANK12.183.L12-1047</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -723,7 +676,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1048</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEISS12.184.L12-1048</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -739,7 +691,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1049</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOSSEN12.187.L12-1049</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -753,7 +704,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1050</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CARTONI12.188.L12-1050</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -767,7 +717,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1051</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHARAF12.190.L12-1051</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -786,7 +735,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1052</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STYMNE12.192.L12-1052</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -799,7 +747,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1053</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JONGEJAN12.193.L12-1053</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -813,7 +760,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1054</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NIEMI12.194.L12-1054</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -826,7 +772,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1055</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARTINDALE12.196.L12-1055</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -839,7 +784,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1056</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ERYIIT12.198.L12-1056</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -855,7 +799,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1057</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GAVRILOV12.199.L12-1057</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -869,7 +812,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1058</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROSEN12.200.L12-1058</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -886,7 +828,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1059</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROBERTS12.201.L12-1059</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -901,7 +842,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1060</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FEILMAYR12.204.L12-1060</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -915,7 +855,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1061</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IVANOVA12.205.L12-1061</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -931,7 +870,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1062</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEUSKI12.206.L12-1062</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -946,7 +884,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1063</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARNULPHY12.207.L12-1063</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -960,7 +897,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1064</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAELENHAUMONT12.208.L12-1064</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -975,7 +911,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1065</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOSCO12.209.L12-1065</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -992,7 +927,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1066</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHARL12.210.L12-1066</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1006,7 +940,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1067</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NOTHDURFT12.211.L12-1067</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1020,7 +953,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1068</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORSBERG12.212.L12-1068</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1034,7 +966,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1069</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TAMBURINI12.213.L12-1069</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1049,7 +980,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1070</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPRINGORUM12.214.L12-1070</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1065,7 +995,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1071</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CATIZONE12.215.L12-1071</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1080,7 +1009,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1072</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARTALESILENZI12.216.L12-1072</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1096,7 +1024,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1073</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HE12.217.L12-1073</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1112,7 +1039,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1074</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ION12.218.L12-1074</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1130,7 +1056,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1075</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KONSTANTOPOULOS12.219.L12-1075</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1144,7 +1069,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1076</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELMAAROUF12.220.L12-1076</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1158,7 +1082,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1077</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORANTE12.221.L12-1077</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1175,7 +1098,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1078</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PLOCH12.222.L12-1078</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1189,7 +1111,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1079</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VZQUEZ12.223.L12-1079</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1204,7 +1125,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1080</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARTNEZALONSO12.225.L12-1080</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1220,7 +1140,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1081</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHARMAGROVER12.226.L12-1081</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1235,7 +1154,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1082</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POLKOV12.228.L12-1082</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1249,7 +1167,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1083</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KAALEP12.229.L12-1083</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1266,7 +1183,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1084</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CLAPHAM12.230.L12-1084</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1280,7 +1196,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1085</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANVICENTE12.231.L12-1085</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1294,7 +1209,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1086</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FERNANDO12.232.L12-1086</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1309,7 +1223,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1087</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SELJAN12.233.L12-1087</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1323,7 +1236,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1088</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEEKER12.235.L12-1088</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1338,7 +1250,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1089</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CARRILLODEALBORNOZ12.236.L12-1089</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1352,7 +1263,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1090</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NOECKERJR12.238.L12-1090</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1367,7 +1277,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1091</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAWALHA12.239.L12-1091</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1382,7 +1291,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1092</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRIERLEY12.240.L12-1092</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1396,7 +1304,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1093</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MATSUSHITA12.241.L12-1093</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1413,7 +1320,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1094</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZHANG12.244.L12-1094</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1426,7 +1332,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1095</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PIMENTEL12.245.L12-1095</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1440,7 +1345,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1096</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COSTA12.246.L12-1096</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1454,7 +1358,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1097</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NIMB12.247.L12-1097</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1469,7 +1372,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1098</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORIN12.248.L12-1098</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1485,7 +1387,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1099</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORIN12.249.L12-1099</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1500,7 +1401,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1100</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KULICK12.251.L12-1100</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1513,7 +1413,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1101</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIEMANN12.252.L12-1101</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1528,7 +1427,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1102</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALAZARD12.254.L12-1102</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1545,7 +1443,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1103</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POPESCUBELIS12.255.L12-1103</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1559,7 +1456,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1104</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MIN12.256.L12-1104</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1573,7 +1469,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1105</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZARCONE12.259.L12-1105</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1588,7 +1483,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1106</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SZAB12.262.L12-1106</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1604,7 +1498,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1107</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WOLISKI12.263.L12-1107</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1618,7 +1511,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1108</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOLODINA12.264.L12-1108</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1632,7 +1524,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1109</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPITKOVSKY12.266.L12-1109</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1646,7 +1537,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1110</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAJLI12.267.L12-1110</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1661,7 +1551,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1111</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEGAETANOORTLIEB12.268.L12-1111</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1675,7 +1564,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1112</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROBERTS12.269.L12-1112</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1689,7 +1577,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1113</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLERKE12.270.L12-1113</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1703,7 +1590,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1114</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DURAN12.272.L12-1114</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1718,7 +1604,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1115</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETROV12.274.L12-1115</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1734,7 +1619,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1116</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VILLAVICENCIO12.276.L12-1116</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1753,7 +1637,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1117</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LI12.277.L12-1117</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1770,7 +1653,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1118</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LI12.278.L12-1118</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1786,7 +1668,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1119</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SADAMITSU12.279.L12-1119</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1803,7 +1684,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1120</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>YAMASAKI12.280.L12-1120</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1816,7 +1696,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1121</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SATO12.282.L12-1121</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1830,7 +1709,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1122</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHANG12.284.L12-1122</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1848,7 +1726,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1123</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>METAXAS12.287.L12-1123</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1862,7 +1739,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1124</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CLARK12.288.L12-1124</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1880,7 +1756,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1125</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGOSTI12.290.L12-1125</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1895,7 +1770,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1126</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAPANGELIS12.291.L12-1126</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1914,7 +1788,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1127</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUNCHUKUTTAN12.292.L12-1127</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1929,7 +1802,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1128</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GONZALEZAGIRRE12.293.L12-1128</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1947,7 +1819,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1129</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AVRAMIDIS12.294.L12-1129</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1963,7 +1834,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1130</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VELARDI12.295.L12-1130</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1978,7 +1848,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1131</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GAGLIARDI12.296.L12-1131</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -1994,7 +1863,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1132</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GHOSH12.297.L12-1132</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2007,7 +1875,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1133</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARBUMITITELU12.299.L12-1133</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2022,7 +1889,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1134</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VASILESCU12.300.L12-1134</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2036,7 +1902,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1135</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FRIBERGHEPPIN12.301.L12-1135</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2051,7 +1916,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1136</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHABUS12.302.L12-1136</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2069,7 +1933,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1137</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LENKIEWICZ12.303.L12-1137</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2082,7 +1945,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1138</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SERETAN12.304.L12-1138</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2098,7 +1960,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1139</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SARAVANAN12.305.L12-1139</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2113,7 +1974,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1140</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHU12.306.L12-1140</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2128,7 +1988,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1141</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORELL12.307.L12-1141</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2145,7 +2004,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1142</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BITTAR12.308.L12-1142</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2160,7 +2018,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1143</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GNREUX12.309.L12-1143</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2175,7 +2032,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1144</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZIERING12.311.L12-1144</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2189,7 +2045,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1145</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DESMEDT12.312.L12-1145</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2203,7 +2058,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1146</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MUHONEN12.313.L12-1146</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2219,7 +2073,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1147</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TANNIER12.314.L12-1147</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2238,7 +2091,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1148</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PEAS12.315.L12-1148</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2254,7 +2106,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1149</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG12.316.L12-1149</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2269,7 +2120,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1150</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GONZALEZAGIRRE12.319.L12-1150</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2286,7 +2136,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1151</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANDENHEUVEL12.320.L12-1151</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2304,7 +2153,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1152</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KARPPA12.321.L12-1152</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2319,7 +2167,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1153</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARTNEZCORTS12.326.L12-1153</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2334,7 +2181,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1154</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOLDHAHN12.327.L12-1154</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2348,7 +2194,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1155</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHRISTIANSEN12.330.L12-1155</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2364,7 +2209,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1156</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HURTADO12.331.L12-1156</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2379,7 +2223,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1157</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHMITT12.333.L12-1157</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2393,7 +2236,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1158</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROBALDO12.334.L12-1158</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2408,7 +2250,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1159</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SMITH12.335.L12-1159</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2425,7 +2266,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1160</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BERKA12.336.L12-1160</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2440,7 +2280,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1161</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PIGHIN12.337.L12-1161</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2455,7 +2294,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1162</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SERAJI12.338.L12-1162</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2469,7 +2307,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1163</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANGODKAR12.340.L12-1163</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2484,7 +2321,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1164</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JUDEA12.341.L12-1164</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2500,7 +2336,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1165</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>QASEMIZADEH12.342.L12-1165</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2517,7 +2352,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1166</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GALIBERT12.343.L12-1166</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2532,7 +2366,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1167</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZHANG12.345.L12-1167</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2545,7 +2378,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1168</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VETULANI12.347.L12-1168</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2559,7 +2391,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1169</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RIOS12.350.L12-1169</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2574,7 +2405,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1170</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZABLOTSKAYA12.352.L12-1170</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2590,7 +2420,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1171</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZABLOTSKAYA12.354.L12-1171</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2604,7 +2433,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1172</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TAJNER12.355.L12-1172</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2621,7 +2449,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1173</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COSTA12.356.L12-1173</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2635,7 +2462,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1174</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HENRICHSEN12.357.L12-1174</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2651,7 +2477,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1175</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CINKOV12.359.L12-1175</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2665,7 +2490,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1176</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AHLBERG12.360.L12-1176</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2680,7 +2504,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1177</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARAN12.361.L12-1177</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2696,7 +2519,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1178</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALONI12.362.L12-1178</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2711,7 +2533,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1179</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GUPTA12.365.L12-1179</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2725,7 +2546,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1180</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LHOMME12.366.L12-1180</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2740,7 +2560,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1181</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PIGHIN12.370.L12-1181</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2755,7 +2574,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1182</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BETHARD12.371.L12-1182</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2771,7 +2589,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1183</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEINTURIER12.372.L12-1183</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2790,7 +2607,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1184</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRANCO12.373.L12-1184</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2805,7 +2621,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1185</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CUADROS12.374.L12-1185</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2822,7 +2637,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1186</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STANKOVI12.375.L12-1186</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2838,7 +2652,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1187</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FIALHO12.376.L12-1187</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2852,7 +2665,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1188</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORNACIARI12.377.L12-1188</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2870,7 +2682,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1189</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LYNN12.378.L12-1189</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2886,7 +2697,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1190</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORDEA12.379.L12-1190</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2901,7 +2711,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1191</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKMAK12.380.L12-1191</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2916,7 +2725,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1192</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARBOT12.381.L12-1192</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2929,7 +2737,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1193</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ION12.382.L12-1193</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2944,7 +2751,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1194</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHEYKHOLESLAM12.384.L12-1194</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2957,7 +2763,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1195</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SRASSET12.387.L12-1195</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2975,7 +2780,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1196</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHOI12.388.L12-1196</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -2991,7 +2795,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1197</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>XIA12.389.L12-1197</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3008,7 +2811,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1198</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CASELLI12.390.L12-1198</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3022,7 +2824,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1199</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MERKUS12.391.L12-1199</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3035,7 +2836,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1200</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOUTILAINEN12.393.L12-1200</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3050,7 +2850,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1201</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAROTO12.394.L12-1201</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3067,7 +2866,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1202</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DELGRATTA12.396.L12-1202</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3083,7 +2881,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1203</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WEBER12.397.L12-1203</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3097,7 +2894,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1204</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KAESHAMMER12.398.L12-1204</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3110,7 +2906,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1205</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHEN12.399.L12-1205</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3126,7 +2921,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1206</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CASSIDY12.400.L12-1206</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3144,7 +2938,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1207</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>XU12.401.L12-1207</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3158,7 +2951,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1208</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SLOETJES12.402.L12-1208</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3177,7 +2969,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1209</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIN12.403.L12-1209</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3193,7 +2984,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1210</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORGIA12.404.L12-1210</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3208,7 +2998,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1211</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AR12.405.L12-1211</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3221,7 +3010,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1212</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CARDOSO12.409.L12-1212</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3235,7 +3023,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1213</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SACALEANU12.411.L12-1213</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3252,7 +3039,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1214</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LANGLAIS12.413.L12-1214</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3265,7 +3051,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1215</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANDERS12.416.L12-1215</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3278,7 +3063,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1216</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RYSOVA12.420.L12-1216</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3291,7 +3075,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1217</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAEKAWA12.422.L12-1217</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3306,7 +3089,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1218</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAZIENZA12.424.L12-1218</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3320,7 +3102,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1219</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STRTGEN12.425.L12-1219</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3336,7 +3117,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1220</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PARAMITA12.426.L12-1220</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3350,7 +3130,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1221</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUENDACASTRO12.427.L12-1221</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3369,7 +3148,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1222</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MONEGLIA12.428.L12-1222</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3388,7 +3166,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1223</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZEMAN12.429.L12-1223</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3402,7 +3179,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1224</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PADR12.430.L12-1224</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3417,7 +3193,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1225</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAYNER12.434.L12-1225</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3432,7 +3207,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1226</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FUCHS12.436.L12-1226</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3447,7 +3221,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1227</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANUYTVANCK12.437.L12-1227</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3463,7 +3236,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1228</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RGNVALDSSON12.440.L12-1228</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3479,7 +3251,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1229</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VAIDYA12.442.L12-1229</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3493,7 +3264,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1230</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAROUBEK12.443.L12-1230</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3511,7 +3281,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1231</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AVRAMIDIS12.444.L12-1231</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3524,7 +3293,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1232</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ERJAVEC12.445.L12-1232</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3539,7 +3307,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1233</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARCICZUK12.446.L12-1233</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3554,7 +3321,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1234</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAKHO12.447.L12-1234</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3567,7 +3333,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1235</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ODIJK12.448.L12-1235</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3582,7 +3347,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1236</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NICOLAS12.450.L12-1236</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3597,7 +3361,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1237</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DERCZYNSKI12.451.L12-1237</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3611,7 +3374,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1238</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EXNER12.452.L12-1238</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3627,7 +3389,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1239</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SUNDBERG12.453.L12-1239</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3642,7 +3403,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1240</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GEBRE12.454.L12-1240</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3657,7 +3417,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1241</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JOHANSSON12.455.L12-1241</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3671,7 +3430,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1242</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAMASAMY12.456.L12-1242</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3688,7 +3446,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1243</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TIEDEMANN12.457.L12-1243</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3703,7 +3460,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1244</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GONALVES12.460.L12-1244</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3717,7 +3473,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1245</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRAFF12.461.L12-1245</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3730,7 +3485,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1246</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TIEDEMANN12.463.L12-1246</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3744,7 +3498,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1247</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IOSIF12.464.L12-1247</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3759,7 +3512,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1248</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MOHAMED12.465.L12-1248</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3775,7 +3527,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1249</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHULZ12.466.L12-1249</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3790,7 +3541,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1250</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FALCO12.467.L12-1250</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3807,7 +3557,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1251</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIMA12.468.L12-1251</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3821,7 +3570,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1252</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RELLO12.469.L12-1252</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3841,7 +3589,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1253</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIMA12.470.L12-1253</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3857,7 +3604,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1254</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARZA12.471.L12-1254</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3873,7 +3619,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1255</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AHMED12.474.L12-1255</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3890,7 +3635,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1256</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ECKLEKOHLER12.475.L12-1256</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3905,7 +3649,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1257</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ECKART12.476.L12-1257</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3919,7 +3662,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1258</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>APIDIANAKI12.478.L12-1258</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3935,7 +3677,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1259</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOUILLON12.480.L12-1259</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3950,7 +3691,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1260</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FISHEL12.481.L12-1260</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3966,7 +3706,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1261</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BABKOMALAYA12.482.L12-1261</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3980,7 +3719,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1262</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TOPKAYA12.483.L12-1262</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -3997,7 +3735,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1263</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZABLOTSKIY12.485.L12-1263</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4014,7 +3751,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1264</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RODRIGUEZFUENTES12.486.L12-1264</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4029,7 +3765,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1265</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRIMES12.487.L12-1265</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4042,7 +3777,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1266</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BACHAN12.488.L12-1266</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4056,7 +3790,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1267</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DALE12.490.L12-1267</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4071,7 +3804,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1268</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>THURMAIR12.493.L12-1268</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4090,7 +3822,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1269</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG12.494.L12-1269</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4108,7 +3839,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1270</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRAVIER12.495.L12-1270</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4123,7 +3853,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1271</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BEL12.496.L12-1271</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4136,7 +3865,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1272</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DELUCA12.502.L12-1272</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4150,7 +3878,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1273</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARINELLI12.503.L12-1273</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4172,7 +3899,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1274</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ANDERSEN12.504.L12-1274</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4187,7 +3913,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1275</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROJASBARAHONA12.505.L12-1275</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4203,7 +3928,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1276</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POTET12.506.L12-1276</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4218,7 +3942,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1277</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HASELBACH12.507.L12-1277</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4233,7 +3956,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1278</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEFEVER12.508.L12-1278</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4247,7 +3969,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1279</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MANSOUR12.509.L12-1279</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4275,7 +3996,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1280</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAJI12.510.L12-1280</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4293,7 +4013,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1281</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FELT12.511.L12-1281</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4310,7 +4029,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1282</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KURTIC12.513.L12-1282</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4324,7 +4042,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1283</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GURRUTXAGA12.514.L12-1283</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4340,7 +4057,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1284</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VIVALDI12.515.L12-1284</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4360,7 +4076,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1285</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAMINERO12.516.L12-1285</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4377,7 +4092,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1286</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TODIRASCU12.518.L12-1286</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4398,7 +4112,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1287</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARIMON12.519.L12-1287</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4413,7 +4126,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1288</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HENDRICKX12.520.L12-1288</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4428,7 +4140,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1289</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SKEPPSTEDT12.521.L12-1289</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4442,7 +4153,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1290</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHOWDHURY12.522.L12-1290</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4458,7 +4168,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1291</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEHOUWER12.524.L12-1291</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4473,7 +4182,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1292</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TOLONE12.525.L12-1292</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4490,7 +4198,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1293</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAN12.526.L12-1293</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4505,7 +4212,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1294</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SNCHEZCARTAGENA12.527.L12-1294</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4518,7 +4224,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1295</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHMIDT12.529.L12-1295</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4538,7 +4243,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1296</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUNT12.530.L12-1296</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4552,7 +4256,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1297</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GHEORGHITA12.531.L12-1297</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4570,7 +4273,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1298</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KONSTANTINOVA12.533.L12-1298</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4586,7 +4288,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1299</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BASILE12.534.L12-1299</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4602,7 +4303,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1300</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KEMPSSNIJDERS12.535.L12-1300</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4618,7 +4318,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1301</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IOSIF12.536.L12-1301</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4634,7 +4333,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1302</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TREURNIET12.537.L12-1302</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4650,7 +4348,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1303</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARZI12.538.L12-1303</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4664,7 +4361,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1304</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TSOURAKIS12.539.L12-1304</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4681,7 +4377,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1305</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POCH12.543.L12-1305</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4696,7 +4391,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1306</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MCCRAE12.544.L12-1306</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4713,7 +4407,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1307</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MENDES12.545.L12-1307</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4728,7 +4421,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1308</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELBERS12.547.L12-1308</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4745,7 +4437,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1309</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PANUNZI12.548.L12-1309</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4761,7 +4452,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1310</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORT12.549.L12-1310</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4779,7 +4469,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1311</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RSNER12.550.L12-1311</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4793,7 +4482,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1312</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>THUILIER12.552.L12-1312</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4809,7 +4497,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1313</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG12.553.L12-1313</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4825,7 +4512,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1314</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOUAMOR12.555.L12-1314</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4840,7 +4526,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1315</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAAMOURI12.557.L12-1315</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4854,7 +4539,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1316</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RODRIGUES12.559.L12-1316</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4870,7 +4554,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1317</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALICANTE12.561.L12-1317</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4886,7 +4569,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1318</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GEORGILA12.562.L12-1318</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4899,7 +4581,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1319</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SATO12.563.L12-1319</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4913,7 +4594,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1320</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WEISER12.566.L12-1320</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4926,7 +4606,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1321</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROCHE12.567.L12-1321</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4941,7 +4620,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1322</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCOTT12.569.L12-1322</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4956,7 +4634,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1323</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MENDES12.570.L12-1323</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4969,7 +4646,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1324</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIONE12.572.L12-1324</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4982,7 +4658,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1325</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAMPILLOSLLANOS12.574.L12-1325</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -4995,7 +4670,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1326</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PARRAESCARTN12.577.L12-1326</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5009,7 +4683,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1327</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SASAKI12.578.L12-1327</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5024,7 +4697,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1328</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HABASH12.579.L12-1328</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5041,7 +4713,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1329</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BROEDER12.581.L12-1329</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5057,7 +4728,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1330</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKER12.583.L12-1330</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5072,7 +4742,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1331</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHULTEIMWALDE12.584.L12-1331</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5087,7 +4756,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1332</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AMBATI12.585.L12-1332</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5103,7 +4771,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1333</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BICK12.586.L12-1333</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5120,7 +4787,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1334</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOEVA12.587.L12-1334</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5136,7 +4802,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1335</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PASSONNEAU12.589.L12-1335</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5153,7 +4818,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1336</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MOTA12.590.L12-1336</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5169,7 +4833,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1337</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DENIS12.593.L12-1337</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5184,7 +4847,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1338</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZUO12.594.L12-1338</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5203,7 +4865,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1339</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGGARWAL12.595.L12-1339</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5218,7 +4879,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1340</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>YU12.596.L12-1340</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5235,7 +4895,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1341</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAMY12.597.L12-1341</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5248,7 +4907,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1342</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KIPP12.598.L12-1342</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5263,7 +4921,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1343</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FIER12.601.L12-1343</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5280,7 +4937,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1344</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHAALAN12.603.L12-1344</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5296,7 +4952,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1345</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEN12.605.L12-1345</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5310,7 +4965,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1346</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HJA12.606.L12-1346</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5326,7 +4980,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1347</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MIYAJIMA12.607.L12-1347</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5341,7 +4994,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1348</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BROEDER12.608.L12-1348</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5357,7 +5009,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1349</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ATTIA12.609.L12-1349</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5371,7 +5022,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1350</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CONSTANT12.610.L12-1350</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5385,7 +5035,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1351</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DRURY12.611.L12-1351</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5398,7 +5047,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1352</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CARL12.614.L12-1352</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5411,7 +5059,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1353</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MACWHINNEY12.616.L12-1353</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5425,7 +5072,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1354</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RYGL12.618.L12-1354</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5438,7 +5084,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1355</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUMAR12.619.L12-1355</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5453,7 +5098,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1356</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LENCI12.622.L12-1356</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5467,7 +5111,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1357</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORT12.623.L12-1357</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5482,7 +5125,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1358</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RASO12.624.L12-1358</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5497,7 +5139,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1359</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKER12.626.L12-1359</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5514,7 +5155,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1360</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MELERO12.627.L12-1360</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5531,7 +5171,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1361</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DAMLJANOVIC12.628.L12-1361</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5546,7 +5185,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1362</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AMOIA12.629.L12-1362</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5562,7 +5200,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1363</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOEFFARD12.632.L12-1363</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5577,7 +5214,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1364</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEWIN12.633.L12-1364</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5591,7 +5227,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1365</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NAVARRETTA12.635.L12-1365</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5608,7 +5243,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1366</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEWIS12.636.L12-1366</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5623,7 +5257,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1367</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TANASIJEVI12.637.L12-1367</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5638,7 +5271,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1368</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LANDRAGIN12.638.L12-1368</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5655,7 +5287,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1369</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NAVARRETTA12.639.L12-1369</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5672,7 +5303,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1370</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LI12.640.L12-1370</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5686,7 +5316,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1371</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHEN12.641.L12-1371</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5700,7 +5329,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1372</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAGGION12.642.L12-1372</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5715,7 +5343,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1373</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CARVALHO12.643.L12-1373</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5728,7 +5355,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1374</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LARASATI12.644.L12-1374</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5750,7 +5376,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1375</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOJAR12.645.L12-1375</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5764,7 +5389,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1376</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DUKES12.646.L12-1376</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5778,7 +5402,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1377</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OGRODNICZUK12.648.L12-1377</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5793,7 +5416,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1378</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KENNINGTON12.649.L12-1378</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5808,7 +5430,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1379</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DINU12.651.L12-1379</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5823,7 +5444,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1380</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EOM12.652.L12-1380</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5836,7 +5456,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1381</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OGRODNICZUK12.653.L12-1381</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5852,7 +5471,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1382</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LAWRIE12.655.L12-1382</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5866,7 +5484,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1383</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VERHAGEN12.656.L12-1383</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5880,7 +5497,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1384</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOUIS12.657.L12-1384</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5897,7 +5513,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1385</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WRIGHT12.658.L12-1385</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5910,7 +5525,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1386</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FILATOVA12.661.L12-1386</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5924,7 +5538,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1387</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALSABBAGH12.663.L12-1387</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5940,7 +5553,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1388</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CLARKE12.664.L12-1388</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5957,7 +5569,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1389</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARUJO12.672.L12-1389</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5972,7 +5583,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1390</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAKLIWAL12.673.L12-1390</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -5987,7 +5597,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1391</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RECASENS12.674.L12-1391</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6003,7 +5612,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1392</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TOKUNAGA12.676.L12-1392</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6017,7 +5625,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1393</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUSUMOTO12.677.L12-1393</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6030,7 +5637,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1394</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHUMANN12.678.L12-1394</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6045,7 +5651,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1395</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OZBAL12.679.L12-1395</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6060,7 +5665,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1396</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DECLERCQ12.680.L12-1396</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6077,7 +5681,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1397</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAZILLON12.682.L12-1397</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6092,7 +5695,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1398</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HONG12.683.L12-1398</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6111,7 +5713,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1399</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BECHET12.684.L12-1399</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6125,7 +5726,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1400</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHERRER12.685.L12-1400</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6140,7 +5740,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1401</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COSTANTINI12.686.L12-1401</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6156,7 +5755,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1402</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PARDELLI12.687.L12-1402</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6173,7 +5771,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1403</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKIBA12.693.L12-1403</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6194,7 +5791,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1404</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORENOSANDOVAL12.697.L12-1404</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6209,7 +5805,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1405</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROUSSEAU12.698.L12-1405</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6222,7 +5817,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1406</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETASIS12.700.L12-1406</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6240,7 +5834,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1407</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAPELLI12.701.L12-1407</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6255,7 +5848,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1408</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PATRIK12.703.L12-1408</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6271,7 +5863,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1409</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SLUBAN12.706.L12-1409</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6289,7 +5880,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1410</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GIRAUDEL12.707.L12-1410</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6303,7 +5893,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1411</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GESMUNDO12.708.L12-1411</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6317,7 +5906,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1412</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PROISL12.709.L12-1412</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6333,7 +5921,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1413</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TAVAREZ12.711.L12-1413</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6348,7 +5935,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1414</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FUJII12.714.L12-1414</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6362,7 +5948,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1415</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BALLESTEROS12.715.L12-1415</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6378,7 +5963,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1416</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CONKIE12.716.L12-1416</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6392,7 +5976,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1417</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STYMNE12.717.L12-1417</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6407,7 +5990,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1418</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BEROVIC12.719.L12-1418</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6423,7 +6005,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1419</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLUEWER12.721.L12-1419</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6440,7 +6021,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1420</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VILLEGAS12.722.L12-1420</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6456,7 +6036,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1421</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OSENOVA12.724.L12-1421</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6471,7 +6050,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1422</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUBINO12.726.L12-1422</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6487,7 +6065,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1423</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>YANG12.727.L12-1423</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6501,7 +6078,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1424</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ISLAM12.729.L12-1424</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6516,7 +6092,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1425</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STRAPPARAVA12.730.L12-1425</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6531,7 +6106,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1426</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIANCHI12.732.L12-1426</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6545,7 +6119,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1427</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NORDHOFF12.733.L12-1427</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6565,7 +6138,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1428</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DAYRELL12.734.L12-1428</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6579,7 +6151,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1429</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALEKSANDROV12.735.L12-1429</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6593,7 +6164,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1430</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WEISS12.736.L12-1430</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6606,7 +6176,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1431</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIS12.737.L12-1431</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6620,7 +6189,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1432</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRAFFORT12.740.L12-1432</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6635,7 +6203,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1433</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GONZALEZ12.741.L12-1433</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6649,7 +6216,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1434</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ILIEV12.743.L12-1434</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6676,7 +6242,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1435</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VASILJEVS12.744.L12-1435</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6693,7 +6258,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1436</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOJUN12.746.L12-1436</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6710,7 +6274,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1437</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REYNAERT12.748.L12-1437</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6731,7 +6294,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1438</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEFVRE12.751.L12-1438</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6746,7 +6308,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1439</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGARWAL12.753.L12-1439</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6762,7 +6323,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1440</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ATSERIAS12.754.L12-1440</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6781,7 +6341,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1441</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAHN12.755.L12-1441</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6796,7 +6355,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1442</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AUGUSTINUS12.756.L12-1442</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6810,7 +6368,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1443</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRISSOMII12.757.L12-1443</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6824,7 +6381,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1444</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DICKINSON12.758.L12-1444</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6839,7 +6395,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1445</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BESANON12.761.L12-1445</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6854,7 +6409,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1446</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOTT12.762.L12-1446</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6870,7 +6424,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1447</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COMELLES12.763.L12-1447</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6886,7 +6439,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1448</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOUTILAINEN12.766.L12-1448</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6901,7 +6453,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1449</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CUTUGNO12.767.L12-1449</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6920,7 +6471,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1450</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CALZOLARI12.769.L12-1450</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6934,7 +6484,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1451</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORASCU12.770.L12-1451</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6951,7 +6500,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1452</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NEGRI12.772.L12-1452</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6968,7 +6516,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1453</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BONDIJOHANNESSEN12.773.L12-1453</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -6985,7 +6532,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1454</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>READ12.774.L12-1454</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7000,7 +6546,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1455</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CVREK12.775.L12-1455</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7016,7 +6561,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1456</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KASPERSSON12.776.L12-1456</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7037,7 +6581,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1457</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SORIA12.777.L12-1457</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7051,7 +6594,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1458</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUPPENHOFER12.778.L12-1458</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7066,7 +6608,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1459</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SUAREZ12.779.L12-1459</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7089,7 +6630,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1460</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FROMMER12.782.L12-1460</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7105,7 +6645,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1461</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZSDER12.783.L12-1461</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7119,7 +6658,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1462</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAZEM12.784.L12-1462</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7136,7 +6674,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1463</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SONG12.785.L12-1463</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7150,7 +6687,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1464</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ORIGLIA12.786.L12-1464</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7166,7 +6702,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1465</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STRIK12.787.L12-1465</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7181,7 +6716,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1466</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IRIN12.788.L12-1466</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7201,7 +6735,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1467</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BASKI12.789.L12-1467</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7216,7 +6749,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1468</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>QUARTERONI12.790.L12-1468</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7231,7 +6763,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1469</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAZIENZA12.794.L12-1469</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7246,7 +6777,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1470</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KARAN12.796.L12-1470</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7261,7 +6791,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1471</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FRICK12.800.L12-1471</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7277,7 +6806,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1472</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHI12.802.L12-1472</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7291,7 +6819,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1473</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SU12.804.L12-1473</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7305,7 +6832,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1474</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WEITZ12.805.L12-1474</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7320,7 +6846,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1475</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WATTAM12.806.L12-1475</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7334,7 +6859,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1476</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BELZ12.807.L12-1476</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7349,7 +6873,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1477</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHI12.808.L12-1477</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7362,7 +6885,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1478</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KANO12.810.L12-1478</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7378,7 +6900,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1479</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MONDARY12.812.L12-1479</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7393,7 +6914,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1480</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUSSO12.813.L12-1480</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7410,7 +6930,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1481</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEINBERGER12.814.L12-1481</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7424,7 +6943,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1482</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELFARDY12.815.L12-1482</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7443,7 +6961,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1483</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FEDERMANN12.816.L12-1483</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7457,7 +6974,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1484</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WELLER12.817.L12-1484</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7472,7 +6988,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1485</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NAWAZ12.818.L12-1485</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7488,7 +7003,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1486</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EBERLE12.819.L12-1486</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7503,7 +7017,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1487</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DECLERCK12.820.L12-1487</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7522,7 +7035,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1488</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ODRIOZOLA12.822.L12-1488</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7542,7 +7054,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1489</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BONGELLI12.823.L12-1489</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7558,7 +7069,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1490</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MOSTEFA12.824.L12-1490</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7579,7 +7089,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1491</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIU12.825.L12-1491</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7598,7 +7107,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1492</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KAFKAS12.827.L12-1492</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7618,7 +7126,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1493</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ADELL12.828.L12-1493</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7635,7 +7142,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1494</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAVKOV12.829.L12-1494</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7649,7 +7155,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1495</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HANA12.830.L12-1495</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7663,7 +7168,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1496</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ABRATE12.831.L12-1496</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7677,7 +7181,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1497</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHFER12.834.L12-1497</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7703,7 +7206,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1498</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AFANTENOS12.836.L12-1498</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7717,7 +7219,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1499</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZAHRA12.838.L12-1499</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7733,7 +7234,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1500</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GBOR12.839.L12-1500</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7749,7 +7249,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1501</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHOUKRI12.842.L12-1501</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7765,7 +7264,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1502</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JAJA12.843.L12-1502</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7784,7 +7282,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1503</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORSTER12.844.L12-1503</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7802,7 +7299,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1504</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CATTONI12.845.L12-1504</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7816,7 +7312,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1505</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHOUKRI12.846.L12-1505</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7831,7 +7326,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1506</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FOKKENS12.848.L12-1506</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7847,7 +7341,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1507</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KIM12.850.L12-1507</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7862,7 +7355,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1508</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TAHON12.853.L12-1508</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7878,7 +7370,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1509</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GAHBICHEBRAHAM12.855.L12-1509</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7892,7 +7383,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1510</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIBER12.857.L12-1510</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7906,7 +7396,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1511</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NAKAGAWA12.860.L12-1511</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7920,7 +7409,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1512</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAYASHI12.863.L12-1512</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7937,7 +7425,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1513</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SZEKELY12.864.L12-1513</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7956,7 +7443,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1514</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARRIDO12.865.L12-1514</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7969,7 +7455,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1515</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELSON12.866.L12-1515</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -7985,7 +7470,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1516</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOSCA12.867.L12-1516</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8000,7 +7484,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1517</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TASLIMIPOOR12.868.L12-1517</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8014,7 +7497,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1518</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARRANZ12.872.L12-1518</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8029,7 +7511,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1519</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEINBERGER12.875.L12-1519</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8046,7 +7527,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1520</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DOUKHAN12.876.L12-1520</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8063,7 +7543,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1521</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARISTARDRY12.878.L12-1521</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8076,7 +7555,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1522</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARTINS12.879.L12-1522</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8091,7 +7569,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1523</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VARGA12.881.L12-1523</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8106,7 +7583,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1524</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FUENTES12.882.L12-1524</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8123,7 +7599,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1525</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEMELO12.884.L12-1525</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8145,7 +7620,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1526</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STRASSEL12.885.L12-1526</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8160,7 +7634,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1527</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOUAMOR12.886.L12-1527</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8177,7 +7650,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1528</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REDEKER12.887.L12-1528</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8192,7 +7664,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1529</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAPP12.888.L12-1529</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8208,7 +7679,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1530</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DRUDE12.891.L12-1530</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8224,7 +7694,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1531</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KHADEMIAN12.892.L12-1531</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8237,7 +7706,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1532</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOUKACHEVITCH12.893.L12-1532</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8253,7 +7721,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1533</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOLACHINA12.894.L12-1533</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8266,7 +7733,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1534</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KERMES12.895.L12-1534</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8281,7 +7747,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1535</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TEMNIKOVA12.898.L12-1535</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8294,7 +7759,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1536</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GHAYOOMI12.900.L12-1536</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8312,7 +7776,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1537</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SUZUKI12.902.L12-1537</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8326,7 +7789,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1538</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELAHIMANESH12.903.L12-1538</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8339,7 +7801,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1539</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GIBBON12.905.L12-1539</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8355,7 +7816,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1540</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OGISO12.906.L12-1540</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8371,7 +7831,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1541</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHOAIB12.907.L12-1541</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8386,7 +7845,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1542</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LAPARRA12.908.L12-1542</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8401,7 +7859,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1543</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRODA12.909.L12-1543</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8417,7 +7874,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1544</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ESKEVICH12.910.L12-1544</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8430,7 +7886,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1545</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHIARCOS12.911.L12-1545</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8452,7 +7907,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1546</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHIARCOS12.912.L12-1546</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8467,7 +7921,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1547</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MANSHADI12.914.L12-1547</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8480,7 +7933,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1548</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHIARCOS12.915.L12-1548</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8495,7 +7947,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1549</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AHTARIDIS12.916.L12-1549</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8509,7 +7960,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1550</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GIANNOULIS12.917.L12-1550</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8522,7 +7972,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1551</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SINGH12.919.L12-1551</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8536,7 +7985,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1552</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAMANATHAN12.921.L12-1552</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8552,7 +8000,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1553</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOTZ12.924.L12-1553</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8577,7 +8024,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1554</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SKADIA12.925.L12-1554</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8592,7 +8038,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1555</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PIASECKI12.926.L12-1555</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8606,7 +8051,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1556</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORAES12.931.L12-1556</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8620,7 +8064,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1557</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHIMA12.934.L12-1557</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8641,7 +8084,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1558</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KESTEMONT12.938.L12-1558</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8656,7 +8098,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1559</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KESKES12.939.L12-1559</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8671,7 +8112,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1560</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MATSUBAYASHI12.941.L12-1560</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8685,7 +8125,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1561</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELAHI12.942.L12-1561</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8699,7 +8138,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1562</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>URYUPINA12.944.L12-1562</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8713,7 +8151,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1563</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BALAHUR12.945.L12-1563</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8729,7 +8166,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1564</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TOLONE12.946.L12-1564</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8744,7 +8180,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1565</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CRISTEA12.947.L12-1565</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8757,7 +8192,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1566</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PINNIS12.948.L12-1566</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8771,7 +8205,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1567</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>INOUE12.951.L12-1567</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8784,7 +8217,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1568</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WINDHOUWER12.954.L12-1568</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8798,7 +8230,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1569</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OSENOVA12.956.L12-1569</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8812,7 +8243,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1570</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOW12.957.L12-1570</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8825,7 +8255,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1571</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PARETI12.958.L12-1571</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8840,7 +8269,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1572</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAK12.960.L12-1572</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8855,7 +8283,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1573</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LI12.964.L12-1573</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8872,7 +8299,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1574</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRODA12.965.L12-1574</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8889,7 +8315,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1575</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FERNANDES12.966.L12-1575</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8904,7 +8329,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1576</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANTOS12.967.L12-1576</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8920,7 +8344,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1577</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEMIR12.968.L12-1577</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8937,7 +8360,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1578</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MILLER12.970.L12-1578</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8952,7 +8374,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1579</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GEORGI12.971.L12-1579</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8966,7 +8387,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1580</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SONG12.973.L12-1580</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -8988,7 +8408,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1581</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CABRAL12.974.L12-1581</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9002,7 +8421,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1582</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAIKENS12.976.L12-1582</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9017,7 +8435,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1583</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STAVROPOULOU12.977.L12-1583</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9033,7 +8450,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1584</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHEIBLE12.978.L12-1584</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9049,7 +8465,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1585</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SILVA12.980.L12-1585</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9063,7 +8478,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1586</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHARTON12.983.L12-1586</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9078,7 +8492,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1587</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AZIZ12.985.L12-1587</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9094,7 +8507,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1588</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LENCI12.986.L12-1588</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9109,7 +8521,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1589</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OHTA12.987.L12-1589</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9132,7 +8543,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1590</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKSAN12.991.L12-1590</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9148,7 +8558,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1591</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HANA12.992.L12-1591</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9166,7 +8575,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1592</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FEDERMANN12.996.L12-1592</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9189,7 +8597,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1593</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GAVRILIDOU12.998.L12-1593</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9202,7 +8609,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1594</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MOMTAZI12.999.L12-1594</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9218,7 +8624,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1595</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HOLMQVIST12.1000.L12-1595</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9233,7 +8638,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1596</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GAVRILA12.1003.L12-1596</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9249,7 +8653,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1597</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PRABHAKARAN12.1006.L12-1597</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9266,7 +8669,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1598</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CORVEY12.1008.L12-1598</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9280,7 +8682,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1599</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POGGI12.1010.L12-1599</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9297,7 +8698,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1600</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHERER12.1011.L12-1600</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9310,7 +8710,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1601</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DAVIS12.1012.L12-1601</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9324,7 +8723,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1602</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAGHERBEYGI12.1013.L12-1602</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9340,7 +8738,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1603</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUMSHISKY12.1014.L12-1603</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9356,7 +8753,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1604</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRNING12.1015.L12-1604</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9373,7 +8769,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1605</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TEPPER12.1016.L12-1605</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9387,7 +8782,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1606</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG12.1017.L12-1606</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9401,7 +8795,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1607</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAKS12.1018.L12-1607</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9415,7 +8808,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1608</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GREZKA12.1020.L12-1608</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9433,7 +8825,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1609</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGIRRE12.1021.L12-1609</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9448,7 +8839,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1610</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOGEL12.1022.L12-1610</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9461,7 +8851,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1611</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ANASTASIOU12.1024.L12-1611</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9481,7 +8870,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1612</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EDLUND12.1026.L12-1612</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9496,7 +8884,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1613</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KURC12.1027.L12-1613</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9510,7 +8897,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1614</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VIRK12.1028.L12-1614</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9526,7 +8912,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1615</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOMES12.1031.L12-1615</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9543,7 +8928,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1616</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FERREIRA12.1034.L12-1616</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9560,7 +8944,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1617</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOELLA12.1035.L12-1617</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9578,7 +8961,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1618</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TOMLINSON12.1036.L12-1618</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9593,7 +8975,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1619</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAUER12.1037.L12-1619</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9609,7 +8990,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1620</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROSNER12.1040.L12-1620</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9624,7 +9004,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1621</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARCIACASADEMONT12.1042.L12-1621</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9640,7 +9019,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1622</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NANBA12.1043.L12-1622</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9654,7 +9032,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1623</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DINARELLI12.1046.L12-1623</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9669,7 +9046,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1624</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POMIKLEK12.1047.L12-1624</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9683,7 +9059,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1625</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG12.1049.L12-1625</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9698,7 +9073,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1626</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHNEIDER12.1052.L12-1626</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9711,7 +9085,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1627</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OHARA12.1053.L12-1627</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9724,7 +9097,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1628</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POPESCU12.1055.L12-1628</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9740,7 +9112,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1629</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BLACK12.1056.L12-1629</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9754,7 +9125,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1630</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ABDULMAGEED12.1057.L12-1630</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9769,7 +9139,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1631</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HARA12.1059.L12-1631</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9784,7 +9153,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1632</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OJAT12.1061.L12-1632</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9801,7 +9169,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1633</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CASTILHO12.1062.L12-1633</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9815,7 +9182,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1634</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUTTERY12.1063.L12-1634</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9829,7 +9195,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1635</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOPE12.1064.L12-1635</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9842,7 +9207,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1636</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MA12.1065.L12-1636</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9856,7 +9220,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1637</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARKER12.1069.L12-1637</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9870,7 +9233,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1638</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAMSUDIN12.1070.L12-1638</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9884,7 +9246,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1639</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPEER12.1072.L12-1639</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9898,7 +9259,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1640</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HULDEN12.1075.L12-1640</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9912,7 +9272,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1641</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WILLIAMS12.1076.L12-1641</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9927,7 +9286,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1642</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WASHINGTON12.1077.L12-1642</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9944,7 +9302,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1643</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WALKER12.1078.L12-1643</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9959,7 +9316,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1644</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROSHCHINA12.1080.L12-1644</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9974,7 +9330,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1645</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PEREZROSAS12.1081.L12-1645</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -9989,7 +9344,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1646</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FERNANDEZORDONEZ12.1082.L12-1646</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10002,7 +9356,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1647</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PIPERIDIS12.1086.L12-1647</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10016,7 +9369,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1648</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAINES12.1087.L12-1648</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10031,7 +9383,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1649</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROBERTS12.1091.L12-1649</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10046,7 +9397,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1650</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ANDREAS12.1095.L12-1650</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10059,7 +9409,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1651</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROBICHAUD12.1096.L12-1651</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10073,7 +9422,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1652</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOLACHINA12.1097.L12-1652</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10086,7 +9434,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1653</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JANSSEN12.1098.L12-1653</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10101,7 +9448,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1654</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUNT12.1107.L12-1654</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10114,7 +9460,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1655</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OKITA12.1109.L12-1655</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10129,7 +9474,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1656</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CASELLI12.1111.L12-1656</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10144,7 +9488,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1657</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WALKER12.1114.L12-1657</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10157,7 +9500,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1658</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIGI12.1116.L12-1658</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10173,7 +9515,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1659</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CIERI12.1117.L12-1659</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10187,7 +9528,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1660</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORUTA12.1120.L12-1660</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10205,7 +9545,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1661</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STKER12.1121.L12-1661</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10220,7 +9559,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1662</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIGI12.1122.L12-1662</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10234,7 +9572,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1663</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PUSTEJOVSKY12.1123.L12-1663</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10248,7 +9585,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1664</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAGOT12.1124.L12-1664</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10268,7 +9604,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1665</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FEDERICO12.1126.L12-1665</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10282,7 +9617,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1666</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAGOT12.1127.L12-1666</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10295,7 +9629,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1667</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HERNANDEZ12.1129.L12-1667</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10311,7 +9644,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1668</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEDDAH12.1130.L12-1668</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10325,7 +9657,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1669</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HANOKA12.1131.L12-1669</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>
@@ -10341,7 +9672,6 @@
   <year>2012</year>
   <address>Istanbul, Turkey</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L12-1670</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGRAWAL12.1132.L12-1670</bibkey>
   <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (LREC-2012)</booktitle>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -26,7 +26,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1001</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VERHOEVEN14.1.L14-1001</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -41,7 +40,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1002</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUS14.1000.L14-1002</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -55,7 +53,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1003</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KESSLER14.1001.L14-1003</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -69,7 +66,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1004</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CLAVEAU14.1003.L14-1004</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -86,7 +82,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1005</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SIMOV14.1005.L14-1005</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -101,7 +96,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1006</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SOLORIO14.1007.L14-1006</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -115,7 +109,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1007</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BLESSING14.1009.L14-1007</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -131,7 +124,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1008</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG14.101.L14-1008</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -145,7 +137,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1009</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FRAISSE14.1010.L14-1009</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -161,7 +152,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1010</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TRIPPEL14.1011.L14-1010</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -178,7 +168,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1011</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BONIAL14.1012.L14-1011</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -191,7 +180,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1012</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WRIGHT14.1016.L14-1012</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -210,7 +198,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1013</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUSCHMEIER14.1017.L14-1013</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -223,7 +210,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1014</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOBYLISKI14.1018.L14-1014</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -239,7 +225,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1015</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JAIN14.1019.L14-1015</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -254,7 +239,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1016</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RICHARDSON14.102.L14-1016</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -275,7 +259,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1017</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CABARRO14.1020.L14-1017</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -291,7 +274,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1018</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TAKALA14.1021.L14-1018</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -305,7 +287,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1019</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAVAR14.1022.L14-1019</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -321,7 +302,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1020</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GLAVA14.1023.L14-1020</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -335,7 +315,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1021</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PUSTEJOVSKY14.1026.L14-1021</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -352,7 +331,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1022</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GALIBERT14.1027.L14-1022</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -367,7 +345,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1023</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KAMHOLZ14.1029.L14-1023</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -380,7 +357,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1024</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TUFI14.103.L14-1024</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -396,7 +372,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1025</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEPAIVA14.1031.L14-1025</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -413,7 +388,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1026</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COMELLES14.1032.L14-1026</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -427,7 +401,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1027</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HE14.1036.L14-1027</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -443,7 +416,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1028</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOZA14.1037.L14-1028</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -457,7 +429,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1029</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHMIDEK14.1038.L14-1029</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -471,7 +442,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1030</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SOLER14.104.L14-1030</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -487,7 +457,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1031</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MOHLER14.1043.L14-1031</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -508,7 +477,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1032</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JUNG14.1046.L14-1032</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -523,7 +491,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1033</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ANDREEVA14.1048.L14-1033</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -536,7 +503,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1034</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAGOT14.105.L14-1034</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -550,7 +516,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1035</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAUMANN14.1051.L14-1035</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -566,7 +531,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1036</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BACCIU14.1052.L14-1036</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -585,7 +549,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1037</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LENKIEWICZ14.1053.L14-1037</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -601,7 +564,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1038</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANHESSEN14.1056.L14-1038</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -615,7 +577,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1039</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LONSDALE14.1057.L14-1039</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -629,7 +590,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1040</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SMRZ14.1058.L14-1040</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -644,7 +604,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1041</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FIORELLI14.1059.L14-1041</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -658,7 +617,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1042</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DENG14.106.L14-1042</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -671,7 +629,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1043</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETASIS14.1060.L14-1043</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -686,7 +643,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1044</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WOLFF14.1061.L14-1044</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -705,7 +661,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1045</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEMARNEFFE14.1062.L14-1045</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -722,7 +677,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1046</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SWANSON14.1063.L14-1046</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -738,7 +692,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1047</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HELLRICH14.1064.L14-1047</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -754,7 +707,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1048</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEE14.1065.L14-1048</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -771,7 +723,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1049</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ESCUDERO14.1066.L14-1049</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -785,7 +736,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1050</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANMARTN14.1067.L14-1050</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -803,7 +753,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1051</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JIANG14.1068.L14-1051</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -817,7 +766,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1052</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LUO14.107.L14-1052</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -832,7 +780,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1053</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARCIAFERNANDEZ14.1070.L14-1053</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -850,7 +797,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1054</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIZZONI14.1071.L14-1054</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -867,7 +813,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1055</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>XIA14.1072.L14-1055</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -880,7 +825,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1056</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CETINOGLU14.1073.L14-1056</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -896,7 +840,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1057</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OJAT14.1074.L14-1057</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -909,7 +852,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1058</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>YAMAGUCHI14.1075.L14-1058</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -922,7 +864,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1059</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHRISTODOULIDES14.1078.L14-1059</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -936,7 +877,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1060</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DANNELLS14.1079.L14-1060</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -951,7 +891,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1061</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRAUNE14.1080.L14-1061</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -966,7 +905,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1062</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REHBEIN14.1081.L14-1062</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -979,7 +917,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1063</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEMELO14.1083.L14-1063</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -996,7 +933,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1064</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROSN14.1085.L14-1064</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1013,7 +949,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1065</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAK14.1086.L14-1065</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1028,7 +963,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1066</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OGRODNICZUK14.1088.L14-1066</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1047,7 +981,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1067</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SILVEIRA14.1089.L14-1067</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1060,7 +993,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1068</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NAJDER14.1090.L14-1068</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1076,7 +1008,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1069</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCERRI14.1092.L14-1069</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1094,7 +1025,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1070</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HONG14.1093.L14-1070</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1118,7 +1048,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1071</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SONG14.1094.L14-1071</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1135,7 +1064,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1072</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LARANJEIRA14.1095.L14-1072</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1153,7 +1081,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1073</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TSVETKOV14.1096.L14-1073</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1168,7 +1095,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1074</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUCK14.1097.L14-1074</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1183,7 +1109,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1075</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VORDERBRCK14.1099.L14-1075</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1198,7 +1123,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1076</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POLAJNAR14.110.L14-1076</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1211,7 +1135,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1077</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAGGION14.1102.L14-1077</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1229,7 +1152,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1078</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FOKKENS14.1103.L14-1078</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1244,7 +1166,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1079</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROUSSEAU14.1104.L14-1079</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1260,7 +1181,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1080</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DUBEY14.1105.L14-1080</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1275,7 +1195,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1081</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FIER14.1106.L14-1081</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1290,7 +1209,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1082</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHIBATA14.1107.L14-1082</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1306,7 +1224,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1083</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FRANCOIS14.1108.L14-1083</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1324,7 +1241,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1084</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HILGERT14.1112.L14-1084</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1339,7 +1255,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1085</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WISNIEWSKI14.1115.L14-1085</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1355,7 +1270,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1086</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOSS14.1116.L14-1086</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1369,7 +1283,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1087</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AUGUIN14.1119.L14-1087</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1385,7 +1298,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1088</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TOMLINSON14.1120.L14-1088</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1403,7 +1315,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1089</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRAFF14.1125.L14-1089</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1418,7 +1329,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1090</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HOKAMP14.1126.L14-1090</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1435,7 +1345,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1091</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RESCHKE14.1127.L14-1091</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1450,7 +1359,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1092</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ULTES14.113.L14-1092</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1463,7 +1371,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1093</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TORAL14.1134.L14-1093</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1478,7 +1385,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1094</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WUBBEN14.1135.L14-1094</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1493,7 +1399,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1095</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>YEKA14.1137.L14-1095</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1510,7 +1415,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1096</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DILSIZIAN14.1138.L14-1096</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1524,7 +1428,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1097</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ADDANKI14.1139.L14-1097</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1538,7 +1441,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1098</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GREEN14.1143.L14-1098</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1552,7 +1454,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1099</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHEN14.1144.L14-1099</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1570,7 +1471,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1100</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAAMOURI14.1145.L14-1100</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1583,7 +1483,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1101</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHEFFLER14.1146.L14-1101</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1597,7 +1496,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1102</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HASTIE14.1147.L14-1102</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1610,7 +1508,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1103</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OHARA14.1149.L14-1103</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1624,7 +1521,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1104</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KRIEGER14.115.L14-1104</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1639,7 +1535,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1105</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BELENGUIX14.1150.L14-1105</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1653,7 +1548,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1106</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EISELEN14.1151.L14-1106</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1669,7 +1563,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1107</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FELT14.1153.L14-1107</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1683,7 +1576,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1108</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OUYANG14.1154.L14-1108</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1700,7 +1592,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1109</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARREIRO14.1155.L14-1109</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1715,7 +1606,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1110</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELLENDORFF14.1156.L14-1110</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1729,7 +1619,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1111</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPRUGNOLI14.1157.L14-1111</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1742,7 +1631,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1112</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MA14.1158.L14-1112</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1759,7 +1647,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1113</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIES14.1159.L14-1113</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1773,7 +1660,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1114</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SENNRICH14.116.L14-1114</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1795,7 +1681,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1115</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIAB14.1161.L14-1115</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1810,7 +1695,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1116</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DECLERCK14.1163.L14-1116</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1824,7 +1708,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1117</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOUYLEKOV14.1166.L14-1117</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1839,7 +1722,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1118</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PONBARRY14.1167.L14-1118</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1853,7 +1735,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1119</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GLEIZE14.1168.L14-1119</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1867,7 +1748,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1120</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROSNER14.1169.L14-1120</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1882,7 +1762,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1121</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MITSUISHI14.1170.L14-1121</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1903,7 +1782,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1122</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FERREIRA14.1174.L14-1122</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1918,7 +1796,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1123</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STRUNK14.1176.L14-1123</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1935,7 +1812,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1124</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HELLAN14.1179.L14-1124</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1953,7 +1829,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1125</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VACHER14.118.L14-1125</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1973,7 +1848,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1126</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEWIS14.1182.L14-1126</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -1987,7 +1861,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1127</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DINU14.1183.L14-1127</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2002,7 +1875,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1128</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DINU14.1184.L14-1128</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2016,7 +1888,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1129</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DSOUZA14.1185.L14-1129</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2033,7 +1904,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1130</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORZOVS14.1189.L14-1130</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2048,7 +1918,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1131</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRIERLEY14.119.L14-1131</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2064,7 +1933,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1132</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MATA14.1193.L14-1132</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2082,7 +1950,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1133</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BHATIA14.1194.L14-1133</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2097,7 +1964,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1134</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REGNERI14.1195.L14-1134</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2111,7 +1977,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1135</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ANTUNES14.1197.L14-1135</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2125,7 +1990,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1136</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LO14.1198.L14-1136</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2140,7 +2004,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1137</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZHANG14.1199.L14-1137</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2154,7 +2017,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1138</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EXNER14.12.L14-1138</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2169,7 +2031,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1139</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KE14.120.L14-1139</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2185,7 +2046,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1140</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DINU14.1200.L14-1140</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2206,7 +2066,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1141</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MATA14.1201.L14-1141</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2224,7 +2083,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1142</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BLACK14.1203.L14-1142</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2239,7 +2097,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1143</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WASHINGTON14.1207.L14-1143</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2253,7 +2110,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1144</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OLIVER14.121.L14-1144</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2267,7 +2123,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1145</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OGRODNICZUK14.1211.L14-1145</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2281,7 +2136,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1146</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHULTZ14.1212.L14-1146</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2295,7 +2149,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1147</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CEAUSU14.1213.L14-1147</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2310,7 +2163,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1148</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIBUCCIO14.1214.L14-1148</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2323,7 +2175,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1149</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CURTIS14.1216.L14-1149</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2340,7 +2191,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1150</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DREXLER14.1217.L14-1150</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2355,7 +2205,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1151</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GELLA14.122.L14-1151</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2370,7 +2219,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1152</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEE14.1222.L14-1152</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2386,7 +2234,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1153</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGRAWAL14.1226.L14-1153</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2404,7 +2251,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1154</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CIERI14.1227.L14-1154</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2420,7 +2266,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1155</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARIANI14.1228.L14-1155</bibkey>
 </paper>
@@ -2435,7 +2280,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1156</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROBERTS14.124.L14-1156</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2449,7 +2293,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1157</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>XAVIER14.125.L14-1157</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2462,7 +2305,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1158</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ANGELOV14.127.L14-1158</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2475,7 +2317,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1159</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MANGEOT14.128.L14-1159</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2492,7 +2333,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1160</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CURTO14.130.L14-1160</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2507,7 +2347,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1161</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SINHA14.132.L14-1161</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2522,7 +2361,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1162</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ERNESTUS14.134.L14-1162</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2536,7 +2374,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1163</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SONG14.138.L14-1163</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2550,7 +2387,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1164</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRUSZCZYSKI14.14.L14-1164</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2563,7 +2399,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1165</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JOKINEN14.143.L14-1165</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2576,7 +2411,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1166</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>UTSUMI14.144.L14-1166</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2590,7 +2424,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1167</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOGDANOVA14.145.L14-1167</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2606,7 +2439,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1168</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FELT14.147.L14-1168</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2626,7 +2458,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1169</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MUZERELLE14.150.L14-1169</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2642,7 +2473,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1170</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUDNICK14.151.L14-1170</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2657,7 +2487,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1171</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BROEDER14.153.L14-1171</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2672,7 +2501,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1172</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WINDHOUWER14.154.L14-1172</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2686,7 +2514,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1173</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IIDA14.155.L14-1173</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2700,7 +2527,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1174</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DURCO14.156.L14-1174</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2716,7 +2542,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1175</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORIN14.159.L14-1175</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2736,7 +2561,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1176</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARREIRO14.16.L14-1176</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2752,7 +2576,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1177</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KIPP14.160.L14-1177</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2769,7 +2592,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1178</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHIMIZU14.162.L14-1178</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2785,7 +2607,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1179</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAKMAK14.163.L14-1179</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2800,7 +2621,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1180</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETUKHOVA14.165.L14-1180</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2817,7 +2637,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1181</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CUCCHIARINI14.168.L14-1181</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2843,7 +2662,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1182</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETUKHOVA14.169.L14-1182</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2856,7 +2674,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1183</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHMIDT14.171.L14-1183</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2870,7 +2687,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1184</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DINU14.175.L14-1184</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2885,7 +2701,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1185</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RIZZO14.176.L14-1185</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2910,7 +2725,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1186</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIU14.178.L14-1186</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2925,7 +2739,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1187</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BHAT14.18.L14-1187</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2942,7 +2755,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1188</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>URYUPINA14.180.L14-1188</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2956,7 +2768,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1189</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HERNANDEZMENA14.182.L14-1189</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2976,7 +2787,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1190</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DELPOZO14.183.L14-1190</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -2991,7 +2801,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1191</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FANKHAUSER14.185.L14-1191</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3005,7 +2814,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1192</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DARWISH14.186.L14-1192</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3023,7 +2831,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1193</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALMEIDA14.187.L14-1193</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3039,7 +2846,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1194</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANSON14.188.L14-1194</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3053,7 +2859,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1195</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANDEGHINSTE14.189.L14-1195</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3068,7 +2873,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1196</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORCHID14.19.L14-1196</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3087,7 +2891,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1197</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KRIEGER14.190.L14-1197</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3102,7 +2905,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1198</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHABUS14.192.L14-1198</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3117,7 +2919,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1199</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POLKOV14.195.L14-1199</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3133,7 +2934,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1200</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PELEMANS14.196.L14-1200</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3148,7 +2948,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1201</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COSTA14.199.L14-1201</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3162,7 +2961,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1202</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ATAAALLAH14.2.L14-1202</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3175,7 +2973,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1203</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KAMOCKI14.202.L14-1203</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3190,7 +2987,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1204</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PRADET14.203.L14-1204</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3205,7 +3001,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1205</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOAICIGA14.205.L14-1205</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3219,7 +3014,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1206</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OOSTDIJK14.206.L14-1206</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3232,7 +3026,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1207</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NOVK14.207.L14-1207</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3249,7 +3042,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1208</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KARPPA14.209.L14-1208</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3264,7 +3056,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1209</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHU14.21.L14-1209</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3279,7 +3070,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1210</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CARL14.210.L14-1210</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3292,7 +3082,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1211</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZEEVAERT14.211.L14-1211</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3311,7 +3100,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1212</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOLDMAN14.214.L14-1212</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3326,7 +3114,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1213</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BETHARD14.218.L14-1213</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3344,7 +3131,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1214</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZRIBI14.219.L14-1214</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3358,7 +3144,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1215</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAYER14.220.L14-1215</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3371,7 +3156,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1216</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAPP14.221.L14-1216</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3386,7 +3170,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1217</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARRAFA14.222.L14-1217</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3407,7 +3190,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1218</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARIAS14.225.L14-1218</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3422,7 +3204,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1219</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANDERS14.227.L14-1219</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3435,7 +3216,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1220</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JELNEK14.228.L14-1220</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3449,7 +3229,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1221</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MIHIL14.23.L14-1221</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3465,7 +3244,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1222</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAIER14.230.L14-1222</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3479,7 +3257,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1223</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARBIERI14.231.L14-1223</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3495,7 +3272,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1224</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TITZE14.233.L14-1224</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3510,7 +3286,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1225</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHOLLET14.235.L14-1225</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3523,7 +3298,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1226</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GROUIN14.236.L14-1226</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3536,7 +3310,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1227</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEIN14.239.L14-1227</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3549,7 +3322,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1228</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BICK14.24.L14-1228</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3573,7 +3345,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1229</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHAIKH14.241.L14-1229</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3588,7 +3359,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1230</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SALABERRI14.242.L14-1230</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3603,7 +3373,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1231</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEPLVEDATORRES14.247.L14-1231</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3618,7 +3387,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1232</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZHANG14.248.L14-1232</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3635,7 +3403,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1233</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LUO14.25.L14-1233</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3653,7 +3420,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1234</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LI14.250.L14-1234</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3668,7 +3434,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1235</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GAVANKAR14.251.L14-1235</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3684,7 +3449,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1236</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOPIVOV14.252.L14-1236</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3699,7 +3463,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1237</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHONE14.253.L14-1237</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3713,7 +3476,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1238</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PILN14.254.L14-1238</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3732,7 +3494,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1239</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BERKLING14.255.L14-1239</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3747,7 +3508,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1240</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAENIG14.258.L14-1240</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3766,7 +3526,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1241</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VINCZE14.262.L14-1241</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3780,7 +3539,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1242</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MNARD14.263.L14-1242</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3795,7 +3553,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1243</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FREITAS14.264.L14-1243</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3812,7 +3569,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1244</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IZUMI14.267.L14-1244</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3826,7 +3582,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1245</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RENNES14.27.L14-1245</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3842,7 +3597,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1246</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZHOU14.270.L14-1246</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3857,7 +3611,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1247</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SADAMITSU14.271.L14-1247</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3871,7 +3624,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1248</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DANDAPAT14.272.L14-1248</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3886,7 +3638,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1249</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RIEDL14.274.L14-1249</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3906,7 +3657,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1250</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>UROOJ14.275.L14-1250</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3921,7 +3671,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1251</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BENIKOVA14.276.L14-1251</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3936,7 +3685,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1252</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIU14.277.L14-1252</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3952,7 +3700,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1253</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BONO14.278.L14-1253</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3970,7 +3717,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1254</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PRZEPIRKOWSKI14.279.L14-1254</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3983,7 +3729,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1255</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AR14.28.L14-1255</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -3998,7 +3743,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1256</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BGEL14.280.L14-1256</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4013,7 +3757,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1257</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PINNIS14.284.L14-1257</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4026,7 +3769,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1258</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VONDIKA14.285.L14-1258</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4041,7 +3783,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1259</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHAIMONGKOL14.286.L14-1259</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4056,7 +3797,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1260</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FALK14.288.L14-1260</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4078,7 +3818,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1261</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>UNDERWOOD14.289.L14-1261</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4091,7 +3830,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1262</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PALTOGLOU14.29.L14-1262</bibkey>
 </paper>
@@ -4102,7 +3840,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1263</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHMIDT14.290.L14-1263</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4120,7 +3857,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1264</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEGAETANOORTLIEB14.291.L14-1264</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4136,7 +3872,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1265</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAIF14.292.L14-1265</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4150,7 +3885,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1266</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LAMBERT14.293.L14-1266</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4166,7 +3900,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1267</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HNTKOV14.294.L14-1267</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4183,7 +3916,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1268</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GUILLOU14.298.L14-1268</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4197,7 +3929,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1269</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIST14.299.L14-1269</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4210,7 +3941,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1270</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TANNIER14.3.L14-1270</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4224,7 +3954,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1271</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUERA14.300.L14-1271</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4248,7 +3977,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1272</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VELCIN14.302.L14-1272</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4265,7 +3993,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1273</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SOLBERG14.303.L14-1273</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4278,7 +4005,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1274</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STHRENBERG14.308.L14-1274</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4292,7 +4018,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1275</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LAKI14.309.L14-1275</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4306,7 +4031,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1276</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPYNS14.31.L14-1276</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4322,7 +4046,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1277</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHO14.311.L14-1277</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4336,7 +4059,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1278</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANHAINEN14.312.L14-1278</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4351,7 +4073,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1279</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ERTEN14.316.L14-1279</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4365,7 +4086,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1280</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REFAEE14.317.L14-1280</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4384,7 +4104,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1281</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MONEGLIA14.318.L14-1281</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4397,7 +4116,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1282</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BENJAMIN14.319.L14-1282</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4411,7 +4129,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1283</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SALMON14.32.L14-1283</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4430,7 +4147,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1284</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LUDUSAN14.320.L14-1284</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4446,7 +4162,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1285</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RSNER14.321.L14-1285</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4461,7 +4176,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1286</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SIDOROV14.322.L14-1286</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4475,7 +4189,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1287</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALSOP14.323.L14-1287</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4490,7 +4203,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1288</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HANSEN14.325.L14-1288</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4505,7 +4217,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1289</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CAMPANO14.327.L14-1289</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4519,7 +4230,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1290</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MIRCEA14.328.L14-1290</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4535,7 +4245,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1291</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIMA14.329.L14-1291</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4549,7 +4258,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1292</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAUTISTA14.330.L14-1292</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4564,7 +4272,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1293</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RCZ14.331.L14-1293</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4580,7 +4287,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1294</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLICHE14.332.L14-1294</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4594,7 +4300,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1295</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FOURATI14.334.L14-1295</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4609,7 +4314,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1296</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DARWISH14.335.L14-1296</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4625,7 +4329,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1297</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HE14.337.L14-1297</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4640,7 +4343,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1298</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHEVELU14.338.L14-1298</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4653,7 +4355,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1299</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JANSCHE14.339.L14-1299</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4669,7 +4370,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1300</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELMAAROUF14.34.L14-1300</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4685,7 +4385,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1301</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VINCZE14.340.L14-1301</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4701,7 +4400,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1302</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SIDOROV14.341.L14-1302</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4715,7 +4413,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1303</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HFLER14.345.L14-1303</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4728,7 +4425,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1304</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHNEIDER14.346.L14-1304</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4743,7 +4439,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1305</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SINDLEROVA14.349.L14-1305</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4758,7 +4453,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1306</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAUR14.350.L14-1306</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4772,7 +4466,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1307</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>XUE14.353.L14-1307</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4786,7 +4479,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1308</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TAKAHASHI14.354.L14-1308</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4802,7 +4494,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1309</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BITTAR14.356.L14-1309</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4818,7 +4509,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1310</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LI14.358.L14-1310</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4833,7 +4523,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1311</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARBUMITITELU14.360.L14-1311</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4848,7 +4537,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1312</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KISS14.361.L14-1312</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4861,7 +4549,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1313</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DECHALENDAR14.362.L14-1313</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4879,7 +4566,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1314</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARELLI14.363.L14-1314</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4894,7 +4580,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1315</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAHAYUDI14.364.L14-1315</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4916,7 +4601,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1316</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HMLINEN14.365.L14-1316</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4937,7 +4621,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1317</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ABRATE14.368.L14-1317</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4954,7 +4637,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1318</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIU14.370.L14-1318</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4968,7 +4650,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1319</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GEER14.371.L14-1319</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4986,7 +4667,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1320</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NIRAULA14.372.L14-1320</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -4999,7 +4679,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1321</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORCADA14.373.L14-1321</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5014,7 +4693,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1322</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HENNIG14.374.L14-1322</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5030,7 +4708,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1323</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORO14.375.L14-1323</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5044,7 +4721,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1324</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BASTINGS14.376.L14-1324</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5060,7 +4736,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1325</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARRIDO14.377.L14-1325</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5076,7 +4751,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1326</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SERAJI14.378.L14-1326</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5090,7 +4764,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1327</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARANES14.379.L14-1327</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5105,7 +4778,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1328</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUCUK14.380.L14-1328</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5126,7 +4798,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1329</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LACHERET14.381.L14-1329</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5146,7 +4817,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1330</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARIMON14.382.L14-1330</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5162,7 +4832,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1331</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GORYAINOVA14.383.L14-1331</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5180,7 +4849,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1332</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>XUE14.384.L14-1332</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5197,7 +4865,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1333</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MEYERS14.385.L14-1333</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5213,7 +4880,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1334</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLASSEN14.386.L14-1334</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5228,7 +4894,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1335</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUIZ14.387.L14-1335</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5243,7 +4908,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1336</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHATZIMINA14.389.L14-1336</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5256,7 +4920,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1337</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAJIOV14.39.L14-1337</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5270,7 +4933,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1338</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KAESHAMMER14.390.L14-1338</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5287,7 +4949,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1339</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOKKINAKIS14.391.L14-1339</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5302,7 +4963,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1340</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAAD14.392.L14-1340</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5318,7 +4978,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1341</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHUPPLER14.394.L14-1341</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5332,7 +4991,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1342</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WINDHOUWER14.396.L14-1342</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5347,7 +5005,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1343</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORIN14.397.L14-1343</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5362,7 +5019,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1344</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOPEZOTERO14.398.L14-1344</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5376,7 +5032,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1345</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MILLER14.4.L14-1345</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5390,7 +5045,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1346</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRISOT14.400.L14-1346</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5409,7 +5063,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1347</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AVRAMIDIS14.401.L14-1347</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5425,7 +5078,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1348</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELHAJ14.402.L14-1348</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5440,7 +5092,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1349</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEFANESCU14.403.L14-1349</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5496,7 +5147,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1350</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REHM14.405.L14-1350</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5510,7 +5160,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1351</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKBIK14.409.L14-1351</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5524,7 +5173,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1352</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHIEL14.41.L14-1352</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5548,7 +5196,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1353</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DESMEDT14.410.L14-1353</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5567,7 +5214,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1354</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HARTMANN14.413.L14-1354</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5584,7 +5230,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1355</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUNCHUKUTTAN14.414.L14-1355</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5598,7 +5243,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1356</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HINRICHS14.415.L14-1356</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5618,7 +5262,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1357</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AI14.416.L14-1357</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5634,7 +5277,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1358</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAIRIDAN14.417.L14-1358</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5648,7 +5290,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1359</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MACWHINNEY14.419.L14-1359</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5663,7 +5304,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1360</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORI14.42.L14-1360</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5678,7 +5318,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1361</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FROMREIDE14.421.L14-1361</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5696,7 +5335,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1362</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KRAUSE14.422.L14-1362</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5712,7 +5350,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1363</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COUILLAULT14.424.L14-1363</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5728,7 +5365,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1364</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKER14.425.L14-1364</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5743,7 +5379,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1365</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEFEVER14.426.L14-1365</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5759,7 +5394,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1366</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BRODA14.427.L14-1366</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5773,7 +5407,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1367</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WINKELMANN14.429.L14-1367</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5787,7 +5420,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1368</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REBOUT14.43.L14-1368</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5802,7 +5434,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1369</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELMAHDY14.430.L14-1369</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5816,7 +5447,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1370</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZAGHOUANI14.431.L14-1370</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5832,7 +5462,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1371</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOISO14.432.L14-1371</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5847,7 +5476,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1372</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELMAHDY14.434.L14-1372</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5861,7 +5489,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1373</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOLDHAHN14.435.L14-1373</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5879,7 +5506,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1374</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOSSEN14.436.L14-1374</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5892,7 +5518,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1375</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LTEKIN14.437.L14-1375</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5910,7 +5535,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1376</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAGEMEIJER14.438.L14-1376</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5927,7 +5551,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1377</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VIITANIEMI14.440.L14-1377</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5941,7 +5564,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1378</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GHAYOOMI14.441.L14-1378</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5962,7 +5584,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1379</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALEGRIA14.442.L14-1379</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5975,7 +5596,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1380</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAJNICZ14.444.L14-1380</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -5995,7 +5615,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1381</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAJZS14.449.L14-1381</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6009,7 +5628,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1382</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORICEAU14.45.L14-1382</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6023,7 +5641,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1383</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TRUYENS14.452.L14-1383</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6037,7 +5654,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1384</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IVANOVA14.453.L14-1384</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6054,7 +5670,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1385</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MASMOUDI14.454.L14-1385</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6069,7 +5684,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1386</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LHOMME14.455.L14-1386</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6090,7 +5704,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1387</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEVIN14.457.L14-1387</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6103,7 +5716,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1388</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ODIJK14.459.L14-1388</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6118,7 +5730,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1389</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GONALOOLIVEIRA14.46.L14-1389</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6134,7 +5745,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1390</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TATEISI14.461.L14-1390</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6150,7 +5760,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1391</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HO14.462.L14-1391</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6172,7 +5781,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1392</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ETCHEGOYHEN14.463.L14-1392</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6189,7 +5797,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1393</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JEZEK14.465.L14-1393</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6202,7 +5809,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1394</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WARBURTON14.466.L14-1394</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6216,7 +5822,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1395</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MUKHERJEE14.467.L14-1395</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6231,7 +5836,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1396</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JACQUET14.468.L14-1396</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6250,7 +5854,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1397</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SPROAT14.47.L14-1397</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6265,7 +5868,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1398</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REZAPOURASHEGHI14.470.L14-1398</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6279,7 +5881,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1399</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARTNEZALONSO14.471.L14-1399</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6293,7 +5894,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1400</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TURCHI14.473.L14-1400</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6308,7 +5908,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1401</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>APIDIANAKI14.475.L14-1401</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6323,7 +5922,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1402</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HOVY14.476.L14-1402</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6336,7 +5934,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1403</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHARDLOW14.479.L14-1403</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6351,7 +5948,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1404</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FINLAYSON14.48.L14-1404</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6365,7 +5961,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1405</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REMUS14.480.L14-1405</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6380,7 +5975,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1406</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ABBASI14.483.L14-1406</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6404,7 +5998,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1407</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FAUTH14.484.L14-1407</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6420,7 +6013,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1408</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STRAPPARAVA14.486.L14-1408</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6433,7 +6025,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1409</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RAPP14.492.L14-1409</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6452,7 +6043,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1410</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CANDITO14.494.L14-1410</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6476,7 +6066,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1411</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CANDITO14.496.L14-1411</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6492,7 +6081,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1412</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SABOU14.497.L14-1412</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6506,7 +6094,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1413</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KORKONTZELOS14.498.L14-1413</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6520,7 +6107,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1414</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RYSOVA14.50.L14-1414</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6534,7 +6120,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1415</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DECLERCK14.500.L14-1415</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6548,7 +6133,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1416</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEVCIKOVA14.501.L14-1416</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6562,7 +6146,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1417</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOST14.502.L14-1417</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6577,7 +6160,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1418</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOLK14.504.L14-1418</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6591,7 +6173,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1419</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MOR14.506.L14-1419</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6605,7 +6186,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1420</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORARDO14.507.L14-1420</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6630,7 +6210,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1421</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRATCH14.508.L14-1421</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6645,7 +6224,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1422</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIGI14.51.L14-1422</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6660,7 +6238,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1423</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GILMANOV14.510.L14-1423</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6678,7 +6255,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1424</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ORR14.511.L14-1424</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6694,7 +6270,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1425</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AMARAL14.513.L14-1425</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6711,7 +6286,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1426</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANTOS14.514.L14-1426</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6727,7 +6301,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1427</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARZDINS14.515.L14-1427</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6742,7 +6315,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1428</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LYDING14.517.L14-1428</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6757,7 +6329,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1429</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOOS14.518.L14-1429</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6772,7 +6343,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1430</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PEREIRA14.519.L14-1430</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6790,7 +6360,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1431</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KILGARRIFF14.52.L14-1431</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6806,7 +6375,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1432</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ESTIVAL14.520.L14-1432</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6825,7 +6393,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1433</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHNEIDER14.521.L14-1433</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6839,7 +6406,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1434</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAMESHIMATABA14.522.L14-1434</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6854,7 +6420,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1435</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOUAMOR14.523.L14-1435</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6868,7 +6433,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1436</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NAVARRETTA14.525.L14-1436</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6886,7 +6450,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1437</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ESPLGOMIS14.529.L14-1437</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6901,7 +6464,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1438</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOTTI14.53.L14-1438</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6914,7 +6476,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1439</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ORASMAA14.530.L14-1439</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6932,7 +6493,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1440</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BASTIANELLI14.531.L14-1440</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6947,7 +6507,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1441</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DAEMS14.532.L14-1441</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6961,7 +6520,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1442</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SALVI14.533.L14-1442</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6978,7 +6536,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1443</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KORVAS14.535.L14-1443</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -6993,7 +6550,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1444</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHLAF14.536.L14-1444</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7008,7 +6564,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1445</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POLYCHRONIOU14.537.L14-1445</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7022,7 +6577,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1446</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WRBLEWSKA14.538.L14-1446</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7037,7 +6591,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1447</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LEBANI14.541.L14-1447</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7051,7 +6604,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1448</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CELEBI14.543.L14-1448</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7066,7 +6618,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1449</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JAWAID14.544.L14-1449</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7082,7 +6633,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1450</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHOLAKOV14.545.L14-1450</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7097,7 +6647,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1451</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROMEO14.546.L14-1451</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7114,7 +6663,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1452</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOPEZ14.549.L14-1452</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7131,7 +6679,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1453</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DELEGER14.552.L14-1453</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7145,7 +6692,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1454</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLESSA14.553.L14-1454</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7162,7 +6708,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1455</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FRONTINI14.556.L14-1455</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7178,7 +6723,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1456</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SALAMA14.558.L14-1456</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7193,7 +6737,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1457</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FLICKINGER14.562.L14-1457</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7209,7 +6752,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1458</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CASELLI14.563.L14-1458</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7222,7 +6764,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1459</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DRAXLER14.564.L14-1459</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7236,7 +6777,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1460</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CRASBORN14.567.L14-1460</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7251,7 +6791,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1461</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FULLER14.568.L14-1461</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7266,7 +6805,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1462</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HERRMANN14.569.L14-1462</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7283,7 +6821,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1463</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PALLOTTI14.570.L14-1463</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7298,7 +6835,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1464</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WITTMANN14.574.L14-1464</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7315,7 +6851,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1465</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELASRI14.575.L14-1465</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7330,7 +6865,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1466</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELASRI14.576.L14-1466</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7345,7 +6879,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1467</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FRIEDRICH14.578.L14-1467</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7359,7 +6892,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1468</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEDE14.579.L14-1468</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7374,7 +6906,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1469</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HATHOUT14.58.L14-1469</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7390,7 +6921,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1470</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOHK14.582.L14-1470</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7406,7 +6936,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1471</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROMEO14.583.L14-1471</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7423,7 +6952,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1472</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FORSTER14.585.L14-1472</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7441,7 +6969,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1473</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CANDEIAS14.587.L14-1473</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7454,7 +6981,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1474</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALANSARY14.588.L14-1474</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7469,7 +6995,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1475</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOPEZDELACALLE14.589.L14-1475</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7485,7 +7010,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1476</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AW14.59.L14-1476</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7501,7 +7025,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1477</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DELLORLETTA14.590.L14-1477</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7517,7 +7040,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1478</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COSTANTINI14.591.L14-1478</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7538,7 +7060,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1479</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PASHA14.593.L14-1479</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7551,7 +7072,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1480</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUMAR14.594.L14-1480</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7567,7 +7087,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1481</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FEELY14.596.L14-1481</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7581,7 +7100,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1482</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DESMET14.597.L14-1482</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7595,7 +7113,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1483</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KPER14.599.L14-1483</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7611,7 +7128,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1484</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WOLFE14.6.L14-1484</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7629,7 +7145,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1485</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HUANG14.60.L14-1485</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7645,7 +7160,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1486</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GUILLAUME14.602.L14-1486</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7661,7 +7175,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1487</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NEVEOL14.604.L14-1487</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7682,7 +7195,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1488</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOYD14.606.L14-1488</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7700,7 +7212,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1489</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ADESAM14.607.L14-1489</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7714,7 +7225,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1490</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JAWAID14.610.L14-1490</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7729,7 +7239,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1491</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHULLER14.611.L14-1491</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7744,7 +7253,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1492</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RELLO14.612.L14-1492</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7758,7 +7266,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1493</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHEN14.616.L14-1493</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7773,7 +7280,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1494</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARCIAFERNANDEZ14.617.L14-1494</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7787,7 +7293,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1495</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOODWIN14.618.L14-1495</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7803,7 +7308,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1496</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PADR14.619.L14-1496</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7816,7 +7320,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1497</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIONE14.62.L14-1497</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7831,7 +7334,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1498</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALTHOBAITI14.621.L14-1498</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7846,7 +7348,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1499</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HWANG14.624.L14-1499</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7859,7 +7360,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1500</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAYASHI14.627.L14-1500</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7876,7 +7376,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1501</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CASSIDY14.628.L14-1501</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7891,7 +7390,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1502</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CULY14.63.L14-1502</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7906,7 +7404,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1503</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TEMNIKOVA14.630.L14-1503</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7924,7 +7421,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1504</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WU14.632.L14-1504</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7937,7 +7433,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1505</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SATO14.633.L14-1505</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7950,7 +7445,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1506</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HOCHGESANG14.634.L14-1506</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7965,7 +7459,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1507</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POPESCU14.636.L14-1507</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7978,7 +7471,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1508</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BENDER14.639.L14-1508</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -7993,7 +7485,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1509</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RODRGUEZVZQUEZ14.640.L14-1509</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8007,7 +7498,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1510</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>COTTERELL14.641.L14-1510</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8022,7 +7512,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1511</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OMODEI14.643.L14-1511</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8038,7 +7527,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1512</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANERP14.645.L14-1512</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8054,7 +7542,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1513</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LIU14.646.L14-1513</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8072,7 +7559,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1514</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGUIAR14.647.L14-1514</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8086,7 +7572,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1515</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORI14.648.L14-1515</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8105,7 +7590,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1516</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CRISTOFORETTI14.650.L14-1516</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8120,7 +7604,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1517</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HLADEK14.656.L14-1517</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8137,7 +7620,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1518</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>QUASTHOFF14.657.L14-1518</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8151,7 +7633,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1519</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOGACHEVA14.658.L14-1519</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8165,7 +7646,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1520</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GANITKEVITCH14.659.L14-1520</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8182,7 +7662,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1521</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VANZAANEN14.66.L14-1521</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8202,7 +7681,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1522</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PADR14.660.L14-1522</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8215,7 +7693,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1523</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>THURMAIR14.661.L14-1523</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8230,7 +7707,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1524</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VILLEGAS14.664.L14-1524</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8245,7 +7721,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1525</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DTREZ14.665.L14-1525</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8258,7 +7733,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1526</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETASIS14.669.L14-1526</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8272,7 +7746,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1527</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAYNARD14.67.L14-1527</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8287,7 +7760,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1528</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARTOLA14.670.L14-1528</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8300,7 +7772,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1529</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LFARSDTTIR14.672.L14-1529</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8315,7 +7786,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1530</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SANGUINETTI14.674.L14-1530</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8335,7 +7805,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1531</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TEMNIKOVA14.675.L14-1531</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8350,7 +7819,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1532</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SERETAN14.676.L14-1532</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8365,7 +7833,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1533</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HELGADTTIR14.677.L14-1533</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8379,7 +7846,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1534</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DAILLE14.679.L14-1534</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8393,7 +7859,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1535</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PLEVA14.680.L14-1535</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8408,7 +7873,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1536</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ORAVECZ14.681.L14-1536</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8424,7 +7888,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1537</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SACHDEVA14.682.L14-1537</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8438,7 +7901,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1538</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DIBUONO14.686.L14-1538</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8454,7 +7916,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1539</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WATTAM14.687.L14-1539</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8472,7 +7933,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1540</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAHM14.688.L14-1540</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8488,7 +7948,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1541</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CALLEJAS14.689.L14-1541</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8502,7 +7961,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1542</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGI14.690.L14-1542</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8517,7 +7975,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1543</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FRANCOM14.691.L14-1543</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8535,7 +7992,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1544</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PHO14.692.L14-1544</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8551,7 +8007,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1545</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGI14.694.L14-1545</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8564,7 +8019,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1546</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRETTER14.695.L14-1546</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8579,7 +8033,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1547</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GHAYOOMI14.696.L14-1547</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8594,7 +8047,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1548</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAETZEL14.697.L14-1548</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8611,7 +8063,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1549</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OROZCOARROYAVE14.7.L14-1549</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8625,7 +8076,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1550</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARTENS14.70.L14-1550</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8640,7 +8090,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1551</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ANICK14.701.L14-1551</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8654,7 +8103,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1552</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLIEGR14.703.L14-1552</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8669,7 +8117,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1553</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BEJEK14.704.L14-1553</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8686,7 +8133,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1554</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HEYLEN14.706.L14-1554</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8702,7 +8148,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1555</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GALINSKAYA14.708.L14-1555</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8722,7 +8167,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1556</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAKTI14.709.L14-1556</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8737,7 +8181,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1557</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BIGI14.71.L14-1557</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8752,7 +8195,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1558</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZGANK14.710.L14-1558</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8769,7 +8211,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1559</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARTOLINI14.712.L14-1559</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8782,7 +8223,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1560</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DAUDARAVICIUS14.714.L14-1560</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8796,7 +8236,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1561</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VARJOKALLIO14.715.L14-1561</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8812,7 +8251,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1562</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ISHIMOTO14.716.L14-1562</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8827,7 +8265,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1563</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NOGUCHI14.717.L14-1563</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8844,7 +8281,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1564</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GORISCH14.719.L14-1564</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8859,7 +8295,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1565</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZINSMEISTER14.721.L14-1565</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8876,7 +8311,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1566</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUSKO14.722.L14-1566</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8890,7 +8324,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1567</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KORDONI14.723.L14-1567</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8906,7 +8339,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1568</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GIRARDI14.726.L14-1568</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8922,7 +8354,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1569</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORO14.727.L14-1569</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8936,7 +8367,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1570</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZNOTINS14.729.L14-1570</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8951,7 +8381,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1571</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MITOCARIU14.73.L14-1571</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8965,7 +8394,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1572</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHRIZMAN14.730.L14-1572</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8981,7 +8409,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1573</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LAVERGNE14.732.L14-1573</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -8997,7 +8424,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1574</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DECLERCQ14.733.L14-1574</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9012,7 +8438,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1575</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PCHEUX14.735.L14-1575</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9029,7 +8454,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1576</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RODRIGUEZFUENTES14.736.L14-1576</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9043,7 +8467,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1577</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARGETT14.737.L14-1577</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9057,7 +8480,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1578</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TOGIA14.738.L14-1578</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9077,7 +8499,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1579</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARCIAMATEO14.739.L14-1579</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9093,7 +8514,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1580</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FUJITA14.74.L14-1580</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9114,7 +8534,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1581</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VIRGINIE14.741.L14-1581</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9131,7 +8550,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1582</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BANSKI14.743.L14-1582</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9149,7 +8567,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1583</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ODRIOZOLA14.744.L14-1583</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9164,7 +8581,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1584</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARGETT14.745.L14-1584</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9180,7 +8596,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1585</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CLAUDELACHENAUD14.747.L14-1585</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9197,7 +8612,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1586</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOCKLET14.748.L14-1586</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9212,7 +8626,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1587</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CABRIO14.750.L14-1587</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9228,7 +8641,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1588</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROY14.751.L14-1588</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9244,7 +8656,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1589</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOPEZ14.753.L14-1589</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9257,7 +8668,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1590</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FERRET14.754.L14-1590</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9272,7 +8682,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1591</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BALVET14.755.L14-1591</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9287,7 +8696,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1592</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOTO14.756.L14-1592</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9303,7 +8711,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1593</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WONG14.758.L14-1593</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9319,7 +8726,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1594</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORI14.763.L14-1594</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9334,7 +8740,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1595</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KIRSCHNICK14.764.L14-1595</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9350,7 +8755,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1596</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAWDEN14.766.L14-1596</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9363,7 +8767,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1597</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WOLISKI14.768.L14-1597</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9379,7 +8782,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1598</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DRAGONI14.769.L14-1598</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9397,7 +8799,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1599</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUDZYNSKA14.77.L14-1599</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9411,7 +8812,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1600</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LONSDALE14.770.L14-1600</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9433,7 +8833,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1601</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LUZZATI14.771.L14-1601</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9450,7 +8849,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1602</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHERRER14.772.L14-1602</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9465,7 +8863,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1603</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VERNEROV14.773.L14-1603</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9486,7 +8883,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1604</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TIAN14.774.L14-1604</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9501,7 +8897,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1605</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AGERRI14.775.L14-1605</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9516,7 +8911,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1606</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MATSUYOSHI14.777.L14-1606</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9535,7 +8929,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1607</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHERIF14.780.L14-1607</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9551,7 +8944,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1608</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOSCA14.781.L14-1608</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9567,7 +8959,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1609</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DROBAC14.784.L14-1609</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9589,7 +8980,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1610</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PIPERIDIS14.786.L14-1610</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9604,7 +8994,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1611</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAUR14.787.L14-1611</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9619,7 +9008,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1612</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DELGRATTA14.788.L14-1612</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9633,7 +9021,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1613</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STEPANOV14.789.L14-1613</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9646,7 +9033,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1614</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RYSOVA14.79.L14-1614</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9662,7 +9048,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1615</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>POCH14.791.L14-1615</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9676,7 +9061,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1616</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HANOKA14.792.L14-1616</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9690,7 +9074,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1617</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BORG14.793.L14-1617</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9703,7 +9086,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1618</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAUKSDTTIR14.795.L14-1618</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9717,7 +9099,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1619</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SCHERRER14.797.L14-1619</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9734,7 +9115,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1620</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TAVAREZ14.799.L14-1620</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9749,7 +9129,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1621</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MORCHID14.8.L14-1621</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9762,7 +9141,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1622</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SNCHEZMARCO14.801.L14-1622</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9778,7 +9156,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1623</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AKER14.803.L14-1623</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9791,7 +9168,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1624</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>REYNAERT14.804.L14-1624</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9807,7 +9183,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1625</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RUBINO14.807.L14-1625</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9820,7 +9195,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1626</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PIMENTEL14.808.L14-1626</bibkey>
 </paper>
@@ -9832,7 +9206,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1627</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEEKER14.809.L14-1627</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9850,7 +9223,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1628</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EHRMANN14.810.L14-1628</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9867,7 +9239,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1629</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KIOMOURTZIS14.813.L14-1629</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9884,7 +9255,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1630</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HENRIKSEN14.814.L14-1630</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9902,7 +9272,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1631</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NASR14.816.L14-1631</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9916,7 +9285,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1632</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LAFOURCADE14.817.L14-1632</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9931,7 +9299,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1633</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SIMI14.818.L14-1633</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9946,7 +9313,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1634</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CIELIEBAK14.820.L14-1634</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9960,7 +9326,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1635</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RICHARDSON14.823.L14-1635</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9974,7 +9339,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1636</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SONNTAG14.824.L14-1636</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -9989,7 +9353,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1637</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAREJALORA14.826.L14-1637</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10004,7 +9367,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1638</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JIN14.828.L14-1638</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10020,7 +9382,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1639</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>UTT14.829.L14-1639</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10037,7 +9398,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1640</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>TANG14.83.L14-1640</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10059,7 +9419,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1641</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KOUTSOMBOGERA14.832.L14-1641</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10074,7 +9433,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1642</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LJUBEI14.834.L14-1642</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10093,7 +9451,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1643</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOJAR14.835.L14-1643</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10108,7 +9465,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1644</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NECSULESCU14.837.L14-1644</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10124,7 +9480,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1645</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHALAMANDARIS14.838.L14-1645</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10138,7 +9493,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1646</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CYBULSKA14.840.L14-1646</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10152,7 +9506,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1647</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LJUBEI14.841.L14-1647</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10166,7 +9519,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1648</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KUPIETZ14.842.L14-1648</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10179,7 +9531,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1649</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HSIEH14.843.L14-1649</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10192,7 +9543,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1650</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KHAN14.844.L14-1650</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10208,7 +9558,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1651</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LLEWELLYN14.845.L14-1651</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10224,7 +9573,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1652</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SKADI14.846.L14-1652</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10242,7 +9590,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1653</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAKS14.847.L14-1653</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10258,7 +9605,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1654</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHINEARIOS14.848.L14-1654</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10276,7 +9622,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1655</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STRTGEN14.849.L14-1655</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10290,7 +9635,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1656</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLINGER14.85.L14-1656</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10308,7 +9652,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1657</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOUAYADAGHA14.850.L14-1657</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10323,7 +9666,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1658</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SEVERO14.851.L14-1658</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10340,7 +9682,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1659</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ECKART14.852.L14-1659</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10357,7 +9698,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1660</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BENKOUSSAS14.853.L14-1660</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10374,7 +9714,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1661</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>INGASON14.855.L14-1661</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10391,7 +9730,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1662</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RDER14.856.L14-1662</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10406,7 +9744,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1663</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CARDEOSOPAYO14.857.L14-1663</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10422,7 +9759,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1664</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>STADTSCHNITZER14.858.L14-1664</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10436,7 +9772,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1665</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LOUKACHEVITCH14.859.L14-1665</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10452,7 +9787,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1666</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FOTH14.860.L14-1666</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10471,7 +9805,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1667</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GALAT14.862.L14-1667</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10487,7 +9820,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1668</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GRACIA14.863.L14-1668</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10500,7 +9832,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1669</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CS14.864.L14-1669</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10514,7 +9845,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1670</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GLASER14.865.L14-1670</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10529,7 +9859,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1671</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>EREKHINSKAYA14.866.L14-1671</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10543,7 +9872,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1672</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZARROUK14.867.L14-1672</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10559,7 +9887,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1673</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PEREZROSAS14.869.L14-1673</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10574,7 +9901,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1674</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GOLDMAN14.870.L14-1674</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10590,7 +9916,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1675</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ABDELALI14.877.L14-1675</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10606,7 +9931,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1676</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PRETKALNIA14.879.L14-1676</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10620,7 +9944,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1677</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KE14.88.L14-1677</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10634,7 +9957,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1678</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KDZIA14.882.L14-1678</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10649,7 +9971,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1679</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SAMVELIAN14.883.L14-1679</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10664,7 +9985,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1680</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HORBACH14.887.L14-1680</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10679,7 +9999,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1681</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG14.889.L14-1681</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10700,7 +10019,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1682</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KLATTER14.89.L14-1682</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10717,7 +10035,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1683</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BJRKELUND14.891.L14-1683</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10733,7 +10050,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1684</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>VOLODINA14.892.L14-1684</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10746,7 +10062,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1685</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHIARCOS14.893.L14-1685</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10761,7 +10076,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1686</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LITTELL14.896.L14-1686</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10777,7 +10091,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1687</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHARTON14.899.L14-1687</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10793,7 +10106,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1688</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARRANZ14.9.L14-1688</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10807,7 +10119,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1689</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KAWAHARA14.90.L14-1689</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10820,7 +10131,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1690</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AMARO14.900.L14-1690</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10835,7 +10145,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1691</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>OSTANKOV14.902.L14-1691</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10848,7 +10157,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1692</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>JURGENS14.904.L14-1692</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10866,7 +10174,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1693</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ALFANO14.906.L14-1693</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10879,7 +10186,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1694</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PARRAESCARTN14.909.L14-1694</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10893,7 +10199,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1695</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BHASHEMI14.911.L14-1695</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10906,7 +10211,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1696</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARTIN14.912.L14-1696</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10921,7 +10225,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1697</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BUITELAAR14.913.L14-1697</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10936,7 +10239,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1698</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IRVINE14.914.L14-1698</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10954,7 +10256,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1699</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROSA14.915.L14-1699</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10968,7 +10269,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1700</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>WANG14.916.L14-1700</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10981,7 +10281,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1701</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GARCIA14.918.L14-1701</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -10994,7 +10293,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1702</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ABDULMAGEED14.919.L14-1702</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11007,7 +10305,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1703</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZADEH14.920.L14-1703</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11020,7 +10317,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1704</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BOTT14.921.L14-1704</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11033,7 +10329,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1705</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEY14.922.L14-1705</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11052,7 +10347,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1706</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>IDE14.926.L14-1706</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11066,7 +10360,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1707</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHRISTODOULIDES14.929.L14-1707</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11081,7 +10374,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1708</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MAIXUAN14.930.L14-1708</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11094,7 +10386,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1709</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PESHKOV14.931.L14-1709</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11109,7 +10400,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1710</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ABEL14.934.L14-1710</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11123,7 +10413,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1711</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BARANCIKOVA14.935.L14-1711</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11137,7 +10426,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1712</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>FAESSLER14.936.L14-1712</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11153,7 +10441,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1713</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>KHAPRA14.94.L14-1713</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11174,7 +10461,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1714</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BAUMGARDT14.940.L14-1714</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11187,7 +10473,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1715</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DELTREDICI14.941.L14-1715</bibkey>
 </paper>
@@ -11202,7 +10487,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1716</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>HAJLAOUI14.943.L14-1716</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11218,7 +10502,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1717</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>MARIANI14.945.L14-1717</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11231,7 +10514,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1718</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SOURY14.947.L14-1718</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11246,7 +10528,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1719</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ROBALDO14.95.L14-1719</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11259,7 +10540,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1720</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BJARNADTTIR14.954.L14-1720</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11279,7 +10559,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1721</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZAGHOUANI14.956.L14-1721</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11293,7 +10572,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1722</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PELLEGRINI14.959.L14-1722</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11307,7 +10585,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1723</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>CHENG14.96.L14-1723</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11323,7 +10600,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1724</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BENJANNET14.960.L14-1724</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11338,7 +10614,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1725</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ARAKI14.963.L14-1725</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11352,7 +10627,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1726</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>SHAH14.964.L14-1726</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11371,7 +10645,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1727</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BALAHUR14.965.L14-1727</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11384,7 +10657,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1728</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>BINGEL14.967.L14-1728</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11397,7 +10669,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1729</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LACROIX14.970.L14-1729</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11410,7 +10681,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1730</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>AI14.971.L14-1730</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11424,7 +10694,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1731</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZERVANOU14.973.L14-1731</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11439,7 +10708,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1732</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ELLIOT14.975.L14-1732</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11453,7 +10721,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1733</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PETERSON14.977.L14-1733</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11468,7 +10735,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1734</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LAPPONI14.978.L14-1734</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11482,7 +10748,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1735</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LABROPOULOU14.979.L14-1735</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11495,7 +10760,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1736</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEGROC14.980.L14-1736</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11509,7 +10773,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1737</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>PAL14.982.L14-1737</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11523,7 +10786,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1738</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>LANDSBERGEN14.983.L14-1738</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11538,7 +10800,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1739</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>YATES14.985.L14-1739</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11553,7 +10814,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1740</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>URESOVA14.99.L14-1740</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11568,7 +10828,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1741</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>NGONGANGOMO14.990.L14-1741</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11582,7 +10841,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1742</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>DEGROC14.991.L14-1742</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11595,7 +10853,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1743</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>GORNOSTAY14.992.L14-1743</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11609,7 +10866,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1744</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ASADULLAH14.995.L14-1744</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11622,7 +10878,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1745</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>ZAMPIERI14.996.L14-1745</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>
@@ -11639,7 +10894,6 @@
   <year>2014</year>
   <address>Reykjavik, Iceland</address>
   <publisher>European Language Resources Association (ELRA)</publisher>
-  <url>http://www.aclweb.org/anthology/L14-1746</url>
   <bibtype>inproceedings</bibtype>
   <bibkey>RETTINGER14.998.L14-1746</bibkey>
   <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (LREC’14)</booktitle>

--- a/data/xml/L18.xml
+++ b/data/xml/L18.xml
@@ -43,7 +43,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-621</url>
+    <url>http://www.aclweb.org/anthology/L18-1001</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1002">
@@ -73,7 +73,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-568</url>
+    <url>http://www.aclweb.org/anthology/L18-1002</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1003">
@@ -91,7 +91,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-678</url>
+    <url>http://www.aclweb.org/anthology/L18-1003</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1004">
@@ -117,7 +117,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-282</url>
+    <url>http://www.aclweb.org/anthology/L18-1004</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1005">
@@ -143,7 +143,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-381</url>
+    <url>http://www.aclweb.org/anthology/L18-1005</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1006">
@@ -161,7 +161,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-78</url>
+    <url>http://www.aclweb.org/anthology/L18-1006</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1007">
@@ -179,7 +179,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-174</url>
+    <url>http://www.aclweb.org/anthology/L18-1007</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1008">
@@ -209,7 +209,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-721</url>
+    <url>http://www.aclweb.org/anthology/L18-1008</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1009">
@@ -235,7 +235,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1056</url>
+    <url>http://www.aclweb.org/anthology/L18-1009</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1010">
@@ -253,7 +253,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1059</url>
+    <url>http://www.aclweb.org/anthology/L18-1010</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1011">
@@ -279,7 +279,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-274</url>
+    <url>http://www.aclweb.org/anthology/L18-1011</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1012">
@@ -317,7 +317,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-337</url>
+    <url>http://www.aclweb.org/anthology/L18-1012</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1013">
@@ -343,7 +343,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-356</url>
+    <url>http://www.aclweb.org/anthology/L18-1013</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1014">
@@ -377,7 +377,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-357</url>
+    <url>http://www.aclweb.org/anthology/L18-1014</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1015">
@@ -423,7 +423,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-562</url>
+    <url>http://www.aclweb.org/anthology/L18-1015</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1016">
@@ -441,7 +441,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-187</url>
+    <url>http://www.aclweb.org/anthology/L18-1016</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1017">
@@ -499,7 +499,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-672</url>
+    <url>http://www.aclweb.org/anthology/L18-1017</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1018">
@@ -525,7 +525,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-824</url>
+    <url>http://www.aclweb.org/anthology/L18-1018</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1019">
@@ -567,7 +567,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-987</url>
+    <url>http://www.aclweb.org/anthology/L18-1019</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1020">
@@ -589,7 +589,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1099</url>
+    <url>http://www.aclweb.org/anthology/L18-1020</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1021">
@@ -611,7 +611,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-313</url>
+    <url>http://www.aclweb.org/anthology/L18-1021</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1022">
@@ -625,7 +625,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-397</url>
+    <url>http://www.aclweb.org/anthology/L18-1022</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1023">
@@ -643,7 +643,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-504</url>
+    <url>http://www.aclweb.org/anthology/L18-1023</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1024">
@@ -673,7 +673,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-894</url>
+    <url>http://www.aclweb.org/anthology/L18-1024</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1025">
@@ -723,7 +723,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-952</url>
+    <url>http://www.aclweb.org/anthology/L18-1025</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1026">
@@ -741,7 +741,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-256</url>
+    <url>http://www.aclweb.org/anthology/L18-1026</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1027">
@@ -755,7 +755,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-329</url>
+    <url>http://www.aclweb.org/anthology/L18-1027</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1028">
@@ -773,7 +773,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-402</url>
+    <url>http://www.aclweb.org/anthology/L18-1028</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1029">
@@ -807,7 +807,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-838</url>
+    <url>http://www.aclweb.org/anthology/L18-1029</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1030">
@@ -825,7 +825,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-957</url>
+    <url>http://www.aclweb.org/anthology/L18-1030</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1031">
@@ -851,7 +851,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-161</url>
+    <url>http://www.aclweb.org/anthology/L18-1031</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1032">
@@ -869,7 +869,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-7</url>
+    <url>http://www.aclweb.org/anthology/L18-1032</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1033">
@@ -887,7 +887,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-393</url>
+    <url>http://www.aclweb.org/anthology/L18-1033</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1034">
@@ -905,7 +905,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-917</url>
+    <url>http://www.aclweb.org/anthology/L18-1034</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1035">
@@ -927,7 +927,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1118</url>
+    <url>http://www.aclweb.org/anthology/L18-1035</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1036">
@@ -949,7 +949,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-27</url>
+    <url>http://www.aclweb.org/anthology/L18-1036</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1037">
@@ -995,7 +995,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-66</url>
+    <url>http://www.aclweb.org/anthology/L18-1037</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1038">
@@ -1017,7 +1017,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-193</url>
+    <url>http://www.aclweb.org/anthology/L18-1038</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1039">
@@ -1043,7 +1043,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-769</url>
+    <url>http://www.aclweb.org/anthology/L18-1039</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1040">
@@ -1073,7 +1073,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-612</url>
+    <url>http://www.aclweb.org/anthology/L18-1040</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1041">
@@ -1099,7 +1099,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-37</url>
+    <url>http://www.aclweb.org/anthology/L18-1041</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1042">
@@ -1144,7 +1144,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-229</url>
+    <url>http://www.aclweb.org/anthology/L18-1042</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1043">
@@ -1170,7 +1170,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-854</url>
+    <url>http://www.aclweb.org/anthology/L18-1043</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1044">
@@ -1204,7 +1204,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1088</url>
+    <url>http://www.aclweb.org/anthology/L18-1044</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1045">
@@ -1222,7 +1222,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-36</url>
+    <url>http://www.aclweb.org/anthology/L18-1045</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1046">
@@ -1240,7 +1240,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-650</url>
+    <url>http://www.aclweb.org/anthology/L18-1046</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1047">
@@ -1254,7 +1254,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-958</url>
+    <url>http://www.aclweb.org/anthology/L18-1047</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1048">
@@ -1280,7 +1280,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1052</url>
+    <url>http://www.aclweb.org/anthology/L18-1048</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1049">
@@ -1302,7 +1302,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-210</url>
+    <url>http://www.aclweb.org/anthology/L18-1049</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1050">
@@ -1324,7 +1324,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-579</url>
+    <url>http://www.aclweb.org/anthology/L18-1050</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1051">
@@ -1342,7 +1342,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-880</url>
+    <url>http://www.aclweb.org/anthology/L18-1051</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1052">
@@ -1360,7 +1360,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-951</url>
+    <url>http://www.aclweb.org/anthology/L18-1052</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1053">
@@ -1378,7 +1378,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-729</url>
+    <url>http://www.aclweb.org/anthology/L18-1053</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1054">
@@ -1396,7 +1396,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-874</url>
+    <url>http://www.aclweb.org/anthology/L18-1054</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1055">
@@ -1418,7 +1418,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1012</url>
+    <url>http://www.aclweb.org/anthology/L18-1055</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1056">
@@ -1436,7 +1436,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-891</url>
+    <url>http://www.aclweb.org/anthology/L18-1056</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1057">
@@ -1458,7 +1458,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-40</url>
+    <url>http://www.aclweb.org/anthology/L18-1057</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1058">
@@ -1472,7 +1472,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-84</url>
+    <url>http://www.aclweb.org/anthology/L18-1058</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1059">
@@ -1486,7 +1486,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-178</url>
+    <url>http://www.aclweb.org/anthology/L18-1059</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1060">
@@ -1508,7 +1508,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-183</url>
+    <url>http://www.aclweb.org/anthology/L18-1060</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1061">
@@ -1534,7 +1534,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-325</url>
+    <url>http://www.aclweb.org/anthology/L18-1061</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1062">
@@ -1552,7 +1552,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-328</url>
+    <url>http://www.aclweb.org/anthology/L18-1062</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1063">
@@ -1590,7 +1590,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-740</url>
+    <url>http://www.aclweb.org/anthology/L18-1063</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1064">
@@ -1620,7 +1620,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-899</url>
+    <url>http://www.aclweb.org/anthology/L18-1064</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1065">
@@ -1642,7 +1642,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-941</url>
+    <url>http://www.aclweb.org/anthology/L18-1065</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1066">
@@ -1672,7 +1672,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-50</url>
+    <url>http://www.aclweb.org/anthology/L18-1066</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1067">
@@ -1690,7 +1690,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-67</url>
+    <url>http://www.aclweb.org/anthology/L18-1067</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1068">
@@ -1708,7 +1708,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-272</url>
+    <url>http://www.aclweb.org/anthology/L18-1068</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1069">
@@ -1758,7 +1758,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-286</url>
+    <url>http://www.aclweb.org/anthology/L18-1069</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1070">
@@ -1780,7 +1780,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-319</url>
+    <url>http://www.aclweb.org/anthology/L18-1070</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1071">
@@ -1798,7 +1798,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-326</url>
+    <url>http://www.aclweb.org/anthology/L18-1071</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1072">
@@ -1816,7 +1816,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-327</url>
+    <url>http://www.aclweb.org/anthology/L18-1072</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1073">
@@ -1878,7 +1878,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-515</url>
+    <url>http://www.aclweb.org/anthology/L18-1073</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1074">
@@ -1900,7 +1900,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-582</url>
+    <url>http://www.aclweb.org/anthology/L18-1074</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1075">
@@ -1950,7 +1950,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-677</url>
+    <url>http://www.aclweb.org/anthology/L18-1075</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1076">
@@ -1964,7 +1964,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-978</url>
+    <url>http://www.aclweb.org/anthology/L18-1076</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1077">
@@ -1982,7 +1982,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-153</url>
+    <url>http://www.aclweb.org/anthology/L18-1077</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1078">
@@ -2024,7 +2024,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-208</url>
+    <url>http://www.aclweb.org/anthology/L18-1078</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1079">
@@ -2058,7 +2058,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-213</url>
+    <url>http://www.aclweb.org/anthology/L18-1079</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1080">
@@ -2076,7 +2076,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-278</url>
+    <url>http://www.aclweb.org/anthology/L18-1080</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1081">
@@ -2106,7 +2106,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-298</url>
+    <url>http://www.aclweb.org/anthology/L18-1081</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1082">
@@ -2124,7 +2124,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-310</url>
+    <url>http://www.aclweb.org/anthology/L18-1082</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1083">
@@ -2142,7 +2142,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-349</url>
+    <url>http://www.aclweb.org/anthology/L18-1083</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1084">
@@ -2160,7 +2160,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-368</url>
+    <url>http://www.aclweb.org/anthology/L18-1084</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1085">
@@ -2190,7 +2190,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-436</url>
+    <url>http://www.aclweb.org/anthology/L18-1085</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1086">
@@ -2292,7 +2292,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-157</url>
+    <url>http://www.aclweb.org/anthology/L18-1086</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1087">
@@ -2310,7 +2310,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-262</url>
+    <url>http://www.aclweb.org/anthology/L18-1087</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1088">
@@ -2336,7 +2336,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-639</url>
+    <url>http://www.aclweb.org/anthology/L18-1088</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1089">
@@ -2358,7 +2358,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-707</url>
+    <url>http://www.aclweb.org/anthology/L18-1089</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1090">
@@ -2376,7 +2376,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-869</url>
+    <url>http://www.aclweb.org/anthology/L18-1090</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1091">
@@ -2398,7 +2398,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-886</url>
+    <url>http://www.aclweb.org/anthology/L18-1091</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1092">
@@ -2424,7 +2424,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-144</url>
+    <url>http://www.aclweb.org/anthology/L18-1092</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1093">
@@ -2450,7 +2450,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-263</url>
+    <url>http://www.aclweb.org/anthology/L18-1093</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1094">
@@ -2472,7 +2472,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-287</url>
+    <url>http://www.aclweb.org/anthology/L18-1094</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1095">
@@ -2494,7 +2494,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-787</url>
+    <url>http://www.aclweb.org/anthology/L18-1095</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1096">
@@ -2508,7 +2508,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1080</url>
+    <url>http://www.aclweb.org/anthology/L18-1096</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1097">
@@ -2530,7 +2530,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-58</url>
+    <url>http://www.aclweb.org/anthology/L18-1097</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1098">
@@ -2548,7 +2548,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-95</url>
+    <url>http://www.aclweb.org/anthology/L18-1098</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1099">
@@ -2570,7 +2570,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-126</url>
+    <url>http://www.aclweb.org/anthology/L18-1099</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1100">
@@ -2588,7 +2588,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-146</url>
+    <url>http://www.aclweb.org/anthology/L18-1100</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1101">
@@ -2614,7 +2614,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-149</url>
+    <url>http://www.aclweb.org/anthology/L18-1101</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1102">
@@ -2636,7 +2636,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-160</url>
+    <url>http://www.aclweb.org/anthology/L18-1102</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1103">
@@ -2686,7 +2686,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-204</url>
+    <url>http://www.aclweb.org/anthology/L18-1103</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1104">
@@ -2708,7 +2708,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-217</url>
+    <url>http://www.aclweb.org/anthology/L18-1104</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1105">
@@ -2730,7 +2730,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-10</url>
+    <url>http://www.aclweb.org/anthology/L18-1105</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1106">
@@ -2744,7 +2744,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-49</url>
+    <url>http://www.aclweb.org/anthology/L18-1106</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1107">
@@ -2770,7 +2770,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-92</url>
+    <url>http://www.aclweb.org/anthology/L18-1107</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1108">
@@ -2788,7 +2788,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-253</url>
+    <url>http://www.aclweb.org/anthology/L18-1108</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1109">
@@ -2810,7 +2810,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-306</url>
+    <url>http://www.aclweb.org/anthology/L18-1109</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1110">
@@ -2828,7 +2828,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-355</url>
+    <url>http://www.aclweb.org/anthology/L18-1110</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1111">
@@ -2846,7 +2846,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-521</url>
+    <url>http://www.aclweb.org/anthology/L18-1111</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1112">
@@ -2868,7 +2868,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-107</url>
+    <url>http://www.aclweb.org/anthology/L18-1112</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1113">
@@ -2886,7 +2886,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-114</url>
+    <url>http://www.aclweb.org/anthology/L18-1113</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1114">
@@ -2900,7 +2900,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-314</url>
+    <url>http://www.aclweb.org/anthology/L18-1114</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1115">
@@ -2922,7 +2922,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-374</url>
+    <url>http://www.aclweb.org/anthology/L18-1115</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1116">
@@ -2944,7 +2944,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-947</url>
+    <url>http://www.aclweb.org/anthology/L18-1116</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1117">
@@ -2974,7 +2974,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-9</url>
+    <url>http://www.aclweb.org/anthology/L18-1117</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1118">
@@ -3008,7 +3008,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-168</url>
+    <url>http://www.aclweb.org/anthology/L18-1118</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1119">
@@ -3026,7 +3026,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-179</url>
+    <url>http://www.aclweb.org/anthology/L18-1119</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1120">
@@ -3084,7 +3084,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-186</url>
+    <url>http://www.aclweb.org/anthology/L18-1120</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1121">
@@ -3106,7 +3106,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-188</url>
+    <url>http://www.aclweb.org/anthology/L18-1121</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1122">
@@ -3120,7 +3120,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-192</url>
+    <url>http://www.aclweb.org/anthology/L18-1122</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1123">
@@ -3142,7 +3142,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-267</url>
+    <url>http://www.aclweb.org/anthology/L18-1123</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1124">
@@ -3168,7 +3168,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-305</url>
+    <url>http://www.aclweb.org/anthology/L18-1124</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1125">
@@ -3190,7 +3190,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-322</url>
+    <url>http://www.aclweb.org/anthology/L18-1125</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1126">
@@ -3208,7 +3208,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-456</url>
+    <url>http://www.aclweb.org/anthology/L18-1126</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1127">
@@ -3222,7 +3222,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-324</url>
+    <url>http://www.aclweb.org/anthology/L18-1127</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1128">
@@ -3240,7 +3240,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-371</url>
+    <url>http://www.aclweb.org/anthology/L18-1128</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1129">
@@ -3262,7 +3262,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-813</url>
+    <url>http://www.aclweb.org/anthology/L18-1129</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1130">
@@ -3280,7 +3280,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1024</url>
+    <url>http://www.aclweb.org/anthology/L18-1130</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1131">
@@ -3314,7 +3314,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1036</url>
+    <url>http://www.aclweb.org/anthology/L18-1131</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1132">
@@ -3332,7 +3332,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-159</url>
+    <url>http://www.aclweb.org/anthology/L18-1132</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1133">
@@ -3350,7 +3350,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-185</url>
+    <url>http://www.aclweb.org/anthology/L18-1133</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1134">
@@ -3372,7 +3372,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-222</url>
+    <url>http://www.aclweb.org/anthology/L18-1134</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1135">
@@ -3386,7 +3386,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-227</url>
+    <url>http://www.aclweb.org/anthology/L18-1135</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1136">
@@ -3412,7 +3412,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-232</url>
+    <url>http://www.aclweb.org/anthology/L18-1136</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1137">
@@ -3426,7 +3426,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-246</url>
+    <url>http://www.aclweb.org/anthology/L18-1137</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1138">
@@ -3448,7 +3448,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-364</url>
+    <url>http://www.aclweb.org/anthology/L18-1138</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1139">
@@ -3474,7 +3474,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-377</url>
+    <url>http://www.aclweb.org/anthology/L18-1139</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1140">
@@ -3492,7 +3492,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-439</url>
+    <url>http://www.aclweb.org/anthology/L18-1140</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1141">
@@ -3518,7 +3518,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-101</url>
+    <url>http://www.aclweb.org/anthology/L18-1141</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1142">
@@ -3544,7 +3544,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-121</url>
+    <url>http://www.aclweb.org/anthology/L18-1142</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1143">
@@ -3566,7 +3566,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-129</url>
+    <url>http://www.aclweb.org/anthology/L18-1143</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1144">
@@ -3588,7 +3588,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-139</url>
+    <url>http://www.aclweb.org/anthology/L18-1144</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1145">
@@ -3618,7 +3618,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-163</url>
+    <url>http://www.aclweb.org/anthology/L18-1145</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1146">
@@ -3640,7 +3640,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-195</url>
+    <url>http://www.aclweb.org/anthology/L18-1146</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1147">
@@ -3666,7 +3666,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-400</url>
+    <url>http://www.aclweb.org/anthology/L18-1147</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1148">
@@ -3688,7 +3688,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-432</url>
+    <url>http://www.aclweb.org/anthology/L18-1148</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1149">
@@ -3714,7 +3714,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-541</url>
+    <url>http://www.aclweb.org/anthology/L18-1149</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1150">
@@ -3732,7 +3732,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-774</url>
+    <url>http://www.aclweb.org/anthology/L18-1150</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1151">
@@ -3754,7 +3754,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-805</url>
+    <url>http://www.aclweb.org/anthology/L18-1151</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1152">
@@ -3772,7 +3772,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-96</url>
+    <url>http://www.aclweb.org/anthology/L18-1152</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1153">
@@ -3798,7 +3798,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-116</url>
+    <url>http://www.aclweb.org/anthology/L18-1153</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1154">
@@ -3824,7 +3824,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-118</url>
+    <url>http://www.aclweb.org/anthology/L18-1154</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1155">
@@ -3838,7 +3838,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-148</url>
+    <url>http://www.aclweb.org/anthology/L18-1155</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1156">
@@ -3860,7 +3860,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-247</url>
+    <url>http://www.aclweb.org/anthology/L18-1156</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1157">
@@ -3878,7 +3878,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-366</url>
+    <url>http://www.aclweb.org/anthology/L18-1157</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1158">
@@ -3904,7 +3904,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-458</url>
+    <url>http://www.aclweb.org/anthology/L18-1158</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1159">
@@ -3934,7 +3934,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-527</url>
+    <url>http://www.aclweb.org/anthology/L18-1159</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1160">
@@ -3956,7 +3956,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-571</url>
+    <url>http://www.aclweb.org/anthology/L18-1160</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1161">
@@ -3986,7 +3986,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-616</url>
+    <url>http://www.aclweb.org/anthology/L18-1161</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1162">
@@ -4016,7 +4016,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-100</url>
+    <url>http://www.aclweb.org/anthology/L18-1162</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1163">
@@ -4038,7 +4038,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-112</url>
+    <url>http://www.aclweb.org/anthology/L18-1163</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1164">
@@ -4072,7 +4072,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-182</url>
+    <url>http://www.aclweb.org/anthology/L18-1164</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1165">
@@ -4102,7 +4102,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-224</url>
+    <url>http://www.aclweb.org/anthology/L18-1165</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1166">
@@ -4124,7 +4124,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-250</url>
+    <url>http://www.aclweb.org/anthology/L18-1166</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1167">
@@ -4142,7 +4142,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-290</url>
+    <url>http://www.aclweb.org/anthology/L18-1167</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1168">
@@ -4172,7 +4172,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-736</url>
+    <url>http://www.aclweb.org/anthology/L18-1168</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1169">
@@ -4202,7 +4202,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-218</url>
+    <url>http://www.aclweb.org/anthology/L18-1169</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1170">
@@ -4220,7 +4220,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-248</url>
+    <url>http://www.aclweb.org/anthology/L18-1170</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1171">
@@ -4238,7 +4238,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-344</url>
+    <url>http://www.aclweb.org/anthology/L18-1171</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1172">
@@ -4252,7 +4252,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-412</url>
+    <url>http://www.aclweb.org/anthology/L18-1172</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1173">
@@ -4270,7 +4270,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-474</url>
+    <url>http://www.aclweb.org/anthology/L18-1173</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1174">
@@ -4292,7 +4292,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-626</url>
+    <url>http://www.aclweb.org/anthology/L18-1174</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1175">
@@ -4314,7 +4314,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-680</url>
+    <url>http://www.aclweb.org/anthology/L18-1175</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1176">
@@ -4332,7 +4332,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-691</url>
+    <url>http://www.aclweb.org/anthology/L18-1176</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1177">
@@ -4354,7 +4354,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-728</url>
+    <url>http://www.aclweb.org/anthology/L18-1177</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1178">
@@ -4384,7 +4384,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-865</url>
+    <url>http://www.aclweb.org/anthology/L18-1178</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1179">
@@ -4410,7 +4410,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-908</url>
+    <url>http://www.aclweb.org/anthology/L18-1179</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1180">
@@ -4428,7 +4428,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1072</url>
+    <url>http://www.aclweb.org/anthology/L18-1180</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1181">
@@ -4442,7 +4442,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1079</url>
+    <url>http://www.aclweb.org/anthology/L18-1181</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1182">
@@ -4468,7 +4468,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-30</url>
+    <url>http://www.aclweb.org/anthology/L18-1182</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1183">
@@ -4502,7 +4502,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-31</url>
+    <url>http://www.aclweb.org/anthology/L18-1183</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1184">
@@ -4524,7 +4524,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-214</url>
+    <url>http://www.aclweb.org/anthology/L18-1184</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1185">
@@ -4542,7 +4542,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-281</url>
+    <url>http://www.aclweb.org/anthology/L18-1185</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1186">
@@ -4560,7 +4560,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-295</url>
+    <url>http://www.aclweb.org/anthology/L18-1186</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1187">
@@ -4578,7 +4578,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-373</url>
+    <url>http://www.aclweb.org/anthology/L18-1187</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1188">
@@ -4608,7 +4608,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-385</url>
+    <url>http://www.aclweb.org/anthology/L18-1188</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1189">
@@ -4630,7 +4630,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-423</url>
+    <url>http://www.aclweb.org/anthology/L18-1189</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1190">
@@ -4656,7 +4656,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-426</url>
+    <url>http://www.aclweb.org/anthology/L18-1190</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1191">
@@ -4674,7 +4674,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-424</url>
+    <url>http://www.aclweb.org/anthology/L18-1191</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1192">
@@ -4700,7 +4700,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-61</url>
+    <url>http://www.aclweb.org/anthology/L18-1192</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1193">
@@ -4726,7 +4726,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-363</url>
+    <url>http://www.aclweb.org/anthology/L18-1193</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1194">
@@ -4760,7 +4760,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-462</url>
+    <url>http://www.aclweb.org/anthology/L18-1194</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1195">
@@ -4774,7 +4774,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-883</url>
+    <url>http://www.aclweb.org/anthology/L18-1195</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1196">
@@ -4800,7 +4800,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-923</url>
+    <url>http://www.aclweb.org/anthology/L18-1196</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1197">
@@ -4818,7 +4818,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-966</url>
+    <url>http://www.aclweb.org/anthology/L18-1197</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1198">
@@ -4848,7 +4848,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-998</url>
+    <url>http://www.aclweb.org/anthology/L18-1198</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1199">
@@ -4866,7 +4866,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1065</url>
+    <url>http://www.aclweb.org/anthology/L18-1199</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1200">
@@ -4892,7 +4892,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-307</url>
+    <url>http://www.aclweb.org/anthology/L18-1200</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1201">
@@ -4914,7 +4914,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-701</url>
+    <url>http://www.aclweb.org/anthology/L18-1201</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1202">
@@ -4944,7 +4944,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1006</url>
+    <url>http://www.aclweb.org/anthology/L18-1202</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1203">
@@ -4970,7 +4970,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-300</url>
+    <url>http://www.aclweb.org/anthology/L18-1203</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1204">
@@ -4992,7 +4992,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-336</url>
+    <url>http://www.aclweb.org/anthology/L18-1204</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1205">
@@ -5018,7 +5018,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-648</url>
+    <url>http://www.aclweb.org/anthology/L18-1205</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1206">
@@ -5072,7 +5072,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-662</url>
+    <url>http://www.aclweb.org/anthology/L18-1206</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1207">
@@ -5098,7 +5098,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-716</url>
+    <url>http://www.aclweb.org/anthology/L18-1207</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1208">
@@ -5140,7 +5140,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-730</url>
+    <url>http://www.aclweb.org/anthology/L18-1208</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1209">
@@ -5182,7 +5182,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-734</url>
+    <url>http://www.aclweb.org/anthology/L18-1209</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1210">
@@ -5204,7 +5204,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-829</url>
+    <url>http://www.aclweb.org/anthology/L18-1210</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1211">
@@ -5238,7 +5238,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-914</url>
+    <url>http://www.aclweb.org/anthology/L18-1211</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1212">
@@ -5256,7 +5256,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-938</url>
+    <url>http://www.aclweb.org/anthology/L18-1212</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1213">
@@ -5302,7 +5302,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1119</url>
+    <url>http://www.aclweb.org/anthology/L18-1213</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1214">
@@ -5336,7 +5336,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8882</url>
+    <url>http://www.aclweb.org/anthology/L18-1214</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1215">
@@ -5358,7 +5358,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8880</url>
+    <url>http://www.aclweb.org/anthology/L18-1215</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1216">
@@ -5392,7 +5392,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8883</url>
+    <url>http://www.aclweb.org/anthology/L18-1216</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1217">
@@ -5414,7 +5414,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-111</url>
+    <url>http://www.aclweb.org/anthology/L18-1217</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1218">
@@ -5428,7 +5428,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-131</url>
+    <url>http://www.aclweb.org/anthology/L18-1218</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1219">
@@ -5450,7 +5450,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-442</url>
+    <url>http://www.aclweb.org/anthology/L18-1219</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1220">
@@ -5471,7 +5471,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-502</url>
+    <url>http://www.aclweb.org/anthology/L18-1220</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1221">
@@ -5493,7 +5493,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-661</url>
+    <url>http://www.aclweb.org/anthology/L18-1221</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1222">
@@ -5519,7 +5519,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-110</url>
+    <url>http://www.aclweb.org/anthology/L18-1222</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1223">
@@ -5537,7 +5537,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-244</url>
+    <url>http://www.aclweb.org/anthology/L18-1223</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1224">
@@ -5563,7 +5563,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-321</url>
+    <url>http://www.aclweb.org/anthology/L18-1224</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1225">
@@ -5585,7 +5585,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-416</url>
+    <url>http://www.aclweb.org/anthology/L18-1225</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1226">
@@ -5611,7 +5611,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-861</url>
+    <url>http://www.aclweb.org/anthology/L18-1226</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1227">
@@ -5637,7 +5637,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-33</url>
+    <url>http://www.aclweb.org/anthology/L18-1227</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1228">
@@ -5659,7 +5659,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-268</url>
+    <url>http://www.aclweb.org/anthology/L18-1228</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1229">
@@ -5681,7 +5681,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-460</url>
+    <url>http://www.aclweb.org/anthology/L18-1229</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1230">
@@ -5707,7 +5707,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-892</url>
+    <url>http://www.aclweb.org/anthology/L18-1230</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1231">
@@ -5744,7 +5744,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1074</url>
+    <url>http://www.aclweb.org/anthology/L18-1231</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1232">
@@ -5766,7 +5766,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-29</url>
+    <url>http://www.aclweb.org/anthology/L18-1232</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1233">
@@ -5788,7 +5788,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-801</url>
+    <url>http://www.aclweb.org/anthology/L18-1233</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1234">
@@ -5814,7 +5814,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-920</url>
+    <url>http://www.aclweb.org/anthology/L18-1234</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1235">
@@ -5848,7 +5848,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-940</url>
+    <url>http://www.aclweb.org/anthology/L18-1235</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1236">
@@ -5870,7 +5870,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-618</url>
+    <url>http://www.aclweb.org/anthology/L18-1236</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1237">
@@ -5892,7 +5892,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-115</url>
+    <url>http://www.aclweb.org/anthology/L18-1237</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1238">
@@ -5922,7 +5922,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-390</url>
+    <url>http://www.aclweb.org/anthology/L18-1238</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1239">
@@ -5936,7 +5936,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-786</url>
+    <url>http://www.aclweb.org/anthology/L18-1239</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1240">
@@ -5954,7 +5954,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1111</url>
+    <url>http://www.aclweb.org/anthology/L18-1240</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1241">
@@ -5972,7 +5972,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-806</url>
+    <url>http://www.aclweb.org/anthology/L18-1241</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1242">
@@ -5990,7 +5990,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-963</url>
+    <url>http://www.aclweb.org/anthology/L18-1242</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1243">
@@ -6008,7 +6008,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-242</url>
+    <url>http://www.aclweb.org/anthology/L18-1243</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1244">
@@ -6038,7 +6038,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-234</url>
+    <url>http://www.aclweb.org/anthology/L18-1244</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1245">
@@ -6068,7 +6068,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1047</url>
+    <url>http://www.aclweb.org/anthology/L18-1245</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1246">
@@ -6094,7 +6094,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-790</url>
+    <url>http://www.aclweb.org/anthology/L18-1246</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1247">
@@ -6120,7 +6120,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-573</url>
+    <url>http://www.aclweb.org/anthology/L18-1247</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1248">
@@ -6142,7 +6142,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-569</url>
+    <url>http://www.aclweb.org/anthology/L18-1248</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1249">
@@ -6164,7 +6164,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-180</url>
+    <url>http://www.aclweb.org/anthology/L18-1249</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1250">
@@ -6202,7 +6202,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-270</url>
+    <url>http://www.aclweb.org/anthology/L18-1250</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1251">
@@ -6236,7 +6236,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-513</url>
+    <url>http://www.aclweb.org/anthology/L18-1251</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1252">
@@ -6266,7 +6266,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-581</url>
+    <url>http://www.aclweb.org/anthology/L18-1252</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1253">
@@ -6284,7 +6284,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8885</url>
+    <url>http://www.aclweb.org/anthology/L18-1253</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1254">
@@ -6310,7 +6310,6 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8881</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1255">
@@ -6356,7 +6355,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8888</url>
+    <url>http://www.aclweb.org/anthology/L18-1255</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1256">
@@ -6378,7 +6377,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-392</url>
+    <url>http://www.aclweb.org/anthology/L18-1256</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1257">
@@ -6396,7 +6395,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-679</url>
+    <url>http://www.aclweb.org/anthology/L18-1257</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1258">
@@ -6426,7 +6425,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-717</url>
+    <url>http://www.aclweb.org/anthology/L18-1258</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1259">
@@ -6444,7 +6443,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-20</url>
+    <url>http://www.aclweb.org/anthology/L18-1259</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1260">
@@ -6470,7 +6469,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-203</url>
+    <url>http://www.aclweb.org/anthology/L18-1260</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1261">
@@ -6500,7 +6499,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-949</url>
+    <url>http://www.aclweb.org/anthology/L18-1261</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1262">
@@ -6526,7 +6525,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-534</url>
+    <url>http://www.aclweb.org/anthology/L18-1262</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1263">
@@ -6548,7 +6547,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-770</url>
+    <url>http://www.aclweb.org/anthology/L18-1263</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1264">
@@ -6582,7 +6581,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-669</url>
+    <url>http://www.aclweb.org/anthology/L18-1264</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1265">
@@ -6608,7 +6607,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1020</url>
+    <url>http://www.aclweb.org/anthology/L18-1265</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1266">
@@ -6653,7 +6652,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-856</url>
+    <url>http://www.aclweb.org/anthology/L18-1266</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1267">
@@ -6679,7 +6678,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-553</url>
+    <url>http://www.aclweb.org/anthology/L18-1267</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1268">
@@ -6701,7 +6700,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-731</url>
+    <url>http://www.aclweb.org/anthology/L18-1268</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1269">
@@ -6719,7 +6718,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-757</url>
+    <url>http://www.aclweb.org/anthology/L18-1269</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1270">
@@ -6733,7 +6732,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1030</url>
+    <url>http://www.aclweb.org/anthology/L18-1270</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1271">
@@ -6755,7 +6754,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1069</url>
+    <url>http://www.aclweb.org/anthology/L18-1271</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1272">
@@ -6777,7 +6776,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1075</url>
+    <url>http://www.aclweb.org/anthology/L18-1272</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1273">
@@ -6799,7 +6798,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-725</url>
+    <url>http://www.aclweb.org/anthology/L18-1273</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1274">
@@ -6825,7 +6824,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-332</url>
+    <url>http://www.aclweb.org/anthology/L18-1274</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1275">
@@ -6847,7 +6846,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-294</url>
+    <url>http://www.aclweb.org/anthology/L18-1275</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1276">
@@ -6881,7 +6880,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-297</url>
+    <url>http://www.aclweb.org/anthology/L18-1276</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1277">
@@ -6915,7 +6914,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-335</url>
+    <url>http://www.aclweb.org/anthology/L18-1277</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1278">
@@ -6937,7 +6936,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-486</url>
+    <url>http://www.aclweb.org/anthology/L18-1278</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1279">
@@ -6971,7 +6970,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-636</url>
+    <url>http://www.aclweb.org/anthology/L18-1279</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1280">
@@ -6993,7 +6992,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1011</url>
+    <url>http://www.aclweb.org/anthology/L18-1280</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1281">
@@ -7011,7 +7010,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-43</url>
+    <url>http://www.aclweb.org/anthology/L18-1281</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1282">
@@ -7033,7 +7032,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-406</url>
+    <url>http://www.aclweb.org/anthology/L18-1282</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1283">
@@ -7055,7 +7054,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-422</url>
+    <url>http://www.aclweb.org/anthology/L18-1283</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1284">
@@ -7077,7 +7076,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-598</url>
+    <url>http://www.aclweb.org/anthology/L18-1284</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1285">
@@ -7107,7 +7106,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-497</url>
+    <url>http://www.aclweb.org/anthology/L18-1285</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1286">
@@ -7137,7 +7136,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-215</url>
+    <url>http://www.aclweb.org/anthology/L18-1286</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1287">
@@ -7183,7 +7182,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-276</url>
+    <url>http://www.aclweb.org/anthology/L18-1287</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1288">
@@ -7201,7 +7200,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-387</url>
+    <url>http://www.aclweb.org/anthology/L18-1288</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1289">
@@ -7223,7 +7222,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-765</url>
+    <url>http://www.aclweb.org/anthology/L18-1289</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1290">
@@ -7249,7 +7248,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1032</url>
+    <url>http://www.aclweb.org/anthology/L18-1290</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1291">
@@ -7271,7 +7270,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-231</url>
+    <url>http://www.aclweb.org/anthology/L18-1291</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1292">
@@ -7285,7 +7284,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-705</url>
+    <url>http://www.aclweb.org/anthology/L18-1292</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1293">
@@ -7347,7 +7346,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-789</url>
+    <url>http://www.aclweb.org/anthology/L18-1293</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1294">
@@ -7377,7 +7376,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-816</url>
+    <url>http://www.aclweb.org/anthology/L18-1294</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1295">
@@ -7391,7 +7390,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-964</url>
+    <url>http://www.aclweb.org/anthology/L18-1295</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1296">
@@ -7413,7 +7412,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-283</url>
+    <url>http://www.aclweb.org/anthology/L18-1296</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1297">
@@ -7435,7 +7434,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-522</url>
+    <url>http://www.aclweb.org/anthology/L18-1297</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1298">
@@ -7461,7 +7460,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1009</url>
+    <url>http://www.aclweb.org/anthology/L18-1298</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1299">
@@ -7515,7 +7514,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1067</url>
+    <url>http://www.aclweb.org/anthology/L18-1299</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1300">
@@ -7533,7 +7532,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-127</url>
+    <url>http://www.aclweb.org/anthology/L18-1300</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1301">
@@ -7555,7 +7554,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-141</url>
+    <url>http://www.aclweb.org/anthology/L18-1301</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1302">
@@ -7581,7 +7580,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-147</url>
+    <url>http://www.aclweb.org/anthology/L18-1302</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1303">
@@ -7599,7 +7598,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-172</url>
+    <url>http://www.aclweb.org/anthology/L18-1303</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1304">
@@ -7621,7 +7620,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-241</url>
+    <url>http://www.aclweb.org/anthology/L18-1304</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1305">
@@ -7643,7 +7642,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-410</url>
+    <url>http://www.aclweb.org/anthology/L18-1305</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1306">
@@ -7661,7 +7660,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-451</url>
+    <url>http://www.aclweb.org/anthology/L18-1306</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1307">
@@ -7687,7 +7686,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-525</url>
+    <url>http://www.aclweb.org/anthology/L18-1307</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1308">
@@ -7717,7 +7716,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-591</url>
+    <url>http://www.aclweb.org/anthology/L18-1308</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1309">
@@ -7739,7 +7738,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-653</url>
+    <url>http://www.aclweb.org/anthology/L18-1309</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1310">
@@ -7761,7 +7760,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-86</url>
+    <url>http://www.aclweb.org/anthology/L18-1310</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1311">
@@ -7779,7 +7778,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-145</url>
+    <url>http://www.aclweb.org/anthology/L18-1311</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1312">
@@ -7797,7 +7796,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-243</url>
+    <url>http://www.aclweb.org/anthology/L18-1312</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1313">
@@ -7823,7 +7822,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-312</url>
+    <url>http://www.aclweb.org/anthology/L18-1313</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1314">
@@ -7845,7 +7844,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-498</url>
+    <url>http://www.aclweb.org/anthology/L18-1314</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1315">
@@ -7871,7 +7870,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-539</url>
+    <url>http://www.aclweb.org/anthology/L18-1315</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1316">
@@ -7909,7 +7908,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-560</url>
+    <url>http://www.aclweb.org/anthology/L18-1316</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1317">
@@ -7931,7 +7930,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-615</url>
+    <url>http://www.aclweb.org/anthology/L18-1317</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1318">
@@ -7953,7 +7952,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-689</url>
+    <url>http://www.aclweb.org/anthology/L18-1318</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1319">
@@ -7983,7 +7982,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-780</url>
+    <url>http://www.aclweb.org/anthology/L18-1319</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1320">
@@ -8005,7 +8004,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1022</url>
+    <url>http://www.aclweb.org/anthology/L18-1320</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1321">
@@ -8027,7 +8026,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-254</url>
+    <url>http://www.aclweb.org/anthology/L18-1321</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1322">
@@ -8049,7 +8048,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-509</url>
+    <url>http://www.aclweb.org/anthology/L18-1322</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1323">
@@ -8067,7 +8066,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-574</url>
+    <url>http://www.aclweb.org/anthology/L18-1323</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1324">
@@ -8089,7 +8088,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-601</url>
+    <url>http://www.aclweb.org/anthology/L18-1324</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1325">
@@ -8107,7 +8106,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-613</url>
+    <url>http://www.aclweb.org/anthology/L18-1325</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1326">
@@ -8129,7 +8128,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-664</url>
+    <url>http://www.aclweb.org/anthology/L18-1326</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1327">
@@ -8151,7 +8150,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-666</url>
+    <url>http://www.aclweb.org/anthology/L18-1327</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1328">
@@ -8169,7 +8168,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-695</url>
+    <url>http://www.aclweb.org/anthology/L18-1328</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1329">
@@ -8203,7 +8202,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-709</url>
+    <url>http://www.aclweb.org/anthology/L18-1329</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1330">
@@ -8221,7 +8220,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-732</url>
+    <url>http://www.aclweb.org/anthology/L18-1330</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1331">
@@ -8275,7 +8274,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-196</url>
+    <url>http://www.aclweb.org/anthology/L18-1331</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1332">
@@ -8289,7 +8288,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-285</url>
+    <url>http://www.aclweb.org/anthology/L18-1332</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1333">
@@ -8307,7 +8306,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-296</url>
+    <url>http://www.aclweb.org/anthology/L18-1333</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1334">
@@ -8329,7 +8328,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-330</url>
+    <url>http://www.aclweb.org/anthology/L18-1334</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1335">
@@ -8347,7 +8346,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-466</url>
+    <url>http://www.aclweb.org/anthology/L18-1335</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1336">
@@ -8373,7 +8372,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-507</url>
+    <url>http://www.aclweb.org/anthology/L18-1336</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1337">
@@ -8387,7 +8386,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-644</url>
+    <url>http://www.aclweb.org/anthology/L18-1337</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1338">
@@ -8417,7 +8416,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-693</url>
+    <url>http://www.aclweb.org/anthology/L18-1338</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1339">
@@ -8443,7 +8442,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-714</url>
+    <url>http://www.aclweb.org/anthology/L18-1339</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1340">
@@ -8465,7 +8464,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-800</url>
+    <url>http://www.aclweb.org/anthology/L18-1340</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1341">
@@ -8479,7 +8478,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-69</url>
+    <url>http://www.aclweb.org/anthology/L18-1341</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1342">
@@ -8497,7 +8496,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-73</url>
+    <url>http://www.aclweb.org/anthology/L18-1342</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1343">
@@ -8523,7 +8522,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-194</url>
+    <url>http://www.aclweb.org/anthology/L18-1343</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1344">
@@ -8541,7 +8540,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-301</url>
+    <url>http://www.aclweb.org/anthology/L18-1344</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1345">
@@ -8563,7 +8562,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-333</url>
+    <url>http://www.aclweb.org/anthology/L18-1345</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1346">
@@ -8581,7 +8580,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-339</url>
+    <url>http://www.aclweb.org/anthology/L18-1346</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1347">
@@ -8607,7 +8606,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-378</url>
+    <url>http://www.aclweb.org/anthology/L18-1347</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1348">
@@ -8629,7 +8628,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-440</url>
+    <url>http://www.aclweb.org/anthology/L18-1348</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1349">
@@ -8647,7 +8646,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-543</url>
+    <url>http://www.aclweb.org/anthology/L18-1349</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1350">
@@ -8669,7 +8668,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-565</url>
+    <url>http://www.aclweb.org/anthology/L18-1350</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1351">
@@ -8687,7 +8686,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-567</url>
+    <url>http://www.aclweb.org/anthology/L18-1351</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1352">
@@ -8709,7 +8708,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-600</url>
+    <url>http://www.aclweb.org/anthology/L18-1352</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1353">
@@ -8731,7 +8730,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8889</url>
+    <url>http://www.aclweb.org/anthology/L18-1353</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1354">
@@ -8757,7 +8756,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8887</url>
+    <url>http://www.aclweb.org/anthology/L18-1354</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1355">
@@ -8791,7 +8790,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8884</url>
+    <url>http://www.aclweb.org/anthology/L18-1355</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1356">
@@ -8825,7 +8824,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-8886</url>
+    <url>http://www.aclweb.org/anthology/L18-1356</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1357">
@@ -8843,7 +8842,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-57</url>
+    <url>http://www.aclweb.org/anthology/L18-1357</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1358">
@@ -8857,7 +8856,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-60</url>
+    <url>http://www.aclweb.org/anthology/L18-1358</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1359">
@@ -8879,7 +8878,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-166</url>
+    <url>http://www.aclweb.org/anthology/L18-1359</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1360">
@@ -8913,7 +8912,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-223</url>
+    <url>http://www.aclweb.org/anthology/L18-1360</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1361">
@@ -8947,7 +8946,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-316</url>
+    <url>http://www.aclweb.org/anthology/L18-1361</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1362">
@@ -8969,7 +8968,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-383</url>
+    <url>http://www.aclweb.org/anthology/L18-1362</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1363">
@@ -8991,7 +8990,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-533</url>
+    <url>http://www.aclweb.org/anthology/L18-1363</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1364">
@@ -9009,7 +9008,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-558</url>
+    <url>http://www.aclweb.org/anthology/L18-1364</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1365">
@@ -9027,7 +9026,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-590</url>
+    <url>http://www.aclweb.org/anthology/L18-1365</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1366">
@@ -9053,7 +9052,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-619</url>
+    <url>http://www.aclweb.org/anthology/L18-1366</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1367">
@@ -9079,7 +9078,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-848</url>
+    <url>http://www.aclweb.org/anthology/L18-1367</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1368">
@@ -9109,7 +9108,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-924</url>
+    <url>http://www.aclweb.org/anthology/L18-1368</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1369">
@@ -9135,7 +9134,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-971</url>
+    <url>http://www.aclweb.org/anthology/L18-1369</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1370">
@@ -9169,7 +9168,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-995</url>
+    <url>http://www.aclweb.org/anthology/L18-1370</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1371">
@@ -9187,7 +9186,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-999</url>
+    <url>http://www.aclweb.org/anthology/L18-1371</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1372">
@@ -9217,7 +9216,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1010</url>
+    <url>http://www.aclweb.org/anthology/L18-1372</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1373">
@@ -9235,7 +9234,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1034</url>
+    <url>http://www.aclweb.org/anthology/L18-1373</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1374">
@@ -9277,7 +9276,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-499</url>
+    <url>http://www.aclweb.org/anthology/L18-1374</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1375">
@@ -9311,7 +9310,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-505</url>
+    <url>http://www.aclweb.org/anthology/L18-1375</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1376">
@@ -9329,7 +9328,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-532</url>
+    <url>http://www.aclweb.org/anthology/L18-1376</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1377">
@@ -9347,7 +9346,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-536</url>
+    <url>http://www.aclweb.org/anthology/L18-1377</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1378">
@@ -9377,7 +9376,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-586</url>
+    <url>http://www.aclweb.org/anthology/L18-1378</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1379">
@@ -9403,7 +9402,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-602</url>
+    <url>http://www.aclweb.org/anthology/L18-1379</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1380">
@@ -9425,7 +9424,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-646</url>
+    <url>http://www.aclweb.org/anthology/L18-1380</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1381">
@@ -9447,7 +9446,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-687</url>
+    <url>http://www.aclweb.org/anthology/L18-1381</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1382">
@@ -9465,7 +9464,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-592</url>
+    <url>http://www.aclweb.org/anthology/L18-1382</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1383">
@@ -9487,7 +9486,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-106</url>
+    <url>http://www.aclweb.org/anthology/L18-1383</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1384">
@@ -9509,7 +9508,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-380</url>
+    <url>http://www.aclweb.org/anthology/L18-1384</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1385">
@@ -9527,7 +9526,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-773</url>
+    <url>http://www.aclweb.org/anthology/L18-1385</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1386">
@@ -9557,7 +9556,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-812</url>
+    <url>http://www.aclweb.org/anthology/L18-1386</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1387">
@@ -9587,7 +9586,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-862</url>
+    <url>http://www.aclweb.org/anthology/L18-1387</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1388">
@@ -9605,7 +9604,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-391</url>
+    <url>http://www.aclweb.org/anthology/L18-1388</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1389">
@@ -9631,7 +9630,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-537</url>
+    <url>http://www.aclweb.org/anthology/L18-1389</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1390">
@@ -9645,7 +9644,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-548</url>
+    <url>http://www.aclweb.org/anthology/L18-1390</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1391">
@@ -9671,7 +9670,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1086</url>
+    <url>http://www.aclweb.org/anthology/L18-1391</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1392">
@@ -9701,7 +9700,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-46</url>
+    <url>http://www.aclweb.org/anthology/L18-1392</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1393">
@@ -9727,7 +9726,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-54</url>
+    <url>http://www.aclweb.org/anthology/L18-1393</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1394">
@@ -9753,7 +9752,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-271</url>
+    <url>http://www.aclweb.org/anthology/L18-1394</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1395">
@@ -9779,7 +9778,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-384</url>
+    <url>http://www.aclweb.org/anthology/L18-1395</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1396">
@@ -9801,7 +9800,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-394</url>
+    <url>http://www.aclweb.org/anthology/L18-1396</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1397">
@@ -9831,7 +9830,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-438</url>
+    <url>http://www.aclweb.org/anthology/L18-1397</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1398">
@@ -9873,7 +9872,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-452</url>
+    <url>http://www.aclweb.org/anthology/L18-1398</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1399">
@@ -9891,7 +9890,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-884</url>
+    <url>http://www.aclweb.org/anthology/L18-1399</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1400">
@@ -9913,7 +9912,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-970</url>
+    <url>http://www.aclweb.org/anthology/L18-1400</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1401">
@@ -9931,7 +9930,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1071</url>
+    <url>http://www.aclweb.org/anthology/L18-1401</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1402">
@@ -9953,7 +9952,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1095</url>
+    <url>http://www.aclweb.org/anthology/L18-1402</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1403">
@@ -9971,7 +9970,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-45</url>
+    <url>http://www.aclweb.org/anthology/L18-1403</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1404">
@@ -9993,7 +9992,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-292</url>
+    <url>http://www.aclweb.org/anthology/L18-1404</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1405">
@@ -10011,7 +10010,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-303</url>
+    <url>http://www.aclweb.org/anthology/L18-1405</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1406">
@@ -10029,7 +10028,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-323</url>
+    <url>http://www.aclweb.org/anthology/L18-1406</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1407">
@@ -10051,7 +10050,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-354</url>
+    <url>http://www.aclweb.org/anthology/L18-1407</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1408">
@@ -10093,7 +10092,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-445</url>
+    <url>http://www.aclweb.org/anthology/L18-1408</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1409">
@@ -10115,7 +10114,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-535</url>
+    <url>http://www.aclweb.org/anthology/L18-1409</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1410">
@@ -10145,7 +10144,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-55</url>
+    <url>http://www.aclweb.org/anthology/L18-1410</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1411">
@@ -10171,7 +10170,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-70</url>
+    <url>http://www.aclweb.org/anthology/L18-1411</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1412">
@@ -10189,7 +10188,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-89</url>
+    <url>http://www.aclweb.org/anthology/L18-1412</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1413">
@@ -10207,7 +10206,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-125</url>
+    <url>http://www.aclweb.org/anthology/L18-1413</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1414">
@@ -10229,7 +10228,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-150</url>
+    <url>http://www.aclweb.org/anthology/L18-1414</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1415">
@@ -10263,7 +10262,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-350</url>
+    <url>http://www.aclweb.org/anthology/L18-1415</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1416">
@@ -10281,7 +10280,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-358</url>
+    <url>http://www.aclweb.org/anthology/L18-1416</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1417">
@@ -10323,7 +10322,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-421</url>
+    <url>http://www.aclweb.org/anthology/L18-1417</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1418">
@@ -10341,7 +10340,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-405</url>
+    <url>http://www.aclweb.org/anthology/L18-1418</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1419">
@@ -10359,7 +10358,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-449</url>
+    <url>http://www.aclweb.org/anthology/L18-1419</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1420">
@@ -10377,7 +10376,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-457</url>
+    <url>http://www.aclweb.org/anthology/L18-1420</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1421">
@@ -10395,7 +10394,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-465</url>
+    <url>http://www.aclweb.org/anthology/L18-1421</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1422">
@@ -10421,7 +10420,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-471</url>
+    <url>http://www.aclweb.org/anthology/L18-1422</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1423">
@@ -10447,7 +10446,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-564</url>
+    <url>http://www.aclweb.org/anthology/L18-1423</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1424">
@@ -10473,7 +10472,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-583</url>
+    <url>http://www.aclweb.org/anthology/L18-1424</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1425">
@@ -10503,7 +10502,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-726</url>
+    <url>http://www.aclweb.org/anthology/L18-1425</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1426">
@@ -10529,7 +10528,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-846</url>
+    <url>http://www.aclweb.org/anthology/L18-1426</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1427">
@@ -10551,7 +10550,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-249</url>
+    <url>http://www.aclweb.org/anthology/L18-1427</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1428">
@@ -10577,7 +10576,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-833</url>
+    <url>http://www.aclweb.org/anthology/L18-1428</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1429">
@@ -10599,7 +10598,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-890</url>
+    <url>http://www.aclweb.org/anthology/L18-1429</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1430">
@@ -10629,7 +10628,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-13</url>
+    <url>http://www.aclweb.org/anthology/L18-1430</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1431">
@@ -10663,7 +10662,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-32</url>
+    <url>http://www.aclweb.org/anthology/L18-1431</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1432">
@@ -10685,7 +10684,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-34</url>
+    <url>http://www.aclweb.org/anthology/L18-1432</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1433">
@@ -10711,7 +10710,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-81</url>
+    <url>http://www.aclweb.org/anthology/L18-1433</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1434">
@@ -10741,7 +10740,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-345</url>
+    <url>http://www.aclweb.org/anthology/L18-1434</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1435">
@@ -10771,7 +10770,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-429</url>
+    <url>http://www.aclweb.org/anthology/L18-1435</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1436">
@@ -10789,7 +10788,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-480</url>
+    <url>http://www.aclweb.org/anthology/L18-1436</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1437">
@@ -10815,7 +10814,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-711</url>
+    <url>http://www.aclweb.org/anthology/L18-1437</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1438">
@@ -10853,7 +10852,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-758</url>
+    <url>http://www.aclweb.org/anthology/L18-1438</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1439">
@@ -10875,7 +10874,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-795</url>
+    <url>http://www.aclweb.org/anthology/L18-1439</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1440">
@@ -10901,7 +10900,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-826</url>
+    <url>http://www.aclweb.org/anthology/L18-1440</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1441">
@@ -10919,7 +10918,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-570</url>
+    <url>http://www.aclweb.org/anthology/L18-1441</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1442">
@@ -10945,7 +10944,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-577</url>
+    <url>http://www.aclweb.org/anthology/L18-1442</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1443">
@@ -10975,7 +10974,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-710</url>
+    <url>http://www.aclweb.org/anthology/L18-1443</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1444">
@@ -10997,7 +10996,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-858</url>
+    <url>http://www.aclweb.org/anthology/L18-1444</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1445">
@@ -11027,7 +11026,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-903</url>
+    <url>http://www.aclweb.org/anthology/L18-1445</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1446">
@@ -11045,7 +11044,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-913</url>
+    <url>http://www.aclweb.org/anthology/L18-1446</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1447">
@@ -11067,7 +11066,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1028</url>
+    <url>http://www.aclweb.org/anthology/L18-1447</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1448">
@@ -11085,7 +11084,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-24</url>
+    <url>http://www.aclweb.org/anthology/L18-1448</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1449">
@@ -11103,7 +11102,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-28</url>
+    <url>http://www.aclweb.org/anthology/L18-1449</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1450">
@@ -11137,7 +11136,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-41</url>
+    <url>http://www.aclweb.org/anthology/L18-1450</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1451">
@@ -11155,7 +11154,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-90</url>
+    <url>http://www.aclweb.org/anthology/L18-1451</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1452">
@@ -11173,7 +11172,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-105</url>
+    <url>http://www.aclweb.org/anthology/L18-1452</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1453">
@@ -11211,7 +11210,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-108</url>
+    <url>http://www.aclweb.org/anthology/L18-1453</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1454">
@@ -11225,7 +11224,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-258</url>
+    <url>http://www.aclweb.org/anthology/L18-1454</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1455">
@@ -11259,7 +11258,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-279</url>
+    <url>http://www.aclweb.org/anthology/L18-1455</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1456">
@@ -11293,7 +11292,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-311</url>
+    <url>http://www.aclweb.org/anthology/L18-1456</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1457">
@@ -11339,7 +11338,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-320</url>
+    <url>http://www.aclweb.org/anthology/L18-1457</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1458">
@@ -11357,7 +11356,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-418</url>
+    <url>http://www.aclweb.org/anthology/L18-1458</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1459">
@@ -11387,7 +11386,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-443</url>
+    <url>http://www.aclweb.org/anthology/L18-1459</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1460">
@@ -11405,7 +11404,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-334</url>
+    <url>http://www.aclweb.org/anthology/L18-1460</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1461">
@@ -11423,7 +11422,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-346</url>
+    <url>http://www.aclweb.org/anthology/L18-1461</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1462">
@@ -11453,7 +11452,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-464</url>
+    <url>http://www.aclweb.org/anthology/L18-1462</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1463">
@@ -11495,7 +11494,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-482</url>
+    <url>http://www.aclweb.org/anthology/L18-1463</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1464">
@@ -11517,7 +11516,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-493</url>
+    <url>http://www.aclweb.org/anthology/L18-1464</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1465">
@@ -11539,7 +11538,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-501</url>
+    <url>http://www.aclweb.org/anthology/L18-1465</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1466">
@@ -11557,7 +11556,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-596</url>
+    <url>http://www.aclweb.org/anthology/L18-1466</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1467">
@@ -11595,7 +11594,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-660</url>
+    <url>http://www.aclweb.org/anthology/L18-1467</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1468">
@@ -11625,7 +11624,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-751</url>
+    <url>http://www.aclweb.org/anthology/L18-1468</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1469">
@@ -11659,7 +11658,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1100</url>
+    <url>http://www.aclweb.org/anthology/L18-1469</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1470">
@@ -11681,7 +11680,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-62</url>
+    <url>http://www.aclweb.org/anthology/L18-1470</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1471">
@@ -11699,7 +11698,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-133</url>
+    <url>http://www.aclweb.org/anthology/L18-1471</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1472">
@@ -11725,7 +11724,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-873</url>
+    <url>http://www.aclweb.org/anthology/L18-1472</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1473">
@@ -11743,7 +11742,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1049</url>
+    <url>http://www.aclweb.org/anthology/L18-1473</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1474">
@@ -11761,7 +11760,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-4</url>
+    <url>http://www.aclweb.org/anthology/L18-1474</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1475">
@@ -11779,7 +11778,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-35</url>
+    <url>http://www.aclweb.org/anthology/L18-1475</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1476">
@@ -11797,7 +11796,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-39</url>
+    <url>http://www.aclweb.org/anthology/L18-1476</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1477">
@@ -11819,7 +11818,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-98</url>
+    <url>http://www.aclweb.org/anthology/L18-1477</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1478">
@@ -11849,7 +11848,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-450</url>
+    <url>http://www.aclweb.org/anthology/L18-1478</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1479">
@@ -11867,7 +11866,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-620</url>
+    <url>http://www.aclweb.org/anthology/L18-1479</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1480">
@@ -11893,7 +11892,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-667</url>
+    <url>http://www.aclweb.org/anthology/L18-1480</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1481">
@@ -11931,7 +11930,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-783</url>
+    <url>http://www.aclweb.org/anthology/L18-1481</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1482">
@@ -11949,7 +11948,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-831</url>
+    <url>http://www.aclweb.org/anthology/L18-1482</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1483">
@@ -11971,7 +11970,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-927</url>
+    <url>http://www.aclweb.org/anthology/L18-1483</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1484">
@@ -11989,7 +11988,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-624</url>
+    <url>http://www.aclweb.org/anthology/L18-1484</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1485">
@@ -12011,7 +12010,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-668</url>
+    <url>http://www.aclweb.org/anthology/L18-1485</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1486">
@@ -12033,7 +12032,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-743</url>
+    <url>http://www.aclweb.org/anthology/L18-1486</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1487">
@@ -12058,7 +12057,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-840</url>
+    <url>http://www.aclweb.org/anthology/L18-1487</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1488">
@@ -12080,7 +12079,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-922</url>
+    <url>http://www.aclweb.org/anthology/L18-1488</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1489">
@@ -12106,7 +12105,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-937</url>
+    <url>http://www.aclweb.org/anthology/L18-1489</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1490">
@@ -12124,7 +12123,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-985</url>
+    <url>http://www.aclweb.org/anthology/L18-1490</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1491">
@@ -12150,7 +12149,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1021</url>
+    <url>http://www.aclweb.org/anthology/L18-1491</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1492">
@@ -12176,7 +12175,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1085</url>
+    <url>http://www.aclweb.org/anthology/L18-1492</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1493">
@@ -12198,7 +12197,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-137</url>
+    <url>http://www.aclweb.org/anthology/L18-1493</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1494">
@@ -12228,7 +12227,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-164</url>
+    <url>http://www.aclweb.org/anthology/L18-1494</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1495">
@@ -12254,7 +12253,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-201</url>
+    <url>http://www.aclweb.org/anthology/L18-1495</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1496">
@@ -12276,7 +12275,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-411</url>
+    <url>http://www.aclweb.org/anthology/L18-1496</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1497">
@@ -12306,7 +12305,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-430</url>
+    <url>http://www.aclweb.org/anthology/L18-1497</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1498">
@@ -12324,7 +12323,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-559</url>
+    <url>http://www.aclweb.org/anthology/L18-1498</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1499">
@@ -12350,7 +12349,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-827</url>
+    <url>http://www.aclweb.org/anthology/L18-1499</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1500">
@@ -12368,7 +12367,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-881</url>
+    <url>http://www.aclweb.org/anthology/L18-1500</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1501">
@@ -12386,7 +12385,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1045</url>
+    <url>http://www.aclweb.org/anthology/L18-1501</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1502">
@@ -12412,7 +12411,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1064</url>
+    <url>http://www.aclweb.org/anthology/L18-1502</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1503">
@@ -12442,7 +12441,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-252</url>
+    <url>http://www.aclweb.org/anthology/L18-1503</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1504">
@@ -12468,7 +12467,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-275</url>
+    <url>http://www.aclweb.org/anthology/L18-1504</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1505">
@@ -12490,7 +12489,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-317</url>
+    <url>http://www.aclweb.org/anthology/L18-1505</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1506">
@@ -12516,7 +12515,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-516</url>
+    <url>http://www.aclweb.org/anthology/L18-1506</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1507">
@@ -12538,7 +12537,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-576</url>
+    <url>http://www.aclweb.org/anthology/L18-1507</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1508">
@@ -12556,7 +12555,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-849</url>
+    <url>http://www.aclweb.org/anthology/L18-1508</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1509">
@@ -12578,7 +12577,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-889</url>
+    <url>http://www.aclweb.org/anthology/L18-1509</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1510">
@@ -12592,7 +12591,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1018</url>
+    <url>http://www.aclweb.org/anthology/L18-1510</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1511">
@@ -12614,7 +12613,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1096</url>
+    <url>http://www.aclweb.org/anthology/L18-1511</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1512">
@@ -12640,7 +12639,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-212</url>
+    <url>http://www.aclweb.org/anthology/L18-1512</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1513">
@@ -12666,7 +12665,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-228</url>
+    <url>http://www.aclweb.org/anthology/L18-1513</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1514">
@@ -12688,7 +12687,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-238</url>
+    <url>http://www.aclweb.org/anthology/L18-1514</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1515">
@@ -12718,7 +12717,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-575</url>
+    <url>http://www.aclweb.org/anthology/L18-1515</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1516">
@@ -12752,7 +12751,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-775</url>
+    <url>http://www.aclweb.org/anthology/L18-1516</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1517">
@@ -12782,7 +12781,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-510</url>
+    <url>http://www.aclweb.org/anthology/L18-1517</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1518">
@@ -12804,7 +12803,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-794</url>
+    <url>http://www.aclweb.org/anthology/L18-1518</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1519">
@@ -12822,7 +12821,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-815</url>
+    <url>http://www.aclweb.org/anthology/L18-1519</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1520">
@@ -12848,7 +12847,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-209</url>
+    <url>http://www.aclweb.org/anthology/L18-1520</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1521">
@@ -12878,7 +12877,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-496</url>
+    <url>http://www.aclweb.org/anthology/L18-1521</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1522">
@@ -12896,7 +12895,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-610</url>
+    <url>http://www.aclweb.org/anthology/L18-1522</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1523">
@@ -12930,7 +12929,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-835</url>
+    <url>http://www.aclweb.org/anthology/L18-1523</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1524">
@@ -12952,7 +12951,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1051</url>
+    <url>http://www.aclweb.org/anthology/L18-1524</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1525">
@@ -12998,7 +12997,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-226</url>
+    <url>http://www.aclweb.org/anthology/L18-1525</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1526">
@@ -13020,7 +13019,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-494</url>
+    <url>http://www.aclweb.org/anthology/L18-1526</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1527">
@@ -13054,7 +13053,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-517</url>
+    <url>http://www.aclweb.org/anthology/L18-1527</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1528">
@@ -13120,7 +13119,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-855</url>
+    <url>http://www.aclweb.org/anthology/L18-1528</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1529">
@@ -13150,7 +13149,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-977</url>
+    <url>http://www.aclweb.org/anthology/L18-1529</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1530">
@@ -13184,7 +13183,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-490</url>
+    <url>http://www.aclweb.org/anthology/L18-1530</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1531">
@@ -13250,7 +13249,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-694</url>
+    <url>http://www.aclweb.org/anthology/L18-1531</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1532">
@@ -13272,7 +13271,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-822</url>
+    <url>http://www.aclweb.org/anthology/L18-1532</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1533">
@@ -13310,7 +13309,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-948</url>
+    <url>http://www.aclweb.org/anthology/L18-1533</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1534">
@@ -13324,7 +13323,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-954</url>
+    <url>http://www.aclweb.org/anthology/L18-1534</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1535">
@@ -13378,7 +13377,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-351</url>
+    <url>http://www.aclweb.org/anthology/L18-1535</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1536">
@@ -13400,7 +13399,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-375</url>
+    <url>http://www.aclweb.org/anthology/L18-1536</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1537">
@@ -13418,7 +13417,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-461</url>
+    <url>http://www.aclweb.org/anthology/L18-1537</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1538">
@@ -13436,7 +13435,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-934</url>
+    <url>http://www.aclweb.org/anthology/L18-1538</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1539">
@@ -13461,7 +13460,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-752</url>
+    <url>http://www.aclweb.org/anthology/L18-1539</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1540">
@@ -13479,7 +13478,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-93</url>
+    <url>http://www.aclweb.org/anthology/L18-1540</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1541">
@@ -13501,7 +13500,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-94</url>
+    <url>http://www.aclweb.org/anthology/L18-1541</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1542">
@@ -13523,7 +13522,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-190</url>
+    <url>http://www.aclweb.org/anthology/L18-1542</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1543">
@@ -13549,7 +13548,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-446</url>
+    <url>http://www.aclweb.org/anthology/L18-1543</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1544">
@@ -13587,7 +13586,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-632</url>
+    <url>http://www.aclweb.org/anthology/L18-1544</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1545">
@@ -13605,7 +13604,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-104</url>
+    <url>http://www.aclweb.org/anthology/L18-1545</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1546">
@@ -13627,7 +13626,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-370</url>
+    <url>http://www.aclweb.org/anthology/L18-1546</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1547">
@@ -13649,7 +13648,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-500</url>
+    <url>http://www.aclweb.org/anthology/L18-1547</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1548">
@@ -13671,7 +13670,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-847</url>
+    <url>http://www.aclweb.org/anthology/L18-1548</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1549">
@@ -13693,7 +13692,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-674</url>
+    <url>http://www.aclweb.org/anthology/L18-1549</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1550">
@@ -13723,7 +13722,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-627</url>
+    <url>http://www.aclweb.org/anthology/L18-1550</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1551">
@@ -13757,7 +13756,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-825</url>
+    <url>http://www.aclweb.org/anthology/L18-1551</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1552">
@@ -13775,7 +13774,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-864</url>
+    <url>http://www.aclweb.org/anthology/L18-1552</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1553">
@@ -13797,7 +13796,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1063</url>
+    <url>http://www.aclweb.org/anthology/L18-1553</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1554">
@@ -13823,7 +13822,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1087</url>
+    <url>http://www.aclweb.org/anthology/L18-1554</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1555">
@@ -13841,7 +13840,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-318</url>
+    <url>http://www.aclweb.org/anthology/L18-1555</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1556">
@@ -13863,7 +13862,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-551</url>
+    <url>http://www.aclweb.org/anthology/L18-1556</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1557">
@@ -13897,7 +13896,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-965</url>
+    <url>http://www.aclweb.org/anthology/L18-1557</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1558">
@@ -13931,7 +13930,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-974</url>
+    <url>http://www.aclweb.org/anthology/L18-1558</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1559">
@@ -13961,7 +13960,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-479</url>
+    <url>http://www.aclweb.org/anthology/L18-1559</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1560">
@@ -13979,7 +13978,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-658</url>
+    <url>http://www.aclweb.org/anthology/L18-1560</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1561">
@@ -14001,7 +14000,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-782</url>
+    <url>http://www.aclweb.org/anthology/L18-1561</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1562">
@@ -14019,7 +14018,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1001</url>
+    <url>http://www.aclweb.org/anthology/L18-1562</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1563">
@@ -14037,7 +14036,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-158</url>
+    <url>http://www.aclweb.org/anthology/L18-1563</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1564">
@@ -14067,7 +14066,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-225</url>
+    <url>http://www.aclweb.org/anthology/L18-1564</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1565">
@@ -14097,7 +14096,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-291</url>
+    <url>http://www.aclweb.org/anthology/L18-1565</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1566">
@@ -14123,7 +14122,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-414</url>
+    <url>http://www.aclweb.org/anthology/L18-1566</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1567">
@@ -14145,7 +14144,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-289</url>
+    <url>http://www.aclweb.org/anthology/L18-1567</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1568">
@@ -14163,7 +14162,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-485</url>
+    <url>http://www.aclweb.org/anthology/L18-1568</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1569">
@@ -14181,7 +14180,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-587</url>
+    <url>http://www.aclweb.org/anthology/L18-1569</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1570">
@@ -14207,7 +14206,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1089</url>
+    <url>http://www.aclweb.org/anthology/L18-1570</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1571">
@@ -14225,7 +14224,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-142</url>
+    <url>http://www.aclweb.org/anthology/L18-1571</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1572">
@@ -14251,7 +14250,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-220</url>
+    <url>http://www.aclweb.org/anthology/L18-1572</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1573">
@@ -14273,7 +14272,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-237</url>
+    <url>http://www.aclweb.org/anthology/L18-1573</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1574">
@@ -14351,7 +14350,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-395</url>
+    <url>http://www.aclweb.org/anthology/L18-1574</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1575">
@@ -14381,7 +14380,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-580</url>
+    <url>http://www.aclweb.org/anthology/L18-1575</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1576">
@@ -14407,7 +14406,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-820</url>
+    <url>http://www.aclweb.org/anthology/L18-1576</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1577">
@@ -14429,7 +14428,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-929</url>
+    <url>http://www.aclweb.org/anthology/L18-1577</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1578">
@@ -14443,7 +14442,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1005</url>
+    <url>http://www.aclweb.org/anthology/L18-1578</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1579">
@@ -14469,7 +14468,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1013</url>
+    <url>http://www.aclweb.org/anthology/L18-1579</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1580">
@@ -14483,7 +14482,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1104</url>
+    <url>http://www.aclweb.org/anthology/L18-1580</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1581">
@@ -14501,7 +14500,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-628</url>
+    <url>http://www.aclweb.org/anthology/L18-1581</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1582">
@@ -14527,7 +14526,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-777</url>
+    <url>http://www.aclweb.org/anthology/L18-1582</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1583">
@@ -14549,7 +14548,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-832</url>
+    <url>http://www.aclweb.org/anthology/L18-1583</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1584">
@@ -14575,7 +14574,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-852</url>
+    <url>http://www.aclweb.org/anthology/L18-1584</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1585">
@@ -14593,7 +14592,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-909</url>
+    <url>http://www.aclweb.org/anthology/L18-1585</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1586">
@@ -14611,7 +14610,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-154</url>
+    <url>http://www.aclweb.org/anthology/L18-1586</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1587">
@@ -14629,7 +14628,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-828</url>
+    <url>http://www.aclweb.org/anthology/L18-1587</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1588">
@@ -14647,7 +14646,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-871</url>
+    <url>http://www.aclweb.org/anthology/L18-1588</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1589">
@@ -14669,7 +14668,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-905</url>
+    <url>http://www.aclweb.org/anthology/L18-1589</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1590">
@@ -14699,7 +14698,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-989</url>
+    <url>http://www.aclweb.org/anthology/L18-1590</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1591">
@@ -14733,7 +14732,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1033</url>
+    <url>http://www.aclweb.org/anthology/L18-1591</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1592">
@@ -14755,7 +14754,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1081</url>
+    <url>http://www.aclweb.org/anthology/L18-1592</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1593">
@@ -14781,7 +14780,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1084</url>
+    <url>http://www.aclweb.org/anthology/L18-1593</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1594">
@@ -14807,7 +14806,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1115</url>
+    <url>http://www.aclweb.org/anthology/L18-1594</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1595">
@@ -14829,7 +14828,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-75</url>
+    <url>http://www.aclweb.org/anthology/L18-1595</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1596">
@@ -14855,7 +14854,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-245</url>
+    <url>http://www.aclweb.org/anthology/L18-1596</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1597">
@@ -14881,7 +14880,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-302</url>
+    <url>http://www.aclweb.org/anthology/L18-1597</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1598">
@@ -14911,7 +14910,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-585</url>
+    <url>http://www.aclweb.org/anthology/L18-1598</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1599">
@@ -14933,7 +14932,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-604</url>
+    <url>http://www.aclweb.org/anthology/L18-1599</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1600">
@@ -14955,7 +14954,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-611</url>
+    <url>http://www.aclweb.org/anthology/L18-1600</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1601">
@@ -14977,7 +14976,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1046</url>
+    <url>http://www.aclweb.org/anthology/L18-1601</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1602">
@@ -14995,7 +14994,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-629</url>
+    <url>http://www.aclweb.org/anthology/L18-1602</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1603">
@@ -15017,7 +15016,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-811</url>
+    <url>http://www.aclweb.org/anthology/L18-1603</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1604">
@@ -15039,7 +15038,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-853</url>
+    <url>http://www.aclweb.org/anthology/L18-1604</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1605">
@@ -15061,7 +15060,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-955</url>
+    <url>http://www.aclweb.org/anthology/L18-1605</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1606">
@@ -15083,7 +15082,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1097</url>
+    <url>http://www.aclweb.org/anthology/L18-1606</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1607">
@@ -15117,7 +15116,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-529</url>
+    <url>http://www.aclweb.org/anthology/L18-1607</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1608">
@@ -15159,7 +15158,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-625</url>
+    <url>http://www.aclweb.org/anthology/L18-1608</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1609">
@@ -15177,7 +15176,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-675</url>
+    <url>http://www.aclweb.org/anthology/L18-1609</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1610">
@@ -15211,7 +15210,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-745</url>
+    <url>http://www.aclweb.org/anthology/L18-1610</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1611">
@@ -15253,7 +15252,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-798</url>
+    <url>http://www.aclweb.org/anthology/L18-1611</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1612">
@@ -15271,7 +15270,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1029</url>
+    <url>http://www.aclweb.org/anthology/L18-1612</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1613">
@@ -15289,7 +15288,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1077</url>
+    <url>http://www.aclweb.org/anthology/L18-1613</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1614">
@@ -15307,7 +15306,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-52</url>
+    <url>http://www.aclweb.org/anthology/L18-1614</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1615">
@@ -15333,7 +15332,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-630</url>
+    <url>http://www.aclweb.org/anthology/L18-1615</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1616">
@@ -15363,7 +15362,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-688</url>
+    <url>http://www.aclweb.org/anthology/L18-1616</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1617">
@@ -15405,7 +15404,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-785</url>
+    <url>http://www.aclweb.org/anthology/L18-1617</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1618">
@@ -15435,7 +15434,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-863</url>
+    <url>http://www.aclweb.org/anthology/L18-1618</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1619">
@@ -15505,7 +15504,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-288</url>
+    <url>http://www.aclweb.org/anthology/L18-1619</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1620">
@@ -15535,7 +15534,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-483</url>
+    <url>http://www.aclweb.org/anthology/L18-1620</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1621">
@@ -15553,7 +15552,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-868</url>
+    <url>http://www.aclweb.org/anthology/L18-1621</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1622">
@@ -15579,7 +15578,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-870</url>
+    <url>http://www.aclweb.org/anthology/L18-1622</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1623">
@@ -15605,7 +15604,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-885</url>
+    <url>http://www.aclweb.org/anthology/L18-1623</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1624">
@@ -15627,7 +15626,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-932</url>
+    <url>http://www.aclweb.org/anthology/L18-1624</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1625">
@@ -15649,7 +15648,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-167</url>
+    <url>http://www.aclweb.org/anthology/L18-1625</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1626">
@@ -15699,7 +15698,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-713</url>
+    <url>http://www.aclweb.org/anthology/L18-1626</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1627">
@@ -15733,7 +15732,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-719</url>
+    <url>http://www.aclweb.org/anthology/L18-1627</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1628">
@@ -15763,7 +15762,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-763</url>
+    <url>http://www.aclweb.org/anthology/L18-1628</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1629">
@@ -15781,7 +15780,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-877</url>
+    <url>http://www.aclweb.org/anthology/L18-1629</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1630">
@@ -15803,7 +15802,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-942</url>
+    <url>http://www.aclweb.org/anthology/L18-1630</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1631">
@@ -15821,7 +15820,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-986</url>
+    <url>http://www.aclweb.org/anthology/L18-1631</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1632">
@@ -15851,7 +15850,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-83</url>
+    <url>http://www.aclweb.org/anthology/L18-1632</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1633">
@@ -15904,7 +15903,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-407</url>
+    <url>http://www.aclweb.org/anthology/L18-1633</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1634">
@@ -15922,7 +15921,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-518</url>
+    <url>http://www.aclweb.org/anthology/L18-1634</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1635">
@@ -15948,7 +15947,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-530</url>
+    <url>http://www.aclweb.org/anthology/L18-1635</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1636">
@@ -15970,7 +15969,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-566</url>
+    <url>http://www.aclweb.org/anthology/L18-1636</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1637">
@@ -16000,7 +15999,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-640</url>
+    <url>http://www.aclweb.org/anthology/L18-1637</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1638">
@@ -16018,7 +16017,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-673</url>
+    <url>http://www.aclweb.org/anthology/L18-1638</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1639">
@@ -16040,7 +16039,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-997</url>
+    <url>http://www.aclweb.org/anthology/L18-1639</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1640">
@@ -16070,7 +16069,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1048</url>
+    <url>http://www.aclweb.org/anthology/L18-1640</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1641">
@@ -16088,7 +16087,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-427</url>
+    <url>http://www.aclweb.org/anthology/L18-1641</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1642">
@@ -16114,7 +16113,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-623</url>
+    <url>http://www.aclweb.org/anthology/L18-1642</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1643">
@@ -16132,7 +16131,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-823</url>
+    <url>http://www.aclweb.org/anthology/L18-1643</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1644">
@@ -16154,7 +16153,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-841</url>
+    <url>http://www.aclweb.org/anthology/L18-1644</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1645">
@@ -16172,7 +16171,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-845</url>
+    <url>http://www.aclweb.org/anthology/L18-1645</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1646">
@@ -16194,7 +16193,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-887</url>
+    <url>http://www.aclweb.org/anthology/L18-1646</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1647">
@@ -16212,7 +16211,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-901</url>
+    <url>http://www.aclweb.org/anthology/L18-1647</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1648">
@@ -16234,7 +16233,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-933</url>
+    <url>http://www.aclweb.org/anthology/L18-1648</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1649">
@@ -16252,7 +16251,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1002</url>
+    <url>http://www.aclweb.org/anthology/L18-1649</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1650">
@@ -16274,7 +16273,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1050</url>
+    <url>http://www.aclweb.org/anthology/L18-1650</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1651">
@@ -16296,7 +16295,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-135</url>
+    <url>http://www.aclweb.org/anthology/L18-1651</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1652">
@@ -16318,7 +16317,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-221</url>
+    <url>http://www.aclweb.org/anthology/L18-1652</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1653">
@@ -16340,7 +16339,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-372</url>
+    <url>http://www.aclweb.org/anthology/L18-1653</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1654">
@@ -16358,7 +16357,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-403</url>
+    <url>http://www.aclweb.org/anthology/L18-1654</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1655">
@@ -16384,7 +16383,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-463</url>
+    <url>http://www.aclweb.org/anthology/L18-1655</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1656">
@@ -16406,7 +16405,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-684</url>
+    <url>http://www.aclweb.org/anthology/L18-1656</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1657">
@@ -16427,7 +16426,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-749</url>
+    <url>http://www.aclweb.org/anthology/L18-1657</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1658">
@@ -16445,7 +16444,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-389</url>
+    <url>http://www.aclweb.org/anthology/L18-1658</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1659">
@@ -16463,7 +16462,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-741</url>
+    <url>http://www.aclweb.org/anthology/L18-1659</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1660">
@@ -16485,7 +16484,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-760</url>
+    <url>http://www.aclweb.org/anthology/L18-1660</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1661">
@@ -16519,7 +16518,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-851</url>
+    <url>http://www.aclweb.org/anthology/L18-1661</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1662">
@@ -16545,7 +16544,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-857</url>
+    <url>http://www.aclweb.org/anthology/L18-1662</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1663">
@@ -16579,7 +16578,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-959</url>
+    <url>http://www.aclweb.org/anthology/L18-1663</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1664">
@@ -16605,7 +16604,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-996</url>
+    <url>http://www.aclweb.org/anthology/L18-1664</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1665">
@@ -16627,7 +16626,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1000</url>
+    <url>http://www.aclweb.org/anthology/L18-1665</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1666">
@@ -16685,7 +16684,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-25</url>
+    <url>http://www.aclweb.org/anthology/L18-1666</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1667">
@@ -16707,7 +16706,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-102</url>
+    <url>http://www.aclweb.org/anthology/L18-1667</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1668">
@@ -16729,7 +16728,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-396</url>
+    <url>http://www.aclweb.org/anthology/L18-1668</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1669">
@@ -16747,7 +16746,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-441</url>
+    <url>http://www.aclweb.org/anthology/L18-1669</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1670">
@@ -16765,7 +16764,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-470</url>
+    <url>http://www.aclweb.org/anthology/L18-1670</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1671">
@@ -16787,7 +16786,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-704</url>
+    <url>http://www.aclweb.org/anthology/L18-1671</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1672">
@@ -16832,7 +16831,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-469</url>
+    <url>http://www.aclweb.org/anthology/L18-1672</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1673">
@@ -16914,7 +16913,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-506</url>
+    <url>http://www.aclweb.org/anthology/L18-1673</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1674">
@@ -16960,7 +16959,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-635</url>
+    <url>http://www.aclweb.org/anthology/L18-1674</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1675">
@@ -16990,7 +16989,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-676</url>
+    <url>http://www.aclweb.org/anthology/L18-1675</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1676">
@@ -17012,7 +17011,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-683</url>
+    <url>http://www.aclweb.org/anthology/L18-1676</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1677">
@@ -17042,7 +17041,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-723</url>
+    <url>http://www.aclweb.org/anthology/L18-1677</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1678">
@@ -17056,7 +17055,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-888</url>
+    <url>http://www.aclweb.org/anthology/L18-1678</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1679">
@@ -17082,7 +17081,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-925</url>
+    <url>http://www.aclweb.org/anthology/L18-1679</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1680">
@@ -17104,7 +17103,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1004</url>
+    <url>http://www.aclweb.org/anthology/L18-1680</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1681">
@@ -17130,7 +17129,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1008</url>
+    <url>http://www.aclweb.org/anthology/L18-1681</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1682">
@@ -17148,7 +17147,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1015</url>
+    <url>http://www.aclweb.org/anthology/L18-1682</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1683">
@@ -17186,7 +17185,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-481</url>
+    <url>http://www.aclweb.org/anthology/L18-1683</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1684">
@@ -17208,7 +17207,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-528</url>
+    <url>http://www.aclweb.org/anthology/L18-1684</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1685">
@@ -17230,7 +17229,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-542</url>
+    <url>http://www.aclweb.org/anthology/L18-1685</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1686">
@@ -17256,7 +17255,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-599</url>
+    <url>http://www.aclweb.org/anthology/L18-1686</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1687">
@@ -17274,7 +17273,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-671</url>
+    <url>http://www.aclweb.org/anthology/L18-1687</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1688">
@@ -17296,7 +17295,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-724</url>
+    <url>http://www.aclweb.org/anthology/L18-1688</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1689">
@@ -17322,7 +17321,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-737</url>
+    <url>http://www.aclweb.org/anthology/L18-1689</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1690">
@@ -17352,7 +17351,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-746</url>
+    <url>http://www.aclweb.org/anthology/L18-1690</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1691">
@@ -17374,7 +17373,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-715</url>
+    <url>http://www.aclweb.org/anthology/L18-1691</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1692">
@@ -17404,7 +17403,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-803</url>
+    <url>http://www.aclweb.org/anthology/L18-1692</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1693">
@@ -17430,7 +17429,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-814</url>
+    <url>http://www.aclweb.org/anthology/L18-1693</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1694">
@@ -17456,7 +17455,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-844</url>
+    <url>http://www.aclweb.org/anthology/L18-1694</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1695">
@@ -17470,7 +17469,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-967</url>
+    <url>http://www.aclweb.org/anthology/L18-1695</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1696">
@@ -17488,7 +17487,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1019</url>
+    <url>http://www.aclweb.org/anthology/L18-1696</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1697">
@@ -17510,7 +17509,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1044</url>
+    <url>http://www.aclweb.org/anthology/L18-1697</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1698">
@@ -17532,7 +17531,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1102</url>
+    <url>http://www.aclweb.org/anthology/L18-1698</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1699">
@@ -17550,7 +17549,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-11</url>
+    <url>http://www.aclweb.org/anthology/L18-1699</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1700">
@@ -17588,7 +17587,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-12</url>
+    <url>http://www.aclweb.org/anthology/L18-1700</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1701">
@@ -17610,7 +17609,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-48</url>
+    <url>http://www.aclweb.org/anthology/L18-1701</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1702">
@@ -17628,7 +17627,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-72</url>
+    <url>http://www.aclweb.org/anthology/L18-1702</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1703">
@@ -17662,7 +17661,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-85</url>
+    <url>http://www.aclweb.org/anthology/L18-1703</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1704">
@@ -17688,7 +17687,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-88</url>
+    <url>http://www.aclweb.org/anthology/L18-1704</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1705">
@@ -17706,7 +17705,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-309</url>
+    <url>http://www.aclweb.org/anthology/L18-1705</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1706">
@@ -17736,7 +17735,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-682</url>
+    <url>http://www.aclweb.org/anthology/L18-1706</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1707">
@@ -17766,7 +17765,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-819</url>
+    <url>http://www.aclweb.org/anthology/L18-1707</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1708">
@@ -17788,7 +17787,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-878</url>
+    <url>http://www.aclweb.org/anthology/L18-1708</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1709">
@@ -17806,7 +17805,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-617</url>
+    <url>http://www.aclweb.org/anthology/L18-1709</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1710">
@@ -17840,7 +17839,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-642</url>
+    <url>http://www.aclweb.org/anthology/L18-1710</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1711">
@@ -17854,7 +17853,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-652</url>
+    <url>http://www.aclweb.org/anthology/L18-1711</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1712">
@@ -17884,7 +17883,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-755</url>
+    <url>http://www.aclweb.org/anthology/L18-1712</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1713">
@@ -17902,7 +17901,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-799</url>
+    <url>http://www.aclweb.org/anthology/L18-1713</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1714">
@@ -17940,7 +17939,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-935</url>
+    <url>http://www.aclweb.org/anthology/L18-1714</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1715">
@@ -17958,7 +17957,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-981</url>
+    <url>http://www.aclweb.org/anthology/L18-1715</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1716">
@@ -17984,7 +17983,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-992</url>
+    <url>http://www.aclweb.org/anthology/L18-1716</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1717">
@@ -18010,7 +18009,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1016</url>
+    <url>http://www.aclweb.org/anthology/L18-1717</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1718">
@@ -18040,7 +18039,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1101</url>
+    <url>http://www.aclweb.org/anthology/L18-1718</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1719">
@@ -18069,7 +18068,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-1109</url>
+    <url>http://www.aclweb.org/anthology/L18-1719</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1720">
@@ -18087,7 +18086,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-119</url>
+    <url>http://www.aclweb.org/anthology/L18-1720</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1721">
@@ -18117,7 +18116,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-259</url>
+    <url>http://www.aclweb.org/anthology/L18-1721</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1722">
@@ -18143,7 +18142,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-277</url>
+    <url>http://www.aclweb.org/anthology/L18-1722</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1723">
@@ -18165,7 +18164,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-308</url>
+    <url>http://www.aclweb.org/anthology/L18-1723</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1724">
@@ -18183,7 +18182,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-547</url>
+    <url>http://www.aclweb.org/anthology/L18-1724</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1725">
@@ -18205,7 +18204,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-603</url>
+    <url>http://www.aclweb.org/anthology/L18-1725</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1726">
@@ -18231,7 +18230,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-706</url>
+    <url>http://www.aclweb.org/anthology/L18-1726</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1727">
@@ -18249,7 +18248,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-792</url>
+    <url>http://www.aclweb.org/anthology/L18-1727</url>
     <bibtype>inproceedings</bibtype>
   </paper>
   <paper id="1728">
@@ -18271,7 +18270,7 @@
     <year>2018</year>
     <address>Miyazaki, Japan</address>
     <publisher>European Language Resource Association</publisher>
-    <url>http://www.aclweb.org/anthology/L18-936</url>
+    <url>http://www.aclweb.org/anthology/L18-1728</url>
     <bibtype>inproceedings</bibtype>
   </paper>
 </volume>


### PR DESCRIPTION
For L18, the `<url>` elements were rewritten to the correct URLs.
For L10, L12, L14, the `<url>` elements were removed.

The added script actually checks whether the URLs are dead or not, but I didn't use this in the end; the reason is that some papers on the LREC website are 404 (not sure why) and that didn't seem like a good reason to remove the link.