### PR TITLE
Add checks for internal filenames & fix wrong filenames

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -91,7 +91,7 @@ class Paper:
                 value = {
                     "filename": element.text,
                     "type": element.get("type", "attachment"),
-                    "url": infer_attachment_url(element.text),
+                    "url": infer_attachment_url(element.text, self.full_id),
                 }
             elif tag in ("author", "editor"):
                 value = PersonName.from_element(element)
@@ -109,6 +109,12 @@ class Paper:
                             ),
                         }
                     ]
+                if not element.text.startswith(self.full_id):
+                    log.error(
+                        "{} must begin with paper ID '{}', but is '{}'".format(
+                            tag, self.full_id, element.text
+                        )
+                    )
                 value = {
                     "value": element.text,
                     "id": element.get("id"),
@@ -122,13 +128,13 @@ class Paper:
                 value = {
                     "filename": element.get("href"),
                     "type": element.get("tag", "video"),
-                    "url": infer_attachment_url(element.get("href")),
+                    "url": infer_attachment_url(element.get("href"), self.full_id),
                 }
             elif tag in ("dataset", "software"):
                 value = {
                     "filename": element.text,
                     "type": tag,
-                    "url": infer_attachment_url(element.text),
+                    "url": infer_attachment_url(element.text, self.full_id),
                 }
                 tag = "attachment"
             else:

--- a/bin/anthology/utils.py
+++ b/bin/anthology/utils.py
@@ -72,11 +72,17 @@ def remove_extra_whitespace(text):
     return re.sub(" +", " ", text.replace("\n", "").strip())
 
 
-def infer_attachment_url(filename):
+def infer_attachment_url(filename, parent_id=None):
     # If filename has a network location, it's interpreted as a complete URL
     if urlparse(filename).netloc:
         return filename
     # Otherwise, treat it as an internal filename
+    if parent_id is not None and not filename.startswith(parent_id):
+        logging.error(
+            "attachment must begin with paper ID '{}', but is '{}'".format(
+                parent_id, filename
+            )
+        )
     return data.ATTACHMENT_URL.format(filename)
 
 

--- a/data/xml/D14.xml
+++ b/data/xml/D14.xml
@@ -2491,7 +2491,7 @@ Learning Abstract Concept Embeddings from Multi-Modal Data: Since You Probably C
     <pages>775–786</pages>
     <url>http://www.aclweb.org/anthology/D14-1085</url>
     <doi>10.3115/v1/D14-1085</doi>
-    <attachment type="attachment">D14-1011.Attachment.zip</attachment>
+    <attachment type="attachment">D14-1085.Attachment.zip</attachment>
     <bibtype>inproceedings</bibtype>
     <bibkey>cheung-penn:2014:EMNLP2014</bibkey>
   </paper>

--- a/data/xml/D17.xml
+++ b/data/xml/D17.xml
@@ -10709,7 +10709,7 @@ In this paper, we demonstrate how the state-of-the-art machine learning and text
     <pages>2335–2341</pages>
     <url>http://www.aclweb.org/anthology/D17-1248</url>
     <doi>10.18653/v1/D17-1248</doi>
-    <attachment type="poster">D17-1219.Poster.pdf</attachment>
+    <attachment type="poster">D17-1248.Poster.pdf</attachment>
     <abstract>
       Much of our online communication is text-mediated and, lately, more common
       with automated agents. Unlike interacting with humans, these agents

--- a/data/xml/N13.xml
+++ b/data/xml/N13.xml
@@ -130,7 +130,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>63–73</pages>
     <url>http://www.aclweb.org/anthology/N13-1007</url>
-    <video href="Minimally Supervised Method for Multilingual Paraphrase Extraction from Definition Sentences on the Web" tag="video"/>
+    <video href="http://techtalks.tv/talks/minimally-supervised-method-for-multilingual-paraphrase-extraction/58434/" tag="video"/>
     <bibtype>inproceedings</bibtype>
     <bibkey>yan-EtAl:2013:NAACL-HLT</bibkey>
   </paper>

--- a/data/xml/N16.xml
+++ b/data/xml/N16.xml
@@ -4486,7 +4486,7 @@
     <publisher>Association for Computational Linguistics</publisher>
     <pages>1233–1239</pages>
     <url>http://www.aclweb.org/anthology/N16-1147</url>
-    <revision id="2">P16-1147v2</revision>
+    <revision id="2">N16-1147v2</revision>
     <doi>10.18653/v1/N16-1147</doi>
     <bibtype>inproceedings</bibtype>
     <bibkey>huang-EtAl:2016:N16-1</bibkey>

--- a/data/xml/P15.xml
+++ b/data/xml/P15.xml
@@ -2015,7 +2015,7 @@
     <pages>1138–1147</pages>
     <url>http://www.aclweb.org/anthology/P15-1110</url>
     <doi>10.3115/v1/P15-1110</doi>
-    <dataset>P15-1100.Datasets.zip</dataset>
+    <dataset>P15-1110.Datasets.zip</dataset>
     <bibtype>inproceedings</bibtype>
     <bibkey>wang-mi-xue:2015:ACL-IJCNLP</bibkey>
   </paper>
@@ -4020,7 +4020,6 @@
     <url>http://www.aclweb.org/anthology/P15-2026</url>
     <doi>10.3115/v1/P15-2026</doi>
     <software>P15-2026.Software.zip</software>
-    <attachment type="note">P15-2061.Notes.pdf</attachment>
     <bibtype>inproceedings</bibtype>
     <bibkey>chatterjee-EtAl:2015:ACL-IJCNLP</bibkey>
   </paper>
@@ -5108,6 +5107,7 @@ The Users Who Say ‘Ni’: Audience Identification in Chinese-language Restaura
     <pages>372–376</pages>
     <url>http://www.aclweb.org/anthology/P15-2061</url>
     <doi>10.3115/v1/P15-2061</doi>
+    <attachment type="note">P15-2061.Notes.pdf</attachment>
     <bibtype>inproceedings</bibtype>
     <bibkey>bronstein-EtAl:2015:ACL-IJCNLP</bibkey>
   </paper>

--- a/data/xml/W15.xml
+++ b/data/xml/W15.xml
@@ -19424,7 +19424,6 @@ UMMU@QALB-2015 Shared Task: Character and Word level SMT pipeline for Automatic 
     <address>Beijing</address>
     <publisher>Association for Computational Linguistics</publisher>
     <pages>6–10</pages>
-    <attachment type="poster">W15-4002.Poster.pdf</attachment>
     <software>W15-4102.Software.zip</software>
     <bibtype>inproceedings</bibtype>
     <bibkey>rikters:2015:HyTra-4</bibkey>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -3524,7 +3524,6 @@ We focus on the identification of omission in statement pairs. We compare three 
     <pages>57–66</pages>
     <url>http://www.aclweb.org/anthology/W17-0807</url>
     <doi>10.18653/v1/W17-0807</doi>
-    <revision id="2">W17-5405</revision>
     <abstract> 
 
 Consistency is a crucial requirement in text annotation. It is especially important in educational applications, as lack of consistency directly affects learners’ motivation and learning performance. This paper presents a quality assessment scheme for English-to-Japanese translations produced by learner translators at university. We constructed a revision typology and a decision tree manually through an application of the OntoNotes method, i.e., an iteration of assessing learners’ translations and hypothesizing the conditions for consistent decision making, as well as re-organizing the typology. Intrinsic evaluation of the created scheme confirmed its potential contribution to the consistent classification of identified erroneous text spans, achieving visibly higher Cohen’s kappa values, up to 0.831, than previous work. This paper also describes an application of our scheme to an English-to-Japanese translation exercise course for undergraduate students at a university in Japan. </abstract>
@@ -33875,6 +33874,7 @@ In this paper, we propose an alternative evaluating metric for word analogy ques
     <pages>33–39</pages>
     <url>http://www.aclweb.org/anthology/W17-5405</url>
     <doi>10.18653/v1/W17-5405</doi>
+    <revision id="2">W17-5405v2</revision>
     <abstract> 
 
 This paper describes our “breaker” submission to the 2017 EMNLP “Build It Break It” shared task on sentiment analysis. In order to cause the “builder” systems to make incorrect predictions, we edited items in the blind test data according to linguistically interpretable strategies that allow us to assess the ease with which the builder systems learn various components of linguistic structure. On the whole, our submitted pairs break all systems at a high rate (72.6%), indicating that sentiment analysis as an NLP task may still have a lot of ground to cover. Of the breaker strategies that we consider, we find our semantic and pragmatic manipulations to pose the most substantial difficulties for the builder systems. </abstract>


### PR DESCRIPTION
This PR adds checks that make the build fail if internal filenames don't start with the paper ID they're attached to. This is currently the convention throughout the Anthology, and filenames that throw errors are almost always mistakes (see #265).

Right now, the build will still fail because of [the unresolved issue with W18-36](https://github.com/acl-org/acl-anthology/issues/265#issuecomment-484060591).