### PR TITLE
Adds support for the EndNote citation format

### DIFF
--- a/bin/build_hugo
+++ b/bin/build_hugo
@@ -38,6 +38,12 @@ if ! [ -x "$(command -v tqdm)" ]; then
 else
     find data-export -name '*.bib' -print0 | xargs -0 -n 1 -P 8 $DIR/bib2xml_wrapper | tqdm --total $(find data-export -name '*.bib' | wc -l) --unit files >/dev/null
 fi
+>&2 echo "INFO     Converting MODS XML files to EndNote..."
+if ! [ -x "$(command -v tqdm)" ]; then
+    find data-export -name '*.xml' -print0 | xargs -0 -n 1 -P 8 $DIR/xml2end_wrapper >/dev/null
+else
+    find data-export -name '*.xml' -print0 | xargs -0 -n 1 -P 8 $DIR/xml2end_wrapper | tqdm --total $(find data-export -name '*.xml' | wc -l) --unit files >/dev/null
+fi
 
 >&2 echo "INFO     Running Hugo... this may take a while."
 hugo --cleanDestinationDir --minify

--- a/bin/xml2end_wrapper
+++ b/bin/xml2end_wrapper
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# Copyright 2019 Martin Villalba <villalba@7c0h.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+xml2end $1 2>&1 > ${1%.xml}.endf

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -141,6 +141,10 @@
       {{ if (fileExists (printf "/data-export/%s" $expfile)) }}
         <a class="btn btn-secondary btn-sm" href="{{ $expfile | relURL }}">MODS XML</a>
       {{ end }}
+      {{ $endfile := printf "/papers/%s/%s/%s.endf" (slicestr $volume_id 0 1) $volume_id $anthology_id }}
+      {{ if (fileExists (printf "/data-export/%s" $endfile)) }}
+        <a class="btn btn-secondary btn-sm" href="{{ $endfile | relURL }}">EndNote</a>
+      {{ end }}
       {{ if (fileExists (printf "/data-export/%s" $bibfile)) }}
         <button type="button" class="btn btn-clipboard btn-secondary btn-sm d-none" data-clipboard-text="{{ readFile (printf "/data-export/%s" $bibfile) }}"><i class="far fa-clipboard pr-2"></i>Copy BibTeX to Clipboard</button>
       {{ end }}

--- a/hugo/layouts/volumes/single.html
+++ b/hugo/layouts/volumes/single.html
@@ -82,6 +82,10 @@
       {{ if (fileExists (printf "/data-export/%s" $expfile)) }}
         <a class="btn btn-secondary btn-sm" href="{{ $expfile | relURL }}">MODS XML</a>
       {{ end }}
+      {{ $endfile := printf "/volumes/%s.endf" $anthology_id }}
+      {{ if (fileExists (printf "/data-export/%s" $endfile)) }}
+        <a class="btn btn-secondary btn-sm" href="{{ $endfile | relURL }}">EndNote</a>
+      {{ end }}
       </dd>
     </dl>
     </div>


### PR DESCRIPTION
This is a pull request to add EndNote citation support to the site. This is in response to Issue #235.

The code ...
  1. creates a new wrapper, `xml2end_wrapper`, that follows the format of the wrapper used for Bib2XML. 
  2. adds a step in `bin/build_hugo` to generate all .endf files
  3. updates the templates in `papers/single.html` and `volumes/single-html` to add a new citation export button

An important detail about this Pull Request: my computer is not powerful enough to run Hugo to the end, and therefore I cannot fully verify that the HTML files are built properly. I have checked that the generated files look fine, and I have also checked that the HTML files that manage to get generated look as one would expect. But I can't run the process all the way to the end.