### PR TITLE
Full first names for some LREC conferences; new `complete` attribute

### DIFF
--- a/bin/check_name_variants.py
+++ b/bin/check_name_variants.py
@@ -1,14 +1,19 @@
 import yaml
 import sys
 import lxml.etree as etree
+import logging
 
 person_fields = {'canonical', 'variants', 'comment'}
 name_fields = {'first', 'last', 'papers'}
 
 def text(node):
     """Extract text from an XML node."""
-    if node is None: return ''
-    s = ''.join(node.itertext())
+    if node is None:
+        return ''
+    if 'complete' in node.attrib:
+        s = node.attrib['complete']
+    else:
+        s = ''.join(node.itertext())
     return ' '.join(s.split())
 
 def name(d):
@@ -20,7 +25,7 @@ if len(sys.argv) > 2:
         try:
             tree = etree.parse(xmlfilename)
         except:
-            print(xmlfilename)
+            logging.error("couldn't parse {}".format(xmlfilename))
             raise
         for paper in tree.getroot().findall('paper'):
             for person in paper.xpath('./author|./editor'):
@@ -40,14 +45,15 @@ for person in doc:
     assert isinstance(person['canonical'], dict), person
     assert set(person['canonical']).issubset(name_fields), person
     if names is not None and name(person['canonical']) not in names:
-        print('unused name', person['canonical'])
+        logging.warning('unused name: {}'.format(person['canonical']))
     dupes = {name(person['canonical'])}
     assert 'variants' in person, person
     assert isinstance(person['variants'], list), person
     for variant in person['variants']:
         assert set(variant).issubset(name_fields), person
         if names is not None and name(variant) not in names:
-            print('unused name', variant)
+            logging.warning('unused name: {}'.format(variant))
         assert name(variant) not in dupes, variant
         dupes.add(name(variant))
         
+print(yaml.dump(doc, allow_unicode=True))

--- a/data/xml/L00.xml
+++ b/data/xml/L00.xml
@@ -2,11 +2,11 @@
 <volume id="L00">
   <paper id="1000">
     <title>Proceedings of the Second International Conference on Language Resources and Evaluation (LREC’00)</title>
-    <editor><first>M.</first><last>Gavrilidou</last></editor>
-    <editor><first>G.</first><last>Carayannis</last></editor>
-    <editor><first>S.</first><last>Markantonatou</last></editor>
-    <editor><first>S.</first><last>Piperidis</last></editor>
-    <editor><first>G.</first><last>Stainhauer</last></editor>
+    <editor><first complete="Maria">M.</first><last>Gavrilidou</last></editor>
+    <editor><first complete="George">G.</first><last>Carayannis</last></editor>
+    <editor><first complete="Stella">S.</first><last>Markantonatou</last></editor>
+    <editor><first complete="Stelios">S.</first><last>Piperidis</last></editor>
+    <editor><first complete="Gregory">G.</first><last>Stainhauer</last></editor>
     <month>May</month>
     <year>2000</year>
     <address>Athens, Greece</address>
@@ -16,7 +16,7 @@
   </paper>
   <paper id="1001" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/1.pdf">
     <author><first>Gérard</first><last>Bailly</last></author>
-    <author><first>Eduardo R.</first><last>Banga</last></author>
+    <author><first complete="Eduardo Rodríguez">Eduardo R.</first><last>Banga</last></author>
     <author><first>Alex</first><last>Monaghan</last></author>
     <author><first>Erhard</first><last>Rank</last></author>
     <title>The Cost258 Signal Generation Test Array</title>
@@ -144,11 +144,11 @@
     <bibkey>jie:15:2000:lrec2000</bibkey>
   </paper>
   <paper id="1012" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/16.pdf">
-    <author><first>S.-E.</first><last>Fotinea</last></author>
-    <author><first>I.</first><last>Dologlou</last></author>
-    <author><first>S.</first><last>Bakamidis</last></author>
-    <author><first>G.</first><last>Stainhauer</last></author>
-    <author><first>G.</first><last>Carayannis</last></author>
+    <author><first complete="Stavroula-Evita">S.-E.</first><last>Fotinea</last></author>
+    <author><first complete="Ioannis">I.</first><last>Dologlou</last></author>
+    <author><first complete="Stylianos">S.</first><last>Bakamidis</last></author>
+    <author><first complete="Gregory">G.</first><last>Stainhauer</last></author>
+    <author><first complete="George">G.</first><last>Carayannis</last></author>
     <title>Perceptual Evaluation of a New Subband Low Bit Rate Speech Compression System based on Waveform Vector Quantization and SVD Postfiltering</title>
     <month>May</month>
     <year>2000</year>
@@ -270,9 +270,9 @@
     <bibkey>abbas:31:2000:lrec2000</bibkey>
   </paper>
   <paper id="1023" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/32.pdf">
-    <author><first>N.</first><last>Chenfour</last></author>
-    <author><first>A.</first><last>Benabbou</last></author>
-    <author><first>A.</first><last>Mouradi</last></author>
+    <author><first complete="Noureddine">N.</first><last>Chenfour</last></author>
+    <author><first complete="Abderrahim">A.</first><last>Benabbou</last></author>
+    <author><first complete="Abdelhak">A.</first><last>Mouradi</last></author>
     <title>Etude et Evaluation de la Di-Syllabe comme Unité Acoustique pour le Système de Synthèse Arabe PARADIS</title>
     <month>May</month>
     <year>2000</year>
@@ -400,16 +400,16 @@
     <bibkey>swerts:43:2000:lrec2000</bibkey>
   </paper>
   <paper id="1033" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/44.pdf">
-    <author><first>I.</first><last>Aduriz</last></author>
-    <author><first>E.</first><last>Agirre</last></author>
-    <author><first>I.</first><last>Aldezabal</last></author>
-    <author><first>X.</first><last>Arregi</last></author>
-    <author><first>J. M.</first><last>Arriola</last></author>
-    <author><first>X.</first><last>Artola</last></author>
-    <author><first>K.</first><last>Gojenola</last></author>
-    <author><first>A.</first><last>Maritxalar</last></author>
-    <author><first>K.</first><last>Sarasola</last></author>
-    <author><first>M.</first><last>Urkia</last></author>
+    <author><first complete="Itziar">I.</first><last>Aduriz</last></author>
+    <author><first complete="Eneko">E.</first><last>Agirre</last></author>
+    <author><first complete="Izaskun">I.</first><last>Aldezabal</last></author>
+    <author><first complete="Xabier">X.</first><last>Arregi</last></author>
+    <author><first complete="Jose Mari">J. M.</first><last>Arriola</last></author>
+    <author><first complete="Xabier">X.</first><last>Artola</last></author>
+    <author><first complete="Koldo">K.</first><last>Gojenola</last></author>
+    <author><first complete="Alberto">A.</first><last>Maritxalar</last></author>
+    <author><first complete="Kepa">K.</first><last>Sarasola</last></author>
+    <author><first complete="Miriam">M.</first><last>Urkia</last></author>
     <title>A Word-level Morphosyntactic Analyzer for Basque</title>
     <month>May</month>
     <year>2000</year>
@@ -610,12 +610,12 @@
     <bibkey>jekat:67:2000:lrec2000</bibkey>
   </paper>
   <paper id="1049" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/68.pdf">
-    <author><first>X.</first><last>Artola</last></author>
-    <author><first>A.</first><last>Díaz de Ilarraza</last></author>
-    <author><first>N.</first><last>Ezeiza</last></author>
-    <author><first>K.</first><last>Gojenola</last></author>
-    <author><first>A.</first><last>Maritxalar</last></author>
-    <author><first>A.</first><last>Soroa</last></author>
+    <author><first complete="Xabier">X.</first><last>Artola</last></author>
+    <author><first complete="Arantza">A.</first><last>Díaz de Ilarraza</last></author>
+    <author><first complete="Nerea">N.</first><last>Ezeiza</last></author>
+    <author><first complete="Koldo">K.</first><last>Gojenola</last></author>
+    <author><first complete="Alberto">A.</first><last>Maritxalar</last></author>
+    <author><first complete="Aitor">A.</first><last>Soroa</last></author>
     <title>A Proposal for the Integration of NLP Tools using SGML-Tagged Documents</title>
     <month>May</month>
     <year>2000</year>
@@ -945,10 +945,10 @@
     <bibkey>kibble:100:2000:lrec2000</bibkey>
   </paper>
   <paper id="1077" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/101.pdf">
-    <author><first>R.</first><last>López-Cózar</last></author>
-    <author><first>A.J.</first><last>Rubio</last></author>
-    <author><first>J.E.</first><last>Díaz Verdejo</last></author>
-    <author><first>A. De</first><last>la Torre</last></author>
+    <author><first complete="Ramón">R.</first><last>López-Cózar</last></author>
+    <author><first complete="Antonio J.">A.J.</first><last>Rubio</last></author>
+    <author><first complete="Jesús E.">J.E.</first><last>Díaz Verdejo</last></author>
+    <author><first complete="Ángel">A.</first><last>De la Torre</last></author>
     <title>Evaluation of a Dialogue System Based on a Generic Model that Combines Robust Speech Understanding and Mixed-initiative Control</title>
     <month>May</month>
     <year>2000</year>
@@ -1096,11 +1096,11 @@
     <bibkey>váradi:122:2000:lrec2000</bibkey>
   </paper>
   <paper id="1091" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/125.pdf">
-    <author><first>D.</first><last>Broeder</last></author>
-    <author><first>H.</first><last>Brugman</last></author>
-    <author><first>A.</first><last>Russel</last></author>
-    <author><first>R.</first><last>Skiba</last></author>
-    <author><first>P.</first><last>Wittenburg</last></author>
+    <author><first complete="Daan">D.</first><last>Broeder</last></author>
+    <author><first complete="Hennie">H.</first><last>Brugman</last></author>
+    <author><first complete="Albert">A.</first><last>Russel</last></author>
+    <author><first complete="Romuald">R.</first><last>Skiba</last></author>
+    <author><first complete="Peter">P.</first><last>Wittenburg</last></author>
     <title>Towards a Standard for Meta-descriptions of Language Resources</title>
     <month>May</month>
     <year>2000</year>
@@ -1449,15 +1449,15 @@
     <bibkey>kinoshita:164:2000:lrec2000</bibkey>
   </paper>
   <paper id="1121" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/165.pdf">
-    <author><first>W.J.</first><last>Black</last></author>
-    <author><first>J.</first><last>McNaught</last></author>
-    <author><first>G.P.</first><last>Zarri</last></author>
-    <author><first>A.</first><last>Persidis</last></author>
-    <author><first>A.</first><last>Brasher</last></author>
-    <author><first>L.</first><last>Gilardoni</last></author>
-    <author><first>E.</first><last>Bertino</last></author>
-    <author><first>G.</first><last>Semeraro</last></author>
-    <author><first>P.</first><last>Leo</last></author>
+    <author><first complete="William J.">W.J.</first><last>Black</last></author>
+    <author><first complete="John">J.</first><last>McNaught</last></author>
+    <author><first complete="Gian Piero">G.P.</first><last>Zarri</last></author>
+    <author><first complete="Andreas">A.</first><last>Persidis</last></author>
+    <author><first complete="Andrew">A.</first><last>Brasher</last></author>
+    <author><first complete="Luca">L.</first><last>Gilardoni</last></author>
+    <author><first complete="Elisa">E.</first><last>Bertino</last></author>
+    <author><first complete="Giovanni">G.</first><last>Semeraro</last></author>
+    <author><first complete="Pietro">P.</first><last>Leo</last></author>
     <title>A Semi-automatic System for Conceptual Annotation, its Application to Resource Construction and Evaluation</title>
     <month>May</month>
     <year>2000</year>
@@ -2134,11 +2134,11 @@
     <bibkey>bouayad-agha:234:2000:lrec2000</bibkey>
   </paper>
   <paper id="1178" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/235.pdf">
-    <author><first>D.</first><last>Vaufreydaz</last></author>
-    <author><first>C.</first><last>Bergamini</last></author>
-    <author><first>J.F.</first><last>Serignat</last></author>
-    <author><first>L.</first><last>Besacier</last></author>
-    <author><first>M.</first><last>Akbar</last></author>
+    <author><first complete="Dominique">D.</first><last>Vaufreydaz</last></author>
+    <author><first complete="Carole">C.</first><last>Bergamini</last></author>
+    <author><first complete="Jean-Francois">J.F.</first><last>Serignat</last></author>
+    <author><first complete="Laurent">L.</first><last>Besacier</last></author>
+    <author><first complete="Mohammad">M.</first><last>Akbar</last></author>
     <title>A New Methodology for Speech Corpora Definition from Internet Documents</title>
     <month>May</month>
     <year>2000</year>
@@ -2213,7 +2213,7 @@
     <author><first>Roger</first><last>Evans</last></author>
     <author><first>Rodger</first><last>Kibble</last></author>
     <author><first>Chris</first><last>Mellish</last></author>
-    <author><first>D.</first><last>Paiva</last></author>
+    <author><first complete="Daniel">D.</first><last>Paiva</last></author>
     <author><first>Mike</first><last>Reape</last></author>
     <author><first>Donia</first><last>Scott</last></author>
     <author><first>Neil</first><last>Tipper</last></author>
@@ -2651,11 +2651,11 @@
     <bibkey>gros:288:2000:lrec2000</bibkey>
   </paper>
   <paper id="1219" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/289.pdf">
-    <author><first>E.</first><last>Kavallieratou</last></author>
-    <author><first>N.</first><last>Liolios</last></author>
-    <author><first>E.</first><last>Koutsogeorgos</last></author>
-    <author><first>N.</first><last>Fakotakis</last></author>
-    <author><first>G.</first><last>Kokkinakis</last></author>
+    <author><first complete="Ergina">E.</first><last>Kavallieratou</last></author>
+    <author><first complete="Nikos">N.</first><last>Liolios</last></author>
+    <author><first complete="Eleni">E.</first><last>Koutsogeorgos</last></author>
+    <author><first complete="Nikos">N.</first><last>Fakotakis</last></author>
+    <author><first complete="George">G.</first><last>Kokkinakis</last></author>
     <title>GRUHD: A Greek database of Unconstrained Handwriting</title>
     <month>May</month>
     <year>2000</year>
@@ -2774,9 +2774,9 @@
     <bibkey>thanopoulos:302:2000:lrec2000</bibkey>
   </paper>
   <paper id="1229" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/303.pdf">
-    <author><first>H.</first><last>Bonneau-Maynard</last></author>
-    <author><first>L.</first><last>Devillers</last></author>
-    <author><first>S.</first><last>Rosset</last></author>
+    <author><first complete="Hélène">H.</first><last>Bonneau-Maynard</last></author>
+    <author><first complete="Laurence">L.</first><last>Devillers</last></author>
+    <author><first complete="Sophie">S.</first><last>Rosset</last></author>
     <title>Predictive Performance of Dialog Systems</title>
     <month>May</month>
     <year>2000</year>
@@ -2952,9 +2952,9 @@
     <bibkey>fluhr-semenova:328:2000:lrec2000</bibkey>
   </paper>
   <paper id="1244" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/329.pdf">
-    <author><first>J.C.</first><last>Roux</last></author>
-    <author><first>E.C.</first><last>Botha</last></author>
-    <author><first>J.A.</first><last>du Preez</last></author>
+    <author><first complete="Justus C.">J.C.</first><last>Roux</last></author>
+    <author><first complete="Elizabeth C.">E.C.</first><last>Botha</last></author>
+    <author><first complete="Johan Adam">J.A.</first><last>du Preez</last></author>
     <title>Developing a Multilingual Telephone Based Information System in African Languages</title>
     <month>May</month>
     <year>2000</year>
@@ -3211,11 +3211,11 @@
     <bibkey>demetriou:357:2000:lrec2000</bibkey>
   </paper>
   <paper id="1266" href="http://www.lrec-conf.org/proceedings/lrec2000/pdf/358.pdf">
-    <author><first>L.</first><last>Cristoforetti</last></author>
-    <author><first>M.</first><last>Matassoni</last></author>
-    <author><first>M.</first><last>Omologo</last></author>
-    <author><first>P.</first><last>Svaizer</last></author>
-    <author><first>E.</first><last>Zovato</last></author>
+    <author><first complete="Luca">L.</first><last>Cristoforetti</last></author>
+    <author><first complete="Marco">M.</first><last>Matassoni</last></author>
+    <author><first complete="Maurizio">M.</first><last>Omologo</last></author>
+    <author><first complete="Piergiorgio">P.</first><last>Svaizer</last></author>
+    <author><first complete="Enrico">E.</first><last>Zovato</last></author>
     <title>Annotation of a Multichannel Noisy Speech Corpus</title>
     <month>May</month>
     <year>2000</year>

--- a/data/xml/L02.xml
+++ b/data/xml/L02.xml
@@ -532,12 +532,12 @@
     <bibkey>lönneker:45:2002:lrec2002</bibkey>
   </paper>
   <paper id="1046" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/46.pdf">
-    <author><first>I.</first><last>Hernáez</last></author>
-    <author><first>E.</first><last>Navas</last></author>
-    <author><first>J.</first><last>Sánchez</last></author>
-    <author><first>I.</first><last>Madariaga</last></author>
-    <author><first>I.</first><last>Gaminde</last></author>
-    <author><first>X.</first><last>Zalbide</last></author>
+    <author><first complete="Inmaculada">I.</first><last>Hernáez</last></author>
+    <author><first complete="Eva">E.</first><last>Navas</last></author>
+    <author><first complete="Jon">J.</first><last>Sánchez</last></author>
+    <author><first complete="Imanol">I.</first><last>Madariaga</last></author>
+    <author><first complete="Iñaki">I.</first><last>Gaminde</last></author>
+    <author><first complete="Xabier">X.</first><last>Zalbide</last></author>
     <title>BIZKAIFON: A sound archive of dialectal varieties of spoken Basque</title>
     <month>May</month>
     <year>2002</year>
@@ -796,13 +796,13 @@
     <bibkey>hacken:67:2002:lrec2002</bibkey>
   </paper>
   <paper id="1068" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/68.pdf">
-    <author><first>A.</first><last>Cappelli</last></author>
-    <author><first>M. N.</first><last>Catarsi</last></author>
-    <author><first>P.</first><last>Michelassi</last></author>
-    <author><first>L.</first><last>Moretti</last></author>
-    <author><first>M.</first><last>Baglioni</last></author>
-    <author><first>F.</first><last>Turini</last></author>
-    <author><first>M.</first><last>Tavoni</last></author>
+    <author><first complete="Amedeo">A.</first><last>Cappelli</last></author>
+    <author><first complete="Maria Novella">M. N.</first><last>Catarsi</last></author>
+    <author><first complete="Patrizia">P.</first><last>Michelassi</last></author>
+    <author><first complete="Lorenzo">L.</first><last>Moretti</last></author>
+    <author><first complete="Mirko">M.</first><last>Baglioni</last></author>
+    <author><first complete="Franco">F.</first><last>Turini</last></author>
+    <author><first complete="Miriam">M.</first><last>Tavoni</last></author>
     <title>Knowledge Mining and Discovery for Searching in Literary Texts</title>
     <month>May</month>
     <year>2002</year>
@@ -1718,7 +1718,7 @@
     <author><first>José F.</first><last>Morlesín</last></author>
     <author><first>Josep M.</first><last>Otero</last></author>
     <author><first>José</first><last>Relaño</last></author>
-    <author><first>M. Carmen</first><last>Rodríguez</last></author>
+    <author><first complete="Mari Carmen">M. Carmen</first><last>Rodríguez</last></author>
     <author><first>Pedro M.</first><last>Ruz</last></author>
     <author><first>Daniel</first><last>Tapias</last></author>
     <title>Design and Evaluation of a SLDS for E-Mail Access through the Telephone</title>
@@ -1848,13 +1848,13 @@
     <bibkey>oh:154:2002:lrec2002</bibkey>
   </paper>
   <paper id="1155" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/155.pdf">
-    <author><first>N.</first><last>Minematsu</last></author>
-    <author><first>Y.</first><last>Tomiyama</last></author>
-    <author><first>K.</first><last>Yoshimoto</last></author>
-    <author><first>K.</first><last>Shimizu</last></author>
-    <author><first>S.</first><last>Nakagawa</last></author>
-    <author><first>M.</first><last>Dantsuji</last></author>
-    <author><first>S.</first><last>Makino</last></author>
+    <author><first complete="Nobuaki">N.</first><last>Minematsu</last></author>
+    <author><first complete="Yoshihiro">Y.</first><last>Tomiyama</last></author>
+    <author><first complete="Kei">K.</first><last>Yoshimoto</last></author>
+    <author><first complete="Katsumasa">K.</first><last>Shimizu</last></author>
+    <author><first complete="Seiichi">S.</first><last>Nakagawa</last></author>
+    <author><first complete="Masatake">M.</first><last>Dantsuji</last></author>
+    <author><first complete="Shozo">S.</first><last>Makino</last></author>
     <title>English Speech Database Read by Japanese Learners for CALL System Development</title>
     <month>May</month>
     <year>2002</year>
@@ -1969,18 +1969,18 @@
     <bibkey>peters:163:2002:lrec2002</bibkey>
   </paper>
   <paper id="1164" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/164.pdf">
-    <author><first>R.</first><last>Muñoz</last></author>
-    <author><first>R.</first><last>Mitkov</last></author>
-    <author><first>M.</first><last>Palomar</last></author>
-    <author><first>J.</first><last>Peral</last></author>
-    <author><first>R.</first><last>Evans</last></author>
-    <author><first>L.</first><last>Moreno</last></author>
-    <author><first>C.</first><last>Orasan</last></author>
-    <author><first>M.</first><last>Saiz-Noeda</last></author>
-    <author><first>A.</first><last>Ferrández</last></author>
-    <author><first>C.</first><last>Barbu</last></author>
-    <author><first>P.</first><last>Martínez-Barco</last></author>
-    <author><first>A.</first><last>Suárez</last></author>
+    <author><first complete="Rafael">R.</first><last>Muñoz</last></author>
+    <author><first complete="Ruslan">R.</first><last>Mitkov</last></author>
+    <author><first complete="Manuel">M.</first><last>Palomar</last></author>
+    <author><first complete="Jesus">J.</first><last>Peral</last></author>
+    <author><first complete="Richard">R.</first><last>Evans</last></author>
+    <author><first complete="Lidia">L.</first><last>Moreno</last></author>
+    <author><first complete="Constantin">C.</first><last>Orasan</last></author>
+    <author><first complete="Maximiliano">M.</first><last>Saiz-Noeda</last></author>
+    <author><first complete="Antonio">A.</first><last>Ferrández</last></author>
+    <author><first complete="Catalina">C.</first><last>Barbu</last></author>
+    <author><first complete="Patricio">P.</first><last>Martínez-Barco</last></author>
+    <author><first complete="Armando">A.</first><last>Suárez</last></author>
     <title>Bilingual alignment of anaphoric expressions</title>
     <month>May</month>
     <year>2002</year>
@@ -2232,9 +2232,9 @@
     <bibkey>hara:184:2002:lrec2002</bibkey>
   </paper>
   <paper id="1185" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/185.pdf">
-    <author><first>A.</first><last>Benabbou</last></author>
-    <author><first>N.</first><last>Chenfour</last></author>
-    <author><first>A.</first><last>Mouradi</last></author>
+    <author><first complete="Abderrahim">A.</first><last>Benabbou</last></author>
+    <author><first complete="Noureddine">N.</first><last>Chenfour</last></author>
+    <author><first complete="Abdelhak">A.</first><last>Mouradi</last></author>
     <title>Study and quantification of the declination for the Arabic speech synthesis system PARADIS. </title>
     <month>May</month>
     <year>2002</year>
@@ -2409,12 +2409,12 @@
     <bibkey>järborg:199:2002:lrec2002</bibkey>
   </paper>
   <paper id="1200" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/200.pdf">
-    <author><first>X.</first><last>Artola</last></author>
-    <author><first>A.</first><last>Díaz de Ilarraza</last></author>
-    <author><first>N.</first><last>Ezeiza</last></author>
-    <author><first>K.</first><last>Gojenola</last></author>
-    <author><first>G.</first><last>Hernández</last></author>
-    <author><first>A.</first><last>Soroa</last></author>
+    <author><first complete="Xabier">X.</first><last>Artola</last></author>
+    <author><first complete="Arantza">A.</first><last>Díaz de Ilarraza</last></author>
+    <author><first complete="Nerea">N.</first><last>Ezeiza</last></author>
+    <author><first complete="Koldo">K.</first><last>Gojenola</last></author>
+    <author><first complete="Gregorio">G.</first><last>Hernández</last></author>
+    <author><first complete="Aitor">A.</first><last>Soroa</last></author>
     <title>A Class Library for the Integration of NLP Tools: Definition and implementation of an Abstract Data Type Collection for the manipulation of SGML documents in a context of stand-off linguistic annotation</title>
     <month>May</month>
     <year>2002</year>
@@ -2635,7 +2635,7 @@
   <paper id="1218" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/218.pdf">
     <author><first>Paul</first><last>Clough</last></author>
     <author><first>Robert</first><last>Gaizauskas</last></author>
-    <author><first>S. L.</first><last>Piao</last></author>
+    <author><first complete="Scott">S. L.</first><last>Piao</last></author>
     <title>Building and annotating a corpus for the study of journalistic text reuse</title>
     <month>May</month>
     <year>2002</year>
@@ -2658,9 +2658,9 @@
     <bibkey>brugman:219:2002:lrec2002</bibkey>
   </paper>
   <paper id="1220" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/220.pdf">
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>W.</first><last>Peters</last></author>
-    <author><first>S.</first><last>Drude</last></author>
+    <author><first complete="Peter">P.</first><last>Wittenburg</last></author>
+    <author><first complete="Wim">W.</first><last>Peters</last></author>
+    <author><first complete="Sebastian">S.</first><last>Drude</last></author>
     <title>Analysis of Lexical Structures from Field Linguistics and Language Engineering</title>
     <month>May</month>
     <year>2002</year>
@@ -2670,9 +2670,9 @@
     <bibkey>wittenburg:220:2002:lrec2002</bibkey>
   </paper>
   <paper id="1221" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/221.pdf">
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>U.</first><last>Mosel</last></author>
-    <author><first>A.</first><last>Dwyer</last></author>
+    <author><first complete="Peter">P.</first><last>Wittenburg</last></author>
+    <author><first complete="Ulrike">U.</first><last>Mosel</last></author>
+    <author><first complete="Arienne">A.</first><last>Dwyer</last></author>
     <title>Methods of Language Documentation in the DOBES project</title>
     <month>May</month>
     <year>2002</year>
@@ -2682,9 +2682,9 @@
     <bibkey>wittenburg:221:2002:lrec2002</bibkey>
   </paper>
   <paper id="1222" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/222.pdf">
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>W.</first><last>Peters</last></author>
-    <author><first>D.</first><last>Broeder</last></author>
+    <author><first complete="Peter">P.</first><last>Wittenburg</last></author>
+    <author><first complete="Wim">W.</first><last>Peters</last></author>
+    <author><first complete="Daan">D.</first><last>Broeder</last></author>
     <title>Metadata Proposals for Corpora and Lexica</title>
     <month>May</month>
     <year>2002</year>
@@ -2694,10 +2694,10 @@
     <bibkey>wittenburg:222:2002:lrec2002</bibkey>
   </paper>
   <paper id="1223" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/223.pdf">
-    <author><first>P.</first><last>Wittenburg</last></author>
-    <author><first>St.</first><last>Levinson</last></author>
-    <author><first>S.</first><last>Kita</last></author>
-    <author><first>H.</first><last>Brugman</last></author>
+    <author><first complete="Peter">P.</first><last>Wittenburg</last></author>
+    <author><first complete="Stephen">St.</first><last>Levinson</last></author>
+    <author><first complete="Sotaro">S.</first><last>Kita</last></author>
+    <author><first complete="Hennie">H.</first><last>Brugman</last></author>
     <title>Multimodal Annotations in Gesture and Sign Language Studies</title>
     <month>May</month>
     <year>2002</year>
@@ -3056,12 +3056,12 @@
     <bibkey>cucchiarini:251:2002:lrec2002</bibkey>
   </paper>
   <paper id="1252" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/252.pdf">
-    <author><first>D.</first><last>Binnenpoorte</last></author>
-    <author><first>F.</first><last>De Vriend</last></author>
-    <author><first>J.</first><last>Sturm</last></author>
-    <author><first>W.</first><last>Daelemans</last></author>
-    <author><first>H.</first><last>Strik</last></author>
-    <author><first>C.</first><last>Cucchiarini</last></author>
+    <author><first complete="Diana">D.</first><last>Binnenpoorte</last></author>
+    <author><first complete="Folkert">F.</first><last>De Vriend</last></author>
+    <author><first complete="Janienke">J.</first><last>Sturm</last></author>
+    <author><first complete="Walter">W.</first><last>Daelemans</last></author>
+    <author><first complete="Helmer">H.</first><last>Strik</last></author>
+    <author><first complete="Catia">C.</first><last>Cucchiarini</last></author>
     <title>A Field Survey for Establishing Priorities in the Development of HLT Resources for Dutch</title>
     <month>May</month>
     <year>2002</year>
@@ -3220,9 +3220,9 @@
     <bibkey>hockenmaier:263:2002:lrec2002</bibkey>
   </paper>
   <paper id="1264" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/264.pdf">
-    <author><first>F.</first><last>de Vriend</last></author>
-    <author><first>P.A.</first><last>Coppen</last></author>
-    <author><first>W.</first><last>Haeseryn</last></author>
+    <author><first complete="Folkert">F.</first><last>de Vriend</last></author>
+    <author><first complete="Peter-Arno">P.A.</first><last>Coppen</last></author>
+    <author><first complete="Walter">W.</first><last>Haeseryn</last></author>
     <title>Using Grammatical Description as a Metalanguage Resource</title>
     <month>May</month>
     <year>2002</year>
@@ -3232,7 +3232,7 @@
     <bibkey>vriend:264:2002:lrec2002</bibkey>
   </paper>
   <paper id="1265" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/265.pdf">
-    <author><first>Hélèn</first><last>François</last></author>
+    <author><first>Hélène</first><last>François</last></author>
     <author><first>Olivier</first><last>Boëffard</last></author>
     <title>The Greedy Algorithm and its Application to the Construction of a Continuous Speech Database</title>
     <month>May</month>
@@ -3365,9 +3365,9 @@
     <bibkey>charfuelán:274:2002:lrec2002</bibkey>
   </paper>
   <paper id="1275" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/275.pdf">
-    <author><first>K. López</first><last>de Ipiña</last></author>
-    <author><first>N.</first><last>Ezeiza</last></author>
-    <author><first>G.</first><last>Bordel</last></author>
+    <author><first complete="Karmele López">K.</first><last>López de Ipiña</last></author>
+    <author><first complete="Nerea">N.</first><last>Ezeiza</last></author>
+    <author><first complete="German">G.</first><last>Bordel</last></author>
     <title>Automatic Morphological Segmentation for Continuous Speech Recognition of Basque</title>
     <month>May</month>
     <year>2002</year>

--- a/data/xml/L04.xml
+++ b/data/xml/L04.xml
@@ -4608,7 +4608,7 @@
   <paper id="1378" href="http://www.lrec-conf.org/proceedings/lrec2004/pdf/609.pdf">
     <author><first>G.</first><last>Bordel</last></author>
     <author><first>A.</first><last>Ezeiza</last></author>
-    <author><first>K. Lopez</first><last>de Ipina</last></author>
+    <author><first>K.</first><last>Lopez de Ipina</last></author>
     <author><first>M.</first><last>Méndez</last></author>
     <author><first>M.</first><last>Peñagarikano</last></author>
     <author><first>T.</first><last>Rico</last></author>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -1250,8 +1250,8 @@
     <bibkey>vriend:192:2006:lrec2006</bibkey>
   </paper>
   <paper id="1103" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/193_pdf.pdf">
-    <author><first>E. Uí</first><last>Dhonnchadha</last></author>
-    <author><first>J. Van</first><last>Genabith</last></author>
+    <author><first>E.</first><last>Uí Dhonnchadha</last></author>
+    <author><first>J.</first><last>Van Genabith</last></author>
     <title>A Part-of-speech tagger for Irish using Finite-State Morphology and Constraint Grammar Disambiguation</title>
     <month>May</month>
     <year>2006</year>
@@ -2326,7 +2326,7 @@
   </paper>
   <paper id="1193" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/336_pdf.pdf">
     <author><first>Peter W.</first><last>Wagacha</last></author>
-    <author><first>Guy De</first><last>Pauw</last></author>
+    <author><first>Guy</first><last>De Pauw</last></author>
     <author><first>Pauline W.</first><last>Githinji</last></author>
     <title>A Grapheme-Based Approach for Accent Restoration in Gikuyu</title>
     <month>May</month>
@@ -2908,7 +2908,7 @@
     <author><first>J-C.</first><last>Martin</last></author>
     <author><first>E.</first><last>Douglas-Cowie</last></author>
     <author><first>S.</first><last>Abrilian</last></author>
-    <author><first>M.</first><last>Mcrorie</last></author>
+    <author><first>M.</first><last>McRorie</last></author>
     <title>Real life emotions in French and English TV video clips: an integrated annotation protocol combining continuous and discrete approaches</title>
     <month>May</month>
     <year>2006</year>
@@ -3064,7 +3064,7 @@
     <author><first>R.</first><last>Bernardi</last></author>
     <author><first>D.</first><last>Calvanese</last></author>
     <author><first>L.</first><last>Dini</last></author>
-    <author><first>V. Di</first><last>Tomaso</last></author>
+    <author><first>V.</first><last>Di Tomaso</last></author>
     <author><first>E.</first><last>Frasnelli</last></author>
     <author><first>U.</first><last>Kugler</last></author>
     <author><first>B.</first><last>Plank</last></author>
@@ -3122,7 +3122,7 @@
     <bibkey>kaji:439:2006:lrec2006</bibkey>
   </paper>
   <paper id="1260" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/440_pdf.pdf">
-    <author><first>Marie-Catherine de</first><last>Marneffe</last></author>
+    <author><first>Marie-Catherine</first><last>de Marneffe</last></author>
     <author><first>Bill</first><last>MacCartney</last></author>
     <author><first>Christopher D.</first><last>Manning</last></author>
     <title>Generating Typed Dependency Parses from Phrase Structure Parses</title>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -163,10 +163,10 @@
     <bibkey>sansò:35:2006:lrec2006</bibkey>
   </paper>
   <paper id="1014" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/36_pdf.pdf">
-    <author><first>M.</first><last>Bahrani</last></author>
-    <author><first>H.</first><last>Sameti</last></author>
-    <author><first>N.</first><last>Hafezi</last></author>
-    <author><first>H.</first><last>Movasagh</last></author>
+    <author><first complete="Mohammad">M.</first><last>Bahrani</last></author>
+    <author><first complete="Hossein">H.</first><last>Sameti</last></author>
+    <author><first complete="Nazila">N.</first><last>Hafezi</last></author>
+    <author><first complete="Hamed">H.</first><last>Movasagh</last></author>
     <title>Building and Incorporating Language Models for Persian Continuous Speech Recognition Systems</title>
     <month>May</month>
     <year>2006</year>
@@ -427,7 +427,7 @@
   <paper id="1036" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/77_pdf.pdf">
     <author><first>Daniela</first><last>Braga</last></author>
     <author><first>Luís</first><last>Coelho</last></author>
-    <author><first>João P.</first><last>Teixeira</last></author>
+    <author><first complete="João Paulo">João P.</first><last>Teixeira</last></author>
     <author><first>Diamantino</first><last>Freitas</last></author>
     <title>Progmatica: A Prosodic Database for European Portuguese</title>
     <month>May</month>
@@ -796,23 +796,23 @@
     <bibkey>storrer:128:2006:lrec2006</bibkey>
   </paper>
   <paper id="1067" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/131_pdf.pdf">
-    <author><first>M.</first><last>Yaseen</last></author>
-    <author><first>M.</first><last>Attia</last></author>
-    <author><first>B.</first><last>Maegaard</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
-    <author><first>N.</first><last>Paulsson</last></author>
-    <author><first>S.</first><last>Haamid</last></author>
-    <author><first>S.</first><last>Krauwer</last></author>
-    <author><first>C.</first><last>Bendahman</last></author>
-    <author><first>H.</first><last>Fersøe</last></author>
-    <author><first>M.</first><last>Rashwan</last></author>
-    <author><first>B.</first><last>Haddad</last></author>
-    <author><first>C.</first><last>Mukbel</last></author>
-    <author><first>A.</first><last>Mouradi</last></author>
-    <author><first>A.</first><last>Al-Kufaishi</last></author>
-    <author><first>M.</first><last>Shahin</last></author>
-    <author><first>N.</first><last>Chenfour</last></author>
-    <author><first>A.</first><last>Ragheb</last></author>
+    <author><first complete="Mustafa">M.</first><last>Yaseen</last></author>
+    <author><first complete="Mohamed">M.</first><last>Attia</last></author>
+    <author><first complete="Bente">B.</first><last>Maegaard</last></author>
+    <author><first complete="Khalid">K.</first><last>Choukri</last></author>
+    <author><first complete="Niklas">N.</first><last>Paulsson</last></author>
+    <author><first complete="Salah">S.</first><last>Haamid</last></author>
+    <author><first complete="Steven">S.</first><last>Krauwer</last></author>
+    <author><first complete="Chomicha">C.</first><last>Bendahman</last></author>
+    <author><first complete="Hanne">H.</first><last>Fersøe</last></author>
+    <author><first complete="Mohsen">M.</first><last>Rashwan</last></author>
+    <author><first complete="Bassam">B.</first><last>Haddad</last></author>
+    <author><first complete="Chafic">C.</first><last>Mukbel</last></author>
+    <author><first complete="Abdelhak">A.</first><last>Mouradi</last></author>
+    <author><first complete="Adil">A.</first><last>Al-Kufaishi</last></author>
+    <author><first complete="Mostafa">M.</first><last>Shahin</last></author>
+    <author><first complete="Noureddine">N.</first><last>Chenfour</last></author>
+    <author><first complete="Ahmed">A.</first><last>Ragheb</last></author>
     <title>Building Annotated Written and Spoken Arabic LRs in NEMLAR Project</title>
     <month>May</month>
     <year>2006</year>
@@ -1166,11 +1166,11 @@
     <bibkey>andrassy:179:2006:lrec2006</bibkey>
   </paper>
   <paper id="1096" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/180_pdf.pdf">
-    <author><first>R.</first><last>Manurung</last></author>
-    <author><first>D.</first><last>O’mara</last></author>
-    <author><first>H.</first><last>Pain</last></author>
-    <author><first>G.</first><last>Ritchie</last></author>
-    <author><first>A.</first><last>Waller</last></author>
+    <author><first complete="Ruli">R.</first><last>Manurung</last></author>
+    <author><first complete="Dave">D.</first><last>O’mara</last></author>
+    <author><first complete="Helen">H.</first><last>Pain</last></author>
+    <author><first complete="Graeme">G.</first><last>Ritchie</last></author>
+    <author><first complete="Annalu">A.</first><last>Waller</last></author>
     <title>Building a Lexical Database for an Interactive Joke-Generator</title>
     <month>May</month>
     <year>2006</year>
@@ -1250,8 +1250,8 @@
     <bibkey>vriend:192:2006:lrec2006</bibkey>
   </paper>
   <paper id="1103" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/193_pdf.pdf">
-    <author><first>E.</first><last>Uí Dhonnchadha</last></author>
-    <author><first>J.</first><last>Van Genabith</last></author>
+    <author><first complete="Elaine">E.</first><last>Uí Dhonnchadha</last></author>
+    <author><first complete="Josef">J.</first><last>Van Genabith</last></author>
     <title>A Part-of-speech tagger for Irish using Finite-State Morphology and Constraint Grammar Disambiguation</title>
     <month>May</month>
     <year>2006</year>
@@ -1304,12 +1304,12 @@
     <bibkey>fiscus:197:2006:lrec2006</bibkey>
   </paper>
   <paper id="1108" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/198_pdf.pdf">
-    <author><first>J.</first><last>Atserias</last></author>
-    <author><first>B.</first><last>Casas</last></author>
-    <author><first>E.</first><last>Comelles</last></author>
-    <author><first>M.</first><last>González</last></author>
-    <author><first>L.</first><last>Padró</last></author>
-    <author><first>M.</first><last>Padró</last></author>
+    <author><first complete="Jordi">J.</first><last>Atserias</last></author>
+    <author><first complete="Bernardino">B.</first><last>Casas</last></author>
+    <author><first complete="Elisabet">E.</first><last>Comelles</last></author>
+    <author><first complete="Meritxell">M.</first><last>González</last></author>
+    <author><first complete="Lluís">L.</first><last>Padró</last></author>
+    <author><first complete="Muntsa">M.</first><last>Padró</last></author>
     <title>FreeLing 1.3: Syntactic and semantic services in an open-source NLP library</title>
     <month>May</month>
     <year>2006</year>
@@ -1353,7 +1353,7 @@
   <paper id="1112" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/203_pdf.pdf">
     <author><first>Judit</first><last>Feliu</last></author>
     <author><first>Jorge</first><last>Vivaldi</last></author>
-    <author><first>M. Teresa</first><last>Cabré</last></author>
+    <author><first complete="Maria Teresa">M. Teresa</first><last>Cabré</last></author>
     <title>SKELETON: Specialised knowledge retrieval on the basis of terms and conceptual relations</title>
     <month>May</month>
     <year>2006</year>
@@ -1482,11 +1482,11 @@
     <bibkey>postolache:224:2006:lrec2006</bibkey>
   </paper>
   <paper id="1123" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/225_pdf.pdf">
-    <author><first>G.</first><last>Tummarello</last></author>
-    <author><first>C.</first><last>Morbidoni</last></author>
-    <author><first>F.</first><last>Kepler</last></author>
-    <author><first>F.</first><last>Piazza</last></author>
-    <author><first>P.</first><last>Puliti</last></author>
+    <author><first complete="Giovanni">G.</first><last>Tummarello</last></author>
+    <author><first complete="Christian">C.</first><last>Morbidoni</last></author>
+    <author><first complete="Fabio">F.</first><last>Kepler</last></author>
+    <author><first complete="Francesco">F.</first><last>Piazza</last></author>
+    <author><first complete="Paolo">P.</first><last>Puliti</last></author>
     <title>A novel Textual Encoding paradigm based on Semantic Web tools and semantics</title>
     <month>May</month>
     <year>2006</year>
@@ -2030,18 +2030,18 @@
     <bibkey>uchimoto:298:2006:lrec2006</bibkey>
   </paper>
   <paper id="1168" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/299_pdf.pdf">
-    <author><first>N.</first><last>Areta</last></author>
-    <author><first>A.</first><last>Gurrutxaga</last></author>
-    <author><first>I.</first><last>Leturia</last></author>
-    <author><first>Z.</first><last>Polin</last></author>
-    <author><first>R.</first><last>Saiz</last></author>
-    <author><first>I.</first><last>Alegria</last></author>
-    <author><first>X.</first><last>Artola</last></author>
-    <author><first>A.</first><last>Diaz de Ilarraza</last></author>
-    <author><first>N.</first><last>Ezeiza</last></author>
-    <author><first>A.</first><last>Sologaistoa</last></author>
-    <author><first>A.</first><last>Soroa</last></author>
-    <author><first>A.</first><last>Valverde</last></author>
+    <author><first complete="Nerea">N.</first><last>Areta</last></author>
+    <author><first complete="Antton">A.</first><last>Gurrutxaga</last></author>
+    <author><first complete="Igor">I.</first><last>Leturia</last></author>
+    <author><first complete="Ziortza">Z.</first><last>Polin</last></author>
+    <author><first complete="Rafa">R.</first><last>Saiz</last></author>
+    <author><first complete="Iñaki">I.</first><last>Alegria</last></author>
+    <author><first complete="Xabier">X.</first><last>Artola</last></author>
+    <author><first complete="Arantza">A.</first><last>Diaz de Ilarraza</last></author>
+    <author><first complete="Nerea">N.</first><last>Ezeiza</last></author>
+    <author><first complete="Aitor">A.</first><last>Sologaistoa</last></author>
+    <author><first complete="Aitor">A.</first><last>Soroa</last></author>
+    <author><first complete="Andoni">A.</first><last>Valverde</last></author>
     <title>Structure, Annotation and Tools in the Basque ZT Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -2406,9 +2406,9 @@
     <bibkey>hoste:342:2006:lrec2006</bibkey>
   </paper>
   <paper id="1199" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/343_pdf.pdf">
-    <author><first>P.</first><last>Cimiano</last></author>
-    <author><first>M.</first><last>Hartung</last></author>
-    <author><first>E.</first><last>Ratsch</last></author>
+    <author><first complete="Philipp">P.</first><last>Cimiano</last></author>
+    <author><first complete="Matthias">M.</first><last>Hartung</last></author>
+    <author><first complete="Esther">E.</first><last>Ratsch</last></author>
     <title>Finding the Appropriate Generalization Level for Binary Ontological Relations Extracted from the Genia Corpus</title>
     <month>May</month>
     <year>2006</year>
@@ -2549,8 +2549,8 @@
     <bibkey>guthrie:357:2006:lrec2006</bibkey>
   </paper>
   <paper id="1211" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/359_pdf.pdf">
-    <author><last>Dobrov</last><first>B.</first></author>
-    <author><last>Loukachevitch</last><first>N.</first></author>
+    <author><last>Dobrov</last><first complete="Boris">B.</first></author>
+    <author><last>Loukachevitch</last><first complete="Natalia">N.</first></author>
     <title>Development of Linguistic Ontology on Natural Sciences and Technology</title>
     <month>May</month>
     <year>2006</year>
@@ -2642,12 +2642,12 @@
     <bibkey>nezda:368:2006:lrec2006</bibkey>
   </paper>
   <paper id="1219" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/372_pdf.pdf">
-    <author><first>M.</first><last>Poesio</last></author>
-    <author><first>M. A.</first><last>Kabadjov</last></author>
+    <author><first complete="Massimo">M.</first><last>Poesio</last></author>
+    <author><first complete="Mijail A.">M. A.</first><last>Kabadjov</last></author>
     <author><first>P.</first><last>Goux</last></author>
-    <author><first>U.</first><last>Kruschwitz</last></author>
-    <author><first>E.</first><last>Bishop</last></author>
-    <author><first>L.</first><last>Corti</last></author>
+    <author><first complete="Udo">U.</first><last>Kruschwitz</last></author>
+    <author><first complete="Elizabeth">E.</first><last>Bishop</last></author>
+    <author><first complete="Louise">L.</first><last>Corti</last></author>
     <title>An Anaphora Resolution-Based Anonymization Module</title>
     <month>May</month>
     <year>2006</year>
@@ -2903,12 +2903,12 @@
     <bibkey>sitbon:410:2006:lrec2006</bibkey>
   </paper>
   <paper id="1242" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/411_pdf.pdf">
-    <author><first>L.</first><last>Devillers</last></author>
-    <author><first>R.</first><last>Cowie</last></author>
-    <author><first>J-C.</first><last>Martin</last></author>
-    <author><first>E.</first><last>Douglas-Cowie</last></author>
-    <author><first>S.</first><last>Abrilian</last></author>
-    <author><first>M.</first><last>McRorie</last></author>
+    <author><first complete="Laurence">L.</first><last>Devillers</last></author>
+    <author><first complete="Roddy">R.</first><last>Cowie</last></author>
+    <author><first complete="Jean-Claude">J-C.</first><last>Martin</last></author>
+    <author><first complete="Ellen">E.</first><last>Douglas-Cowie</last></author>
+    <author><first complete="Sarkis">S.</first><last>Abrilian</last></author>
+    <author><first complete="Margaret">M.</first><last>McRorie</last></author>
     <title>Real life emotions in French and English TV video clips: an integrated annotation protocol combining continuous and discrete approaches</title>
     <month>May</month>
     <year>2006</year>
@@ -3061,13 +3061,13 @@
     <bibkey>baude:430:2006:lrec2006</bibkey>
   </paper>
   <paper id="1255" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/433_pdf.pdf">
-    <author><first>R.</first><last>Bernardi</last></author>
-    <author><first>D.</first><last>Calvanese</last></author>
-    <author><first>L.</first><last>Dini</last></author>
-    <author><first>V.</first><last>Di Tomaso</last></author>
-    <author><first>E.</first><last>Frasnelli</last></author>
-    <author><first>U.</first><last>Kugler</last></author>
-    <author><first>B.</first><last>Plank</last></author>
+    <author><first complete="Raffaella">R.</first><last>Bernardi</last></author>
+    <author><first complete="Diego">D.</first><last>Calvanese</last></author>
+    <author><first complete="Luca">L.</first><last>Dini</last></author>
+    <author><first complete="Vittorio">V.</first><last>Di Tomaso</last></author>
+    <author><first complete="Elisabeth">E.</first><last>Frasnelli</last></author>
+    <author><first complete="Ulrike">U.</first><last>Kugler</last></author>
+    <author><first complete="Barbara">B.</first><last>Plank</last></author>
     <title>Multilingual Search in Libraries. The case-study of the Free University of Bozen-Bolzano</title>
     <month>May</month>
     <year>2006</year>
@@ -3134,9 +3134,9 @@
     <bibkey>marneffe:440:2006:lrec2006</bibkey>
   </paper>
   <paper id="1261" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/441_pdf.pdf">
-    <author><first>S.</first><last>Frota</last></author>
-    <author><first>M.</first><last>Vigário</last></author>
-    <author><first>F.</first><last>Martins</last></author>
+    <author><first complete="Sónia">S.</first><last>Frota</last></author>
+    <author><first complete="Marina">M.</first><last>Vigário</last></author>
+    <author><first complete="Fernando">F.</first><last>Martins</last></author>
     <title>FreP: An electronic tool for extracting frequency information of phonological units from Portuguese written text</title>
     <month>May</month>
     <year>2006</year>
@@ -3325,11 +3325,11 @@
     <bibkey>zhang:464:2006:lrec2006</bibkey>
   </paper>
   <paper id="1278" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/465_pdf.pdf">
-    <author><first>J.-C.</first><last>Martin</last></author>
-    <author><first>G.</first><last>Caridakis</last></author>
-    <author><first>L.</first><last>Devillers</last></author>
-    <author><first>K.</first><last>Karpouzis</last></author>
-    <author><first>S.</first><last>Abrilian</last></author>
+    <author><first complete="Jean-Claude">J.-C.</first><last>Martin</last></author>
+    <author><first complete="George">G.</first><last>Caridakis</last></author>
+    <author><first complete="Laurence">L.</first><last>Devillers</last></author>
+    <author><first complete="Kostas">K.</first><last>Karpouzis</last></author>
+    <author><first complete="Sarkis">S.</first><last>Abrilian</last></author>
     <title>Manual Annotation and Automatic Image Processing of Multimodal Emotional Behaviours: Validating the Annotation of TV Interviews</title>
     <month>May</month>
     <year>2006</year>
@@ -3493,12 +3493,12 @@
     <bibkey>ciobanu:484:2006:lrec2006</bibkey>
   </paper>
   <paper id="1291" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/485_pdf.pdf">
-    <author><first>G.</first><last>Ajani</last></author>
-    <author><first>G.</first><last>Boella</last></author>
-    <author><first>L.</first><last>Lesmo</last></author>
-    <author><first>M.</first><last>Martin</last></author>
-    <author><first>A.</first><last>Mazzei</last></author>
-    <author><first>P.</first><last>Rossi</last></author>
+    <author><first complete="Gianmaria">G.</first><last>Ajani</last></author>
+    <author><first complete="Guido">G.</first><last>Boella</last></author>
+    <author><first complete="Leonardo">L.</first><last>Lesmo</last></author>
+    <author><first complete="Marco">M.</first><last>Martin</last></author>
+    <author><first complete="Alessandro">A.</first><last>Mazzei</last></author>
+    <author><first complete="Piercarlo">P.</first><last>Rossi</last></author>
     <title>A Development Tool For Multilingual Ontology-based Conceptual</title>
     <month>May</month>
     <year>2006</year>
@@ -3630,9 +3630,9 @@
     <bibkey>ferret:500:2006:lrec2006</bibkey>
   </paper>
   <paper id="1302" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/501_pdf.pdf">
-    <author><first>P.</first><last>Bouquet</last></author>
-    <author><first>L.</first><last>Serafini</last></author>
-    <author><first>S.</first><last>Zanobini</last></author>
+    <author><first complete="Paolo">P.</first><last>Bouquet</last></author>
+    <author><first complete="Luciano">L.</first><last>Serafini</last></author>
+    <author><first complete="Stefano">S.</first><last>Zanobini</last></author>
     <title>The role of lexical resources in matching classification schemas</title>
     <month>May</month>
     <year>2006</year>
@@ -3760,9 +3760,9 @@
     <bibkey>levy:513:2006:lrec2006</bibkey>
   </paper>
   <paper id="1312" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/515_pdf.pdf">
-    <author><first>L.</first><last>Gillard</last></author>
-    <author><first>P.</first><last>Bellot</last></author>
-    <author><first>M.</first><last>El-Bèze</last></author>
+    <author><first complete="Laurent">L.</first><last>Gillard</last></author>
+    <author><first complete="Patrice">P.</first><last>Bellot</last></author>
+    <author><first complete="Marc">M.</first><last>El-Bèze</last></author>
     <title>Question Answering Evaluation Survey</title>
     <month>May</month>
     <year>2006</year>
@@ -3772,14 +3772,14 @@
     <bibkey>gillard:515:2006:lrec2006</bibkey>
   </paper>
   <paper id="1313" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/518_pdf.pdf">
-    <author><first>B.</first><last>Magnini</last></author>
-    <author><first>E.</first><last>Pianta</last></author>
-    <author><first>C.</first><last>Girardi</last></author>
-    <author><first>M.</first><last>Negri</last></author>
-    <author><first>L.</first><last>Romano</last></author>
-    <author><first>M.</first><last>Speranza</last></author>
-    <author><first>V. Bartalesi</first><last>Lenzi</last></author>
-    <author><first>R.</first><last>Sprugnoli</last></author>
+    <author><first complete="Bernardo">B.</first><last>Magnini</last></author>
+    <author><first complete="Emanuele">E.</first><last>Pianta</last></author>
+    <author><first complete="Christian">C.</first><last>Girardi</last></author>
+    <author><first complete="Matteo">M.</first><last>Negri</last></author>
+    <author><first complete="Lorenza">L.</first><last>Romano</last></author>
+    <author><first complete="Manuela">M.</first><last>Speranza</last></author>
+    <author><first complete="Valentina">V.</first><last>Bartalesi Lenzi</last></author>
+    <author><first complete="Rachele">R.</first><last>Sprugnoli</last></author>
     <title>I-CAB: the Italian Content Annotation Bank</title>
     <month>May</month>
     <year>2006</year>
@@ -3859,9 +3859,9 @@
     <bibkey>cieri:530:2006:lrec2006</bibkey>
   </paper>
   <paper id="1319" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/531_pdf.pdf">
-    <author><first>S.</first><last>Abrilian</last></author>
-    <author><first>L.</first><last>Devillers</last></author>
-    <author><first>J-C.</first><last>Martin</last></author>
+    <author><first complete="Sarkis">S.</first><last>Abrilian</last></author>
+    <author><first complete="Laurence">L.</first><last>Devillers</last></author>
+    <author><first complete="Jean-Claude">J-C.</first><last>Martin</last></author>
     <title>Annotation of Emotions in Real-Life Video Interviews: Variability between Coders</title>
     <month>May</month>
     <year>2006</year>
@@ -4314,14 +4314,14 @@
     <bibkey>roventini:584:2006:lrec2006</bibkey>
   </paper>
   <paper id="1355" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/586_pdf.pdf">
-    <author><first>O.</first><last>Hamon</last></author>
-    <author><first>A.</first><last>Popescu-Belis</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
-    <author><first>M.</first><last>Dabbadie</last></author>
-    <author><first>A.</first><last>Hartley</last></author>
-    <author><first>W.</first><last>Mustafa El Hadi</last></author>
-    <author><first>M.</first><last>Rajman</last></author>
-    <author><first>I.</first><last>Timimi</last></author>
+    <author><first complete="Olivier">O.</first><last>Hamon</last></author>
+    <author><first complete="Andrei">A.</first><last>Popescu-Belis</last></author>
+    <author><first complete="Khalid">K.</first><last>Choukri</last></author>
+    <author><first complete="Marianne">M.</first><last>Dabbadie</last></author>
+    <author><first complete="Anthony">A.</first><last>Hartley</last></author>
+    <author><first complete="Widad">W.</first><last>Mustafa El Hadi</last></author>
+    <author><first complete="Martin">M.</first><last>Rajman</last></author>
+    <author><first complete="Ismaïl">I.</first><last>Timimi</last></author>
     <title>CESTA: First Conclusions of the Technolangue MT Evaluation Campaign</title>
     <month>May</month>
     <year>2006</year>
@@ -4411,10 +4411,10 @@
     <bibkey>bosch:597:2006:lrec2006</bibkey>
   </paper>
   <paper id="1363" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/599_pdf.pdf">
-    <author><last>Lechenadec</last><first>G.</first></author>
-    <author><last>Maffiolo</last><first>V.</first></author>
-    <author><last>Chateau</last><first>N.</first></author>
-    <author><last>Colletta</last><first>J.M.</first></author>
+    <author><last>Lechenadec</last><first complete="Gilles">G.</first></author>
+    <author><last>Maffiolo</last><first complete="Valérie">V.</first></author>
+    <author><last>Chateau</last><first complete="Noël">N.</first></author>
+    <author><last>Colletta</last><first complete="Jean-Marc">J.M.</first></author>
     <title>Creation of a corpus of multimodal spontaneous expressions of emotions in Human-Machine Interaction</title>
     <month>May</month>
     <year>2006</year>
@@ -4512,10 +4512,10 @@
     <bibkey>inui:610:2006:lrec2006</bibkey>
   </paper>
   <paper id="1371" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/611_pdf.pdf">
-    <author><first>C.</first><last>Onelli</last></author>
-    <author><first>D.</first><last>Proietti</last></author>
-    <author><first>C.</first><last>Seidenari</last></author>
-    <author><first>F.</first><last>Tamburini</last></author>
+    <author><first complete="Corinna">C.</first><last>Onelli</last></author>
+    <author><first complete="Domenico">D.</first><last>Proietti</last></author>
+    <author><first complete="Corrado">C.</first><last>Seidenari</last></author>
+    <author><first complete="Fabio">F.</first><last>Tamburini</last></author>
     <title>The DiaCORIS project: a diachronic corpus of written Italian</title>
     <month>May</month>
     <year>2006</year>
@@ -4567,7 +4567,7 @@
   </paper>
   <paper id="1375" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/615_pdf.pdf">
     <author><first>Jan</first><last>Hoidekr</last></author>
-    <author><first>J.V.</first><last>Psutka</last></author>
+    <author><first complete="Josef V.">J.V.</first><last>Psutka</last></author>
     <author><first>Aleš</first><last>Pražák</last></author>
     <author><first>Josef</first><last>Psutka</last></author>
     <title>Benefit of a Class-based Language Model for Real-time Closed-captioning of TV Ice-hockey Commentaries</title>
@@ -4645,7 +4645,7 @@
   <paper id="1382" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/624_pdf.pdf">
     <author><first>Benjamin K.</first><last>Tsou</last></author>
     <author><first>Tom B.Y.</first><last>Lai</last></author>
-    <author><first>K.K.</first><last>Sin</last></author>
+    <author><first complete="King Kui">K.K.</first><last>Sin</last></author>
     <author><first>Lawrence Y.L.</first><last>Cheung</last></author>
     <title>Court Stenography-To-Text (“STT”) in Hong Kong: A Jurilinguistic Engineering Effort</title>
     <month>May</month>
@@ -4679,17 +4679,17 @@
     <bibkey>reidsma:626:2006:lrec2006</bibkey>
   </paper>
   <paper id="1385" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/627_pdf.pdf">
-    <author><first>H.</first><last>Bonneau-Maynard</last></author>
-    <author><first>C.</first><last>Ayache</last></author>
-    <author><first>F.</first><last>Bechet</last></author>
-    <author><first>A.</first><last>Denis</last></author>
-    <author><first>A.</first><last>Kuhn</last></author>
-    <author><first>F.</first><last>Lefevre</last></author>
-    <author><first>D.</first><last>Mostefa</last></author>
-    <author><first>M.</first><last>Quignard</last></author>
-    <author><first>S.</first><last>Rosset</last></author>
-    <author><first>C.</first><last>Servan</last></author>
-    <author><first>J.</first><last>Villaneau</last></author>
+    <author><first complete="Hélène">H.</first><last>Bonneau-Maynard</last></author>
+    <author><first complete="Christelle">C.</first><last>Ayache</last></author>
+    <author><first complete="Frédéric">F.</first><last>Bechet</last></author>
+    <author><first complete="Alexandre">A.</first><last>Denis</last></author>
+    <author><first complete="Anne">A.</first><last>Kuhn</last></author>
+    <author><first complete="Fabrice">F.</first><last>Lefevre</last></author>
+    <author><first complete="Djamel">D.</first><last>Mostefa</last></author>
+    <author><first complete="Matthieu">M.</first><last>Quignard</last></author>
+    <author><first complete="Sophie">S.</first><last>Rosset</last></author>
+    <author><first complete="Christophe">C.</first><last>Servan</last></author>
+    <author><first complete="Jeanne">J.</first><last>Villaneau</last></author>
     <title>Results of the French Evalda-Media evaluation campaign for literal understanding</title>
     <month>May</month>
     <year>2006</year>
@@ -4875,12 +4875,12 @@
     <bibkey>miller:645:2006:lrec2006</bibkey>
   </paper>
   <paper id="1400" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/646_pdf.pdf">
-    <author><first>S.</first><last>Galliano</last></author>
-    <author><first>E.</first><last>Geoffrois</last></author>
-    <author><first>G.</first><last>Gravier</last></author>
-    <author><first>J.-F.</first><last>Bonastre</last></author>
-    <author><first>D.</first><last>Mostefa</last></author>
-    <author><first>K.</first><last>Choukri</last></author>
+    <author><first complete="Sylvain">S.</first><last>Galliano</last></author>
+    <author><first complete="Edouard">E.</first><last>Geoffrois</last></author>
+    <author><first complete="Guillaume">G.</first><last>Gravier</last></author>
+    <author><first complete="Jean-François">J.-F.</first><last>Bonastre</last></author>
+    <author><first complete="Djamel">D.</first><last>Mostefa</last></author>
+    <author><first complete="Khalid">K.</first><last>Choukri</last></author>
     <title>Corpus description of the ESTER Evaluation Campaign for the Rich Transcription of French Broadcast News</title>
     <month>May</month>
     <year>2006</year>
@@ -5157,7 +5157,7 @@
     <bibkey>ibekwe-sanjuan:678:2006:lrec2006</bibkey>
   </paper>
   <paper id="1423" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/679_pdf.pdf">
-    <author><first>A.</first><last>Moreno</last></author>
+    <author><first complete="Asuncion">A.</first><last>Moreno</last></author>
     <author><first>Albert</first><last>Febrer</last></author>
     <author><first>Lluis</first><last>Màrquez</last></author>
     <title>Generation of Language Resources for the Development of Speech Technologies in Catalan</title>
@@ -5195,8 +5195,8 @@
     <bibkey>trón:683:2006:lrec2006</bibkey>
   </paper>
   <paper id="1426" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/685_pdf.pdf">
-    <author><last>Le</last><first>H. Phuong</first></author>
-    <author><last>Nguyen</last><first>T. M. Huyen</first></author>
+    <author><last>Le</last><first complete="Hong Phuong">H. Phuong</first></author>
+    <author><last>Nguyen</last><first complete="Thi Minh Huyen">T. M. Huyen</first></author>
     <author><last>Romary</last><first>Laurent</first></author>
     <author><last>Roussanaly</last><first>Azim</first></author>
     <title>A Lexicalized Tree-Adjoining Grammar for Vietnamese</title>
@@ -5457,15 +5457,15 @@
     <bibkey>cieri:717:2006:lrec2006</bibkey>
   </paper>
   <paper id="1448" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/719_pdf.pdf">
-    <author><first>A.</first><last>Bonafonte</last></author>
-    <author><first>H.</first><last>Höge</last></author>
-    <author><first>I.</first><last>Kiss</last></author>
-    <author><first>A.</first><last>Moreno</last></author>
-    <author><first>U.</first><last>Ziegenhain</last></author>
-    <author><first>H.</first><last>van den Heuvel</last></author>
-    <author><first>H.-U.</first><last>Hain</last></author>
-    <author><first>X. S.</first><last>Wang</last></author>
-    <author><first>M. N.</first><last>Garcia</last></author>
+    <author><first complete="Antonio">A.</first><last>Bonafonte</last></author>
+    <author><first complete="Harald">H.</first><last>Höge</last></author>
+    <author><first complete="Imre">I.</first><last>Kiss</last></author>
+    <author><first complete="Asuncion">A.</first><last>Moreno</last></author>
+    <author><first complete="Ute">U.</first><last>Ziegenhain</last></author>
+    <author><first complete="Henk">H.</first><last>van den Heuvel</last></author>
+    <author><first complete="Horst-Udo">H.-U.</first><last>Hain</last></author>
+    <author><first complete="Xia S.">X. S.</first><last>Wang</last></author>
+    <author><first complete="Marie-Neige">M. N.</first><last>Garcia</last></author>
     <title>TC-STAR:Specifications of Language Resources and Evaluation for Speech Synthesis</title>
     <month>May</month>
     <year>2006</year>
@@ -5547,8 +5547,8 @@
     <bibkey>miller:727:2006:lrec2006</bibkey>
   </paper>
   <paper id="1455" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/729_pdf.pdf">
-    <author><first>O.</first><last>Hamon</last></author>
-    <author><first>M.</first><last>Rajman</last></author>
+    <author><first complete="Olivier">O.</first><last>Hamon</last></author>
+    <author><first complete="Martin">M.</first><last>Rajman</last></author>
     <title>X-Score: Automatic Evaluation of Machine Translation Grammaticality</title>
     <month>May</month>
     <year>2006</year>
@@ -5623,12 +5623,12 @@
     <bibkey>lesmo:740:2006:lrec2006</bibkey>
   </paper>
   <paper id="1462" href="http://www.lrec-conf.org/proceedings/lrec2006/pdf/742_pdf.pdf">
-    <author><first>A.</first><last>Nazarenko</last></author>
-    <author><first>E.</first><last>Alphonse</last></author>
-    <author><first>J.</first><last>Derivière</last></author>
-    <author><first>T.</first><last>Hamon</last></author>
-    <author><first>G.</first><last>Vauvert</last></author>
-    <author><first>D.</first><last>Weissenbacher</last></author>
+    <author><first complete="Adeline">A.</first><last>Nazarenko</last></author>
+    <author><first complete="Erick">E.</first><last>Alphonse</last></author>
+    <author><first complete="Julien">J.</first><last>Derivière</last></author>
+    <author><first complete="Thierry">T.</first><last>Hamon</last></author>
+    <author><first complete="Guillaume">G.</first><last>Vauvert</last></author>
+    <author><first complete="Davy">D.</first><last>Weissenbacher</last></author>
     <title>The ALVIS Format for Linguistically Annotated Documents</title>
     <month>May</month>
     <year>2006</year>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -2295,7 +2295,7 @@
     <author><first>Francesca</first><last>Bertagna</last></author>
     <author><first>Nicoletta</first><last>Calzolari</last></author>
     <author><first>Antonio</first><last>Toral</last></author>
-    <author><first>Valentina Bartalesi</first><last>Lenzi</last></author>
+    <author><first>Valentina</first><last>Bartalesi Lenzi</last></author>
     <author><first>Rachele</first><last>Sprugnoli</last></author>
     <author><first>Manuela</first><last>Speranza</last></author>
     <title>Evaluation of Natural Language Tools for Italian: EVALITA 2007</title>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -1001,7 +1001,7 @@
   <pages>3692–3696</pages>
 </paper>
 <paper id="1072" href="http://www.lrec-conf.org/proceedings/lrec2012/pdf/216_Paper.pdf">
-  <author><first>Valentina Bartalesi</first><last>Lenzi</last></author>
+  <author><first>Valentina</first><last>Bartalesi Lenzi</last></author>
   <author><first>Giovanni</first><last>Moretti</last></author>
   <author><first>Rachele</first><last>Sprugnoli</last></author>
   <title>CAT: the CELCT Annotation Tool</title>

--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -2973,7 +2973,7 @@
     <title>GrawlTCQ: Terminology and Corpora Building by Ranking Simultaneously Terms, Queries and Documents using Graph Random Walks</title>
     <author><first>Xavier</first><last>Tannier</last></author>
     <author><first>Javier</first><last>Couto</last></author>
-    <author><first>ClÉment</first><last>de Groc</last></author>
+    <author><first>Clément</first><last>de Groc</last></author>
     <booktitle>Proceedings of TextGraphs-6: Graph-based Methods for Natural Language Processing</booktitle>
     <month>June</month>
     <year>2011</year>

--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -7,8 +7,14 @@ fixed-case = element fixed-case { MarkupText }
 tex-math = element tex-math { text }
 MarkupText = (text | b | i | url | fixed-case | tex-math )+
 
-first = element first { text }
-last = element last { text }
+first = element first {
+  attribute complete { string }?,
+  text
+}
+last = element last {
+  attribute complete { string }?,
+  text
+}
 Person = (first? & last)
 
 Paper = element paper {

--- a/data/xml/schema.rng
+++ b/data/xml/schema.rng
@@ -40,11 +40,21 @@
   </define>
   <define name="first">
     <element name="first">
+      <optional>
+        <attribute name="complete">
+          <data type="string"/>
+        </attribute>
+      </optional>
       <text/>
     </element>
   </define>
   <define name="last">
     <element name="last">
+      <optional>
+        <attribute name="complete">
+          <data type="string"/>
+        </attribute>
+      </optional>
       <text/>
     </element>
   </define>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -2483,7 +2483,7 @@
   - {first: Paramveer, last: Dhillon}
 - canonical: {first: Elaine Uí, last: Dhonnchadha}
   variants:
-  - {first: E. Uí, last: Dhonnchadha}
+  - {first: E., last: Uí Dhonnchadha}
 - canonical: {first: Luigi, last: Di Caro}
   variants:
   - {first: Luigi, last: di Caro}
@@ -10448,7 +10448,7 @@
   - {first: David, last: Tomás}
 - canonical: {first: Vittorio Di, last: Tomaso}
   variants:
-  - {first: V. Di, last: Tomaso}
+  - {first: V., last: Di Tomaso}
 - canonical: {first: Masaru, last: Tomita}
   variants:
   - {first: Masaru, last: TOMITA}
@@ -10833,7 +10833,7 @@
   - {first: Josef Van, last: Genabith}
   - {first: Josef, last: Van Genabith}
   - {first: Josef van, last: Genabith}
-  - {first: J. Van, last: Genabith}
+  - {first: J., last: Van Genabith}
 - canonical: {first: Willem Robert, last: van Hage}
   variants:
   - {first: Willem Van, last: Hage}

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -1,4 +1,3 @@
----
 - canonical: {first: Solomon Teferra, last: Abate}
   variants:
   - {first: Solomon, last: Teferra Abate}
@@ -37,6 +36,9 @@
   variants:
   - {first: Jose I., last: Abreu}
   - {first: José, last: Abreu}
+- canonical: {first: Sarkis, last: Abrilian}
+  variants:
+  - {first: S., last: Abrilian}
 - canonical: {first: Amjad, last: Abu-Jbara}
   variants:
   - {first: Amjad, last: Abu Jbara}
@@ -151,6 +153,9 @@
 - canonical: {first: Mohamed, last: Al-Badrashiny}
   variants:
   - {first: Mohamed, last: AlBadrashiny}
+- canonical: {first: Adil, last: Al-Kufaishi}
+  variants:
+  - {first: A., last: Al-Kufaishi}
 - canonical: {first: Rami, last: Al-Rfou’}
   variants:
   - {first: Rami, last: Al-Rfou}
@@ -356,8 +361,9 @@
   variants:
   - {first: X, last: Arregi}
   - {first: X., last: Arregi}
-- canonical: {first: J. M., last: Arriola}
+- canonical: {first: Jose Mari, last: Arriola}
   variants:
+  - {first: J. M., last: Arriola}
   - {first: J.M, last: Arriola}
   - {first: J.M., last: Arriola}
 - canonical: {first: Núria, last: Artigas}
@@ -455,15 +461,24 @@
 - canonical: {first: Hee-Sook, last: Bae}
   variants:
   - {first: Hee Sook, last: Bae}
+- canonical: {first: Mirko, last: Baglioni}
+  variants:
+  - {first: M., last: Baglioni}
 - canonical: {first: L. R., last: Bahl}
   variants:
   - {first: L.R., last: Bahl}
+- canonical: {first: Mohammad, last: Bahrani}
+  variants:
+  - {first: M., last: Bahrani}
 - canonical: {first: Vít, last: Baisa}
   variants:
   - {first: Vit, last: Baisa}
 - canonical: {first: Ondřej, last: Bajgar}
   variants:
   - {first: Ondrej, last: Bajgar}
+- canonical: {first: Stylianos, last: Bakamidis}
+  variants:
+  - {first: S., last: Bakamidis}
 - canonical: {first: Collin F., last: Baker}
   variants:
   - {first: Collin, last: Baker}
@@ -696,6 +711,9 @@
   - {first: Abdelmajid, last: Ben hamadou}
   - {first: Abdelmajid, last: Benhamadou}
   - {first: Abdelmajid-Lin, last: Ben Hamadou}
+- canonical: {first: Abderrahim, last: Benabbou}
+  variants:
+  - {first: A., last: Benabbou}
 - canonical: {first: Farah, last: Benamara}
   variants:
   - {first: Farah, last: Beanamara}
@@ -727,6 +745,9 @@
 - canonical: {first: Tamara, last: Berg}
   variants:
   - {first: Tamara L., last: Berg}
+- canonical: {first: Carole, last: Bergamini}
+  variants:
+  - {first: C., last: Bergamini}
 - canonical: {first: Adam, last: Berger}
   variants:
   - {first: Adam L., last: Berger}
@@ -746,6 +767,9 @@
 - canonical: {first: Francesca, last: Bertagna}
   variants:
   - {first: Francesca, last: BERTAGNA}
+- canonical: {first: Elisa, last: Bertino}
+  variants:
+  - {first: E., last: Bertino}
 - canonical: {first: Núria, last: Bertomeu}
   variants:
   - {first: Nuria, last: Bertomeu}
@@ -834,6 +858,9 @@
 - canonical: {first: Diana, last: Binnenpoorte}
   variants:
   - {first: D., last: Binnenpoorte}
+- canonical: {first: Elizabeth, last: Bishop}
+  variants:
+  - {first: E., last: Bishop}
 - canonical: {first: André, last: Bittar}
   variants:
   - {first: Andre, last: Bittar}
@@ -992,6 +1019,9 @@
 - canonical: {first: Matko, last: Bosnjak}
   variants:
   - {first: Matko, last: Bošnjak}
+- canonical: {first: Elizabeth C., last: Botha}
+  variants:
+  - {first: E.C., last: Botha}
 - canonical: {first: Alexandre, last: Bouchard-Côté}
   variants:
   - {first: Alexandre, last: Bouchard}
@@ -1081,6 +1111,9 @@
   - {first: Antonio, last: Branco}
   - {first: Antonio H., last: Branco}
   - {first: Antônio Horta, last: Branco}
+- canonical: {first: Andrew, last: Brasher}
+  variants:
+  - {first: A., last: Brasher}
 - canonical: {first: Harry, last: Bratt}
   variants:
   - {first: H., last: Bratt}
@@ -1232,8 +1265,9 @@
 - canonical: {first: Luís Miguel, last: Cabral}
   variants:
   - {first: Luís, last: Cabral}
-- canonical: {first: M. Teresa, last: Cabré}
+- canonical: {first: Maria Teresa, last: Cabré}
   variants:
+  - {first: M. Teresa, last: Cabré}
   - {first: Teresa, last: Cabré}
 - canonical: {first: Whitney L., last: Cade}
   variants:
@@ -1345,6 +1379,9 @@
   - {first: P., last: Cardoso}
   - {first: Paula C. Figueira, last: Cardoso}
   - {first: Paula C. F., last: Cardoso}
+- canonical: {first: George, last: Caridakis}
+  variants:
+  - {first: G., last: Caridakis}
 - canonical: {first: Jean, last: Carletta}
   variants:
   - {first: JEAN, last: CARLETTA}
@@ -1423,8 +1460,9 @@
 - canonical: {first: Dolors, last: Català}
   variants:
   - {first: Dolors, last: Catala}
-- canonical: {first: M. N., last: CATARSI}
+- canonical: {first: Maria Novella, last: Catarsi}
   variants:
+  - {first: M. N., last: CATARSI}
   - {first: M. N., last: Catarsi}
 - canonical: {first: Roberta, last: Catizone}
   variants:
@@ -1488,10 +1526,11 @@
   variants:
   - {first: Sharath Chandra, last: Guntuku}
 - canonical: {first: Raman, last: Chandrasekar}
+  comment: Raman Chandrasekar is the canonical spelling of his name, even though it
+    doesn't appear on any Anthology paper
   variants:
   - {first: R., last: Chandrasekar}
   - {first: Raman, last: Chandraseker}
-  comment: {Raman Chandrasekar is the canonical spelling of his name, even though it doesn't appear on any Anthology paper}
 - canonical: {first: Muthu Kumar, last: Chandrasekaran}
   variants:
   - {first: Muthu, last: Kumar Chandrasekaran}
@@ -1564,6 +1603,9 @@
 - canonical: {first: Eric, last: Charton}
   variants:
   - {first: Éric, last: Charton}
+- canonical: {first: Noël, last: Chateau}
+  variants:
+  - {first: N., last: Chateau}
 - canonical: {first: Niladri, last: Chatterjee}
   variants:
   - {first: N., last: Chatterjee}
@@ -1924,6 +1966,9 @@
 - canonical: {first: Christophe, last: Collet}
   variants:
   - {first: C., last: Collet}
+- canonical: {first: Jean-Marc, last: Colletta}
+  variants:
+  - {first: J.M., last: Colletta}
 - canonical: {first: Edward, last: Collins}
   variants:
   - {first: Ed, last: Collins}
@@ -1964,6 +2009,9 @@
 - canonical: {first: TERRY, last: COPECK}
   variants:
   - {first: Terry, last: Copeck}
+- canonical: {first: Peter-Arno, last: Coppen}
+  variants:
+  - {first: P.A., last: Coppen}
 - canonical: {first: Ornella, last: Corazzari}
   variants:
   - {first: O., last: Corazzari}
@@ -2000,6 +2048,9 @@
 - canonical: {first: Simon, last: Corston-Oliver}
   variants:
   - {first: Simon H., last: Corston-Oliver}
+- canonical: {first: Louise, last: Corti}
+  variants:
+  - {first: L., last: Corti}
 - canonical: {first: Santiago, last: Cortés Vaíllo}
   variants:
   - {first: Santiago, last: Cortes}
@@ -2047,6 +2098,9 @@
   variants:
   - {first: Daniel, last: Couto-Vale}
   - {first: Daniel, last: Vale}
+- canonical: {first: Roddy, last: Cowie}
+  variants:
+  - {first: R., last: Cowie}
 - canonical: {first: Benoit, last: Crabbé}
   variants:
   - {first: Benoît, last: Crabbé}
@@ -2289,10 +2343,10 @@
 - canonical: {first: Clément, last: de Groc}
   variants:
   - {first: Clément De, last: Groc}
-  - {first: ClÉment, last: de Groc}
-- canonical: {first: K. López, last: de Ipiña}
+- canonical: {first: Karmele López, last: de Ipiña}
   variants:
-  - {first: K. Lopez, last: de Ipina}
+  - {first: K., last: López de Ipiña}
+  - {first: K., last: Lopez de Ipina}
 - canonical: {first: Josafá, last: de Jesus Aguiar Pontes}
   variants:
   - {first: Josafá de Jesus Aguiar, last: Pontes}
@@ -2371,6 +2425,7 @@
   - {first: F., last: de Vriend}
   - {first: Folkert de, last: Vriend}
   - {first: Folkert De, last: Vriend}
+  - {first: Folkert, last: De Vriend}
 - canonical: {first: Fathi, last: Debili}
   variants:
   - {first: Fathi, last: DEBILI}
@@ -2408,6 +2463,17 @@
   variants:
   - {first: SYLVAIN, last: DELISLE}
   - {first: Sylvain, last: DELISLE}
+- canonical: {first: Stephen A., last: Della Pietra}
+  variants:
+  - {first: S., last: DELLA PIETRA}
+  - {first: S., last: Della Pietra}
+  - {first: Stephen, last: Della Pietra}
+  - {first: Stephen, last: DellaPietra}
+- canonical: {first: Vincent J., last: Della Pietra}
+  variants:
+  - {first: V., last: DELLA PIETRA}
+  - {first: V., last: Della Pietra}
+  - {first: Vincent, last: DellaPietra}
 - canonical: {first: Felice, last: Dell’Orletta}
   variants:
   - {first: Felice, last: Dell’orletta}
@@ -2444,6 +2510,9 @@
 - canonical: {first: Jan Milan, last: Deriu}
   variants:
   - {first: Jan, last: Deriu}
+- canonical: {first: Julien, last: Derivière}
+  variants:
+  - {first: J., last: Derivière}
 - canonical: {first: Louis, last: des Tombe}
   variants:
   - {first: L., last: des Tombe}
@@ -2492,6 +2561,10 @@
   variants:
   - {first: Giuseppe, last: Fabbrizio}
   - {first: Giuseppe Di, last: Fabbrizio}
+- canonical: {first: Vittorio, last: Di Tomaso}
+  variants:
+  - {first: Vittorio Di, last: Tomaso}
+  - {first: V., last: Di Tomaso}
 - canonical: {first: Mona, last: Diab}
   variants:
   - {first: Mona T., last: Diab}
@@ -2597,6 +2670,9 @@
 - canonical: {first: William B., last: Dolan}
   variants:
   - {first: William, last: Dolan}
+- canonical: {first: Ioannis, last: Dologlou}
+  variants:
+  - {first: I., last: Dologlou}
 - canonical: {first: Marc, last: Domenig}
   variants:
   - {first: Marc, last: DOMENIG}
@@ -2626,6 +2702,9 @@
 - canonical: {first: Shuji, last: Doshita}
   variants:
   - {first: Shuji, last: DOSHITA}
+- canonical: {first: Ellen, last: Douglas-Cowie}
+  variants:
+  - {first: E., last: Douglas-Cowie}
 - canonical: {first: Yerai, last: Doval}
   variants:
   - {first: Yerai, last: Doval Mosquera}
@@ -2651,6 +2730,9 @@
 - canonical: {first: Sebastian, last: Drude}
   variants:
   - {first: S., last: Drude}
+- canonical: {first: Johan Adam, last: du Preez}
+  variants:
+  - {first: J.A., last: du Preez}
 - canonical: {first: Jianyong, last: Duan}
   variants:
   - {first: Jian-Yong, last: Duan}
@@ -2698,6 +2780,9 @@
 - canonical: {first: Ondřej, last: Dušek}
   variants:
   - {first: Ondrej, last: Dusek}
+- canonical: {first: Arienne, last: Dwyer}
+  variants:
+  - {first: A., last: Dwyer}
 - canonical: {first: Laila, last: Dybkjaer}
   variants:
   - {first: Laila, last: Dybkjær}
@@ -2732,6 +2817,9 @@
   - {first: A., last: Díaz de Ilarraza}
   - {first: Arantza, last: Diaz de Ilarraza}
   - {first: A., last: Diaz de Ilarraza Sanchez}
+- canonical: {first: Jesús E., last: Díaz Verdejo}
+  variants:
+  - {first: J.E., last: Díaz Verdejo}
 - canonical: {first: Elisabeth, last: D’Halleweyn}
   variants:
   - {first: Elizabeth, last: D’Halleweyn}
@@ -3212,6 +3300,9 @@
 - canonical: {first: Kilian A., last: Foth}
   variants:
   - {first: Kilian, last: Foth}
+- canonical: {first: Stavroula-Evita, last: Fotinea}
+  variants:
+  - {first: S.-E., last: Fotinea}
 - canonical: {first: Christophe, last: Fouqueré}
   variants:
   - {first: C., last: Fouquere}
@@ -3240,9 +3331,6 @@
 - canonical: {first: Claire, last: François}
   variants:
   - {first: Claire, last: Francois}
-- canonical: {first: Hélène, last: François}
-  variants:
-  - {first: Hélèn, last: François}
 - canonical: {first: Thomas, last: François}
   variants:
   - {first: Thomas, last: Francois}
@@ -3255,6 +3343,9 @@
 - canonical: {first: Norman M., last: Fraser}
   variants:
   - {first: Norman, last: Fraser}
+- canonical: {first: Elisabeth, last: Frasnelli}
+  variants:
+  - {first: E., last: Frasnelli}
 - canonical: {first: Zuzana, last: Fraterova}
   variants:
   - {first: Zuzana, last: Fráterová}
@@ -3280,6 +3371,9 @@
 - canonical: {first: Carol, last: Friedman}
   variants:
   - {first: C., last: Friedman}
+- canonical: {first: Sónia, last: Frota}
+  variants:
+  - {first: S., last: Frota}
 - canonical: {first: Takeshi, last: FUCHI}
   variants:
   - {first: Takeshi, last: Fuchi}
@@ -3350,6 +3444,9 @@
 - canonical: {first: Ascension, last: Gallardo-Antolin}
   variants:
   - {first: Ascension, last: Gallardo}
+- canonical: {first: Sylvain, last: Galliano}
+  variants:
+  - {first: S., last: Galliano}
 - canonical: {first: Bruno, last: Galmar}
   variants:
   - {first: Bruno, last: GALMAR}
@@ -3361,6 +3458,9 @@
   - {first: BJORN, last: GAMBACK}
   - {first: Bjorn, last: Gamback}
   - {first: Björn, last: Gämback}
+- canonical: {first: Iñaki, last: Gaminde}
+  variants:
+  - {first: I., last: Gaminde}
 - canonical: {first: Kok Wee, last: Gan}
   variants:
   - {first: Kok-Wee, last: Gan}
@@ -3391,6 +3491,9 @@
   variants:
   - {first: Fernando, last: García-Granada}
   - {first: Fernando, last: García}
+- canonical: {first: Marie-Neige, last: Garcia}
+  variants:
+  - {first: M. N., last: Garcia}
 - canonical: {first: Jorge, last: Garcia Flores}
   variants:
   - {first: Jorge J., last: Garcia Flores}
@@ -3671,6 +3774,7 @@
 - canonical: {first: Meritxell, last: Gonzàlez}
   variants:
   - {first: Meritxell, last: González}
+  - {first: M., last: González}
 - canonical: {first: Edgar, last: Gonzàlez Pellicer}
   variants:
   - {first: Edgar, last: Gonzàlez}
@@ -3987,6 +4091,9 @@
 - canonical: {first: Anne, last: Haake}
   variants:
   - {first: Anne R., last: Haake}
+- canonical: {first: Salah, last: Haamid}
+  variants:
+  - {first: S., last: Haamid}
 - canonical: {first: Andrew, last: Haas}
   variants:
   - {first: Andrew R., last: Haas}
@@ -4003,6 +4110,9 @@
 - canonical: {first: Yaakov, last: HaCohen-Kerner}
   variants:
   - {first: Yaakov, last: Hacohen-Kerner}
+- canonical: {first: Bassam, last: Haddad}
+  variants:
+  - {first: B., last: Haddad}
 - canonical: {first: Kais, last: Haddar}
   variants:
   - {first: Kais, last: HADDAR}
@@ -4026,6 +4136,12 @@
 - canonical: {first: KARIN, last: HAENELT}
   variants:
   - {first: Karin, last: Haenelt}
+- canonical: {first: Walter, last: Haeseryn}
+  variants:
+  - {first: W., last: Haeseryn}
+- canonical: {first: Nazila, last: Hafezi}
+  variants:
+  - {first: N., last: Hafezi}
 - canonical: {first: Caroline, last: Hagège}
   variants:
   - {first: Caroline, last: Hagege}
@@ -4038,6 +4154,9 @@
 - canonical: {first: Negacy, last: Hailu}
   variants:
   - {first: Negacy D., last: Hailu}
+- canonical: {first: Horst-Udo, last: Hain}
+  variants:
+  - {first: H.-U., last: Hain}
 - canonical: {first: Jan, last: Hajic}
   variants:
   - {first: Jan, last: HAJIC}
@@ -4264,6 +4383,9 @@
   - {first: Inmaculada, last: Hernaez}
   - {first: Inma, last: Hernaez}
   - {first: Inma, last: Hernáez}
+- canonical: {first: Gregorio, last: Hernández}
+  variants:
+  - {first: G., last: Hernández}
 - canonical: {first: Luis, last: Hernández}
   variants:
   - {first: Luis Hernández, last: Gomez}
@@ -4402,9 +4524,6 @@
 - canonical: {first: Jia-Fei, last: Hong}
   variants:
   - {first: Jia-Fei, last: Hung}
-- canonical: {first: H., last: Rodriguez Hontoria}
-  variants:
-  - {first: H., last: Rodriguez}
 - canonical: {first: Philip, last: Hoole}
   variants:
   - {first: Phil, last: Hoole}
@@ -4685,9 +4804,6 @@
 - canonical: {first: Yukihiro, last: Itoh}
   variants:
   - {first: Yukihiro, last: Ito}
-- canonical: {first: Hiromi Itoh, last: Ozaku}
-  variants:
-  - {first: Hiromi itoh, last: Ozaku}
 - canonical: {first: Abe, last: Ittycheriah}
   variants:
   - {first: A, last: Ittycheriah}
@@ -5092,6 +5208,9 @@
   variants:
   - {first: HANS, last: KARLGREN}
   - {first: Hans, last: KARLGREN}
+- canonical: {first: Kostas, last: Karpouzis}
+  variants:
+  - {first: K., last: Karpouzis}
 - canonical: {first: Hideki, last: Kashioka}
   variants:
   - {first: H, last: Kashioka}
@@ -5356,6 +5475,9 @@
 - canonical: {first: Chunyu, last: Kit}
   variants:
   - {first: Chun-yu, last: Kit}
+- canonical: {first: Sotaro, last: Kita}
+  variants:
+  - {first: S., last: Kita}
 - canonical: {first: Richard, last: Kittredge}
   variants:
   - {first: R., last: Kittredge}
@@ -5495,6 +5617,9 @@
 - canonical: {first: Guy-Noel, last: Kouarata}
   variants:
   - {first: Guy-Noël, last: Kouarata}
+- canonical: {first: Eleni, last: Koutsogeorgos}
+  variants:
+  - {first: E., last: Koutsogeorgos}
 - canonical: {first: John J., last: Kovarik}
   variants:
   - {first: John, last: Kovarik}
@@ -5573,6 +5698,12 @@
 - canonical: {first: Marianne, last: Kugler}
   variants:
   - {first: MARIANNE, last: KUGLER}
+- canonical: {first: Ulrike, last: Kugler}
+  variants:
+  - {first: U., last: Kugler}
+- canonical: {first: Anne, last: Kuhn}
+  variants:
+  - {first: A., last: Kuhn}
 - canonical: {first: Robert J., last: Kuhns}
   variants:
   - {first: Robert J., last: KUHNS}
@@ -5869,6 +6000,9 @@
 - canonical: {first: Jean-Luc, last: LeBrun}
   variants:
   - {first: Jean-Luc, last: Lebrun}
+- canonical: {first: Gilles, last: Lechenadec}
+  variants:
+  - {first: G., last: Lechenadec}
 - canonical: {first: Alain, last: Lecomte}
   variants:
   - {first: Alain, last: LECOMTE}
@@ -5997,10 +6131,12 @@
 - canonical: {first: Gaël, last: Lejeune}
   variants:
   - {first: Gael, last: Lejeune}
-- canonical: {first: Valentina Bartalesi, last: Lenzi}
+- canonical: {first: Valentina, last: Bartalesi Lenzi}
   variants:
-  - {first: V. Bartalesi, last: Lenzi}
-  - {first: Valentina, last: Bartalesi Lenzi}
+  - {first: V., last: Bartalesi Lenzi}
+- canonical: {first: Pietro, last: Leo}
+  variants:
+  - {first: P., last: Leo}
 - canonical: {first: Jacqueline, last: Leon}
   variants:
   - {first: Jacqueline, last: Léon}
@@ -6190,6 +6326,9 @@
 - canonical: {first: Maria Teresa, last: Lino}
   variants:
   - {first: Teresa, last: Lino}
+- canonical: {first: Nikos, last: Liolios}
+  variants:
+  - {first: N., last: Liolios}
 - canonical: {first: Hsien-Chin, last: Liou}
   variants:
   - {first: Hsien-chin, last: Liou}
@@ -6486,6 +6625,9 @@
 - canonical: {first: Catherine, last: Macleod}
   variants:
   - {first: Catherine, last: MacLeod}
+- canonical: {first: Imanol, last: Madariaga}
+  variants:
+  - {first: I., last: Madariaga}
 - canonical: {first: Pranava Swaroop, last: Madhyastha}
   variants:
   - {first: Pranava, last: Madhyastha}
@@ -6496,6 +6638,9 @@
 - canonical: {first: Kikuo, last: Maekawa}
   variants:
   - {first: K., last: Maekawa}
+- canonical: {first: Valérie, last: Maffiolo}
+  variants:
+  - {first: V., last: Maffiolo}
 - canonical: {first: David M., last: Magerman}
   variants:
   - {first: David, last: Magerman}
@@ -6533,6 +6678,9 @@
 - canonical: {first: John, last: Makhoul}
   variants:
   - {first: J., last: Makhoul}
+- canonical: {first: Shozo, last: Makino}
+  variants:
+  - {first: S., last: Makino}
 - canonical: {first: Takaki, last: Makino}
   variants:
   - {first: Takaki, last: MAKINO}
@@ -6686,10 +6834,12 @@
 - canonical: {first: Andre, last: Mariotti}
   variants:
   - {first: André, last: Mariotti}
+- canonical: {first: Alberto, last: Maritxalar}
+  variants:
+  - {first: A., last: Maritxalar}
 - canonical: {first: Montse, last: Maritxalar}
   variants:
   - {first: M, last: Maritxalar}
-  - {first: A., last: Maritxalar}
 - canonical: {first: José B., last: Mariño}
   variants:
   - {first: José, last: Mariño}
@@ -6714,18 +6864,22 @@
 - canonical: {first: Alvin, last: Martin}
   variants:
   - {first: Alvin F., last: Martin}
-- canonical: {first: J-C., last: Martin}
-  variants:
-  - {first: J.-C., last: Martin}
-  - {first: J.C., last: Martin}
 - canonical: {first: James H., last: Martin}
   variants:
   - {first: James H., last: MARTIN}
   - {first: James, last: Martin}
+- canonical: {first: Jean-Claude, last: Martin}
+  variants:
+  - {first: J-C., last: Martin}
+  - {first: J.-C., last: Martin}
+  - {first: J.C., last: Martin}
 - canonical: {first: M. Patrick, last: Martin}
   variants:
   - {first: Pierre M., last: Martin}
   - {first: Patrick, last: Martin}
+- canonical: {first: Marco, last: Martin}
+  variants:
+  - {first: M., last: Martin}
 - canonical: {first: Melanie, last: Martin}
   variants:
   - {first: Melanie J., last: Martin}
@@ -6749,6 +6903,9 @@
   - {first: Andre, last: Martins}
   - {first: André, last: Martins}
   - {first: André F.T., last: Martins}
+- canonical: {first: Fernando, last: Martins}
+  variants:
+  - {first: F., last: Martins}
 - canonical: {first: Ronaldo Teixeira, last: Martins}
   variants:
   - {first: Ronaldo, last: Martins}
@@ -6840,6 +6997,9 @@
 - canonical: {first: Hiroshi, last: Masuichi}
   variants:
   - {first: Hiroshi, last: Mashuichi}
+- canonical: {first: Marco, last: Matassoni}
+  variants:
+  - {first: M., last: Matassoni}
 - canonical: {first: Yannick, last: Mathieu}
   variants:
   - {first: Yvette Yannick, last: Mathieu}
@@ -6978,6 +7138,9 @@
 - canonical: {first: John, last: McNaught}
   variants:
   - {first: J., last: McNaught}
+- canonical: {first: Margaret, last: McRorie}
+  variants:
+  - {first: M., last: McRorie}
 - canonical: {first: Susan W., last: McRoy}
   variants:
   - {first: Susan, last: McRoy}
@@ -7111,6 +7274,9 @@
 - canonical: {first: Lisa N., last: Michaud}
   variants:
   - {first: Lisa, last: Michaud}
+- canonical: {first: Patrizia, last: Michelassi}
+  variants:
+  - {first: P., last: Michelassi}
 - canonical: {first: Archibald, last: Michiels}
   variants:
   - {first: A., last: MICHIELS}
@@ -7414,6 +7580,9 @@
 - canonical: {first: Alex, last: Moruz}
   variants:
   - {first: Mihai Alex, last: Moruz}
+- canonical: {first: Ulrike, last: Mosel}
+  variants:
+  - {first: U., last: Mosel}
 - canonical: {first: Sjur, last: Moshagen}
   variants:
   - {first: Sjur Nørstebø, last: Moshagen}
@@ -7428,6 +7597,12 @@
 - canonical: {first: Jessica, last: Moszkowicz}
   variants:
   - {first: Jessica L., last: Moszkowicz}
+- canonical: {first: Abdelhak, last: Mouradi}
+  variants:
+  - {first: A., last: Mouradi}
+- canonical: {first: Hamed, last: Movasagh}
+  variants:
+  - {first: H., last: Movasagh}
 - canonical: {first: Danielle L., last: Mowery}
   variants:
   - {first: Danielle, last: Mowery}
@@ -7443,6 +7618,9 @@
 - canonical: {first: Thomas, last: Mueller}
   variants:
   - {first: Thomas, last: Müller}
+- canonical: {first: Chafic, last: Mukbel}
+  variants:
+  - {first: C., last: Mukbel}
 - canonical: {first: Rutu, last: Mulkar-Mehta}
   variants:
   - {first: Rutu, last: Mulkar}
@@ -7726,6 +7904,7 @@
 - canonical: {first: Thi Minh Huyen, last: Nguyen}
   variants:
   - {first: Thi Minh Huyền, last: Nguyễn}
+  - {first: T. M. Huyen, last: Nguyen}
 - canonical: {first: ThuyLinh, last: Nguyen}
   variants:
   - {first: Thuy Linh, last: Nguyen}
@@ -7945,6 +8124,9 @@
 - canonical: {first: Arturo, last: Oncevay}
   variants:
   - {first: Arturo, last: Oncevay-Marcos}
+- canonical: {first: Corinna, last: Onelli}
+  variants:
+  - {first: C., last: Onelli}
 - canonical: {first: Takashi, last: Onishi}
   variants:
   - {first: Takeshi, last: Onishi}
@@ -8011,6 +8193,9 @@
 - canonical: {first: Hiromi, last: Ozaku}
   variants:
   - {first: Hiromi, last: OZAKU}
+- canonical: {first: Hiromi Itoh, last: Ozaku}
+  variants:
+  - {first: Hiromi itoh, last: Ozaku}
 - canonical: {first: Canberk, last: Ozdemir}
   variants:
   - {first: Canberk, last: Özdemir}
@@ -8030,6 +8215,9 @@
 - canonical: {first: Dianne P., last: O’Leary}
   variants:
   - {first: Dianne, last: O’Leary}
+- canonical: {first: Dave, last: O’mara}
+  variants:
+  - {first: D., last: O’mara}
 - canonical: {first: Ian M., last: O’Neill}
   variants:
   - {first: Ian, last: O’Neill}
@@ -8075,6 +8263,9 @@
 - canonical: {first: Jean-Pierre, last: Paillet}
   variants:
   - {first: JEAN PIERRE, last: PAILLET}
+- canonical: {first: Helen, last: Pain}
+  variants:
+  - {first: H., last: Pain}
 - canonical: {first: Daniel, last: Paiva}
   variants:
   - {first: D, last: Paiva}
@@ -8375,11 +8566,15 @@
   - {first: E., last: Pianta}
 - canonical: {first: Scott S.L., last: Piao}
   variants:
+  - {first: Scott, last: Piao}
   - {first: S. L., last: Piao}
   - {first: Scott S. L., last: Piao}
 - canonical: {first: Christine, last: Piatko}
   variants:
   - {first: Christine D., last: Piatko}
+- canonical: {first: Francesco, last: Piazza}
+  variants:
+  - {first: F., last: Piazza}
 - canonical: {first: Eugenio, last: Picchi}
   variants:
   - {first: Eugenio, last: PICCHI}
@@ -8403,17 +8598,6 @@
 - canonical: {first: Janet, last: Pierrehumbert}
   variants:
   - {first: Janet B., last: Pierrehumbert}
-- canonical: {first: Stephen A., last: Della Pietra}
-  variants:
-  - {first: S., last: DELLA PIETRA}
-  - {first: S., last: Della Pietra}
-  - {first: Stephen, last: Della Pietra}
-  - {first: Stephen, last: DellaPietra}
-- canonical: {first: Vincent J., last: Della Pietra}
-  variants:
-  - {first: V., last: DELLA PIETRA}
-  - {first: V., last: Della Pietra}
-  - {first: Vincent, last: DellaPietra}
 - canonical: {first: Paola, last: Pietrandrea}
   variants:
   - {first: Paola, last: Pietandrea}
@@ -8482,6 +8666,9 @@
 - canonical: {first: Joseph, last: Polifroni}
   variants:
   - {first: Joseph H., last: Polifroni}
+- canonical: {first: Ziortza, last: Polin}
+  variants:
+  - {first: Z., last: Polin}
 - canonical: {first: Carl, last: Pollard}
   variants:
   - {first: Carl J., last: Pollard}
@@ -8577,6 +8764,9 @@
   - {first: IRINA, last: PRODANOF}
   - {first: Irina, last: PRODANOF}
   - {first: I., last: Prodanof}
+- canonical: {first: Domenico, last: Proietti}
+  variants:
+  - {first: D., last: Proietti}
 - canonical: {first: Jelena, last: Prokić}
   variants:
   - {first: Jelena, last: Prokic}
@@ -8611,6 +8801,9 @@
 - canonical: {first: Rajkumar, last: Pujari}
   variants:
   - {first: Pujari, last: Rajkumar}
+- canonical: {first: Paolo, last: Puliti}
+  variants:
+  - {first: P., last: Puliti}
 - canonical: {first: Geoffrey K., last: Pullum}
   variants:
   - {first: Geoffrey, last: Pullum}
@@ -8759,6 +8952,9 @@
 - canonical: {first: Adwait, last: Ratnaparkhi}
   variants:
   - {first: A., last: Ratnaparkhi}
+- canonical: {first: Esther, last: Ratsch}
+  variants:
+  - {first: E., last: Ratsch}
 - canonical: {first: Lisa, last: Rau}
   variants:
   - {first: Lisa F., last: Rau}
@@ -8923,6 +9119,9 @@
   variants:
   - {first: Kepa J., last: Rodríguez}
   - {first: Kepa Joseba, last: Rodríguez}
+- canonical: {first: H., last: Rodriguez Hontoria}
+  variants:
+  - {first: H., last: Rodriguez}
 - canonical: {first: Victor, last: Rodriguez-Doncel}
   variants:
   - {first: Víctor, last: Rodríguez}
@@ -9061,8 +9260,9 @@
 - canonical: {first: Bryan R., last: Routledge}
   variants:
   - {first: Bryan, last: Routledge}
-- canonical: {first: J. C., last: Roux}
+- canonical: {first: Justus C., last: Roux}
   variants:
+  - {first: J. C., last: Roux}
   - {first: J.C., last: Roux}
 - canonical: {first: Adriana, last: Roventini}
   variants:
@@ -9080,6 +9280,9 @@
 - canonical: {first: Raphael, last: Rubino}
   variants:
   - {first: Raphaël, last: Rubino}
+- canonical: {first: Antonio J., last: Rubio}
+  variants:
+  - {first: A.J., last: Rubio}
 - canonical: {first: Alexander, last: Rudnicky}
   variants:
   - {first: Alexander I., last: Rudnicky}
@@ -9183,6 +9386,9 @@
 - canonical: {first: Suguru, last: Saitô}
   variants:
   - {first: Suguru, last: Saito}
+- canonical: {first: Rafa, last: Saiz}
+  variants:
+  - {first: R., last: Saiz}
 - canonical: {first: Maximiliano, last: Saiz-Noeda}
   variants:
   - {first: M., last: Saiz-Noeda}
@@ -9509,6 +9715,9 @@
 - canonical: {first: Iulian Vlad, last: Serban}
   variants:
   - {first: Iulian, last: Serban}
+- canonical: {first: Jean-Francois, last: Serignat}
+  variants:
+  - {first: J.F., last: Serignat}
 - canonical: {first: Christophe, last: Servan}
   variants:
   - {first: C., last: Servan}
@@ -9536,6 +9745,9 @@
 - canonical: {first: Ritesh, last: Shah}
   variants:
   - {first: Ritesh M., last: Shah}
+- canonical: {first: Mostafa, last: Shahin}
+  variants:
+  - {first: M., last: Shahin}
 - canonical: {first: Zoya M., last: Shalyapina}
   variants:
   - {first: Z.M., last: Shalyapina}
@@ -9611,7 +9823,7 @@
 - canonical: {first: Hideo, last: Shimazu}
   variants:
   - {first: Hideo, last: SHIMAZU}
-- canonical: {first: Kei, last: Shimizu}
+- canonical: {first: Katsumasa, last: Shimizu}
   variants:
   - {first: K., last: Shimizu}
 - canonical: {first: Tohru, last: Shimizu}
@@ -9718,12 +9930,11 @@
   variants:
   - {first: Kiril, last: SIMOV}
   - {first: Kiril Iv., last: Simov}
-- canonical: {first: K.K., last: Sin}
-  variants:
-  - {first: K. K., last: Sin}
 - canonical: {first: King Kui, last: Sin}
   variants:
   - {first: KingKui, last: Sin}
+  - {first: K. K., last: Sin}
+  - {first: K.K., last: Sin}
 - canonical: {first: Anil Kumar, last: Singh}
   variants:
   - {first: Anil, last: Kumar Singh}
@@ -9841,15 +10052,18 @@
 - canonical: {first: Artem, last: Sokolov}
   variants:
   - {first: Artem, last: Sokokov}
-- canonical: {first: Joan, last: Soler i Bou}
-  variants:
-  - {first: Joan, last: Soler}
 - canonical: {first: Juan José Rodríguez, last: Soler}
   variants:
   - {first: Juan José, last: Rodríguez}
+- canonical: {first: Joan, last: Soler i Bou}
+  variants:
+  - {first: Joan, last: Soler}
 - canonical: {first: Juan, last: Soler-Company}
   variants:
   - {first: Juan, last: Soler Company}
+- canonical: {first: Aitor, last: Sologaistoa}
+  variants:
+  - {first: A., last: Sologaistoa}
 - canonical: {first: Illés, last: Solt}
   variants:
   - {first: Illes, last: Solt}
@@ -10091,9 +10305,6 @@
   variants:
   - {first: Keh-Yih, last: SU}
   - {first: Ken-Yih, last: Su}
-- canonical: {first: Ana, last: Suarez}
-  variants:
-  - {first: A., last: Suárez}
 - canonical: {first: L. Venkata, last: Subramaniam}
   variants:
   - {first: L. V., last: Subramaniam}
@@ -10167,9 +10378,15 @@
 - canonical: {first: Masaru, last: Suzuki}
   variants:
   - {first: Masaru, last: SUZUKI}
+- canonical: {first: Armando, last: Suárez}
+  variants:
+  - {first: A., last: Suárez}
 - canonical: {first: Mari Carmen, last: Suárez-Figueroa}
   variants:
   - {first: M. Carmen, last: Suárez-Figueroa}
+- canonical: {first: Piergiorgio, last: Svaizer}
+  variants:
+  - {first: P., last: Svaizer}
 - canonical: {first: Lukáš, last: Svoboda}
   variants:
   - {first: Lukas, last: Svoboda}
@@ -10205,6 +10422,7 @@
 - canonical: {first: Jon, last: Sánchez}
   variants:
   - {first: Jon, last: Sanchez}
+  - {first: J., last: Sánchez}
 - canonical: {first: Víctor M., last: Sánchez-Cartagena}
   variants:
   - {first: Victor M., last: Sánchez-Cartagena}
@@ -10333,6 +10551,9 @@
   variants:
   - {first: Mariona, last: Taule}
   - {first: M., last: Taulé}
+- canonical: {first: Miriam, last: Tavoni}
+  variants:
+  - {first: M., last: Tavoni}
 - canonical: {first: Sarah, last: Taylor}
   variants:
   - {first: Sarah M., last: Taylor}
@@ -10342,6 +10563,9 @@
 - canonical: {first: William J., last: Teahan}
   variants:
   - {first: W. J., last: Teahan}
+- canonical: {first: João Paulo, last: Teixeira}
+  variants:
+  - {first: João P., last: Teixeira}
 - canonical: {first: Eric Sadit, last: Tellez}
   variants:
   - {first: Eric S., last: Tellez}
@@ -10446,13 +10670,13 @@
 - canonical: {first: David, last: Tomas}
   variants:
   - {first: David, last: Tomás}
-- canonical: {first: Vittorio Di, last: Tomaso}
-  variants:
-  - {first: V., last: Di Tomaso}
 - canonical: {first: Masaru, last: Tomita}
   variants:
   - {first: Masaru, last: TOMITA}
   - {first: M., last: Tomita}
+- canonical: {first: Yoshihiro, last: Tomiyama}
+  variants:
+  - {first: Y., last: Tomiyama}
 - canonical: {first: Laura Mayfield, last: Tomokiyo}
   variants:
   - {first: Laura, last: Mayfield}
@@ -10633,6 +10857,9 @@
   - {first: Dan, last: Tufis}
   - {first: Dan, last: TUFIS}
   - {first: Dan, last: Tufiș}
+- canonical: {first: Giovanni, last: Tummarello}
+  variants:
+  - {first: G., last: Tummarello}
 - canonical: {first: Gokhan, last: Tur}
   variants:
   - {first: Gokhan, last: Tür}
@@ -10646,6 +10873,9 @@
 - canonical: {first: Joseph, last: Turian}
   variants:
   - {first: Joseph P., last: Turian}
+- canonical: {first: Franco, last: Turini}
+  variants:
+  - {first: F., last: Turini}
 - canonical: {first: Jordi, last: Turmo}
   variants:
   - {first: J., last: Turmo}
@@ -10713,8 +10943,9 @@
 - canonical: {first: Ruben, last: Urizar}
   variants:
   - {first: R., last: Urizar}
-- canonical: {first: M., last: Urkia}
+- canonical: {first: Miriam, last: Urkia}
   variants:
+  - {first: M., last: Urkia}
   - {first: M, last: Urkia}
 - canonical: {first: Cristian, last: Ursu}
   variants:
@@ -10760,6 +10991,9 @@
 - canonical: {first: Andre, last: Valli}
   variants:
   - {first: André, last: Valli}
+- canonical: {first: Andoni, last: Valverde}
+  variants:
+  - {first: A., last: Valverde}
 - canonical: {first: M. Pilar, last: Valverde Ibáñez}
   variants:
   - {first: M. Pilar, last: Valverde-Ibanez}
@@ -10935,11 +11169,17 @@
 - canonical: {first: Alexander, last: Vasserman}
   variants:
   - {first: Alex, last: Vasserman}
+- canonical: {first: Dominique, last: Vaufreydaz}
+  variants:
+  - {first: D., last: Vaufreydaz}
 - canonical: {first: Bernard, last: Vauquois}
   variants:
   - {first: B., last: VAUQUOIS}
   - {first: B., last: Vauquois}
   - {first: BERNARD, last: VAUQUOIS}
+- canonical: {first: Guillaume, last: Vauvert}
+  variants:
+  - {first: G., last: Vauvert}
 - canonical: {first: Eva Maria, last: Vecchi}
   variants:
   - {first: Eva, last: Vecchi}
@@ -10999,6 +11239,9 @@
 - canonical: {first: Sarah, last: Vieweg}
   variants:
   - {first: Sarah E., last: Vieweg}
+- canonical: {first: Marina, last: Vigário}
+  variants:
+  - {first: M., last: Vigário}
 - canonical: {first: K., last: Vijay-Shanker}
   variants:
   - {first: K, last: Vijay-Shanker}
@@ -11228,6 +11471,10 @@
 - canonical: {first: William S-Y., last: Wang}
   variants:
   - {first: William S.-Y., last: Wang}
+- canonical: {first: Xia, last: Wang}
+  variants:
+  - {first: Xia S., last: Wang}
+  - {first: X. S., last: Wang}
 - canonical: {first: Xiao-Long, last: Wang}
   variants:
   - {first: XiaoLong, last: Wang}
@@ -11703,6 +11950,9 @@
   - {first: Remi, last: ZAJAC}
   - {first: REMI, last: ZAJAC}
   - {first: Rémi, last: Zajac}
+- canonical: {first: Xabier, last: Zalbide}
+  variants:
+  - {first: X., last: Zalbide}
 - canonical: {first: Jordi Porta, last: Zamorano}
   variants:
   - {first: Jordi, last: Porta}
@@ -11715,6 +11965,9 @@
 - canonical: {first: Hongying, last: Zan}
   variants:
   - {first: Hong-ying, last: Zan}
+- canonical: {first: Stefano, last: Zanobini}
+  variants:
+  - {first: S., last: Zanobini}
 - canonical: {first: Fabio Massimo, last: Zanzotto}
   variants:
   - {first: Fabio, last: Massimo Zanzotto}
@@ -11726,6 +11979,9 @@
 - canonical: {first: Haïfa, last: Zargayouna}
   variants:
   - {first: Haifa, last: Zargayouna}
+- canonical: {first: Gian Piero, last: Zarri}
+  variants:
+  - {first: G.P., last: Zarri}
 - canonical: {first: George, last: Zavaliagkos}
   variants:
   - {first: G., last: Zavaliagkos}
@@ -11876,6 +12132,9 @@
 - canonical: {first: Chengqing, last: Zong}
   variants:
   - {first: Cheng-qing, last: Zong}
+- canonical: {first: Enrico, last: Zovato}
+  variants:
+  - {first: E., last: Zovato}
 - canonical: {first: Richard, last: Zuber}
   variants:
   - {first: R., last: Zuber}


### PR DESCRIPTION
Here's what the full first names look like using the `complete` attribute. The `name_variants.yaml` has been updated to include both the abbreviated and complete names, but in my opinion it should eventually include only the complete names.

Currently the `complete` attribute doesn't show up anywhere; the easiest way to enable it would be to modify `anthology.people.PersonName.from_element()` to substitute in the value of the `complete` attribute if it exists, but I'll defer to @mbollmann for the right way to do it.

Also (of course) there are a handful of other corrections to the XML.

Closes #245