### PR TITLE
Hotfix requirements.txt

### DIFF
--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -5,4 +5,4 @@ python-slugify>=2.0
 PyYAML>=3.0
 stop-words
 tqdm
-texsoup
+texsoup<=0.1.4


### PR DESCRIPTION
New 0.2.0 release of TeXSoup breaks the build.