### PR TITLE
Filling in a few first names

### DIFF
--- a/data/xml/H90.xml
+++ b/data/xml/H90.xml
@@ -268,7 +268,7 @@
 		<author><first>S.</first><last>Das</last></author>
 		<author><first>P. V.</first><last>deSouza</last></author>
 		<author><first>M.</first><last>Epstein</last></author>
-		<author><first>R. L.</first><last>Mercer</last></author>
+		<author><first complete="Robert L.">R. L.</first><last>Mercer</last></author>
 		<author><first>B.</first><last>Merialdo</last></author>
 		<author><first>D.</first><last>Nahamoo</last></author>
 		<author><first>M. A.</first><last>Picheny</last></author>

--- a/data/xml/H92.xml
+++ b/data/xml/H92.xml
@@ -149,10 +149,10 @@
 
 	<paper id="1020">
 		<title>ADAPTIVE LANGUAGE MODELING USING MINIMUM DISCRIMINANT ESTIMATION*</title>
-		<author><first>S.</first><last>Della Pietra</last></author>
-		<author><first>V.</first><last>Della Pietra</last></author>
-		<author><first>R. L.</first><last>Mercer</last></author>
-		<author><first>S.</first><last>Roukos</last></author>
+		<author><first complete="Stephen">S.</first><last>Della Pietra</last></author>
+		<author><first complete="Vincent">V.</first><last>Della Pietra</last></author>
+		<author><first complete="Robert L.">R. L.</first><last>Mercer</last></author>
+		<author><first complete="Salim">S.</first><last>Roukos</last></author>
 	</paper>
 
 	<paper id="1021">
@@ -171,7 +171,7 @@
 		<author><first>Ezra</first><last>Black</last></author>
 		<author><first>Fred</first><last>Jelinek</last></author>
 		<author><first>John</first><last>Lafferty</last></author>
-		<author><first>Robert</first><last>Mercer</last></author>
+		<author><first complete="Robert L.">Robert</first><last>Mercer</last></author>
 		<author><first>Salim</first><last>Roukos</last></author>
 	</paper>
 
@@ -193,7 +193,7 @@
 		<author><first>Fred</first><last>Jelinek</last></author>
 		<author><first>John</first><last>Lafferty</last></author>
 		<author><first>David M.</first><last>Magerman</last></author>
-		<author><first>Robert</first><last>Mercer</last></author>
+		<author><first complete="Robert L.">Robert</first><last>Mercer</last></author>
 		<author><first>Salim</first><last>Roukos</last></author>
 	</paper>
 

--- a/data/xml/H94.xml
+++ b/data/xml/H94.xml
@@ -356,12 +356,12 @@
 
 	<paper id="1052">
 		<title>Decision Tree Parsing using a Hidden Derivation Model</title>
-		<author><first>F.</first><last>Jelinek</last></author>
-		<author><first>J.</first><last>Lafferty</last></author>
-		<author><first>D.</first><last>Magerman</last></author>
-		<author><first>R.</first><last>Mercer</last></author>
-		<author><first>A.</first><last>Ratnaparkhi</last></author>
-		<author><first>S.</first><last>Roukos</last></author>
+		<author><first complete="Frederick">F.</first><last>Jelinek</last></author>
+		<author><first complete="John">J.</first><last>Lafferty</last></author>
+		<author><first complete="David">D.</first><last>Magerman</last></author>
+		<author><first complete="Robert L.">R.</first><last>Mercer</last></author>
+		<author><first complete="Adwait">A.</first><last>Ratnaparkhi</last></author>
+		<author><first complete="Salim">S.</first><last>Roukos</last></author>
 	</paper>
 
 	<paper id="1053">

--- a/data/xml/P93.xml
+++ b/data/xml/P93.xml
@@ -72,7 +72,7 @@
  <author><first>Fred</first><last>Jelinek</last></author>
  <author><first>John</first><last>Lafrerty</last></author>
  <author><first>David M.</first><last>Magerman</last></author>
- <author><first complete="Robert L."">Robert</first><last>Mercer</last></author>
+ <author><first complete="Robert L.">Robert</first><last>Mercer</last></author>
  <author><first>Salim</first><last>Roukos</last></author>
  <address>Columbus, Ohio, USA</address>
  <bibkey>black-EtAl:1993:ACL</bibkey>

--- a/data/xml/P93.xml
+++ b/data/xml/P93.xml
@@ -72,7 +72,7 @@
  <author><first>Fred</first><last>Jelinek</last></author>
  <author><first>John</first><last>Lafrerty</last></author>
  <author><first>David M.</first><last>Magerman</last></author>
- <author><first>Robert</first><last>Mercer</last></author>
+ <author><first complete="Robert L."">Robert</first><last>Mercer</last></author>
  <author><first>Salim</first><last>Roukos</last></author>
  <address>Columbus, Ohio, USA</address>
  <bibkey>black-EtAl:1993:ACL</bibkey>

--- a/data/xml/W13.xml
+++ b/data/xml/W13.xml
@@ -190,11 +190,11 @@
 
   <paper id="0112">
     <title>Multi-Step Regression Learning for Compositional Distributional Semantics</title>
-    <author><first>E.</first><last>Grefenstette</last></author>
-    <author><first>G.</first><last>Dinu</last></author>
-    <author><first>Y[ao-Zhong]</first><last>Zhang</last></author>
-    <author><first>M.</first><last>Sadrzadeh</last></author>
-    <author><first>M.</first><last>Baroni</last></author>
+    <author><first complete="Edward">E.</first><last>Grefenstette</last></author>
+    <author><first complete="Georgiana">G.</first><last>Dinu</last></author>
+    <author><first complete="Yao-Zhong">Y.</first><last>Zhang</last></author>
+    <author><first complete="Mehrnoosh">M.</first><last>Sadrzadeh</last></author>
+    <author><first complete="Marco">M.</first><last>Baroni</last></author>
     <booktitle>Proceedings of the 10th International Conference on Computational Semantics (IWCS 2013) – Long Papers</booktitle>
     <month>March</month>
     <year>2013</year>

--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -8027,7 +8027,7 @@ Automated Measures of Specific Vocabulary Knowledge from Constructed Responses (
       <last>Houngbo</last>
     </author>
     <author>
-      <first>Robert</first>
+      <first complete="Robert E.">Robert</first>
       <last>Mercer</last>
     </author>
     <booktitle>Proceedings of the First Workshop on Argumentation Mining</booktitle>
@@ -8304,7 +8304,7 @@ Automated Measures of Specific Vocabulary Knowledge from Constructed Responses (
       <last>Graves</last>
     </author>
     <author>
-      <first>Robert</first>
+      <first complete="Robert E.">Robert</first>
       <last>Mercer</last>
     </author>
     <author>
@@ -8329,7 +8329,7 @@ Automated Measures of Specific Vocabulary Knowledge from Constructed Responses (
       <last>Ibn Faiz</last>
     </author>
     <author>
-      <first>Robert</first>
+      <first complete="Robert E.">Robert</first>
       <last>Mercer</last>
     </author>
     <booktitle>Proceedings of the First Workshop on Argumentation Mining</booktitle>
@@ -8403,7 +8403,7 @@ Automated Measures of Specific Vocabulary Knowledge from Constructed Responses (
       <last>Mao</last>
     </author>
     <author>
-      <first>Robert</first>
+      <first complete="Robert E.">Robert</first>
       <last>Mercer</last>
     </author>
     <author>
@@ -10794,7 +10794,7 @@ Automated Measures of Specific Vocabulary Knowledge from Constructed Responses (
       <last>Xiao</last>
     </author>
     <author>
-      <first>Robert</first>
+      <first complete="Robert E.">Robert</first>
       <last>Mercer</last>
     </author>
     <booktitle>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -12039,10 +12039,11 @@
 - canonical: {first: Xiuzhen (Jenny), last: Zhang}
   variants:
   - {first: Xiuzhen, last: Zhang}
-- canonical: {first: Yao-zhong, last: Zhang}
+- canonical: {first: Yao-Zhong, last: Zhang}
   variants:
   - {first: Yao Zhong, last: Zhang}
-  - {first: 'Y[ao-Zhong]', last: Zhang}
+  - {first: Yao-zhong, last: Zhang}
+  - {first: Y., last: Zhang}
 - canonical: {first: Ying, last: Zhang}
   variants:
   - {first: Joy Ying, last: Zhang}

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -2473,6 +2473,7 @@
   variants:
   - {first: V., last: DELLA PIETRA}
   - {first: V., last: Della Pietra}
+  - {first: Vincent, last: Della Pietra}
   - {first: Vincent, last: DellaPietra}
 - canonical: {first: Felice, last: Dell’Orletta}
   variants:
@@ -7204,7 +7205,6 @@
     Robert Mercer
   variants:
   - {first: Robert E., last: MERCER}
-  - {first: Robert, last: Mercer}
 - canonical: {first: Robert L., last: Mercer}
   comment: IBM; also published as Robert Mercer, overlapping with another Robert Mercer
   variants:


### PR DESCRIPTION
The first commit here eliminates the square brackets in one author's name that I thought was too collision prone (discussed at https://github.com/acl-org/acl-anthology/pull/217#issuecomment-479718771).

The second commit uses the `complete` attribute to resolve the ambiguous author name "Robert Mercer" (discussed at #208). My thought is that in this type of situation, the `complete` attribute is sufficient for disambiguation, and this is the right way to do it. I'm trying out this one case so you can see how it looks. If it looks good, there's at least one other I'm aware of, but probably more.