### PR TITLE
Use first/last name completions

### DIFF
--- a/bin/anthology/people.py
+++ b/bin/anthology/people.py
@@ -31,9 +31,15 @@ class PersonName:
             tag = element.tag
             # These are guaranteed to occur at most once by the schema
             if tag == "first":
-                first = element.text or ""
+                if "complete" in element.attrib:
+                    first = element.attrib["complete"]
+                else:
+                    first = element.text or ""
             elif tag == "last":
-                last = element.text or ""
+                if "complete" in element.attrib:
+                    last = element.attrib["complete"]
+                else:
+                    last = element.text or ""
         return PersonName(first, last)
 
     def from_repr(repr_):

--- a/bin/check_name_variants.py
+++ b/bin/check_name_variants.py
@@ -36,6 +36,7 @@ else:
     names = None
 
 doc = yaml.load(open(sys.argv[1]))
+new_doc = []
 
 assert isinstance(doc, list)
 for person in doc:
@@ -45,15 +46,21 @@ for person in doc:
     assert isinstance(person['canonical'], dict), person
     assert set(person['canonical']).issubset(name_fields), person
     if names is not None and name(person['canonical']) not in names:
-        logging.warning('unused name: {}'.format(person['canonical']))
+        logging.warning('please remove unused canonical name: {}'.format(person['canonical']))
     dupes = {name(person['canonical'])}
     assert 'variants' in person, person
     assert isinstance(person['variants'], list), person
+    new_variants = []
     for variant in person['variants']:
         assert set(variant).issubset(name_fields), person
         if names is not None and name(variant) not in names:
-            logging.warning('unused name: {}'.format(variant))
+            logging.warning('removing unused variant: {}'.format(variant))
+        else:
+            new_variants.append(variant)
         assert name(variant) not in dupes, variant
         dupes.add(name(variant))
+    if len(new_variants) > 0:
+        person['variants'] = new_variants
+        new_doc.append(person)
         
-print(yaml.dump(doc, allow_unicode=True))
+print(yaml.dump(new_doc, allow_unicode=True))

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -26,19 +26,12 @@
   - {first: Andrew, last: Abel}
 - canonical: {first: Steven, last: Abney}
   variants:
-  - {first: S., last: Abney}
   - {first: Steve, last: Abney}
   - {first: Steven P., last: Abney}
-- canonical: {first: Victor, last: Abrash}
-  variants:
-  - {first: V., last: Abrash}
 - canonical: {first: José I., last: Abreu}
   variants:
   - {first: Jose I., last: Abreu}
   - {first: José, last: Abreu}
-- canonical: {first: Sarkis, last: Abrilian}
-  variants:
-  - {first: S., last: Abrilian}
 - canonical: {first: Amjad, last: Abu-Jbara}
   variants:
   - {first: Amjad, last: Abu Jbara}
@@ -53,30 +46,9 @@
 - canonical: {first: Kübra, last: Adali}
   variants:
   - {first: Kübra, last: ADALI}
-- canonical: {first: Gilles, last: Adda}
-  variants:
-  - {first: G., last: Adda}
-- canonical: {first: Martine, last: Adda-Decker}
-  variants:
-  - {first: M., last: Adda-Decker}
-- canonical: {first: Giovanni, last: Adorni}
-  variants:
-  - {first: G., last: Adorni}
 - canonical: {first: GEERT, last: ADRIAENS}
   variants:
-  - {first: G., last: ADRIAENS}
   - {first: Geert, last: Adriaens}
-- canonical: {first: Itziar, last: Aduriz}
-  variants:
-  - {first: I, last: Aduriz}
-  - {first: I., last: Aduriz}
-- canonical: {first: Rodrigo, last: Agerri}
-  variants:
-  - {first: R., last: Agerri}
-- canonical: {first: Eneko, last: Agirre}
-  variants:
-  - {first: E., last: Agirre}
-  - {first: E, last: Agirre}
 - canonical: {first: Željko, last: Agić}
   variants:
   - {first: Zeljko, last: Agic}
@@ -119,9 +91,6 @@
 - canonical: {first: Teruaki, last: Aizawa}
   variants:
   - {first: Teruaki, last: AIZAWA}
-- canonical: {first: Gianmaria, last: Ajani}
-  variants:
-  - {first: G., last: Ajani}
 - canonical: {first: Hiroyuki, last: Akama}
   variants:
   - {first: Hiroyuki, last: Akam}
@@ -131,7 +100,6 @@
 - canonical: {first: Mohammad, last: AKBAR}
   variants:
   - {first: Mohammad, last: Akbar}
-  - {first: M., last: Akbar}
 - canonical: {first: A., last: Akilandeswari}
   variants:
   - {first: Akilandeswari, last: A}
@@ -153,9 +121,6 @@
 - canonical: {first: Mohamed, last: Al-Badrashiny}
   variants:
   - {first: Mohamed, last: AlBadrashiny}
-- canonical: {first: Adil, last: Al-Kufaishi}
-  variants:
-  - {first: A., last: Al-Kufaishi}
 - canonical: {first: Rami, last: Al-Rfou’}
   variants:
   - {first: Rami, last: Al-Rfou}
@@ -168,12 +133,8 @@
 - canonical: {first: Danniel Liwanag, last: Alcantara}
   variants:
   - {first: Danniel, last: Alcantara}
-- canonical: {first: Izaskun, last: Aldezabal}
-  variants:
-  - {first: I., last: Aldezabal}
 - canonical: {first: Iñaki, last: Alegria}
   variants:
-  - {first: I, last: Alegria}
   - {first: I., last: Alegria}
 - canonical: {first: Beatrice, last: Alex}
   variants:
@@ -181,9 +142,6 @@
 - canonical: {first: Zoltán, last: Alexin}
   variants:
   - {first: Z., last: ALEXIN}
-- canonical: {first: James, last: Allan}
-  variants:
-  - {first: J., last: Allan}
 - canonical: {first: James, last: Allen}
   variants:
   - {first: James F., last: Allen}
@@ -195,7 +153,6 @@
   - {first: Hector, last: Allende}
 - canonical: {first: Fil, last: Alleva}
   variants:
-  - {first: F., last: Alleva}
   - {first: Fileno, last: Alleva}
 - canonical: {first: José João, last: Almeida}
   variants:
@@ -218,9 +175,6 @@
   variants:
   - {first: Laura, last: Alonso i Alemany}
   - {first: Laura, last: Alonso}
-- canonical: {first: Erick, last: Alphonse}
-  variants:
-  - {first: E., last: Alphonse}
 - canonical: {first: Hiyan, last: Alshawi}
   variants:
   - {first: Hiyan, last: Alsawi}
@@ -311,15 +265,6 @@
 - canonical: {first: Peter, last: Anick}
   variants:
   - {first: Peter G., last: ANICK}
-- canonical: {first: Olatz, last: Ansa}
-  variants:
-  - {first: O., last: Ansa}
-- canonical: {first: Georges, last: Antoniadis}
-  variants:
-  - {first: G., last: Antoniadis}
-- canonical: {first: Juliano D., last: Antonio}
-  variants:
-  - {first: J.D., last: Antonio}
 - canonical: {first: Waqas, last: Anwar}
   variants:
   - {first: Muhammad Waqas, last: Anwar}
@@ -331,12 +276,6 @@
   variants:
   - {first: Balamurali, last: A.R.}
   - {first: Balamurali, last: A.R}
-- canonical: {first: Kenji, last: Araki}
-  variants:
-  - {first: K., last: Araki}
-- canonical: {first: Masahiro, last: Araki}
-  variants:
-  - {first: M., last: Araki}
 - canonical: {first: Eiji, last: Aramaki}
   variants:
   - {first: Eiji, last: ARAMAKI}
@@ -346,12 +285,8 @@
 - canonical: {first: Nikolay, last: Arefyev}
   variants:
   - {first: Nikolay, last: Arefiev}
-- canonical: {first: Nerea, last: Areta}
-  variants:
-  - {first: N., last: Areta}
 - canonical: {first: Susan, last: Armstrong}
   variants:
-  - {first: S., last: Warwick-Armstrong}
   - {first: Susan, last: Warwick-Armstrong}
   - {first: Susan, last: Warwick}
 - canonical: {first: Alan R., last: Aronson}
@@ -359,19 +294,9 @@
   - {first: Alan, last: Aronson}
 - canonical: {first: Xabier, last: Arregi}
   variants:
-  - {first: X, last: Arregi}
   - {first: X., last: Arregi}
-- canonical: {first: Jose Mari, last: Arriola}
-  variants:
-  - {first: J. M., last: Arriola}
-  - {first: J.M, last: Arriola}
-  - {first: J.M., last: Arriola}
-- canonical: {first: Núria, last: Artigas}
-  variants:
-  - {first: N., last: Artigas}
 - canonical: {first: Xabier, last: Artola}
   variants:
-  - {first: X, last: Artola}
   - {first: X., last: Artola}
 - canonical: {first: Kavosh, last: Asadi Atui}
   variants:
@@ -390,11 +315,7 @@
   - {first: LARS, last: ASKER}
 - canonical: {first: Jordi, last: Atserias}
   variants:
-  - {first: J., last: Atserias}
   - {first: Jordi, last: Atserias Batalla}
-- canonical: {first: Mohamed, last: Attia}
-  variants:
-  - {first: M., last: Attia}
 - canonical: {first: Eric, last: Atwell}
   variants:
   - {first: Eric Steven, last: Atwell}
@@ -405,9 +326,6 @@
 - canonical: {first: Jeremy, last: Auguste}
   variants:
   - {first: Jérémy, last: Auguste}
-- canonical: {first: Steve, last: Austin}
-  variants:
-  - {first: S., last: Austin}
 - canonical: {first: Luciana Beatriz, last: Avila}
   variants:
   - {first: Luciana Beatriz, last: Ávila}
@@ -416,20 +334,15 @@
   variants:
   - {first: AiTi, last: Aw}
   - {first: Ai Ti, last: Aw}
-- canonical: {first: Christelle, last: Ayache}
-  variants:
-  - {first: C., last: Ayache}
 - canonical: {first: Necip Fazil, last: Ayan}
   variants:
   - {first: Necip, last: Fazil Ayan}
 - canonical: {first: Damaris, last: Ayuso}
   variants:
   - {first: Damaris M., last: Ayuso}
-  - {first: D., last: Ayuso}
 - canonical: {first: Saliha, last: Azzam}
   variants:
   - {first: Saliha, last: AZZAM}
-  - {first: S., last: Azzam}
 - canonical: {first: Homa, last: B. Hashemi}
   variants:
   - {first: Homa B., last: Hashemi}
@@ -439,15 +352,9 @@
 - canonical: {first: Ismail, last: Babaoğlu}
   variants:
   - {first: Ismail, last: Babaoglu}
-- canonical: {first: Ciprian, last: Bacalu}
-  variants:
-  - {first: C., last: Bacalu}
 - canonical: {first: Ngo Xuan, last: Bach}
   variants:
   - {first: Ngo, last: Xuan Bach}
-- canonical: {first: Joan, last: Bachenko}
-  variants:
-  - {first: J., last: Bachenko}
 - canonical: {first: Daniel, last: Bachut}
   variants:
   - {first: D., last: BACHUT}
@@ -461,24 +368,15 @@
 - canonical: {first: Hee-Sook, last: Bae}
   variants:
   - {first: Hee Sook, last: Bae}
-- canonical: {first: Mirko, last: Baglioni}
-  variants:
-  - {first: M., last: Baglioni}
 - canonical: {first: L. R., last: Bahl}
   variants:
   - {first: L.R., last: Bahl}
-- canonical: {first: Mohammad, last: Bahrani}
-  variants:
-  - {first: M., last: Bahrani}
 - canonical: {first: Vít, last: Baisa}
   variants:
   - {first: Vit, last: Baisa}
 - canonical: {first: Ondřej, last: Bajgar}
   variants:
   - {first: Ondrej, last: Bajgar}
-- canonical: {first: Stylianos, last: Bakamidis}
-  variants:
-  - {first: S., last: Bakamidis}
 - canonical: {first: Collin F., last: Baker}
   variants:
   - {first: Collin, last: Baker}
@@ -514,7 +412,6 @@
   - {first: Catherine, last: Ball}
 - canonical: {first: Bruce W., last: Ballard}
   variants:
-  - {first: B., last: Ballard}
   - {first: Bruce, last: Ballard}
 - canonical: {first: Rafael E., last: Banchs}
   variants:
@@ -541,7 +438,6 @@
 - canonical: {first: Cătălina, last: Barbu}
   variants:
   - {first: Catalina, last: Barbu}
-  - {first: C., last: Barbu}
 - canonical: {first: Verginica, last: Barbu Mititelu}
   variants:
   - {first: Verginica Barbu, last: Mititelu}
@@ -558,25 +454,12 @@
 - canonical: {first: John, last: Barnden}
   variants:
   - {first: John A., last: Barnden}
-  - {first: J.A., last: Barnden}
-- canonical: {first: Marco, last: Baroni}
-  variants:
-  - {first: M., last: Baroni}
 - canonical: {first: Roberto, last: Barra-Chicote}
   variants:
   - {first: Roberto Barra, last: Chicote}
-- canonical: {first: Sergio, last: Barrachina}
-  variants:
-  - {first: S., last: Barrachina}
-- canonical: {first: Claude, last: Barras}
-  variants:
-  - {first: C., last: Barras}
 - canonical: {first: Caroline, last: Barriere}
   variants:
   - {first: Caroline, last: Barrière}
-- canonical: {first: Chris, last: Barry}
-  variants:
-  - {first: C., last: Barry}
 - canonical: {first: François, last: Barthélemy}
   variants:
   - {first: Francois, last: Barthelemy}
@@ -589,9 +472,6 @@
 - canonical: {first: Karine, last: Baschung}
   variants:
   - {first: K., last: BASCHUNG}
-- canonical: {first: Roberto, last: Basili}
-  variants:
-  - {first: R., last: Basili}
 - canonical: {first: Colin, last: Batchelor}
   variants:
   - {first: Colin R., last: Batchelor}
@@ -601,20 +481,12 @@
 - canonical: {first: Madeleine, last: Bates}
   variants:
   - {first: Madeline, last: Bates}
-  - {first: M., last: Bates}
 - canonical: {first: Riza Theresa, last: Batista-Navarro}
   variants:
   - {first: Riza, last: Batista-Navarro}
-- canonical: {first: Anton, last: Batliner}
-  variants:
-  - {first: A., last: Batliner}
 - canonical: {first: Istvan, last: Batori}
   variants:
-  - {first: I., last: Batori}
   - {first: ISTVAN, last: BATORI}
-- canonical: {first: Marco, last: Battista}
-  variants:
-  - {first: M., last: Battista}
 - canonical: {first: William A., last: 'Baumgartner, Jr.'}
   variants:
   - {first: William A., last: Baumgartner Jr.}
@@ -633,9 +505,6 @@
 - canonical: {first: David L., last: Bean}
   variants:
   - {first: David, last: Bean}
-- canonical: {first: John, last: Bear}
-  variants:
-  - {first: J., last: Bear}
 - canonical: {first: John L., last: BEAVEN}
   variants:
   - {first: John L., last: Beaven}
@@ -653,7 +522,6 @@
   - {first: Frédéric, last: Bechet}
   - {first: FREDERIC, last: BECHET}
   - {first: Frederic, last: Béchet}
-  - {first: F., last: Bechet}
 - canonical: {first: Chedi, last: Bechikh Ali}
   variants:
   - {first: Chedi, last: Bechikh}
@@ -686,15 +554,9 @@
 - canonical: {first: Narjès, last: Bellamine Ben Saoud}
   variants:
   - {first: Narjès Bellamine Ben, last: Saoud}
-- canonical: {first: Patrice, last: Bellot}
-  variants:
-  - {first: P., last: Bellot}
 - canonical: {first: Valérie, last: Bellynck}
   variants:
   - {first: Valerie, last: Bellynck}
-- canonical: {first: Islam, last: Beltagy}
-  variants:
-  - {first: I., last: Beltagy}
 - canonical: {first: Robert S., last: Belvin}
   variants:
   - {first: Robert, last: Belvin}
@@ -711,16 +573,10 @@
   - {first: Abdelmajid, last: Ben hamadou}
   - {first: Abdelmajid, last: Benhamadou}
   - {first: Abdelmajid-Lin, last: Ben Hamadou}
-- canonical: {first: Abderrahim, last: Benabbou}
-  variants:
-  - {first: A., last: Benabbou}
 - canonical: {first: Farah, last: Benamara}
   variants:
   - {first: Farah, last: Beanamara}
   - {first: Farah, last: Benamara Zitoune}
-- canonical: {first: Chomicha, last: Bendahman}
-  variants:
-  - {first: C., last: Bendahman}
 - canonical: {first: Emily M., last: Bender}
   variants:
   - {first: Emily, last: Bender}
@@ -745,18 +601,12 @@
 - canonical: {first: Tamara, last: Berg}
   variants:
   - {first: Tamara L., last: Berg}
-- canonical: {first: Carole, last: Bergamini}
-  variants:
-  - {first: C., last: Bergamini}
 - canonical: {first: Adam, last: Berger}
   variants:
   - {first: Adam L., last: Berger}
 - canonical: {first: Sabine, last: Bergler}
   variants:
   - {first: Sabine, last: BERGLER}
-- canonical: {first: Raffaella, last: Bernardi}
-  variants:
-  - {first: R., last: Bernardi}
 - canonical: {first: Niels Ole, last: Bernsen}
   variants:
   - {first: Niels Ole, last: Bernse}
@@ -767,9 +617,6 @@
 - canonical: {first: Francesca, last: Bertagna}
   variants:
   - {first: Francesca, last: BERTAGNA}
-- canonical: {first: Elisa, last: Bertino}
-  variants:
-  - {first: E., last: Bertino}
 - canonical: {first: Núria, last: Bertomeu}
   variants:
   - {first: Nuria, last: Bertomeu}
@@ -783,9 +630,6 @@
   variants:
   - {first: Gabriel G., last: Bès}
   - {first: Gabriel, last: Bès}
-- canonical: {first: Laurent, last: Besacier}
-  variants:
-  - {first: L., last: Besacier}
 - canonical: {first: Štefan, last: Beňuš}
   variants:
   - {first: Stefan, last: Benus}
@@ -807,9 +651,6 @@
 - canonical: {first: Ergun, last: Bicici}
   variants:
   - {first: Ergun, last: Biçici}
-- canonical: {first: Eckhard, last: Bick}
-  variants:
-  - {first: E., last: Bick}
 - canonical: {first: Timothy W., last: Bickmore}
   variants:
   - {first: Timothy, last: Bickmore}
@@ -826,7 +667,6 @@
   - {first: Marie, last: Bienkowski}
 - canonical: {first: Alan W., last: Biermann}
   variants:
-  - {first: A., last: Biermann}
   - {first: Alan, last: Biermann}
 - canonical: {first: Jeffrey P., last: Bigham}
   variants:
@@ -855,12 +695,6 @@
 - canonical: {first: Remo, last: Bindi}
   variants:
   - {first: Remo, last: BINDI}
-- canonical: {first: Diana, last: Binnenpoorte}
-  variants:
-  - {first: D., last: Binnenpoorte}
-- canonical: {first: Elizabeth, last: Bishop}
-  variants:
-  - {first: E., last: Bishop}
 - canonical: {first: André, last: Bittar}
   variants:
   - {first: Andre, last: Bittar}
@@ -870,18 +704,15 @@
 - canonical: {first: Alan W., last: Black}
   variants:
   - {first: Alan, last: Black}
-  - {first: A.W., last: Black}
   - {first: Alan W, last: Black}
 - canonical: {first: Ezra, last: Black}
   variants:
   - {first: Ezra W., last: Black}
-  - {first: E., last: Black}
 - canonical: {first: Lois M., last: Black}
   variants:
   - {first: Lois, last: Black}
 - canonical: {first: William J., last: Black}
   variants:
-  - {first: W.J., last: Black}
   - {first: William, last: Black}
 - canonical: {first: Frédéric, last: Blain}
   variants:
@@ -890,12 +721,6 @@
   variants:
   - {first: Herve, last: BLANCHON}
   - {first: Herve, last: Blanchon}
-- canonical: {first: Christian, last: Blaschke}
-  variants:
-  - {first: C., last: Blaschke}
-- canonical: {first: Nate, last: Blaylock}
-  variants:
-  - {first: N., last: Blaylock}
 - canonical: {first: David, last: Blei}
   variants:
   - {first: David M., last: Blei}
@@ -905,9 +730,6 @@
 - canonical: {first: Hans Ulrich, last: Block}
   variants:
   - {first: Hans-Ulrich, last: Block}
-- canonical: {first: Marsden S., last: Blois}
-  variants:
-  - {first: M. S., last: Blois}
 - canonical: {first: Phil, last: Blunsom}
   variants:
   - {first: Philip, last: Blunsom}
@@ -917,7 +739,6 @@
 - canonical: {first: Robert, last: Bobrow}
   variants:
   - {first: Robert J., last: Bobrow}
-  - {first: R., last: Bobrow}
 - canonical: {first: Rens, last: Bod}
   variants:
   - {first: RENS, last: BOD}
@@ -927,9 +748,6 @@
 - canonical: {first: Adams B., last: Bodomo}
   variants:
   - {first: Adams, last: Bodomo}
-- canonical: {first: Guido, last: Boella}
-  variants:
-  - {first: G., last: Boella}
 - canonical: {first: Katharina, last: Boesefeldt}
   variants:
   - {first: K., last: BOESEFELDT}
@@ -938,7 +756,6 @@
   - {first: Chris, last: Bogart}
 - canonical: {first: Branimir, last: Boguraev}
   variants:
-  - {first: B.K., last: Boguraev}
   - {first: Branimir K., last: Boguraev}
   - {first: Bran, last: BOGURAEV}
   - {first: Bran, last: Boguraev}
@@ -947,11 +764,7 @@
   - {first: Igor M., last: Boguslavsky}
 - canonical: {first: Dan, last: Bohus}
   variants:
-  - {first: D., last: Bohus}
   - {first: Dan, last: Bohuş}
-- canonical: {first: Sean, last: Boisen}
-  variants:
-  - {first: S., last: Boisen}
 - canonical: {first: Christian, last: Boitet}
   variants:
   - {first: Christian, last: BOITET}
@@ -968,9 +781,6 @@
 - canonical: {first: Gemma, last: Boleda}
   variants:
   - {first: Gemma, last: Boleda Torrent}
-- canonical: {first: Andrea, last: Bolognesi}
-  variants:
-  - {first: A., last: Bolognesi}
 - canonical: {first: Igor A., last: Bolshakov}
   variants:
   - {first: Igor A., last: BOLSHAKOV}
@@ -978,14 +788,10 @@
 - canonical: {first: Filip, last: Boltužić}
   variants:
   - {first: Filip, last: Boltuzic}
-- canonical: {first: Antonio, last: Bonafonte}
-  variants:
-  - {first: A., last: Bonafonte}
 - canonical: {first: Jean-François, last: Bonastre}
   variants:
   - {first: Jean-Francois, last: Bonastre}
   - {first: J-F., last: Bonastre}
-  - {first: J.-F., last: Bonastre}
 - canonical: {first: Guillaume, last: Bonfante}
   variants:
   - {first: Guillame, last: Bonfante}
@@ -997,11 +803,9 @@
   - {first: Marco Aldo, last: Piccolino Boniforti}
 - canonical: {first: Hélène, last: Bonneau-Maynard}
   variants:
-  - {first: H., last: Bonneau-Maynard}
   - {first: Hélène, last: Maynard}
 - canonical: {first: German, last: Bordel}
   variants:
-  - {first: G., last: Bordel}
   - {first: Germán, last: Bordel}
 - canonical: {first: Tiberiu, last: Boroş}
   variants:
@@ -1019,9 +823,6 @@
 - canonical: {first: Matko, last: Bosnjak}
   variants:
   - {first: Matko, last: Bošnjak}
-- canonical: {first: Elizabeth C., last: Botha}
-  variants:
-  - {first: E.C., last: Botha}
 - canonical: {first: Alexandre, last: Bouchard-Côté}
   variants:
   - {first: Alexandre, last: Bouchard}
@@ -1046,12 +847,6 @@
 - canonical: {first: G., last: Boulianne}
   variants:
   - {first: Gilles, last: Boulianne}
-- canonical: {first: Paolo, last: Bouquet}
-  variants:
-  - {first: P., last: Bouquet}
-- canonical: {first: Laurent, last: Bourbeau}
-  variants:
-  - {first: L., last: Bourbeau}
 - canonical: {first: Didier, last: Bourigault}
   variants:
   - {first: Didier, last: BOURIGAULT}
@@ -1099,9 +894,6 @@
 - canonical: {first: Deborah, last: Brady}
   variants:
   - {first: Deb, last: Brady}
-- canonical: {first: Annelies, last: Braffort}
-  variants:
-  - {first: A., last: Braffort}
 - canonical: {first: S.R.K., last: Branavan}
   variants:
   - {first: S. R. K., last: Branavan}
@@ -1111,12 +903,6 @@
   - {first: Antonio, last: Branco}
   - {first: Antonio H., last: Branco}
   - {first: Antônio Horta, last: Branco}
-- canonical: {first: Andrew, last: Brasher}
-  variants:
-  - {first: A., last: Brasher}
-- canonical: {first: Harry, last: Bratt}
-  variants:
-  - {first: H., last: Bratt}
 - canonical: {first: Eric, last: Breck}
   variants:
   - {first: Eric J., last: Breck}
@@ -1145,9 +931,6 @@
 - canonical: {first: Benny, last: Brodda}
   variants:
   - {first: BENNY, last: BRODDA}
-- canonical: {first: Daan, last: Broeder}
-  variants:
-  - {first: D., last: Broeder}
 - canonical: {first: Michael K., last: Brown}
   variants:
   - {first: Michael, last: Brown}
@@ -1165,16 +948,9 @@
 - canonical: {first: Rebecca, last: Bruce}
   variants:
   - {first: Rebecca F., last: Bruce}
-- canonical: {first: Hennie, last: Brugman}
-  variants:
-  - {first: H., last: Brugman}
 - canonical: {first: Ernst, last: Buchberger}
   variants:
   - {first: Ernst, last: BUCHBERGER}
-  - {first: E., last: Buchberger}
-- canonical: {first: Chris, last: Buckley}
-  variants:
-  - {first: C., last: Buckley}
 - canonical: {first: Sven, last: Buechel}
   variants:
   - {first: Sven, last: Büchel}
@@ -1211,7 +987,6 @@
   - {first: Diego, last: Burgos}
 - canonical: {first: Bianka, last: Buschbeck}
   variants:
-  - {first: B., last: Buschbeck}
   - {first: Bianka, last: Buschbeck-Wolf}
 - canonical: {first: Stephan, last: Busemann}
   variants:
@@ -1221,12 +996,10 @@
   - {first: Andrei M., last: Butnaru}
 - canonical: {first: William, last: Byrne}
   variants:
-  - {first: W., last: Byrne}
   - {first: William J., last: Byrne}
 - canonical: {first: Donna, last: Byron}
   variants:
   - {first: Donna K., last: Byron}
-  - {first: D., last: Byron}
 - canonical: {first: Denis, last: Béchet}
   variants:
   - {first: Denis, last: Bechet}
@@ -1283,7 +1056,6 @@
   - {first: Michael, last: Cafarella}
 - canonical: {first: Lynne, last: Cahill}
   variants:
-  - {first: L, last: Cahill}
   - {first: Lynne J., last: Cahill}
 - canonical: {first: Dongfeng, last: Cai}
   variants:
@@ -1307,21 +1079,14 @@
 - canonical: {first: Martine De, last: Calmès}
   variants:
   - {first: M., last: de CALMES}
-- canonical: {first: Diego, last: Calvanese}
-  variants:
-  - {first: D., last: Calvanese}
 - canonical: {first: Nicoletta, last: Calzolari}
   variants:
   - {first: Nicoletta, last: CALZOLARI}
   - {first: NICOLETTA, last: CALZOLARI}
-  - {first: N., last: Calzolari}
   - {first: Nicoletta Calzolari, last: Zamorani}
 - canonical: {first: Jose, last: Camacho-Collados}
   variants:
   - {first: José, last: Camacho-Collados}
-- canonical: {first: Ellen, last: Campana}
-  variants:
-  - {first: E., last: Campana}
 - canonical: {first: Joseph P., last: Campbell}
   variants:
   - {first: Joseph, last: Campbell}
@@ -1346,13 +1111,9 @@
 - canonical: {first: Amedeo, last: Cappelli}
   variants:
   - {first: A., last: CAPPELLI}
-  - {first: A., last: Cappelli}
 - canonical: {first: Olivier, last: Cappé}
   variants:
   - {first: Olivier, last: Cappe}
-- canonical: {first: George, last: Carayannis}
-  variants:
-  - {first: G., last: Carayannis}
 - canonical: {first: José María, last: Carazo}
   variants:
   - {first: José-María, last: Carazo}
@@ -1368,20 +1129,10 @@
 - canonical: {first: Antonio, last: Cardenal}
   variants:
   - {first: Antonio, last: Cardenal-Lopez}
-- canonical: {first: Claire, last: Cardie}
-  variants:
-  - {first: C., last: Cardie}
-- canonical: {first: Patrick, last: Cardinal}
-  variants:
-  - {first: P., last: Cardinal}
 - canonical: {first: Paula, last: Cardoso}
   variants:
-  - {first: P., last: Cardoso}
   - {first: Paula C. Figueira, last: Cardoso}
   - {first: Paula C. F., last: Cardoso}
-- canonical: {first: George, last: Caridakis}
-  variants:
-  - {first: G., last: Caridakis}
 - canonical: {first: Jean, last: Carletta}
   variants:
   - {first: JEAN, last: CARLETTA}
@@ -1419,15 +1170,9 @@
 - canonical: {first: Vitor, last: Carvalho}
   variants:
   - {first: Vitor R., last: Carvalho}
-- canonical: {first: Bernardino, last: Casas}
-  variants:
-  - {first: B., last: Casas}
 - canonical: {first: Helena de Medeiros, last: Caseli}
   variants:
   - {first: Helena, last: de Medeiros Caseli}
-- canonical: {first: Arantza, last: Casillas}
-  variants:
-  - {first: A., last: Casillas}
 - canonical: {first: José, last: Castaño}
   variants:
   - {first: José M., last: Castaño}
@@ -1463,10 +1208,6 @@
 - canonical: {first: Maria Novella, last: Catarsi}
   variants:
   - {first: M. N., last: CATARSI}
-  - {first: M. N., last: Catarsi}
-- canonical: {first: Roberta, last: Catizone}
-  variants:
-  - {first: R., last: Catizone}
 - canonical: {first: Patrick, last: Caudal}
   variants:
   - {first: Patrick, last: CAUDAL}
@@ -1491,9 +1232,6 @@
 - canonical: {first: Jeong-Won, last: Cha}
   variants:
   - {first: Jeongwon, last: Cha}
-- canonical: {first: Seungho, last: Cha}
-  variants:
-  - {first: S., last: Cha}
 - canonical: {first: Joyce, last: Chai}
   variants:
   - {first: Joyce Yue, last: Chai}
@@ -1503,20 +1241,15 @@
   - {first: Kian Ming Adam, last: Chai}
 - canonical: {first: Aimilios, last: Chalamandaris}
   variants:
-  - {first: A., last: Chalamandaris}
   - {first: Chalamandaris, last: Aimilios}
 - canonical: {first: Nathanael, last: Chambers}
   variants:
   - {first: Nathan, last: Chambers}
-- canonical: {first: Gary K. K., last: Chan}
-  variants:
-  - {first: G. K. K., last: Chan}
 - canonical: {first: Kwok-Ping, last: Chan}
   variants:
   - {first: Kwok Ping, last: Chan}
 - canonical: {first: Samuel W. K., last: Chan}
   variants:
-  - {first: S. W. K., last: Chan}
   - {first: Samuel W.K., last: Chan}
 - canonical: {first: Brian J., last: CHANDLER}
   variants:
@@ -1529,7 +1262,6 @@
   comment: Raman Chandrasekar is the canonical spelling of his name, even though it
     doesn't appear on any Anthology paper
   variants:
-  - {first: R., last: Chandrasekar}
   - {first: Raman, last: Chandraseker}
 - canonical: {first: Muthu Kumar, last: Chandrasekaran}
   variants:
@@ -1603,12 +1335,6 @@
 - canonical: {first: Eric, last: Charton}
   variants:
   - {first: Éric, last: Charton}
-- canonical: {first: Noël, last: Chateau}
-  variants:
-  - {first: N., last: Chateau}
-- canonical: {first: Niladri, last: Chatterjee}
-  variants:
-  - {first: N., last: Chatterjee}
 - canonical: {first: Rajen, last: Chatterjee}
   variants:
   - {first: Rajan, last: Chatterjee}
@@ -1621,7 +1347,6 @@
   - {first: Himani, last: Chaudhary}
 - canonical: {first: Bidyut Baran, last: Chaudhuri}
   variants:
-  - {first: B. B., last: Chaudhuri}
   - {first: Bidyut B., last: Chaudhuri}
 - canonical: {first: Alvin Cheng-Hsien, last: Chen}
   variants:
@@ -1718,9 +1443,6 @@
 - canonical: {first: Charles, last: 'Chen, Jr.'}
   variants:
   - {first: Charles, last: Chen}
-- canonical: {first: Noureddine, last: Chenfour}
-  variants:
-  - {first: N., last: Chenfour}
 - canonical: {first: Wen-Huei, last: Cheng}
   variants:
   - {first: Wen-Hui, last: Cheng}
@@ -1729,7 +1451,6 @@
   - {first: Xue-Qi, last: Cheng}
 - canonical: {first: Lawrence Y. L., last: Cheung}
   variants:
-  - {first: L. Y. L., last: Cheung}
   - {first: Lawrence Y.L., last: Cheung}
 - canonical: {first: Peter A., last: Chew}
   variants:
@@ -1749,7 +1470,6 @@
 - canonical: {first: Nancy, last: Chinchor}
   variants:
   - {first: Nancy A., last: Chinchor}
-  - {first: N., last: Chinchor}
 - canonical: {first: P. C., last: Ching}
   variants:
   - {first: P.C., last: Ching}
@@ -1757,9 +1477,6 @@
   variants:
   - {first: Manoj K., last: Chinnakotla}
   - {first: Manoj Kumar, last: Chinnakotla}
-- canonical: {first: Luminita, last: Chiran}
-  variants:
-  - {first: L., last: Chiran}
 - canonical: {first: Mahesh V., last: Chitrao}
   variants:
   - {first: Mahesh, last: Chitrao}
@@ -1783,15 +1500,9 @@
   - {first: KEY-SUN, last: CHOI}
   - {first: Key-sun, last: Choi}
   - {first: Key-Sun, last: CHOI}
-- canonical: {first: Annick, last: Choisier}
-  variants:
-  - {first: A., last: Choisier}
 - canonical: {first: Mickey W. C., last: Chong}
   variants:
   - {first: Mickey W.C., last: Chong}
-- canonical: {first: George, last: Chou}
-  variants:
-  - {first: G., last: Chou}
 - canonical: {first: Seng-Cho T., last: Chou}
   variants:
   - {first: Seng-cho T., last: Chou}
@@ -1801,7 +1512,6 @@
 - canonical: {first: Khalid, last: Choukri}
   variants:
   - {first: Kalid, last: Choukri}
-  - {first: K., last: Choukri}
 - canonical: {first: Yen-Lu, last: Chow}
   variants:
   - {first: Yen-lu, last: Chow}
@@ -1863,9 +1573,6 @@
 - canonical: {first: Ricardo Rodrigues, last: Ciferri}
   variants:
   - {first: Ricardo, last: Rodrigues}
-- canonical: {first: Philipp, last: Cimiano}
-  variants:
-  - {first: P., last: Cimiano}
 - canonical: {first: Silvie, last: Cinková}
   variants:
   - {first: Silvie, last: Cinkova}
@@ -1875,19 +1582,12 @@
 - canonical: {first: Fabio, last: Ciravegna}
   variants:
   - {first: Fabio, last: CIRAVEGNA}
-  - {first: F., last: Ciravegna}
-- canonical: {first: Montserrat, last: Civit}
-  variants:
-  - {first: M., last: Civit}
 - canonical: {first: Chris, last: Clark}
   variants:
   - {first: Christine, last: Clark}
 - canonical: {first: Jonathan H., last: Clark}
   variants:
   - {first: Jonathan, last: Clark}
-- canonical: {first: Charles L. A., last: Clarke}
-  variants:
-  - {first: C. L. A., last: Clarke}
 - canonical: {first: Luka A., last: Clarke}
   variants:
   - {first: Luka, last: Clarke}
@@ -1903,9 +1603,6 @@
 - canonical: {first: Martin, last: Cmejrek}
   variants:
   - {first: Martin, last: Čmejrek}
-- canonical: {first: Noah, last: Coccaro}
-  variants:
-  - {first: N., last: Coccaro}
 - canonical: {first: Jose, last: Coch}
   variants:
   - {first: José, last: Coch}
@@ -1951,7 +1648,6 @@
   - {first: Andrew, last: Cole}
 - canonical: {first: Ronald, last: Cole}
   variants:
-  - {first: R., last: Cole}
   - {first: Ron, last: Cole}
   - {first: Ronald A., last: Cole}
 - canonical: {first: John, last: Coleman}
@@ -1960,21 +1656,12 @@
 - canonical: {first: Mariona, last: Coll Ardanuy}
   variants:
   - {first: Mariona Coll, last: Ardanuy}
-- canonical: {first: Christophe, last: Collet}
-  variants:
-  - {first: C., last: Collet}
-- canonical: {first: Jean-Marc, last: Colletta}
-  variants:
-  - {first: J.M., last: Colletta}
 - canonical: {first: Edward, last: Collins}
   variants:
   - {first: Ed, last: Collins}
 - canonical: {first: Michael, last: Collins}
   variants:
   - {first: Michael John, last: Collins}
-- canonical: {first: Sandra, last: Collovini}
-  variants:
-  - {first: S., last: Collovini}
 - canonical: {first: Pere, last: Comas}
   variants:
   - {first: Pere R., last: Comas}
@@ -1982,9 +1669,6 @@
   variants:
   - {first: Don, last: Comeau}
   - {first: Donald, last: Comeau}
-- canonical: {first: Elisabet, last: Comelles}
-  variants:
-  - {first: E., last: Comelles}
 - canonical: {first: Kristian, last: Concepcion}
   variants:
   - {first: Kris, last: Concepcion}
@@ -2006,12 +1690,6 @@
 - canonical: {first: TERRY, last: COPECK}
   variants:
   - {first: Terry, last: Copeck}
-- canonical: {first: Peter-Arno, last: Coppen}
-  variants:
-  - {first: P.A., last: Coppen}
-- canonical: {first: Ornella, last: Corazzari}
-  variants:
-  - {first: O., last: Corazzari}
 - canonical: {first: Greville C., last: Corbett}
   variants:
   - {first: Greville, last: Corbett}
@@ -2045,9 +1723,6 @@
 - canonical: {first: Simon, last: Corston-Oliver}
   variants:
   - {first: Simon H., last: Corston-Oliver}
-- canonical: {first: Louise, last: Corti}
-  variants:
-  - {first: L., last: Corti}
 - canonical: {first: Santiago, last: Cortés Vaíllo}
   variants:
   - {first: Santiago, last: Cortes}
@@ -2095,9 +1770,6 @@
   variants:
   - {first: Daniel, last: Couto-Vale}
   - {first: Daniel, last: Vale}
-- canonical: {first: Roddy, last: Cowie}
-  variants:
-  - {first: R., last: Cowie}
 - canonical: {first: Benoit, last: Crabbé}
   variants:
   - {first: Benoît, last: Crabbé}
@@ -2114,9 +1786,6 @@
 - canonical: {first: Dan, last: Cristea}
   variants:
   - {first: Dan, last: CRISTEA}
-- canonical: {first: Luca, last: Cristoforetti}
-  variants:
-  - {first: L., last: Cristoforetti}
 - canonical: {first: Matthew, last: Crocker}
   variants:
   - {first: Matthew, last: CROCKER}
@@ -2146,25 +1815,18 @@
 - canonical: {first: Alessandro, last: Cucchiarelli}
   variants:
   - {first: Alessandro, last: CUCCHIARELLI}
-- canonical: {first: Catia, last: Cucchiarini}
-  variants:
-  - {first: C., last: Cucchiarini}
 - canonical: {first: Silviu, last: Cucerzan}
   variants:
   - {first: Silviu-Petru, last: Cucerzan}
 - canonical: {first: Chris, last: Culy}
   variants:
   - {first: Christopher, last: Culy}
-- canonical: {first: Hamish, last: Cunningham}
-  variants:
-  - {first: H., last: Cunningham}
 - canonical: {first: Arturo, last: Curiel}
   variants:
   - {first: Arturo, last: Curiel Díaz}
 - canonical: {first: Jan, last: Cuřín}
   variants:
   - {first: Jan, last: Curin}
-  - {first: J., last: Curín}
 - canonical: {first: James R., last: Curran}
   variants:
   - {first: James, last: Curran}
@@ -2180,15 +1842,6 @@
 - canonical: {first: Scott, last: Cyphers}
   variants:
   - {first: D. Scott, last: Cyphers}
-- canonical: {first: Iria, last: da Cunha}
-  variants:
-  - {first: I., last: da Cunha}
-- canonical: {first: Marianne, last: Dabbadie}
-  variants:
-  - {first: M., last: Dabbadie}
-- canonical: {first: Walter, last: Daelemans}
-  variants:
-  - {first: W., last: Daelemans}
 - canonical: {first: Ido, last: Dagan}
   variants:
   - {first: IDO, last: DAGAN}
@@ -2196,10 +1849,6 @@
 - canonical: {first: Deborah A., last: Dahl}
   variants:
   - {first: Deborah, last: Dahl}
-  - {first: D., last: Dahl}
-- canonical: {first: Kathleen, last: Dahlgren}
-  variants:
-  - {first: K., last: Dahlgren}
 - canonical: {first: Li-Rong, last: Dai}
   variants:
   - {first: LiRong, last: Dai}
@@ -2219,9 +1868,6 @@
   variants:
   - {first: Bojana Dalbelo, last: Bašić}
   - {first: Bojana, last: Dalbelo Basic}
-- canonical: {first: Patrice, last: Dalle}
-  variants:
-  - {first: P., last: Dalle}
 - canonical: {first: Bhavana, last: Dalvi}
   variants:
   - {first: Bhavana, last: Dalvi Mishra}
@@ -2240,9 +1886,6 @@
 - canonical: {first: Géraldine, last: Damnati}
   variants:
   - {first: Geraldine, last: Damnati}
-- canonical: {first: Robert I., last: Damper}
-  variants:
-  - {first: R.I., last: Damper}
 - canonical: {first: Sandipan, last: Dandapat}
   variants:
   - {first: Sandipan, last: Dandpat}
@@ -2259,9 +1902,6 @@
 - canonical: {first: Dana, last: Dannélls}
   variants:
   - {first: Dana, last: Dannells}
-- canonical: {first: Masatake, last: Dantsuji}
-  variants:
-  - {first: M., last: Dantsuji}
 - canonical: {first: Aswarth Abhilash, last: Dara}
   variants:
   - {first: Aswarth, last: Dara}
@@ -2340,10 +1980,6 @@
 - canonical: {first: Clément, last: de Groc}
   variants:
   - {first: Clément De, last: Groc}
-- canonical: {first: Karmele, last: López de Ipiña}
-  variants:
-  - {first: K., last: López de Ipiña}
-  - {first: K., last: Lopez de Ipina}
 - canonical: {first: Josafá, last: de Jesus Aguiar Pontes}
   variants:
   - {first: Josafá de Jesus Aguiar, last: Pontes}
@@ -2417,8 +2053,6 @@
   - {first: Lance De, last: Vine}
 - canonical: {first: Folkert, last: de Vriend}
   variants:
-  - {first: F., last: De Vriend}
-  - {first: F., last: de Vriend}
   - {first: Folkert de, last: Vriend}
   - {first: Folkert De, last: Vriend}
   - {first: Folkert, last: De Vriend}
@@ -2462,21 +2096,16 @@
 - canonical: {first: Stephen A., last: Della Pietra}
   variants:
   - {first: S., last: DELLA PIETRA}
-  - {first: S., last: Della Pietra}
   - {first: Stephen, last: Della Pietra}
   - {first: Stephen, last: DellaPietra}
 - canonical: {first: Vincent J., last: Della Pietra}
   variants:
   - {first: V., last: DELLA PIETRA}
-  - {first: V., last: Della Pietra}
   - {first: Vincent, last: Della Pietra}
   - {first: Vincent, last: DellaPietra}
 - canonical: {first: Felice, last: Dell’Orletta}
   variants:
   - {first: Felice, last: Dell’orletta}
-- canonical: {first: Rodolfo, last: Delmonte}
-  variants:
-  - {first: R., last: Delmonte}
 - canonical: {first: Véronique, last: Delvaux}
   variants:
   - {first: Veronique, last: Delvaux}
@@ -2492,27 +2121,15 @@
 - canonical: {first: Isin, last: Demirsahin}
   variants:
   - {first: Işin, last: Demirşahin}
-- canonical: {first: Peter, last: Deng}
-  variants:
-  - {first: P., last: Deng}
 - canonical: {first: Xinyu, last: Deng}
   variants:
   - {first: XinYu, last: Deng}
 - canonical: {first: Zhi-Hong, last: Deng}
   variants:
   - {first: Zhihong, last: Deng}
-- canonical: {first: Alexandre, last: Denis}
-  variants:
-  - {first: A., last: Denis}
 - canonical: {first: Jan Milan, last: Deriu}
   variants:
   - {first: Jan, last: Deriu}
-- canonical: {first: Julien, last: Derivière}
-  variants:
-  - {first: J., last: Derivière}
-- canonical: {first: Louis, last: des Tombe}
-  variants:
-  - {first: L., last: des Tombe}
 - canonical: {first: Maunendra Sankar, last: Desarkar}
   variants:
   - {first: Maunendra, last: Sankar Desarkar}
@@ -2524,10 +2141,8 @@
 - canonical: {first: Elina, last: Desipri}
   variants:
   - {first: Elina, last: Desypri}
-  - {first: E., last: Desipri}
 - canonical: {first: Peter V., last: deSouza}
   variants:
-  - {first: P. V., last: deSouza}
   - {first: P.V., last: de Souza}
 - canonical: {first: José, last: Deulofeu}
   variants:
@@ -2535,9 +2150,6 @@
 - canonical: {first: Arturo Calvo, last: Devesa}
   variants:
   - {first: Arturo, last: Calvo}
-- canonical: {first: Laurence, last: Devillers}
-  variants:
-  - {first: L., last: Devillers}
 - canonical: {first: Paradip, last: DEY}
   variants:
   - {first: Pradip, last: Dey}
@@ -2547,9 +2159,6 @@
 - canonical: {first: Paramveer S., last: Dhillon}
   variants:
   - {first: Paramveer, last: Dhillon}
-- canonical: {first: Elaine Uí, last: Dhonnchadha}
-  variants:
-  - {first: E., last: Uí Dhonnchadha}
 - canonical: {first: Luigi, last: Di Caro}
   variants:
   - {first: Luigi, last: di Caro}
@@ -2561,7 +2170,6 @@
 - canonical: {first: Vittorio, last: Di Tomaso}
   variants:
   - {first: Vittorio Di, last: Tomaso}
-  - {first: V., last: Di Tomaso}
 - canonical: {first: Mona, last: Diab}
   variants:
   - {first: Mona T., last: Diab}
@@ -2586,9 +2194,6 @@
 - canonical: {first: Mireia, last: Diez}
   variants:
   - {first: Mireia, last: Díez}
-- canonical: {first: Vassilios, last: Digalakis}
-  variants:
-  - {first: V., last: Digalakis}
 - canonical: {first: Brian W., last: Dillon}
   variants:
   - {first: Brian, last: Dillon}
@@ -2608,10 +2213,6 @@
 - canonical: {first: Luca, last: Dini}
   variants:
   - {first: LUCA, last: DINI}
-  - {first: L., last: Dini}
-- canonical: {first: Georgiana, last: Dinu}
-  variants:
-  - {first: G., last: Dinu}
 - canonical: {first: Liviu P., last: Dinu}
   variants:
   - {first: Liviu, last: Dinu}
@@ -2647,7 +2248,6 @@
 - canonical: {first: Boris V., last: Dobrov}
   variants:
   - {first: Boris, last: Dobrov}
-  - {first: B., last: Dobrov}
 - canonical: {first: Laura, last: Docio-Fernandez}
   variants:
   - {first: Laura, last: Docío-Fernández}
@@ -2667,9 +2267,6 @@
 - canonical: {first: William B., last: Dolan}
   variants:
   - {first: William, last: Dolan}
-- canonical: {first: Ioannis, last: Dologlou}
-  variants:
-  - {first: I., last: Dologlou}
 - canonical: {first: Marc, last: Domenig}
   variants:
   - {first: Marc, last: DOMENIG}
@@ -2682,9 +2279,6 @@
 - canonical: {first: Xin Luna, last: Dong}
   variants:
   - {first: Xin, last: Dong}
-- canonical: {first: Christine, last: Doran}
-  variants:
-  - {first: C, last: Doran}
 - canonical: {first: Bonnie, last: Dorr}
   variants:
   - {first: Bonnie J., last: Dorr}
@@ -2699,15 +2293,9 @@
 - canonical: {first: Shuji, last: Doshita}
   variants:
   - {first: Shuji, last: DOSHITA}
-- canonical: {first: Ellen, last: Douglas-Cowie}
-  variants:
-  - {first: E., last: Douglas-Cowie}
 - canonical: {first: Yerai, last: Doval}
   variants:
   - {first: Yerai, last: Doval Mosquera}
-- canonical: {first: John, last: Dowding}
-  variants:
-  - {first: J., last: Dowding}
 - canonical: {first: Jennifer, last: Doyon}
   variants:
   - {first: Jennifer B., last: Doyon}
@@ -2724,12 +2312,6 @@
 - canonical: {first: Witold, last: Drożdżyński}
   variants:
   - {first: Witold, last: Drozdzynski}
-- canonical: {first: Sebastian, last: Drude}
-  variants:
-  - {first: S., last: Drude}
-- canonical: {first: Johan Adam, last: du Preez}
-  variants:
-  - {first: J.A., last: du Preez}
 - canonical: {first: Jianyong, last: Duan}
   variants:
   - {first: Jian-Yong, last: Duan}
@@ -2777,9 +2359,6 @@
 - canonical: {first: Ondřej, last: Dušek}
   variants:
   - {first: Ondrej, last: Dusek}
-- canonical: {first: Arienne, last: Dwyer}
-  variants:
-  - {first: A., last: Dwyer}
 - canonical: {first: Laila, last: Dybkjaer}
   variants:
   - {first: Laila, last: Dybkjær}
@@ -2809,23 +2388,15 @@
   - {first: Victor J., last: Díaz}
 - canonical: {first: Arantza, last: Díaz de Ilarraza}
   variants:
-  - {first: A, last: Diaz de Ilarraza}
   - {first: A., last: Diaz de Ilarraza}
-  - {first: A., last: Díaz de Ilarraza}
   - {first: Arantza, last: Diaz de Ilarraza}
   - {first: A., last: Diaz de Ilarraza Sanchez}
-- canonical: {first: Jesús E., last: Díaz Verdejo}
-  variants:
-  - {first: J.E., last: Díaz Verdejo}
 - canonical: {first: Elisabeth, last: D’Halleweyn}
   variants:
   - {first: Elizabeth, last: D’Halleweyn}
 - canonical: {first: Luis Fernando, last: D’Haro}
   variants:
   - {first: Luis F., last: d’Haro}
-- canonical: {first: Susana, last: Early}
-  variants:
-  - {first: S., last: Early}
 - canonical: {first: Kurt, last: Eberle}
   variants:
   - {first: Kurt, last: EBERLE}
@@ -2844,9 +2415,6 @@
 - canonical: {first: Liat, last: Ein Dor}
   variants:
   - {first: Liat, last: Ein-Dor}
-- canonical: {first: Andreas, last: Eisele}
-  variants:
-  - {first: A., last: Eisele}
 - canonical: {first: Jason, last: Eisner}
   variants:
   - {first: Jason M., last: Eisner}
@@ -2876,7 +2444,6 @@
   variants:
   - {first: Marc, last: EL-BEZE}
   - {first: Marc, last: El-Beze}
-  - {first: M., last: El-Bèze}
 - canonical: {first: Wassim, last: El-Hajj}
   variants:
   - {first: Wassim, last: El Hajj}
@@ -2907,9 +2474,6 @@
 - canonical: {first: David, last: Ellis}
   variants:
   - {first: David Ellis, last: Rogers}
-- canonical: {first: T. Mark, last: Ellison}
-  variants:
-  - {first: T. M., last: Ellison}
 - canonical: {first: Samira, last: Ellouze}
   variants:
   - {first: Samira Walha, last: Ellouze}
@@ -2927,18 +2491,6 @@
 - canonical: {first: Martin C., last: Emele}
   variants:
   - {first: Martin, last: Emele}
-- canonical: {first: Louisette, last: Emirkanian}
-  variants:
-  - {first: L., last: Emirkanian}
-- canonical: {first: Chantal, last: Enguehard}
-  variants:
-  - {first: C., last: Enguehard}
-- canonical: {first: Mark, last: Epstein}
-  variants:
-  - {first: M., last: Epstein}
-- canonical: {first: Adoram, last: Erell}
-  variants:
-  - {first: A., last: Erell}
 - canonical: {first: Gunnar, last: Eriksson}
   variants:
   - {first: Gunnar, last: ERIKSSON}
@@ -2962,9 +2514,6 @@
 - canonical: {first: Iris, last: Eshkol}
   variants:
   - {first: Iris, last: Eshkol-Taravella}
-- canonical: {first: Salvador, last: España}
-  variants:
-  - {first: S., last: España}
 - canonical: {first: Luis, last: Espinosa Anke}
   variants:
   - {first: Luis, last: Espinosa-Anke}
@@ -2979,8 +2528,6 @@
 - canonical: {first: Dominique, last: Estival}
   variants:
   - {first: Dominique, last: ESTIVAL}
-  - {first: D, last: Estival}
-  - {first: D., last: Estival}
 - canonical: {first: Yannick, last: Estève}
   variants:
   - {first: Yannick, last: Esteve}
@@ -2992,12 +2539,6 @@
 - canonical: {first: Edmund Grimley, last: Evans}
   variants:
   - {first: Edmund, last: Grimley-Evans}
-- canonical: {first: Roger, last: Evans}
-  variants:
-  - {first: R, last: Evans}
-- canonical: {first: Richard, last: Evans}
-  variants:
-  - {first: R., last: Evans}
 - canonical: {first: Martha, last: Evens}
   variants:
   - {first: MARTHA, last: EVENS}
@@ -3006,9 +2547,6 @@
 - canonical: {first: Stephanie S., last: Everett}
   variants:
   - {first: Stephanie, last: Everett}
-- canonical: {first: Lindsay J., last: Evett}
-  variants:
-  - {first: L.J., last: Evett}
 - canonical: {first: Frank Van, last: Eynde}
   variants:
   - {first: Frank VAN, last: EYNDE}
@@ -3017,10 +2555,6 @@
 - canonical: {first: Rémi, last: Eyraud}
   variants:
   - {first: Remi, last: Eyraud}
-- canonical: {first: Nerea, last: Ezeiza}
-  variants:
-  - {first: N, last: Ezeiza}
-  - {first: N., last: Ezeiza}
 - canonical: {first: Cécile, last: Fabre}
   variants:
   - {first: Cecile, last: Fabre}
@@ -3041,7 +2575,6 @@
   - {first: Cedrick, last: Fairon}
 - canonical: {first: Nikos, last: Fakotakis}
   variants:
-  - {first: N., last: Fakotakis}
   - {first: Nikos D., last: Fakotakis}
 - canonical: {first: Agnieszka, last: Falenska}
   variants:
@@ -3061,9 +2594,6 @@
 - canonical: {first: Tanveer A., last: Faruquie}
   variants:
   - {first: Tanveer, last: Faruquie}
-- canonical: {first: David, last: Farwell}
-  variants:
-  - {first: D., last: Farwell}
 - canonical: {first: Dan, last: Fass}
   variants:
   - {first: Dan, last: FASS}
@@ -3097,9 +2627,6 @@
   variants:
   - {first: Valéria, last: Feltrim}
   - {first: Valéria D., last: Feltrim}
-- canonical: {first: Fangfang, last: Feng}
-  variants:
-  - {first: F., last: Feng}
 - canonical: {first: Jens Erik, last: Fenstad}
   variants:
   - {first: Jens-Erik, last: Fenstad}
@@ -3144,7 +2671,6 @@
 - canonical: {first: Antonio, last: Ferrández}
   variants:
   - {first: A., last: Ferrandez}
-  - {first: A., last: Ferrández}
   - {first: Antonio, last: Ferrandez}
 - canonical: {first: Óscar, last: Ferrández}
   variants:
@@ -3157,7 +2683,6 @@
   - {first: Dani, last: Ferrés}
 - canonical: {first: Hanne, last: Fersøe}
   variants:
-  - {first: H., last: Fersøe}
   - {first: Hanne, last: Fersoe}
 - canonical: {first: Charles J., last: Fillmore}
   variants:
@@ -3170,9 +2695,6 @@
 - canonical: {first: Alex, last: Fine}
   variants:
   - {first: Alex B., last: Fine}
-- canonical: {first: Linda, last: Fineman}
-  variants:
-  - {first: L., last: Fineman}
 - canonical: {first: Tim, last: Finin}
   variants:
   - {first: Timothy W., last: Finin}
@@ -3196,33 +2718,22 @@
   - {first: Beatríz, last: Fisas}
 - canonical: {first: Jonathan G., last: Fiscus}
   variants:
-  - {first: J. G., last: Fiscus}
   - {first: Johathan G., last: Fiscus}
   - {first: Jonathan C., last: Fiscus}
   - {first: Jonathan, last: Fiscus}
-- canonical: {first: David, last: Fisher}
-  variants:
-  - {first: D., last: Fisher}
 - canonical: {first: William M., last: Fisher}
   variants:
-  - {first: W. M., last: Fisher}
-  - {first: W., last: Fisher}
   - {first: William, last: Fisher}
 - canonical: {first: Sisay, last: Fissaha Adafre}
   variants:
   - {first: Sisay, last: Fissaha}
   - {first: Sisay Fissaha, last: Adafre}
-- canonical: {first: Eileen, last: Fitzpatrick}
-  variants:
-  - {first: E., last: Fitzpatrick}
 - canonical: {first: Darja, last: Fišer}
   variants:
   - {first: Darja, last: Fiser}
 - canonical: {first: James L., last: Flanagan}
   variants:
   - {first: James, last: Flanagan}
-  - {first: J., last: Flanagan}
-  - {first: J. L., last: Flanagan}
 - canonical: {first: Sébastien, last: Flavier}
   variants:
   - {first: Sebastien, last: Flavier}
@@ -3232,21 +2743,13 @@
 - canonical: {first: Dan, last: Flickinger}
   variants:
   - {first: Daniel, last: Flickinger}
-  - {first: D., last: Flickenger}
   - {first: Daniel P., last: Flickinger}
-- canonical: {first: Radu, last: Florian}
-  variants:
-  - {first: R, last: Florian}
 - canonical: {first: Christian, last: Fluhr}
   variants:
   - {first: C., last: FLUHR}
-  - {first: C., last: Fluhr}
 - canonical: {first: Achille, last: Fokoue-Nkoutche}
   variants:
   - {first: Achille, last: Fokoue}
-- canonical: {first: Helka, last: Folch}
-  variants:
-  - {first: H., last: Folch}
 - canonical: {first: Peter, last: Foltz}
   variants:
   - {first: Peter W., last: Foltz}
@@ -3301,9 +2804,6 @@
 - canonical: {first: Kilian A., last: Foth}
   variants:
   - {first: Kilian, last: Foth}
-- canonical: {first: Stavroula-Evita, last: Fotinea}
-  variants:
-  - {first: S.-E., last: Fotinea}
 - canonical: {first: Christophe, last: Fouqueré}
   variants:
   - {first: C., last: Fouquere}
@@ -3344,18 +2844,12 @@
 - canonical: {first: Norman M., last: Fraser}
   variants:
   - {first: Norman, last: Fraser}
-- canonical: {first: Elisabeth, last: Frasnelli}
-  variants:
-  - {first: E., last: Frasnelli}
 - canonical: {first: Zuzana, last: Fraterova}
   variants:
   - {first: Zuzana, last: Fráterová}
 - canonical: {first: Robert, last: Frederking}
   variants:
   - {first: Robert E., last: Frederking}
-- canonical: {first: Dayne, last: Freitag}
-  variants:
-  - {first: D., last: Freitag}
 - canonical: {first: André, last: Freitas}
   variants:
   - {first: Andre, last: Freitas}
@@ -3369,12 +2863,6 @@
   variants:
   - {first: Karin Friberg, last: Heppin}
   - {first: Karin, last: Friberg}
-- canonical: {first: Carol, last: Friedman}
-  variants:
-  - {first: C., last: Friedman}
-- canonical: {first: Sónia, last: Frota}
-  variants:
-  - {first: S., last: Frota}
 - canonical: {first: Takeshi, last: FUCHI}
   variants:
   - {first: Takeshi, last: Fuchi}
@@ -3402,9 +2890,6 @@
 - canonical: {first: Pascale, last: Fung}
   variants:
   - {first: Pascale, last: FUNG}
-- canonical: {first: Sadaoki, last: Furui}
-  variants:
-  - {first: S., last: Furui}
 - canonical: {first: Osamu, last: Furuse}
   variants:
   - {first: Osamu, last: FURUSE}
@@ -3428,7 +2913,6 @@
   - {first: Robert, last: GAIZAUSKAS}
   - {first: Robert J., last: Gaizauskas}
   - {first: Rob, last: Gaizauskas}
-  - {first: R., last: Gaizauskas}
 - canonical: {first: Nuria, last: Gala}
   variants:
   - {first: Núria, last: Gala}
@@ -3445,9 +2929,6 @@
 - canonical: {first: Ascension, last: Gallardo-Antolin}
   variants:
   - {first: Ascension, last: Gallardo}
-- canonical: {first: Sylvain, last: Galliano}
-  variants:
-  - {first: S., last: Galliano}
 - canonical: {first: Bruno, last: Galmar}
   variants:
   - {first: Bruno, last: GALMAR}
@@ -3459,9 +2940,6 @@
   - {first: BJORN, last: GAMBACK}
   - {first: Bjorn, last: Gamback}
   - {first: Björn, last: Gämback}
-- canonical: {first: Iñaki, last: Gaminde}
-  variants:
-  - {first: I., last: Gaminde}
 - canonical: {first: Kok Wee, last: Gan}
   variants:
   - {first: Kok-Wee, last: Gan}
@@ -3492,9 +2970,6 @@
   variants:
   - {first: Fernando, last: García-Granada}
   - {first: Fernando, last: García}
-- canonical: {first: Marie-Neige, last: Garcia}
-  variants:
-  - {first: M. N., last: Garcia}
 - canonical: {first: Jorge, last: Garcia Flores}
   variants:
   - {first: Jorge J., last: Garcia Flores}
@@ -3535,11 +3010,8 @@
 - canonical: {first: Roberto, last: Garigliano}
   variants:
   - {first: Roberto, last: GARIGLIANO}
-  - {first: R., last: Garigliano}
 - canonical: {first: John S., last: Garofolo}
   variants:
-  - {first: J. S., last: Garofolo}
-  - {first: J., last: Garofolo}
   - {first: John, last: Garofolo}
 - canonical: {first: Juan María, last: Garrido}
   variants:
@@ -3572,12 +3044,8 @@
 - canonical: {first: Marsal, last: Gavalda}
   variants:
   - {first: Marsal, last: Gavaldà}
-- canonical: {first: Maria, last: Gavrilidou}
-  variants:
-  - {first: M., last: Gavrilidou}
 - canonical: {first: Jean Mark, last: Gawron}
   variants:
-  - {first: J. M., last: Gawron}
   - {first: Mark, last: Gawron}
   - {first: J. Mark, last: Gawron}
 - canonical: {first: Barbara, last: Gawronska}
@@ -3613,9 +3081,6 @@
 - canonical: {first: Damien, last: Genthial}
   variants:
   - {first: Damien, last: GENTHIAL}
-- canonical: {first: Edouard, last: Geoffrois}
-  variants:
-  - {first: E., last: Geoffrois}
 - canonical: {first: Panayiotis, last: Georgiou}
   variants:
   - {first: Panayiotis G., last: Georgiou}
@@ -3630,9 +3095,6 @@
 - canonical: {first: Abigail S., last: Gertner}
   variants:
   - {first: Abigail, last: Gertner}
-- canonical: {first: Pablo, last: Gervás}
-  variants:
-  - {first: P., last: Gervás}
 - canonical: {first: Gholamreza, last: Ghassem-Sani}
   variants:
   - {first: Gholamreza, last: Ghassem-sani}
@@ -3643,9 +3105,6 @@
 - canonical: {first: Soumya Sankar, last: Ghosh}
   variants:
   - {first: Soumya, last: Ghosh}
-- canonical: {first: Egidio, last: Giachin}
-  variants:
-  - {first: E., last: Giachin}
 - canonical: {first: Dafydd, last: Gibbon}
   variants:
   - {first: Dafydd, last: GIBBON}
@@ -3656,12 +3115,6 @@
 - canonical: {first: Helen M., last: Gigley}
   variants:
   - {first: Helen, last: Gigley}
-- canonical: {first: Luca, last: Gilardoni}
-  variants:
-  - {first: L., last: Gilardoni}
-- canonical: {first: Laurent, last: Gillard}
-  variants:
-  - {first: L., last: Gillard}
 - canonical: {first: Dan, last: Gillick}
   variants:
   - {first: Daniel, last: Gillick}
@@ -3680,18 +3133,12 @@
 - canonical: {first: Alexandru-Lucian, last: Ginsca}
   variants:
   - {first: Alexandru, last: Ginsca}
-- canonical: {first: Voula, last: Giouli}
-  variants:
-  - {first: V., last: Giouli}
 - canonical: {first: Emiliano, last: Giovannetti}
   variants:
   - {first: Emiliano, last: Giovanetti}
 - canonical: {first: Joan, last: Giralt Duran}
   variants:
   - {first: Joan Giralt, last: Duran}
-- canonical: {first: Christian, last: Girardi}
-  variants:
-  - {first: C., last: Girardi}
 - canonical: {first: Roxana, last: Girju}
   variants:
   - {first: Roxana, last: Gîrju}
@@ -3701,7 +3148,6 @@
 - canonical: {first: Sheila R., last: Glasbey}
   variants:
   - {first: Sheila, last: Glasbey}
-  - {first: S.R., last: Glasbey}
 - canonical: {first: James, last: Glass}
   variants:
   - {first: James R., last: Glass}
@@ -3719,19 +3165,12 @@
 - canonical: {first: Daniele, last: Godard}
   variants:
   - {first: Danièle, last: Godard}
-- canonical: {first: Guenther, last: Goerz}
-  variants:
-  - {first: G., last: Goerz}
-- canonical: {first: Sebastian, last: Goeser}
-  variants:
-  - {first: S., last: Goeser}
 - canonical: {first: Chooi-Ling, last: Goh}
   variants:
   - {first: Chooi Ling, last: Goh}
   - {first: Chooi-Ling, last: GOH}
 - canonical: {first: Koldo, last: Gojenola}
   variants:
-  - {first: K., last: Gojenola}
   - {first: Koldobika, last: Gojenola}
   - {first: Koldo, last: Gojenola Galletebeitia}
 - canonical: {first: Memduh, last: Gokirmak}
@@ -3743,9 +3182,6 @@
 - canonical: {first: Andrew B., last: Goldberg}
   variants:
   - {first: Andrew, last: Goldberg}
-- canonical: {first: Eli, last: Goldberg}
-  variants:
-  - {first: E., last: Goldberg}
 - canonical: {first: Jade, last: Goldstein}
   variants:
   - {first: Jade, last: Goldstein-Stewart}
@@ -3775,7 +3211,6 @@
 - canonical: {first: Meritxell, last: Gonzàlez}
   variants:
   - {first: Meritxell, last: González}
-  - {first: M., last: González}
 - canonical: {first: Edgar, last: Gonzàlez Pellicer}
   variants:
   - {first: Edgar, last: Gonzàlez}
@@ -3805,9 +3240,6 @@
 - canonical: {first: Teresa, last: Gonçalves}
   variants:
   - {first: Teresa, last: Goncalves}
-- canonical: {first: David, last: Goodine}
-  variants:
-  - {first: D., last: Goodine}
 - canonical: {first: Joshua, last: Goodman}
   variants:
   - {first: Joshua T., last: Goodman}
@@ -3832,9 +3264,6 @@
 - canonical: {first: Matthew R., last: Gormley}
   variants:
   - {first: Matthew, last: Gormley}
-- canonical: {first: Genevieve, last: Gorrell}
-  variants:
-  - {first: G., last: Gorrell}
 - canonical: {first: Gunther, last: Gorz}
   variants:
   - {first: Gunther, last: GORZ}
@@ -3844,12 +3273,6 @@
 - canonical: {first: Thilo, last: Gotz}
   variants:
   - {first: Thilo, last: Götz}
-- canonical: {first: Jérôme, last: Goulian}
-  variants:
-  - {first: J., last: Goulian}
-- canonical: {first: Cyril, last: Goutte}
-  variants:
-  - {first: C., last: Goutte}
 - canonical: {first: Arthur C., last: Graesser}
   variants:
   - {first: Art, last: Graesser}
@@ -3878,9 +3301,6 @@
 - canonical: {first: Agustin, last: Gravano}
   variants:
   - {first: Agustín, last: Gravano}
-- canonical: {first: Guillaume, last: Gravier}
-  variants:
-  - {first: G., last: Gravier}
 - canonical: {first: João, last: Graça}
   variants:
   - {first: João, last: Graca}
@@ -3905,12 +3325,8 @@
 - canonical: {first: Mark A., last: Greenwood}
   variants:
   - {first: Mark, last: Greenwood}
-- canonical: {first: Edward, last: Grefenstette}
-  variants:
-  - {first: E., last: Grefenstette}
 - canonical: {first: Michelle, last: Gregory}
   variants:
-  - {first: M. L., last: Gregory}
   - {first: Michelle L., last: Gregory}
 - canonical: {first: Warren, last: Greiff}
   variants:
@@ -3924,7 +3340,6 @@
 - canonical: {first: Ralph, last: Grishman}
   variants:
   - {first: RALPH, last: GRISHMAN}
-  - {first: R., last: Grishman}
 - canonical: {first: Loïc, last: Grobol}
   variants:
   - {first: Loic, last: Grobol}
@@ -3961,9 +3376,6 @@
 - canonical: {first: Hung-Yan, last: Gu}
   variants:
   - {first: Hung-yan, last: Gu}
-- canonical: {first: Franz, last: Guenthner}
-  variants:
-  - {first: F., last: Guenthner}
 - canonical: {first: Emiliano Raul, last: Guevara}
   variants:
   - {first: Emiliano, last: Guevara}
@@ -3974,9 +3386,6 @@
 - canonical: {first: Jean-Philippe, last: GUILBAUD}
   variants:
   - {first: Jean-Philippe, last: Guilbaud}
-- canonical: {first: PIERRE, last: GUILLAUME}
-  variants:
-  - {first: P., last: GUILLAUME}
 - canonical: {first: Sylvie, last: GUILLEMIN-LANNE}
   variants:
   - {first: Sylvie, last: Guillemin-Lanne}
@@ -4015,23 +3424,13 @@
 - canonical: {first: Naman K., last: Gupta}
   variants:
   - {first: Naman, last: Gupta}
-- canonical: {first: Vineet, last: Gupta}
-  variants:
-  - {first: V., last: Gupta}
-- canonical: {first: Antton, last: Gurrutxaga}
-  variants:
-  - {first: A., last: Gurrutxaga}
 - canonical: {first: Sofia, last: Gustafson-Capková}
   variants:
   - {first: Sofia, last: Gustafson Capková}
-- canonical: {first: Louise, last: Guthrie}
-  variants:
-  - {first: L., last: Guthrie}
 - canonical: {first: E. Dario, last: Gutierrez}
   variants:
   - {first: E.Dario, last: Gutierrez}
   - {first: Elkin, last: Darío Gutiérrez}
-  - {first: E. D., last: Gutiérrez}
 - canonical: {first: Yoan, last: Gutiérrez}
   variants:
   - {first: Yoan, last: Gutierrez}
@@ -4092,9 +3491,6 @@
 - canonical: {first: Anne, last: Haake}
   variants:
   - {first: Anne R., last: Haake}
-- canonical: {first: Salah, last: Haamid}
-  variants:
-  - {first: S., last: Haamid}
 - canonical: {first: Andrew, last: Haas}
   variants:
   - {first: Andrew R., last: Haas}
@@ -4104,16 +3500,9 @@
 - canonical: {first: Benoit, last: Habert}
   variants:
   - {first: Benoît, last: Habert}
-  - {first: B., last: Habert}
-- canonical: {first: Kadri, last: Hacioglu}
-  variants:
-  - {first: K., last: Hacioglu}
 - canonical: {first: Yaakov, last: HaCohen-Kerner}
   variants:
   - {first: Yaakov, last: Hacohen-Kerner}
-- canonical: {first: Bassam, last: Haddad}
-  variants:
-  - {first: B., last: Haddad}
 - canonical: {first: Kais, last: Haddar}
   variants:
   - {first: Kais, last: HADDAR}
@@ -4124,7 +3513,6 @@
   variants:
   - {first: Widad Mustafa, last: El Hadi}
   - {first: Widad, last: Mustafa El Hadi}
-  - {first: W., last: Mustafa El Hadi}
 - canonical: {first: Mohamed Nassime, last: Hadjadj}
   variants:
   - {first: Mohamed, last: Hadjadj}
@@ -4137,12 +3525,6 @@
 - canonical: {first: KARIN, last: HAENELT}
   variants:
   - {first: Karin, last: Haenelt}
-- canonical: {first: Walter, last: Haeseryn}
-  variants:
-  - {first: W., last: Haeseryn}
-- canonical: {first: Nazila, last: Hafezi}
-  variants:
-  - {first: N., last: Hafezi}
 - canonical: {first: Caroline, last: Hagège}
   variants:
   - {first: Caroline, last: Hagege}
@@ -4155,9 +3537,6 @@
 - canonical: {first: Negacy, last: Hailu}
   variants:
   - {first: Negacy D., last: Hailu}
-- canonical: {first: Horst-Udo, last: Hain}
-  variants:
-  - {first: H.-U., last: Hain}
 - canonical: {first: Jan, last: Hajic}
   variants:
   - {first: Jan, last: HAJIC}
@@ -4170,7 +3549,6 @@
   - {first: Eva, last: Hajicová}
   - {first: EVA, last: HAJICOVA}
   - {first: Eva, last: Hajičová}
-  - {first: E., last: Hajicova}
 - canonical: {first: Dilek, last: Hakkani-Tur}
   variants:
   - {first: Dilek, last: Hakkani-Tür}
@@ -4185,7 +3563,6 @@
   - {first: Mark Michael, last: Hall}
 - canonical: {first: Susan, last: Haller}
   variants:
-  - {first: S.M., last: Haller}
   - {first: Susan M., last: Haller}
 - canonical: {first: Péter, last: Halácsy}
   variants:
@@ -4193,12 +3570,6 @@
 - canonical: {first: Hugo Van, last: hamme}
   variants:
   - {first: Hugo, last: Van hamme}
-- canonical: {first: Olivier, last: Hamon}
-  variants:
-  - {first: O., last: Hamon}
-- canonical: {first: Thierry, last: Hamon}
-  variants:
-  - {first: T., last: Hamon}
 - canonical: {first: Chung-hye, last: Han}
   variants:
   - {first: Chung-Hye, last: Han}
@@ -4209,10 +3580,6 @@
 - canonical: {first: K., last: Hanakata}
   variants:
   - {first: Kenji, last: HANAKATA}
-- canonical: {first: Philip, last: Hanna}
-  variants:
-  - {first: P., last: Hanna}
-  - {first: P, last: Hanna}
 - canonical: {first: Dorte Haltrup, last: Hansen}
   variants:
   - {first: Dorte H., last: Hansen}
@@ -4230,19 +3597,13 @@
   - {first: Robert, last: Haralick}
 - canonical: {first: Mary, last: Harper}
   variants:
-  - {first: M. P., last: Harper}
   - {first: Mary P., last: Harper}
 - canonical: {first: Phil, last: Harrison}
   variants:
-  - {first: P., last: Harrison}
   - {first: Philip, last: Harrison}
 - canonical: {first: Anthony, last: Hartley}
   variants:
   - {first: Anthony F., last: Hartley}
-  - {first: A., last: Hartley}
-- canonical: {first: Matthias, last: Hartung}
-  variants:
-  - {first: M., last: Hartung}
 - canonical: {first: Md. Maruf, last: Hasan}
   variants:
   - {first: Md Maruf, last: Hasan}
@@ -4253,9 +3614,6 @@
 - canonical: {first: Saša, last: Hasan}
   variants:
   - {first: Sasa, last: Hasan}
-- canonical: {first: Tatsunori B., last: Hashimoto}
-  variants:
-  - {first: Tatsunori, last: Hashimoto}
 - canonical: {first: Koiti, last: Hasida}
   variants:
   - {first: Koiti, last: HASIDA}
@@ -4263,9 +3621,6 @@
 - canonical: {first: Ahmed, last: Hassan}
   variants:
   - {first: Ahmed Hassan, last: Awadallah}
-- canonical: {first: Hany, last: Hassan}
-  variants:
-  - {first: H, last: Hassan}
 - canonical: {first: Helen, last: Hastie}
   variants:
   - {first: Helen Wright, last: Hastie}
@@ -4294,7 +3649,6 @@
 - canonical: {first: Yoshihiko, last: Hayashi}
   variants:
   - {first: Yoshihiko, last: HAYASHI}
-  - {first: Y., last: Hayashi}
 - canonical: {first: Cory, last: Hayes}
   variants:
   - {first: Cory J., last: Hayes}
@@ -4307,9 +3661,6 @@
 - canonical: {first: Amir, last: Hazem}
   variants:
   - {first: Amir, last: HAZEM}
-- canonical: {first: Timothy J., last: Hazen}
-  variants:
-  - {first: T. J., last: Hazen}
 - canonical: {first: Patrick, last: Healey}
   variants:
   - {first: Pat, last: Healey}
@@ -4321,9 +3672,6 @@
 - canonical: {first: Peter A., last: Heeman}
   variants:
   - {first: Peter, last: Heeman}
-- canonical: {first: George E., last: Heidorn}
-  variants:
-  - {first: G. E., last: Heidorn}
 - canonical: {first: Katarina, last: Heimann Mühlenbock}
   variants:
   - {first: Katarina, last: Mühlenbock}
@@ -4368,7 +3716,6 @@
 - canonical: {first: Renate, last: Henschel}
   variants:
   - {first: Renate, last: HENSCHEL}
-  - {first: R., last: Henschel}
 - canonical: {first: Aurélie, last: Herbelot}
   variants:
   - {first: Aurelie, last: Herbelot}
@@ -4380,13 +3727,9 @@
   - {first: Daniel Hernández, last: López}
 - canonical: {first: Inmaculada, last: Hernáez}
   variants:
-  - {first: I., last: Hernáez}
   - {first: Inmaculada, last: Hernaez}
   - {first: Inma, last: Hernaez}
   - {first: Inma, last: Hernáez}
-- canonical: {first: Gregorio, last: Hernández}
-  variants:
-  - {first: G., last: Hernández}
 - canonical: {first: Luis, last: Hernández}
   variants:
   - {first: Luis Hernández, last: Gomez}
@@ -4413,9 +3756,6 @@
 - canonical: {first: Dirk, last: Heylen}
   variants:
   - {first: Dirk, last: HEYLEN}
-- canonical: {first: James, last: Hieronymus}
-  variants:
-  - {first: J., last: Hieronymus}
 - canonical: {first: Almut Silja, last: Hildebrand}
   variants:
   - {first: Silja, last: Hildebrand}
@@ -4423,12 +3763,8 @@
 - canonical: {first: Lucas Welter, last: Hilgert}
   variants:
   - {first: Lucas, last: Hilgert}
-- canonical: {first: Dustin, last: Hillard}
-  variants:
-  - {first: D., last: Hillard}
 - canonical: {first: Donald, last: Hindle}
   variants:
-  - {first: D., last: Hindle}
   - {first: Don, last: Hindle}
 - canonical: {first: Elizabeth A., last: Hinkelman}
   variants:
@@ -4439,16 +3775,12 @@
 - canonical: {first: Marie, last: Hinrichs}
   variants:
   - {first: Marie, last: Boyle-Hinrichs}
-- canonical: {first: Hideki, last: Hirakawa}
-  variants:
-  - {first: H., last: Hirakawa}
 - canonical: {first: Julia, last: Hirschberg}
   variants:
   - {first: Julia B., last: Hirschberg}
   - {first: Julia, last: Hirchberg}
 - canonical: {first: Lynette, last: Hirschman}
   variants:
-  - {first: L., last: Hirschman}
   - {first: Lynette, last: Hirshman}
 - canonical: {first: Graeme, last: Hirst}
   variants:
@@ -4457,13 +3789,9 @@
   variants:
   - {first: Toru, last: HITAKA}
   - {first: Tooru, last: Hitaka}
-- canonical: {first: Janet, last: Hitzeman}
-  variants:
-  - {first: J., last: Hitzeman}
 - canonical: {first: Barbora, last: Hladká}
   variants:
   - {first: Barbora, last: Hladka}
-  - {first: B., last: Hladká}
 - canonical: {first: Jaroslava, last: Hlaváčová}
   variants:
   - {first: Jaroslava, last: Hlavacova}
@@ -4483,10 +3811,8 @@
 - canonical: {first: Jerry R., last: Hobbs}
   variants:
   - {first: Jerry, last: Hobbs}
-  - {first: J.R., last: Hobbs}
 - canonical: {first: Beth Ann, last: Hockey}
   variants:
-  - {first: B. A., last: Hockey}
   - {first: Beth A., last: Hockey}
   - {first: Beth, last: Hockey}
 - canonical: {first: Edward, last: Hoenkamp}
@@ -4513,13 +3839,6 @@
 - canonical: {first: Tomáš, last: Holan}
   variants:
   - {first: Tomas, last: Holan}
-- canonical: {first: Natsuko, last: Holden}
-  variants:
-  - {first: N., last: Holden}
-- canonical: {first: Hsiao-Wuen, last: Hon}
-  variants:
-  - {first: H.W., last: Hon}
-  - {first: H., last: Hon}
 - canonical: {first: Takeo, last: Honda}
   variants:
   - {first: Takeo, last: HONDA}
@@ -4660,10 +3979,6 @@
   variants:
   - {first: Ting-Hao (Kenneth), last: Huang}
   - {first: Ting-Hao ‘Kenneth’, last: Huang}
-- canonical: {first: Xuedong, last: Huang}
-  variants:
-  - {first: X.D., last: Huang}
-  - {first: X., last: Huang}
 - canonical: {first: Xiangji, last: Huang}
   variants:
   - {first: Jimmy Xiangji, last: Huang}
@@ -4687,16 +4002,9 @@
 - canonical: {first: Kevin, last: Humphreys}
   variants:
   - {first: Kevin, last: HUMPHREYS}
-  - {first: K., last: Humphreys}
 - canonical: {first: Jeih-weih, last: Hung}
   variants:
   - {first: Jeih-Weih, last: Hung}
-- canonical: {first: Kate, last: Hunicke-Smith}
-  variants:
-  - {first: K., last: Hunicke-Smith}
-- canonical: {first: Dan, last: Hunter}
-  variants:
-  - {first: D., last: Hunter}
 - canonical: {first: Lawrence, last: Hunter}
   variants:
   - {first: Lawrence E., last: Hunter}
@@ -4711,12 +4019,6 @@
 - canonical: {first: W. John, last: Hutchins}
   variants:
   - {first: John, last: Hutchins}
-- canonical: {first: Christian, last: Huyck}
-  variants:
-  - {first: C., last: Huyck}
-- canonical: {first: Mei-Yuh, last: Hwang}
-  variants:
-  - {first: M., last: Hwang}
 - canonical: {first: Young-Sook, last: Hwang}
   variants:
   - {first: YoungSook, last: Hwang}
@@ -4729,7 +4031,6 @@
 - canonical: {first: Harald, last: Höge}
   variants:
   - {first: Harald, last: Hoege}
-  - {first: H., last: Höge}
 - canonical: {first: Ali, last: Hürriyetoğlu}
   variants:
   - {first: Ali, last: Hurriyetoglu}
@@ -4761,9 +4062,6 @@
 - canonical: {first: Michael, last: Ingleby}
   variants:
   - {first: Michael, last: INGLEBY}
-- canonical: {first: Robert, last: Ingria}
-  variants:
-  - {first: R., last: Ingria}
 - canonical: {first: Diana, last: Inkpen}
   variants:
   - {first: Diana Zaiu, last: Inkpen}
@@ -4777,18 +4075,12 @@
 - canonical: {first: José, last: Iria}
   variants:
   - {first: Jose, last: Iria}
-- canonical: {first: Mikel, last: Iruskieta}
-  variants:
-  - {first: M., last: Iruskieta}
 - canonical: {first: Hitoshi, last: Isahara}
   variants:
   - {first: Hitoshi, last: ISAHARA}
 - canonical: {first: Anas El, last: Isbihani}
   variants:
   - {first: Anas, last: El Isbihani}
-- canonical: {first: Masato, last: Ishizaki}
-  variants:
-  - {first: M., last: Ishizaki}
 - canonical: {first: Aminul, last: Islam}
   variants:
   - {first: Md. Aminul, last: Islam}
@@ -4810,9 +4102,6 @@
 - canonical: {first: Yukihiro, last: Itoh}
   variants:
   - {first: Yukihiro, last: Ito}
-- canonical: {first: Abe, last: Ittycheriah}
-  variants:
-  - {first: A, last: Ittycheriah}
 - canonical: {first: Un-Gian, last: Iunn}
   variants:
   - {first: Un-gian, last: Iu}
@@ -4839,16 +4128,12 @@
 - canonical: {first: Litton, last: J Kurisinkel}
   variants:
   - {first: Litton J., last: Kurisinkel}
-- canonical: {first: Eric, last: Jackson}
-  variants:
-  - {first: E., last: Jackson}
 - canonical: {first: Cassandra L., last: Jacobs}
   variants:
   - {first: Cassandra, last: Jacobs}
 - canonical: {first: Paul S., last: Jacobs}
   variants:
   - {first: Paul, last: Jacobs}
-  - {first: P., last: Jacobs}
 - canonical: {first: Christian, last: Jacquemin}
   variants:
   - {first: Christian, last: JACQUEMIN}
@@ -4903,7 +4188,6 @@
 - canonical: {first: Michèle, last: Jardino}
   variants:
   - {first: Michele, last: Jardino}
-  - {first: M., last: Jardino}
 - canonical: {first: Gaja, last: Jarosz}
   variants:
   - {first: Gaja E., last: Jarosz}
@@ -4919,13 +4203,11 @@
 - canonical: {first: Frederick, last: Jelinek}
   variants:
   - {first: F., last: JELINEK}
-  - {first: F., last: Jelinek}
   - {first: Fred, last: Jelinek}
   - {first: Fredrick, last: Jelinek}
 - canonical: {first: Karen, last: Jensen}
   variants:
   - {first: Karen, last: JENSEN}
-  - {first: K., last: Jensen}
 - canonical: {first: Lars Juhl, last: Jensen}
   variants:
   - {first: Lars J., last: Jensen}
@@ -4963,12 +4245,6 @@
 - canonical: {first: Salud María, last: Jiménez-Zafra}
   variants:
   - {first: Salud M., last: Jiménez-Zafra}
-- canonical: {first: Petr, last: Jirku}
-  variants:
-  - {first: P., last: Jirku}
-- canonical: {first: Amanda C., last: Jobbins}
-  variants:
-  - {first: A.C., last: Jobbins}
 - canonical: {first: Janne Bondi, last: Johannessen}
   variants:
   - {first: Janne, last: Bondi Johannessen}
@@ -4993,9 +4269,6 @@
 - canonical: {first: R.L., last: Johnson}
   variants:
   - {first: R., last: Johnson}
-- canonical: {first: Michael, last: Johnston}
-  variants:
-  - {first: M., last: Johnston}
 - canonical: {first: Trevor, last: Johnston}
   variants:
   - {first: Trevor, last: Johnson}
@@ -5051,9 +4324,6 @@
   variants:
   - {first: Aravind K., last: Joshi}
   - {first: Aravind K., last: JOSHI}
-  - {first: A.K., last: Joshi}
-  - {first: A. K., last: Joshi}
-  - {first: A., last: Joshi}
   - {first: Aravin K., last: Joshi}
 - canonical: {first: Sachindra, last: Joshi}
   variants:
@@ -5061,7 +4331,7 @@
 - canonical: {first: Shafiq, last: Joty}
   variants:
   - {first: Shafiq R., last: Joty}
-- canonical: {first: Estevam R., last: "Hruschka, Jr."}
+- canonical: {first: Estevam R., last: 'Hruschka, Jr.'}
   variants:
   - {first: Estevam R., last: Hruschka Jr.}
 - canonical: {first: Yun-Cheng, last: Ju}
@@ -5115,7 +4385,6 @@
 - canonical: {first: Mijail, last: Kabadjov}
   variants:
   - {first: Mijail A., last: Kabadjov}
-  - {first: M. A., last: Kabadjov}
   - {first: Mijail, last: Alexandrov-Kabadjov}
 - canonical: {first: Michael B., last: Kac}
   variants:
@@ -5142,14 +4411,12 @@
 - canonical: {first: Jugal, last: Kalita}
   variants:
   - {first: Jugal K., last: Kalita}
-  - {first: J.K., last: Kalita}
 - canonical: {first: Rihards, last: Kalniņš}
   variants:
   - {first: Rihards, last: Kalnins}
 - canonical: {first: Nanda, last: Kambhatla}
   variants:
   - {first: Nandakishore, last: Kambhatla}
-  - {first: N, last: Kambhatla}
 - canonical: {first: Shin-ichiro, last: Kamei}
   variants:
   - {first: Shin-ichiro, last: KAMEI}
@@ -5175,9 +4442,6 @@
 - canonical: {first: Rose Catherine, last: Kanjirathinkal}
   variants:
   - {first: Rose, last: Catherine}
-- canonical: {first: Ashvin, last: Kannan}
-  variants:
-  - {first: A., last: Kannan}
 - canonical: {first: Paul, last: Kantor}
   variants:
   - {first: Paul B., last: Kantor}
@@ -5214,19 +4478,10 @@
   variants:
   - {first: HANS, last: KARLGREN}
   - {first: Hans, last: KARLGREN}
-- canonical: {first: Kostas, last: Karpouzis}
-  variants:
-  - {first: K., last: Karpouzis}
-- canonical: {first: Hideki, last: Kashioka}
-  variants:
-  - {first: H, last: Kashioka}
 - canonical: {first: Robert T., last: Kasper}
   variants:
   - {first: Robert T., last: KASPER}
   - {first: Robert, last: Kasper}
-- canonical: {first: Walter, last: Kasper}
-  variants:
-  - {first: W., last: Kasper}
 - canonical: {first: Yasuhiro, last: Katagiri}
   variants:
   - {first: Yasuhiro, last: KATAGIRI}
@@ -5248,9 +4503,6 @@
 - canonical: {first: Jason, last: Katz-Brown}
   variants:
   - {first: Jason, last: Brown}
-- canonical: {first: Ergina, last: Kavallieratou}
-  variants:
-  - {first: E., last: Kavallieratou}
 - canonical: {first: Takeshi, last: KAWABATA}
   variants:
   - {first: Takeshi, last: Kawabata}
@@ -5296,7 +4548,6 @@
   - {first: Casey Redd, last: Kennington}
 - canonical: {first: Fabio, last: Kepler}
   variants:
-  - {first: F., last: Kepler}
   - {first: Fabio N., last: Kepler}
   - {first: Fabio Natanael, last: Kepler}
 - canonical: {first: Sue J., last: Ker}
@@ -5342,18 +4593,9 @@
 - canonical: {first: Hatim, last: Khouzaimi}
   variants:
   - {first: Hatim, last: KHOUZAIMI}
-- canonical: {first: Sanjeev, last: Khudanpur}
-  variants:
-  - {first: S., last: Khudanpur}
-- canonical: {first: Rodger, last: Kibble}
-  variants:
-  - {first: R., last: Kibble}
 - canonical: {first: Chloé, last: Kiddon}
   variants:
   - {first: Chloe, last: Kiddon}
-- canonical: {first: Bernd, last: Kiefer}
-  variants:
-  - {first: B., last: Kiefer}
 - canonical: {first: Hoang, last: Kiem}
   variants:
   - {first: Kiem, last: Hoang}
@@ -5363,7 +4605,6 @@
 - canonical: {first: Hideaki, last: Kikuchi}
   variants:
   - {first: Hideaki, last: KIKUCHI}
-  - {first: H., last: Kikuchi}
 - canonical: {first: Gen-ichiro, last: KIKUI}
   variants:
   - {first: Gen’ichiro, last: KIKUI}
@@ -5427,9 +4668,6 @@
 - canonical: {first: Yung Taek, last: Kim}
   variants:
   - {first: Yung-Taek, last: KIM}
-- canonical: {first: Owen, last: Kimball}
-  variants:
-  - {first: O., last: Kimball}
 - canonical: {first: Kazuhiro, last: Kimura}
   variants:
   - {first: Kazuhiro, last: KIMURA}
@@ -5442,9 +4680,6 @@
 - canonical: {first: Tracy Holloway, last: King}
   variants:
   - {first: Tracy H., last: King}
-- canonical: {first: Brian, last: Kingsbury}
-  variants:
-  - {first: B., last: Kingsbury}
 - canonical: {first: Satoshi, last: Kinoshita}
   variants:
   - {first: Satoshi, last: KINOSHITA}
@@ -5475,24 +4710,12 @@
 - canonical: {first: Balázs, last: Kis}
   variants:
   - {first: Balazs, last: Kis}
-- canonical: {first: Imre, last: Kiss}
-  variants:
-  - {first: I., last: Kiss}
 - canonical: {first: Chunyu, last: Kit}
   variants:
   - {first: Chun-yu, last: Kit}
-- canonical: {first: Sotaro, last: Kita}
-  variants:
-  - {first: S., last: Kita}
-- canonical: {first: Richard, last: Kittredge}
-  variants:
-  - {first: R., last: Kittredge}
 - canonical: {first: Masaki, last: Kiyono}
   variants:
   - {first: Masaki, last: KIYONO}
-- canonical: {first: Esther, last: Klabbers}
-  variants:
-  - {first: E., last: Klabbers}
 - canonical: {first: Ioannis, last: Klapaftis}
   variants:
   - {first: Ioannis P., last: Klapaftis}
@@ -5503,7 +4726,6 @@
   variants:
   - {first: Judith, last: KLAVANS}
   - {first: Judith, last: Klavans}
-  - {first: J., last: Klavans}
 - canonical: {first: Ewan, last: Klein}
   variants:
   - {first: Ewan, last: KLEIN}
@@ -5513,9 +4735,6 @@
 - canonical: {first: Sheldon, last: Klein}
   variants:
   - {first: Sheldon, last: KLEIN}
-- canonical: {first: Wolfgang, last: Klein}
-  variants:
-  - {first: W., last: Klein}
 - canonical: {first: Jörg, last: Kleinz}
   variants:
   - {first: Jorg, last: Kleinz}
@@ -5531,9 +4750,6 @@
 - canonical: {first: Catherine, last: KOBUS}
   variants:
   - {first: Catherine, last: Kobus}
-- canonical: {first: Krzysztof, last: Kochut}
-  variants:
-  - {first: K., last: Kochut}
 - canonical: {first: Andras, last: Kocsor}
   variants:
   - {first: András, last: Kocsor}
@@ -5547,19 +4763,11 @@
 - canonical: {first: Dieter, last: Kohl}
   variants:
   - {first: DIETER, last: KOHL}
-- canonical: {first: Hanae, last: Koiso}
-  variants:
-  - {first: H., last: Koiso}
 - canonical: {first: Mare, last: Koit}
   variants:
   - {first: Mare, last: KOIT}
-  - {first: M., last: Koit}
-- canonical: {first: Atsuko, last: Koizumi}
-  variants:
-  - {first: A., last: Koizumi}
 - canonical: {first: George, last: Kokkinakis}
   variants:
-  - {first: G., last: Kokkinakis}
   - {first: George K., last: Kokkinakis}
 - canonical: {first: Sofie Johansson, last: Kokkinakis}
   variants:
@@ -5583,9 +4791,6 @@
 - canonical: {first: Markus, last: Kommenda}
   variants:
   - {first: Markus, last: KOMMENDA}
-- canonical: {first: Rik, last: Koncel-Kedziorski}
-  variants:
-  - {first: R., last: Koncel-Kedziorski}
 - canonical: {first: Ravikumar, last: Kondadadi}
   variants:
   - {first: Ravi, last: Kondadadi}
@@ -5623,9 +4828,6 @@
 - canonical: {first: Guy-Noel, last: Kouarata}
   variants:
   - {first: Guy-Noël, last: Kouarata}
-- canonical: {first: Eleni, last: Koutsogeorgos}
-  variants:
-  - {first: E., last: Koutsogeorgos}
 - canonical: {first: John J., last: Kovarik}
   variants:
   - {first: John, last: Kovarik}
@@ -5641,21 +4843,9 @@
 - canonical: {first: Emiel, last: Krahmer}
   variants:
   - {first: Emiel J., last: Krahmer}
-- canonical: {first: Olivier, last: Kraif}
-  variants:
-  - {first: O., last: Kraif}
-- canonical: {first: Martin, last: Krallinger}
-  variants:
-  - {first: M., last: Krallinger}
-- canonical: {first: Steven, last: Krauwer}
-  variants:
-  - {first: S., last: Krauwer}
 - canonical: {first: Hans-Ulrich, last: Krieger}
   variants:
   - {first: HansUlrich, last: Krieger}
-- canonical: {first: Raghava, last: Krishnan}
-  variants:
-  - {first: R., last: Krishnan}
 - canonical: {first: Rihards, last: Krišlauks}
   variants:
   - {first: Rihards, last: Krislauks}
@@ -5675,9 +4865,6 @@
 - canonical: {first: George, last: Krupka}
   variants:
   - {first: George R., last: Krupka}
-- canonical: {first: Udo, last: Kruschwitz}
-  variants:
-  - {first: U., last: Kruschwitz}
 - canonical: {first: Germán, last: Kruszewski}
   variants:
   - {first: German, last: Kruszewski}
@@ -5687,9 +4874,6 @@
 - canonical: {first: Vincent, last: Kríž}
   variants:
   - {first: Vincent, last: Kriz}
-- canonical: {first: Francis, last: Kubala}
-  variants:
-  - {first: F., last: Kubala}
 - canonical: {first: Petr, last: Kubon}
   variants:
   - {first: PETR, last: KUBON}
@@ -5704,12 +4888,6 @@
 - canonical: {first: Marianne, last: Kugler}
   variants:
   - {first: MARIANNE, last: KUGLER}
-- canonical: {first: Ulrike, last: Kugler}
-  variants:
-  - {first: U., last: Kugler}
-- canonical: {first: Anne, last: Kuhn}
-  variants:
-  - {first: A., last: Kuhn}
 - canonical: {first: Robert J., last: Kuhns}
   variants:
   - {first: Robert J., last: KUHNS}
@@ -5757,9 +4935,6 @@
 - canonical: {first: Mohamed Zakaria, last: Kurdi}
   variants:
   - {first: Mohamed-Zakaria, last: Kurdi}
-- canonical: {first: Nicholas, last: Kushmerick}
-  variants:
-  - {first: N., last: Kushmerick}
 - canonical: {first: A., last: Kustner}
   variants:
   - {first: Andreas, last: KUSTNER}
@@ -5811,9 +4986,6 @@
 - canonical: {first: Gorka, last: Labaka}
   variants:
   - {first: G., last: Labaka}
-- canonical: {first: Penny, last: Labropoulou}
-  variants:
-  - {first: P., last: Labropoulou}
 - canonical: {first: Finley, last: Lacatusu}
   variants:
   - {first: V. Finley, last: Lacatusu}
@@ -5823,7 +4995,6 @@
 - canonical: {first: John, last: Lafferty}
   variants:
   - {first: John D., last: Lafferty}
-  - {first: J., last: Lafferty}
   - {first: John, last: Lafrerty}
 - canonical: {first: Frederique, last: Laforest}
   variants:
@@ -5854,7 +5025,6 @@
   - {first: Min Hua, last: Lai}
 - canonical: {first: Tom B.Y., last: Lai}
   variants:
-  - {first: T. B. Y., last: Lai}
   - {first: Tom B. Y., last: Lai}
   - {first: Tom B.Y, last: Lai}
 - canonical: {first: Tom Bong-yeung, last: Lai}
@@ -5880,7 +5050,6 @@
 - canonical: {first: Lori, last: Lamel}
   variants:
   - {first: Lori F., last: Lamel}
-  - {first: L.F., last: Lamel}
 - canonical: {first: Andre, last: Lamurias}
   variants:
   - {first: André, last: Lamúrias}
@@ -5948,18 +5117,9 @@
 - canonical: {first: Raymond, last: Lau}
   variants:
   - {first: Raymond, last: LAU}
-- canonical: {first: Alberto, last: Lavelli}
-  variants:
-  - {first: A., last: Lavelli}
 - canonical: {first: Julia, last: Lavid-López}
   variants:
   - {first: Julia, last: Lavid}
-- canonical: {first: Alon, last: Lavie}
-  variants:
-  - {first: A., last: Lavie}
-- canonical: {first: Benoit, last: Lavoie}
-  variants:
-  - {first: B., last: Lavoie}
 - canonical: {first: Seamus, last: Lawless}
   variants:
   - {first: Séamus, last: Lawless}
@@ -5987,7 +5147,6 @@
   - {first: Phuong, last: Le-Hong}
   - {first: Hồng Phương, last: Lê}
   - {first: Hong Phuong, last: Le}
-  - {first: H. Phuong, last: Le}
 - canonical: {first: Sébastien, last: Le Maguer}
   variants:
   - {first: Sébastien Le, last: Maguer}
@@ -6006,9 +5165,6 @@
 - canonical: {first: Jean-Luc, last: LeBrun}
   variants:
   - {first: Jean-Luc, last: Lebrun}
-- canonical: {first: Gilles, last: Lechenadec}
-  variants:
-  - {first: G., last: Lechenadec}
 - canonical: {first: Alain, last: Lecomte}
   variants:
   - {first: Alain, last: LECOMTE}
@@ -6062,9 +5218,6 @@
 - canonical: {first: Joo-Young, last: Lee}
   variants:
   - {first: JooYoung, last: Lee}
-- canonical: {first: Kai-Fu, last: Lee}
-  variants:
-  - {first: K.F., last: Lee}
 - canonical: {first: Kyung-Soon, last: Lee}
   variants:
   - {first: KyungSoon, last: Lee}
@@ -6078,7 +5231,6 @@
 - canonical: {first: Mark, last: Lee}
   variants:
   - {first: Mark G., last: Lee}
-  - {first: M.G., last: Lee}
 - canonical: {first: Sang-Jo, last: Lee}
   variants:
   - {first: Sang Jo, last: Lee}
@@ -6109,7 +5261,6 @@
 - canonical: {first: Fabrice, last: Lefèvre}
   variants:
   - {first: Fabrice, last: Lefevre}
-  - {first: F., last: Lefevre}
 - canonical: {first: Gurpreet Singh, last: Lehal}
   variants:
   - {first: Gurpreet, last: Singh Lehal}
@@ -6120,11 +5271,6 @@
 - canonical: {first: Wendy, last: Lehnert}
   variants:
   - {first: Wendy G., last: Lehnert}
-  - {first: W., last: Lehnert}
-- canonical: {first: Aarno, last: Lehtola}
-  variants:
-  - {first: A., last: Lehtola}
-  - {first: A, last: Lehtola}
 - canonical: {first: Jochen L., last: Leidner}
   variants:
   - {first: Jochen, last: Leidner}
@@ -6140,12 +5286,6 @@
 - canonical: {first: Gaël, last: Lejeune}
   variants:
   - {first: Gael, last: Lejeune}
-- canonical: {first: Valentina, last: Bartalesi Lenzi}
-  variants:
-  - {first: V., last: Bartalesi Lenzi}
-- canonical: {first: Pietro, last: Leo}
-  variants:
-  - {first: P., last: Leo}
 - canonical: {first: Jacqueline, last: Leon}
   variants:
   - {first: Jacqueline, last: Léon}
@@ -6161,7 +5301,6 @@
 - canonical: {first: Leonardo, last: Lesmo}
   variants:
   - {first: Leonardo, last: LESMO}
-  - {first: L., last: Lesmo}
 - canonical: {first: Dessi Puji, last: Lestari}
   variants:
   - {first: Dessi, last: Lestari}
@@ -6171,9 +5310,6 @@
 - canonical: {first: Sylvain, last: Letourneau}
   variants:
   - {first: Sylvain, last: LETOURNEAU}
-- canonical: {first: Igor, last: Leturia}
-  variants:
-  - {first: I., last: Leturia}
 - canonical: {first: Gustav, last: Leunbach}
   variants:
   - {first: GUSTAV, last: LEUNBACH}
@@ -6183,14 +5319,6 @@
 - canonical: {first: Lori, last: Levin}
   variants:
   - {first: Lori S., last: Levin}
-- canonical: {first: Stephen E., last: Levinson}
-  variants:
-  - {first: S. E., last: Levinson}
-  comment: Bell Labs
-- canonical: {first: Stephen, last: Levinson}
-  variants:
-  - {first: St., last: Levinson}
-  comment: Max-Planck-Institute for Psycholinguistics
 - canonical: {first: Gina-Anne, last: Levow}
   variants:
   - {first: Gina, last: Levow}
@@ -6258,8 +5386,6 @@
 - canonical: {first: Mark, last: Liberman}
   variants:
   - {first: Mark Y., last: Liberman}
-  - {first: M. Y., last: Liberman}
-  - {first: M., last: Liberman}
 - canonical: {first: Jindřich, last: Libovický}
   variants:
   - {first: Jindrich, last: Libovicky}
@@ -6340,9 +5466,6 @@
 - canonical: {first: Maria Teresa, last: Lino}
   variants:
   - {first: Teresa, last: Lino}
-- canonical: {first: Nikos, last: Liolios}
-  variants:
-  - {first: N., last: Liolios}
 - canonical: {first: Hsien-Chin, last: Liou}
   variants:
   - {first: Hsien-chin, last: Liou}
@@ -6397,10 +5520,6 @@
 - canonical: {first: Xiaomo, last: Liu}
   variants:
   - {first: XIAOMO, last: LIU}
-- canonical: {first: Yang, last: Liu}
-  comment: There are at least three researchers with this name
-  variants:
-  - {first: Y., last: Liu}
 - canonical: {first: Nikola, last: Ljubešić}
   variants:
   - {first: Nikola, last: Ljubesic}
@@ -6420,10 +5539,6 @@
 - canonical: {first: Agusti, last: LLoberas}
   variants:
   - {first: Agusti, last: Lloberas}
-- canonical: {first: Andrej, last: Ljolje}
-  variants:
-  - {first: A., last: Ljolje}
-  - {first: A, last: Ljolje}
 - canonical: {first: Fernando, last: Llopis}
   variants:
   - {first: Fernando, last: LLopis}
@@ -6472,7 +5587,6 @@
 - canonical: {first: Natalia, last: Loukachevitch}
   variants:
   - {first: Natalia V., last: Loukachevitch}
-  - {first: N., last: Loukachevitch}
 - canonical: {first: John B., last: Lowe}
   variants:
   - {first: John, last: Lowe}
@@ -6488,9 +5602,6 @@
 - canonical: {first: Bin, last: Lu}
   variants:
   - {first: Bin, last: LU}
-- canonical: {first: Qin, last: Lu}
-  variants:
-  - {first: Q., last: Lu}
 - canonical: {first: Wei-lun, last: Lu}
   variants:
   - {first: Wei-Lwun, last: Lu}
@@ -6509,9 +5620,6 @@
 - canonical: {first: Peter J., last: Ludlow}
   variants:
   - {first: Peter, last: Ludlow}
-- canonical: {first: Robert W.P., last: Luk}
-  variants:
-  - {first: R.W.P., last: Luk}
 - canonical: {first: Robert Wing Pong, last: Luk}
   variants:
   - {first: Wing-Pong, last: Luk}
@@ -6520,7 +5628,6 @@
   - {first: Stephanie M., last: Lukin}
 - canonical: {first: Suen Caesar, last: Lun}
   variants:
-  - {first: C, last: Lun}
   - {first: Caesar Suen, last: Lun}
   - {first: Caesar, last: Lun}
   - {first: S. Caesar, last: Lun}
@@ -6571,9 +5678,6 @@
 - canonical: {first: M. Soledad, last: López Gambino}
   variants:
   - {first: Soledad, last: López Gambino}
-- canonical: {first: Ramón, last: López-Cózar}
-  variants:
-  - {first: R., last: López-Cózar}
 - canonical: {first: Kaidi, last: Lõo}
   variants:
   - {first: Kaidi, last: Loo}
@@ -6639,32 +5743,18 @@
 - canonical: {first: Catherine, last: Macleod}
   variants:
   - {first: Catherine, last: MacLeod}
-- canonical: {first: Imanol, last: Madariaga}
-  variants:
-  - {first: I., last: Madariaga}
 - canonical: {first: Pranava Swaroop, last: Madhyastha}
   variants:
   - {first: Pranava, last: Madhyastha}
 - canonical: {first: Bente, last: Maegaard}
   variants:
   - {first: BENTE, last: MAEGAARD}
-  - {first: B., last: Maegaard}
-- canonical: {first: Kikuo, last: Maekawa}
-  variants:
-  - {first: K., last: Maekawa}
-- canonical: {first: Valérie, last: Maffiolo}
-  variants:
-  - {first: V., last: Maffiolo}
 - canonical: {first: David M., last: Magerman}
   variants:
   - {first: David, last: Magerman}
-  - {first: D., last: Magerman}
 - canonical: {first: Brunelle, last: Magnana Ekoukou}
   variants:
   - {first: Brunelle Magnana, last: Ekoukou}
-- canonical: {first: Bernardo, last: Magnini}
-  variants:
-  - {first: B., last: Magnini}
 - canonical: {first: Guðrun, last: Magnúsdóttir}
   variants:
   - {first: Guðrún, last: Magnúsdóttir}
@@ -6689,12 +5779,6 @@
 - canonical: {first: François, last: Mairesse}
   variants:
   - {first: Francois, last: Mairesse}
-- canonical: {first: John, last: Makhoul}
-  variants:
-  - {first: J., last: Makhoul}
-- canonical: {first: Shozo, last: Makino}
-  variants:
-  - {first: S., last: Makino}
 - canonical: {first: Takaki, last: Makino}
   variants:
   - {first: Takaki, last: MAKINO}
@@ -6723,9 +5807,6 @@
 - canonical: {first: GIOVANNI, last: MALNATI}
   variants:
   - {first: Giovanni, last: Malnati}
-- canonical: {first: Preetam, last: Maloor}
-  variants:
-  - {first: P., last: Maloor}
 - canonical: {first: Robert, last: Malouf}
   variants:
   - {first: Rob, last: Malouf}
@@ -6739,9 +5820,6 @@
 - canonical: {first: Yuan, last: Man}
   variants:
   - {first: Yuan, last: Ma}
-- canonical: {first: Nadia, last: Mana}
-  variants:
-  - {first: N., last: Mana}
 - canonical: {first: Esmeralda, last: Manandise}
   variants:
   - {first: Esme, last: Manandise}
@@ -6763,9 +5841,6 @@
 - canonical: {first: Mathieu, last: Mangeot}
   variants:
   - {first: Mathieu, last: Mangeot-Lerebours}
-- canonical: {first: Lidia, last: Mangu}
-  variants:
-  - {first: L., last: Mangu}
 - canonical: {first: Enrique, last: Manjavacas}
   variants:
   - {first: Enrique, last: Manjavacas Arevalo}
@@ -6792,9 +5867,6 @@
 - canonical: {first: Mairgup, last: Mansur}
   variants:
   - {first: Mansur, last: Mairgup}
-- canonical: {first: Ruli, last: Manurung}
-  variants:
-  - {first: R., last: Manurung}
 - canonical: {first: Ramesh, last: Manuvinakurike}
   variants:
   - {first: Ramesh, last: Manuvirakurike}
@@ -6817,9 +5889,6 @@
 - canonical: {first: Ana, last: Marasović}
   variants:
   - {first: Ana, last: Marasovic}
-- canonical: {first: Yannick, last: Marchand}
-  variants:
-  - {first: Y., last: Marchand}
 - canonical: {first: Giulia, last: Marchesini}
   variants:
   - {first: Giulia, last: Marchesi}
@@ -6830,11 +5899,9 @@
   variants:
   - {first: Mitchell, last: Marcus}
   - {first: Mitchell P., last: Marcus}
-  - {first: M., last: Marcus}
 - canonical: {first: Joseph, last: Mariani}
   variants:
   - {first: J., last: MARIANI}
-  - {first: J., last: Mariani}
 - canonical: {first: Montserrat, last: Marimon}
   variants:
   - {first: Montserrat, last: Marimón}
@@ -6848,18 +5915,9 @@
 - canonical: {first: Andre, last: Mariotti}
   variants:
   - {first: André, last: Mariotti}
-- canonical: {first: Alberto, last: Maritxalar}
-  variants:
-  - {first: A., last: Maritxalar}
-- canonical: {first: Montse, last: Maritxalar}
-  variants:
-  - {first: M, last: Maritxalar}
 - canonical: {first: José B., last: Mariño}
   variants:
   - {first: José, last: Mariño}
-- canonical: {first: Stella, last: Markantonatou}
-  variants:
-  - {first: S., last: Markantonatou}
 - canonical: {first: Aleksandra Zögling, last: Markuš}
   variants:
   - {first: Aleksandra, last: Zögling}
@@ -6882,24 +5940,13 @@
   variants:
   - {first: James H., last: MARTIN}
   - {first: James, last: Martin}
-- canonical: {first: Jean-Claude, last: Martin}
-  variants:
-  - {first: J-C., last: Martin}
-  - {first: J.-C., last: Martin}
-  - {first: J.C., last: Martin}
 - canonical: {first: M. Patrick, last: Martin}
   variants:
   - {first: Pierre M., last: Martin}
   - {first: Patrick, last: Martin}
-- canonical: {first: Marco, last: Martin}
-  variants:
-  - {first: M., last: Martin}
 - canonical: {first: Melanie, last: Martin}
   variants:
   - {first: Melanie J., last: Martin}
-- canonical: {first: William A., last: Martin}
-  variants:
-  - {first: W. A., last: Martin}
 - canonical: {first: Willy, last: Martin}
   variants:
   - {first: WILLY, last: MARTIN}
@@ -6916,10 +5963,6 @@
   variants:
   - {first: Andre, last: Martins}
   - {first: André, last: Martins}
-  - {first: André F.T., last: Martins}
-- canonical: {first: Fernando, last: Martins}
-  variants:
-  - {first: F., last: Martins}
 - canonical: {first: Ronaldo Teixeira, last: Martins}
   variants:
   - {first: Ronaldo, last: Martins}
@@ -6931,8 +5974,6 @@
 - canonical: {first: M. Antònia, last: Martí}
   variants:
   - {first: M. A., last: Marti}
-  - {first: M.A., last: Martí}
-  - {first: M. A., last: Martí}
   - {first: M. Antonia, last: Martí}
   - {first: M.Antònia, last: Martí}
   - {first: M. Antonia, last: Marti}
@@ -6972,7 +6013,6 @@
   variants:
   - {first: Patricio, last: Martinez-Barco}
   - {first: Patricio Martinez, last: Barco}
-  - {first: P., last: Martínez-Barco}
 - canonical: {first: Pascual, last: Martínez-Gómez}
   variants:
   - {first: Pascual, last: Martinez-Gomez}
@@ -7005,15 +6045,9 @@
 - canonical: {first: Demetrios, last: Master}
   variants:
   - {first: Demitrios, last: Master}
-- canonical: {first: Fumito, last: Masui}
-  variants:
-  - {first: F., last: Masui}
 - canonical: {first: Hiroshi, last: Masuichi}
   variants:
   - {first: Hiroshi, last: Mashuichi}
-- canonical: {first: Marco, last: Matassoni}
-  variants:
-  - {first: M., last: Matassoni}
 - canonical: {first: Yannick, last: Mathieu}
   variants:
   - {first: Yvette Yannick, last: Mathieu}
@@ -7033,9 +6067,6 @@
 - canonical: {first: Christian M.I.M., last: Matthiessen}
   variants:
   - {first: Christian M. I. M., last: Matthiessen}
-- canonical: {first: Irina, last: Matveeva}
-  variants:
-  - {first: I., last: Matveeva}
 - canonical: {first: Stan, last: Matwin}
   variants:
   - {first: Stan, last: MATWIN}
@@ -7072,12 +6103,6 @@
 - canonical: {first: Pawel, last: Mazur}
   variants:
   - {first: Paweł, last: Mazur}
-- canonical: {first: Alessandro, last: Mazzei}
-  variants:
-  - {first: A., last: Mazzei}
-- canonical: {first: Giampaolo, last: Mazzini}
-  variants:
-  - {first: G., last: Mazzini}
 - canonical: {first: Manuel J., last: Maña López}
   variants:
   - {first: Manuel J., last: Maña}
@@ -7088,7 +6113,6 @@
   - {first: Michael L., last: McHale}
 - canonical: {first: Gordon I., last: McCalla}
   variants:
-  - {first: G.I., last: McCalla}
   - {first: Gordon, last: McCalla}
 - canonical: {first: J. Scott, last: McCarley}
   variants:
@@ -7099,9 +6123,6 @@
 - canonical: {first: Diana, last: McCarthy}
   variants:
   - {first: Diana F., last: McCarthy}
-- canonical: {first: Joe, last: McCarthy}
-  variants:
-  - {first: J., last: McCarthy}
 - canonical: {first: Michael C., last: McCord}
   variants:
   - {first: Michael, last: McCord}
@@ -7120,9 +6141,6 @@
   variants:
   - {first: David D., last: MCDONALD}
   - {first: David, last: McDonald}
-- canonical: {first: Joyce, last: McDowell}
-  variants:
-  - {first: J., last: McDowell}
 - canonical: {first: Tony, last: McEnery}
   variants:
   - {first: Tony, last: McENERY}
@@ -7149,18 +6167,9 @@
 - canonical: {first: Danielle S., last: McNamara}
   variants:
   - {first: Danielle, last: McNamara}
-- canonical: {first: John, last: McNaught}
-  variants:
-  - {first: J., last: McNaught}
-- canonical: {first: Margaret, last: McRorie}
-  variants:
-  - {first: M., last: McRorie}
 - canonical: {first: Susan W., last: McRoy}
   variants:
   - {first: Susan, last: McRoy}
-- canonical: {first: Kevin, last: McTait}
-  variants:
-  - {first: K., last: McTait}
 - canonical: {first: Michael F., last: McTear}
   variants:
   - {first: Michael, last: McTear}
@@ -7190,13 +6199,10 @@
   - {first: Alan, last: Melby}
 - canonical: {first: Chris, last: Mellish}
   variants:
-  - {first: C, last: Mellish}
-  - {first: C. S., last: Mellish}
   - {first: Chris S., last: Mellish}
 - canonical: {first: Igor, last: Mel’čuk}
   variants:
   - {first: I., last: MEL’CUK}
-  - {first: I. A., last: Mel’čuk}
 - canonical: {first: Alfonso, last: Mendes}
   variants:
   - {first: Afonso, last: Mendes}
@@ -7221,15 +6227,10 @@
 - canonical: {first: Robert L., last: Mercer}
   comment: IBM; also published as Robert Mercer, overlapping with another Robert Mercer
   variants:
-  - {first: R. L., last: Mercer}
   - {first: R., last: MERCER}
-  - {first: R., last: Mercer}
 - canonical: {first: Roberta H., last: Merchant}
   variants:
   - {first: Roberta, last: Merchant}
-- canonical: {first: Bernard, last: Merialdo}
-  variants:
-  - {first: B., last: Merialdo}
 - canonical: {first: Magnus, last: Merkel}
   variants:
   - {first: Magnus, last: MERKEL}
@@ -7251,9 +6252,6 @@
 - canonical: {first: Marie Hélène, last: Metzger}
   variants:
   - {first: Marie-Hélène, last: Metzger}
-- canonical: {first: Dieter, last: Metzing}
-  variants:
-  - {first: D., last: Metzing}
 - canonical: {first: Frédéric, last: Meunier}
   variants:
   - {first: FREDERIC, last: MEUNIER}
@@ -7261,15 +6259,9 @@
   variants:
   - {first: W. Detmar, last: Meurers}
   - {first: Walt Detmar, last: Meurers}
-- canonical: {first: Montserrat, last: Meya}
-  variants:
-  - {first: M., last: Meya}
 - canonical: {first: Ingrid, last: Meyer}
   variants:
   - {first: INGRID, last: MEYER}
-- canonical: {first: Adam, last: Meyers}
-  variants:
-  - {first: A., last: Meyers}
 - canonical: {first: Benjamin S., last: Meyers}
   variants:
   - {first: Benjamin, last: Meyers}
@@ -7287,13 +6279,9 @@
 - canonical: {first: Lisa N., last: Michaud}
   variants:
   - {first: Lisa, last: Michaud}
-- canonical: {first: Patrizia, last: Michelassi}
-  variants:
-  - {first: P., last: Michelassi}
 - canonical: {first: Archibald, last: Michiels}
   variants:
   - {first: A., last: MICHIELS}
-  - {first: A., last: Michiels}
 - canonical: {first: Lesly, last: Miculicich Werlen}
   variants:
   - {first: Lesly, last: Miculicich}
@@ -7324,12 +6312,6 @@
 - canonical: {first: Keith J., last: Miller}
   variants:
   - {first: Keith, last: Miller}
-- canonical: {first: Lance A., last: Miller}
-  variants:
-  - {first: L. A., last: Miller}
-- canonical: {first: Laura G., last: Miller}
-  variants:
-  - {first: L. G., last: Miller}
 - canonical: {first: Timothy, last: Miller}
   variants:
   - {first: Tim, last: Miller}
@@ -7352,9 +6334,6 @@
   variants:
   - {first: Behrouz, last: Minaei-bidgoli}
   - {first: Behrouz, last: Minaei}
-- canonical: {first: Nobuaki, last: Minematsu}
-  variants:
-  - {first: N., last: Minematsu}
 - canonical: {first: Zhaoyan, last: Ming}
   variants:
   - {first: Zhao-Yan, last: Ming}
@@ -7370,9 +6349,6 @@
 - canonical: {first: Dipendra, last: Misra}
   variants:
   - {first: Dipendra Kumar, last: Misra}
-- canonical: {first: Brian, last: Mitchell}
-  variants:
-  - {first: B., last: Mitchell}
 - canonical: {first: Christopher, last: Mitchell}
   variants:
   - {first: Christopher M., last: Mitchell}
@@ -7385,7 +6361,6 @@
 - canonical: {first: Ruslan, last: Mitkov}
   variants:
   - {first: Ruslan, last: MITKOV}
-  - {first: R., last: Mitkov}
 - canonical: {first: Yutaka, last: Mitsuishi}
   variants:
   - {first: Yutaka, last: MITSUISHI}
@@ -7435,7 +6410,6 @@
   - {first: Cristian, last: Moldovan}
 - canonical: {first: Dan, last: Moldovan}
   variants:
-  - {first: D., last: Moldovan}
   - {first: Dan I., last: Moldovan}
 - canonical: {first: M. Dolores, last: Molina-González}
   variants:
@@ -7452,7 +6426,6 @@
 - canonical: {first: Simonetta, last: Montemagni}
   variants:
   - {first: SIMONETTA, last: MONTEMAGNI}
-  - {first: S., last: Montemagni}
 - canonical: {first: Calkin S., last: Montero}
   variants:
   - {first: Calkin, last: Montero}
@@ -7486,17 +6459,12 @@
 - canonical: {first: Johanna D., last: Moore}
   variants:
   - {first: Johanna, last: Moore}
-  - {first: J. D., last: Moore}
 - canonical: {first: Robert C., last: Moore}
   variants:
-  - {first: R. C., last: Moore}
   - {first: Robert, last: Moore}
 - canonical: {first: Roger K., last: Moore}
   variants:
   - {first: Roger, last: Moore}
-- canonical: {first: Michael, last: Moortgat}
-  variants:
-  - {first: M., last: Moortgat}
 - canonical: {first: Nafise Sadat, last: Moosavi}
   variants:
   - {first: Nafise, last: Moosavi}
@@ -7511,9 +6479,6 @@
   variants:
   - {first: Paul, last: Morărescu}
   - {first: Paul C., last: Morărescu}
-- canonical: {first: Christian, last: Morbidoni}
-  variants:
-  - {first: C., last: Morbidoni}
 - canonical: {first: Grégoire, last: Moreau de Montcheuil}
   variants:
   - {first: Grégoire, last: de Montcheuil}
@@ -7525,10 +6490,6 @@
   variants:
   - {first: Asuncion, last: Moreno}
   - {first: Asuncíon, last: Moreno}
-  - {first: A., last: Moreno}
-- canonical: {first: Lidia, last: Moreno}
-  variants:
-  - {first: L., last: Moreno}
 - canonical: {first: Julian, last: Moreno Schneider}
   variants:
   - {first: Julian, last: Moreno-Schneider}
@@ -7548,7 +6509,6 @@
 - canonical: {first: Lorenzo, last: Moretti}
   variants:
   - {first: L., last: MORETTI}
-  - {first: L., last: Moretti}
 - canonical: {first: Richard G., last: Morgan}
   variants:
   - {first: Richard, last: Morgan}
@@ -7596,9 +6556,6 @@
 - canonical: {first: Alex, last: Moruz}
   variants:
   - {first: Mihai Alex, last: Moruz}
-- canonical: {first: Ulrike, last: Mosel}
-  variants:
-  - {first: U., last: Mosel}
 - canonical: {first: Sjur, last: Moshagen}
   variants:
   - {first: Sjur Nørstebø, last: Moshagen}
@@ -7609,34 +6566,21 @@
 - canonical: {first: Djamel, last: Mostefa}
   variants:
   - {first: Djamel, last: MOSTEFA}
-  - {first: D., last: Mostefa}
 - canonical: {first: Jessica, last: Moszkowicz}
   variants:
   - {first: Jessica L., last: Moszkowicz}
-- canonical: {first: Abdelhak, last: Mouradi}
-  variants:
-  - {first: A., last: Mouradi}
-- canonical: {first: Hamed, last: Movasagh}
-  variants:
-  - {first: H., last: Movasagh}
 - canonical: {first: Danielle L., last: Mowery}
   variants:
   - {first: Danielle, last: Mowery}
 - canonical: {first: Nikola, last: Mrkšić}
   variants:
   - {first: Nikola, last: Mrksic}
-- canonical: {first: Joanna, last: Mrozinski}
-  variants:
-  - {first: J., last: Mrozinski}
 - canonical: {first: Christian, last: Mueller}
   variants:
   - {first: Christian, last: Müller}
 - canonical: {first: Thomas, last: Mueller}
   variants:
   - {first: Thomas, last: Müller}
-- canonical: {first: Chafic, last: Mukbel}
-  variants:
-  - {first: C., last: Mukbel}
 - canonical: {first: Rutu, last: Mulkar-Mehta}
   variants:
   - {first: Rutu, last: Mulkar}
@@ -7655,9 +6599,6 @@
 - canonical: {first: Hema A., last: Murthy}
   variants:
   - {first: Hema, last: Murthy}
-- canonical: {first: Hy, last: Murveit}
-  variants:
-  - {first: H., last: Murveit}
 - canonical: {first: Claudiu, last: Musat}
   variants:
   - {first: Claudiu Cristian, last: Musat}
@@ -7669,7 +6610,6 @@
   - {first: Pradeep, last: Muthukrishan}
 - canonical: {first: Rafael, last: Muñoz}
   variants:
-  - {first: R., last: Muñoz}
   - {first: Rafael, last: Muñoz Guillena}
   - {first: Rafael, last: Muñoz-Guillena}
 - canonical: {first: Sung-Hyon, last: Myaeng}
@@ -7686,7 +6626,6 @@
   variants:
   - {first: Lluis, last: Marquez}
   - {first: Lluis, last: Màrquez}
-  - {first: L., last: Màrquez}
 - canonical: {first: Pierre André, last: Ménard}
   variants:
   - {first: Pierre Andre, last: Menard}
@@ -7722,7 +6661,6 @@
 - canonical: {first: Makoto, last: Nagao}
   variants:
   - {first: Makoto, last: NAGAO}
-  - {first: M., last: Nagao}
 - canonical: {first: Meenakshi, last: Nagarajan}
   variants:
   - {first: Meena, last: Nagarajan}
@@ -7743,7 +6681,6 @@
 - canonical: {first: Seiichi, last: Nakagawa}
   variants:
   - {first: Seiichi, last: NAKAGAWA}
-  - {first: S., last: Nakagawa}
 - canonical: {first: Hiromi, last: Nakaiwa}
   variants:
   - {first: Hiromi, last: NAKAIWA}
@@ -7763,9 +6700,6 @@
 - canonical: {first: Christine H., last: Nakatani}
   variants:
   - {first: Christine, last: Nakatani}
-- canonical: {first: Shu, last: Nakazato}
-  variants:
-  - {first: S., last: Nakazato}
 - canonical: {first: Preslav, last: Nakov}
   variants:
   - {first: Preslav I., last: Nakov}
@@ -7808,36 +6742,21 @@
 - canonical: {first: Borja, last: Navarro}
   variants:
   - {first: Borja, last: Navarro-Colorado}
-  - {first: B., last: Navarro}
-- canonical: {first: Eva, last: Navas}
-  variants:
-  - {first: E., last: Navas}
 - canonical: {first: Tapas, last: Nayak}
   variants:
   - {first: Tapas, last: Nayek}
 - canonical: {first: Adeline, last: Nazarenko}
   variants:
   - {first: Adeline, last: NAZARENKO-PERRIN}
-  - {first: A., last: Nazarenko}
-- canonical: {first: Jeannette G., last: Neal}
-  variants:
-  - {first: J.G., last: Neal}
 - canonical: {first: NICOLAS, last: NEDOBEJKINE}
   variants:
   - {first: N., last: Nedobejkine}
-  - {first: N., last: NEDOBEJKINE}
 - canonical: {first: Mary S., last: Neff}
   variants:
   - {first: Mary, last: Neff}
-- canonical: {first: Matteo, last: Negri}
-  variants:
-  - {first: M., last: Negri}
 - canonical: {first: Anil Kumar, last: Nelakanti}
   variants:
   - {first: Anil, last: Kumar}
-- canonical: {first: Esa, last: Nelimarkka}
-  variants:
-  - {first: E., last: Nelimarkka}
 - canonical: {first: Dávid Márk, last: Nemeskey}
   variants:
   - {first: David Mark, last: Nemeskey}
@@ -7869,12 +6788,7 @@
   - {first: Bruce, last: Nevin}
 - canonical: {first: Paula, last: Newman}
   variants:
-  - {first: P. S., last: Newman}
-  - {first: P., last: Newman}
   - {first: Paula S., last: Newman}
-- canonical: {first: Hermann, last: Ney}
-  variants:
-  - {first: H., last: Ney}
 - canonical: {first: Gunta, last: Nešpore}
   variants:
   - {first: Gunta, last: Nespore-Berzkalne}
@@ -7898,10 +6812,6 @@
 - canonical: {first: Huy Tien, last: Nguyen}
   variants:
   - {first: Huy-Tien, last: Nguyen}
-- canonical: {first: Long, last: Nguyen}
-  comment: BBN
-  variants:
-  - {first: L., last: Nguyen}
 - canonical: {first: Minh Le, last: Nguyen}
   comment: JAIST
   variants:
@@ -7920,7 +6830,6 @@
 - canonical: {first: Thi Minh Huyen, last: Nguyen}
   variants:
   - {first: Thi Minh Huyền, last: Nguyễn}
-  - {first: T. M. Huyen, last: Nguyen}
 - canonical: {first: ThuyLinh, last: Nguyen}
   variants:
   - {first: Thuy Linh, last: Nguyen}
@@ -7940,15 +6849,9 @@
 - canonical: {first: Vinh Van, last: Nguyen}
   variants:
   - {first: Vinh-Van, last: Nguyen}
-- canonical: {first: Nicolas, last: Nicolov}
-  variants:
-  - {first: N, last: Nicolov}
 - canonical: {first: Jian-Yun, last: Nie}
   variants:
   - {first: Jian-yun, last: Nie}
-- canonical: {first: Sonja, last: Nieflen}
-  variants:
-  - {first: S., last: Nieflen}
 - canonical: {first: Rodney, last: Nielsen}
   variants:
   - {first: Rodney D., last: Nielsen}
@@ -7968,7 +6871,6 @@
 - canonical: {first: Sergei, last: Nirenburg}
   variants:
   - {first: Sergei, last: NIRENBURG}
-  - {first: S., last: Nirenburg}
   - {first: Sergei, last: Nirenberg}
 - canonical: {first: Fujio, last: Nishida}
   variants:
@@ -8041,7 +6943,6 @@
 - canonical: {first: Elmar, last: Nöth}
   variants:
   - {first: Elmar, last: Noth}
-  - {first: E., last: Nöth}
 - canonical: {first: Douglas W., last: Oard}
   variants:
   - {first: Douglas, last: Oard}
@@ -8059,14 +6960,10 @@
   variants:
   - {first: Franz J., last: Och}
   - {first: Franz, last: Och}
-  - {first: F. J., last: Och}
 - canonical: {first: Cheol-Young, last: Ock}
   variants:
   - {first: Cheolyoung, last: Ock}
   - {first: Cheol-young, last: Ock}
-- canonical: {first: Jan, last: Odijk}
-  variants:
-  - {first: J., last: Odijk}
 - canonical: {first: Pinar, last: Oezden Wennerberg}
   variants:
   - {first: Pinar, last: Wennerberg}
@@ -8134,15 +7031,9 @@
 - canonical: {first: Mari Broman, last: Olsen}
   variants:
   - {first: Mari, last: Olsen}
-- canonical: {first: Maurizio, last: Omologo}
-  variants:
-  - {first: M., last: Omologo}
 - canonical: {first: Arturo, last: Oncevay}
   variants:
   - {first: Arturo, last: Oncevay-Marcos}
-- canonical: {first: Corinna, last: Onelli}
-  variants:
-  - {first: C., last: Onelli}
 - canonical: {first: Takashi, last: Onishi}
   variants:
   - {first: Takeshi, last: Onishi}
@@ -8159,13 +7050,9 @@
 - canonical: {first: Constantin, last: Orasan}
   variants:
   - {first: Constantin, last: Orăsan}
-  - {first: C., last: Orasan}
 - canonical: {first: Zeynep, last: Orhan}
   variants:
   - {first: Orhan, last: Zeynep}
-- canonical: {first: Maite, last: Oronoz}
-  variants:
-  - {first: M., last: Oronoz}
 - canonical: {first: J. Walker, last: Orr}
   variants:
   - {first: Walker, last: Orr}
@@ -8188,10 +7075,6 @@
 - canonical: {first: David Yoshikazu, last: Oshima}
   variants:
   - {first: David Y., last: Oshima}
-- canonical: {first: Mari, last: Ostendorf}
-  variants:
-  - {first: M., last: Ostendorf}
-  - {first: M, last: Ostendorf}
 - canonical: {first: Julia, last: Otmakhova}
   variants:
   - {first: Yulia, last: Otmakhova}
@@ -8231,15 +7114,11 @@
 - canonical: {first: Dianne P., last: O’Leary}
   variants:
   - {first: Dianne, last: O’Leary}
-- canonical: {first: Dave, last: O’mara}
-  variants:
-  - {first: D., last: O’mara}
 - canonical: {first: Ian M., last: O’Neill}
   variants:
   - {first: Ian, last: O’Neill}
 - canonical: {first: Douglas, last: O’Shaughnessy}
   variants:
-  - {first: D., last: O’Shaughnessy}
   - {first: Douglas D., last: O’Shaughnessy}
 - canonical: {first: Deepak, last: P}
   variants:
@@ -8256,11 +7135,9 @@
 - canonical: {first: Lluís, last: Padró}
   variants:
   - {first: Lluis, last: Padro}
-  - {first: L., last: Padró}
   - {first: L., last: Padro}
 - canonical: {first: Muntsa, last: Padró}
   variants:
-  - {first: M., last: Padró}
   - {first: M., last: Padrón}
 - canonical: {first: Elena V., last: PADUCHEVA}
   variants:
@@ -8279,13 +7156,8 @@
 - canonical: {first: Jean-Pierre, last: Paillet}
   variants:
   - {first: JEAN PIERRE, last: PAILLET}
-- canonical: {first: Helen, last: Pain}
-  variants:
-  - {first: H., last: Pain}
 - canonical: {first: Daniel, last: Paiva}
   variants:
-  - {first: D, last: Paiva}
-  - {first: D., last: Paiva}
   - {first: Daniel S., last: Paiva}
 - canonical: {first: Sergey V., last: Pakhomov}
   variants:
@@ -8298,8 +7170,6 @@
   - {first: Chris, last: Pal}
 - canonical: {first: David S., last: Pallett}
   variants:
-  - {first: D. S., last: Pallett}
-  - {first: D., last: Pallett}
   - {first: David, last: Pallett}
 - canonical: {first: David D., last: Palmer}
   variants:
@@ -8308,9 +7178,6 @@
   variants:
   - {first: Martha Stone, last: Palmer}
   - {first: Martha S., last: Palmer}
-- canonical: {first: Manuel, last: Palomar}
-  variants:
-  - {first: M., last: Palomar}
 - canonical: {first: Girish, last: Palshikar}
   variants:
   - {first: Girish K., last: Palshikar}
@@ -8394,9 +7261,6 @@
   variants:
   - {first: Oiwi, last: Parker Jones}
   - {first: Oiwi Parker, last: Jones}
-- canonical: {first: Patrick, last: Paroubek}
-  variants:
-  - {first: P., last: Paroubek}
 - canonical: {first: Carla, last: Parra Escartín}
   variants:
   - {first: Carla, last: Parra}
@@ -8435,15 +7299,9 @@
   variants:
   - {first: Jon D., last: Patrick}
   - {first: Jon David, last: Patrick}
-- canonical: {first: Terry, last: Patten}
-  variants:
-  - {first: T., last: Patten}
 - canonical: {first: Michael, last: Paul}
   variants:
   - {first: Michael J., last: Paul}
-- canonical: {first: Niklas, last: Paulsson}
-  variants:
-  - {first: N., last: Paulsson}
 - canonical: {first: Guy De, last: Pauw}
   variants:
   - {first: Guy, last: De Pauw}
@@ -8453,7 +7311,6 @@
 - canonical: {first: Maria Teresa, last: Pazienza}
   variants:
   - {first: M.T., last: Pazienza}
-  - {first: M. T., last: Pazienza}
   - {first: Maria Teresa, last: Pazienze}
   - {first: Maria, last: Pazienza}
 - canonical: {first: LAURA, last: PECCHIA}
@@ -8468,9 +7325,6 @@
 - canonical: {first: Víctor, last: Peinado}
   variants:
   - {first: Victor, last: Peinado}
-- canonical: {first: Bryan, last: Pellom}
-  variants:
-  - {first: B., last: Pellom}
 - canonical: {first: Mikel, last: Penagarikano}
   variants:
   - {first: M., last: Peñagarikano}
@@ -8480,7 +7334,6 @@
 - canonical: {first: Jesús, last: Peral}
   variants:
   - {first: Jesus, last: Peral}
-  - {first: J., last: Peral}
 - canonical: {first: Fernando, last: Perdigão}
   variants:
   - {first: Fernando S., last: Perdigão}
@@ -8497,9 +7350,6 @@
 - canonical: {first: Luísa, last: Pereira}
   variants:
   - {first: Luisa, last: Pereira}
-- canonical: {first: Martín, last: Pereira-Fariña}
-  variants:
-  - {first: M., last: Pereira-Fariña}
 - canonical: {first: Cenel-Augusto, last: Perez}
   variants:
   - {first: Cenel Augusto, last: Perez}
@@ -8515,9 +7365,6 @@
 - canonical: {first: C. Raymond, last: Perrault}
   variants:
   - {first: Raymond, last: Perrault}
-- canonical: {first: Andreas, last: Persidis}
-  variants:
-  - {first: A., last: Persidis}
 - canonical: {first: Marie-Paule, last: Pery-Woodley}
   variants:
   - {first: Marie-Paule, last: PERY-WOODLEY}
@@ -8527,9 +7374,6 @@
 - canonical: {first: Carol, last: Peters}
   variants:
   - {first: CAROL, last: PETERS}
-- canonical: {first: Wim, last: Peters}
-  variants:
-  - {first: W., last: Peters}
 - canonical: {first: Daniel, last: Peterson}
   variants:
   - {first: Daniel W., last: Peterson}
@@ -8567,29 +7411,16 @@
 - canonical: {first: Tuoi Thi, last: Phan}
   variants:
   - {first: Tuoi, last: T. Phan}
-- canonical: {first: Michael, last: Phillips}
-  variants:
-  - {first: M., last: Phillips}
 - canonical: {first: Robert, last: Phillips}
   variants:
   - {first: Rob, last: Phillips}
-- canonical: {first: Fabio, last: Pianesi}
-  variants:
-  - {first: F., last: Pianesi}
-- canonical: {first: Emanuele, last: Pianta}
-  variants:
-  - {first: E., last: Pianta}
 - canonical: {first: Scott S.L., last: Piao}
   variants:
   - {first: Scott, last: Piao}
-  - {first: S. L., last: Piao}
   - {first: Scott S. L., last: Piao}
 - canonical: {first: Christine, last: Piatko}
   variants:
   - {first: Christine D., last: Piatko}
-- canonical: {first: Francesco, last: Piazza}
-  variants:
-  - {first: F., last: Piazza}
 - canonical: {first: Eugenio, last: Picchi}
   variants:
   - {first: Eugenio, last: PICCHI}
@@ -8604,9 +7435,6 @@
 - canonical: {first: David, last: Picó}
   variants:
   - {first: David, last: Pico}
-- canonical: {first: Roberto, last: Pieraccini}
-  variants:
-  - {first: R., last: Pieraccini}
 - canonical: {first: David, last: Pierce}
   variants:
   - {first: David R., last: Pierce}
@@ -8641,7 +7469,6 @@
 - canonical: {first: Stelios, last: Piperidis}
   variants:
   - {first: Stelios, last: Piperdis}
-  - {first: S., last: Piperidis}
 - canonical: {first: Tommi A., last: Pirinen}
   variants:
   - {first: Tommi, last: Pirinen}
@@ -8651,15 +7478,9 @@
 - canonical: {first: Luiz Augusto, last: Pizzato}
   variants:
   - {first: Luiz Augusto Sangoi, last: Pizzato}
-- canonical: {first: Paul, last: Placeway}
-  variants:
-  - {first: P., last: Placeway}
 - canonical: {first: Mihaela, last: Plamada-Onofrei}
   variants:
   - {first: Mihaela, last: Onofrei}
-- canonical: {first: Barbara, last: Plank}
-  variants:
-  - {first: B., last: Plank}
 - canonical: {first: Martin, last: Platek}
   variants:
   - {first: Martin, last: PLATEK}
@@ -8670,7 +7491,6 @@
 - canonical: {first: Massimo, last: Poesio}
   variants:
   - {first: Massimo, last: POESIO}
-  - {first: M., last: Poesio}
 - canonical: {first: Livia, last: Polanyi}
   variants:
   - {first: Livia, last: POLANYI}
@@ -8681,9 +7501,6 @@
 - canonical: {first: Joseph, last: Polifroni}
   variants:
   - {first: Joseph H., last: Polifroni}
-- canonical: {first: Ziortza, last: Polin}
-  variants:
-  - {first: Z., last: Polin}
 - canonical: {first: Carl, last: Pollard}
   variants:
   - {first: Carl J., last: Pollard}
@@ -8709,7 +7526,6 @@
   variants:
   - {first: Andrei, last: POPESCU-BELIS}
   - {first: Andrei, last: Popescu Belis}
-  - {first: A., last: Popescu-Belis}
 - canonical: {first: Maja, last: Popović}
   variants:
   - {first: Maja, last: Popovic}
@@ -8722,23 +7538,13 @@
 - canonical: {first: Oana, last: Postolache}
   variants:
   - {first: Oana-Diana, last: Postolache}
-- canonical: {first: Daniel, last: Povey}
-  variants:
-  - {first: D., last: Povey}
-- canonical: {first: David M. W., last: Powers}
-  variants:
-  - {first: D. M. W., last: Powers}
 - canonical: {first: Maria, last: Pozzi}
   variants:
   - {first: María, last: Pozzi}
   - {first: Mara, last: Pozzi}
 - canonical: {first: Sameer, last: Pradhan}
   variants:
-  - {first: S., last: Pradhan}
   - {first: Sameer S., last: Pradhan}
-- canonical: {first: Federico, last: Prat}
-  variants:
-  - {first: F., last: Prat}
 - canonical: {first: Aleš, last: Pražák}
   variants:
   - {first: Ales, last: Prazak}
@@ -8759,8 +7565,6 @@
   - {first: Susanne, last: PREUẞ}
 - canonical: {first: Patti, last: Price}
   variants:
-  - {first: P. J., last: Price}
-  - {first: P., last: Price}
   - {first: Patti J., last: Price}
 - canonical: {first: Belém, last: Priego Sanchez}
   variants:
@@ -8778,10 +7582,6 @@
   variants:
   - {first: IRINA, last: PRODANOF}
   - {first: Irina, last: PRODANOF}
-  - {first: I., last: Prodanof}
-- canonical: {first: Domenico, last: Proietti}
-  variants:
-  - {first: D., last: Proietti}
 - canonical: {first: Jelena, last: Prokić}
   variants:
   - {first: Jelena, last: Prokic}
@@ -8804,9 +7604,7 @@
   - {first: Laurent, last: PREVOT}
 - canonical: {first: Josef, last: Psutka}
   variants:
-  - {first: J., last: Psutka}
   - {first: Josef V., last: Psutka}
-  - {first: J.V., last: Psutka}
 - canonical: {first: Jan, last: Ptacek}
   variants:
   - {first: Jan, last: Ptáček}
@@ -8816,22 +7614,16 @@
 - canonical: {first: Rajkumar, last: Pujari}
   variants:
   - {first: Pujari, last: Rajkumar}
-- canonical: {first: Paolo, last: Puliti}
-  variants:
-  - {first: P., last: Puliti}
 - canonical: {first: Geoffrey K., last: Pullum}
   variants:
   - {first: Geoffrey, last: Pullum}
 - canonical: {first: Stephen, last: Pulman}
   variants:
   - {first: Stephen G., last: Pulman}
-  - {first: S.G., last: Pulman}
-  - {first: S. G., last: Pulman}
 - canonical: {first: James, last: Pustejovsky}
   variants:
   - {first: James, last: PUSTEJOVSKY}
   - {first: James D., last: Pustejovsky}
-  - {first: J., last: Pustejovsky}
 - canonical: {first: Georgiana, last: Puşcaşu}
   variants:
   - {first: Georgiana, last: Puscasu}
@@ -8872,12 +7664,6 @@
 - canonical: {first: Yun-Qian, last: Qu}
   variants:
   - {first: Yunqian, last: Qu}
-- canonical: {first: MAURICE, last: QUEZEL-AMBRUNAZ}
-  variants:
-  - {first: M., last: QUEZEL-AMBRUNAZ}
-- canonical: {first: Matthieu, last: Quignard}
-  variants:
-  - {first: M., last: Quignard}
 - canonical: {first: Alex, last: Quilici}
   variants:
   - {first: Alex, last: QUILICI}
@@ -8891,24 +7677,15 @@
 - canonical: {first: Hazem, last: Raafat}
   variants:
   - {first: Hazem, last: M. Raafat}
-- canonical: {first: Lawrence R., last: Rabiner}
-  variants:
-  - {first: L. R., last: Rabiner}
 - canonical: {first: David Nicolas, last: Racca}
   variants:
   - {first: David Nicolás, last: Racca}
 - canonical: {first: Dragomir, last: Radev}
   variants:
   - {first: Dragomir R., last: Radev}
-- canonical: {first: Remo, last: Raffaelli}
-  variants:
-  - {first: R., last: Raffaelli}
 - canonical: {first: Anna N., last: Rafferty}
   variants:
   - {first: Anna, last: Rafferty}
-- canonical: {first: Ahmed, last: Ragheb}
-  variants:
-  - {first: A., last: Ragheb}
 - canonical: {first: Achla M., last: Raina}
   variants:
   - {first: Achla, last: Raina}
@@ -8918,16 +7695,10 @@
 - canonical: {first: Rajakrishnan, last: Rajkumar}
   variants:
   - {first: Rajkumar, last: Rajakrishnan}
-- canonical: {first: Martin, last: Rajman}
-  variants:
-  - {first: M., last: Rajman}
 - canonical: {first: Ekaterina V., last: RAKHILINA}
   variants:
   - {first: Ekaterina V., last: Rakhilina}
   - {first: Ekaterina, last: Rakhilina}
-- canonical: {first: Bhuvana, last: Ramabhadran}
-  variants:
-  - {first: B., last: Ramabhadran}
 - canonical: {first: Ananth, last: Ramakrishnan A.}
   variants:
   - {first: Ananth, last: Ramakrishnan A}
@@ -8955,33 +7726,15 @@
 - canonical: {first: Peter A., last: Rankel}
   variants:
   - {first: Peter, last: Rankel}
-- canonical: {first: Spyros, last: Raptis}
-  variants:
-  - {first: S., last: Raptis}
-- canonical: {first: Mohsen, last: Rashwan}
-  variants:
-  - {first: M., last: Rashwan}
 - canonical: {first: Lev, last: Ratinov}
   variants:
   - {first: Lev-Arie, last: Ratinov}
-- canonical: {first: Adwait, last: Ratnaparkhi}
-  variants:
-  - {first: A., last: Ratnaparkhi}
-- canonical: {first: Esther, last: Ratsch}
-  variants:
-  - {first: E., last: Ratsch}
 - canonical: {first: Lisa, last: Rau}
   variants:
   - {first: Lisa F., last: Rau}
-- canonical: {first: Yael, last: Ravin}
-  variants:
-  - {first: Y., last: Ravin}
 - canonical: {first: Balaraman, last: Ravindran}
   variants:
   - {first: B., last: Ravindran}
-- canonical: {first: Manny, last: Rayner}
-  variants:
-  - {first: M., last: Rayner}
 - canonical: {first: Agha Ali, last: Raza}
   variants:
   - {first: Agha, last: Ali Raza}
@@ -8990,20 +7743,13 @@
   - {first: Tim, last: READ}
 - canonical: {first: Mike, last: Reape}
   variants:
-  - {first: M, last: Reape}
   - {first: Mike, last: REAPE}
 - canonical: {first: Gábor, last: Recski}
   variants:
   - {first: Gabor, last: Recski}
-- canonical: {first: Chris, last: Reed}
-  variants:
-  - {first: C., last: Reed}
 - canonical: {first: Florence, last: Reeder}
   variants:
   - {first: Florence M., last: Reeder}
-- canonical: {first: Larry H., last: Reeker}
-  variants:
-  - {first: L.H., last: Reeker}
 - canonical: {first: Peter A., last: Reich}
   variants:
   - {first: Peter A., last: REICH}
@@ -9044,18 +7790,12 @@
   variants:
   - {first: Alexander R., last: Fabbri}
   - {first: Alexander, last: Fabbri}
-- canonical: {first: German, last: Rigau}
-  variants:
-  - {first: G., last: Rigau}
 - canonical: {first: Matīss, last: Rikters}
   variants:
   - {first: Matiss, last: Rikters}
 - canonical: {first: Michael, last: Riley}
   variants:
   - {first: Michael D., last: Riley}
-- canonical: {first: Ellen, last: Riloff}
-  variants:
-  - {first: E., last: Riloff}
 - canonical: {first: Mori, last: Rimon}
   variants:
   - {first: Mori, last: RIMON}
@@ -9077,9 +7817,7 @@
   - {first: Eric, last: Ristad}
 - canonical: {first: Graeme, last: Ritchie}
   variants:
-  - {first: G.D., last: Ritchie}
   - {first: Graeme D., last: Ritchie}
-  - {first: G., last: Ritchie}
 - canonical: {first: Hammam, last: Riza}
   variants:
   - {first: Ir. Hammam, last: Riza}
@@ -9100,9 +7838,6 @@
 - canonical: {first: Jane J., last: Robinson}
   variants:
   - {first: Jane, last: Robinson}
-- canonical: {first: Patricia, last: Robinson}
-  variants:
-  - {first: P., last: Robinson}
 - canonical: {first: Leonida Della, last: Rocca}
   variants:
   - {first: Leonida, last: Della-Rocca}
@@ -9147,7 +7882,6 @@
 - canonical: {first: Mari Carmen, last: Rodriguez-Gancedo}
   variants:
   - {first: M. Carmen Rodríguez, last: Gancedo}
-  - {first: M. Carmen, last: Rodríguez}
   - {first: Mari Carmen, last: Rodríguez}
 - canonical: {first: Carlos, last: Rodriguez-Penagos}
   variants:
@@ -9172,8 +7906,6 @@
   - {first: Rohini, last: U}
 - canonical: {first: J. Robin, last: Rohlicek}
   variants:
-  - {first: J.R., last: Rohlicek}
-  - {first: J. R., last: Rohlicek}
   - {first: Robin, last: Rohlicek}
 - canonical: {first: David M., last: Rojas}
   variants:
@@ -9191,19 +7923,12 @@
 - canonical: {first: Daniela M., last: Romano}
   variants:
   - {first: Daniela, last: Romano}
-- canonical: {first: Lorenza, last: Romano}
-  variants:
-  - {first: L., last: Romano}
 - canonical: {first: Laurent, last: Romary}
   variants:
   - {first: Laurent, last: ROMARY}
-  - {first: L., last: Romary}
 - canonical: {first: Verónica, last: Romero}
   variants:
   - {first: Veronica, last: Romero}
-- canonical: {first: Tiit, last: Roosmaa}
-  variants:
-  - {first: T., last: Roosmaa}
 - canonical: {first: Carolyn, last: Rose}
   variants:
   - {first: Carolyn P., last: Rose}
@@ -9214,38 +7939,25 @@
   - {first: Carolyn Penstein, last: Rosé}
   - {first: Carolyn, last: Penstein-Rosé}
   - {first: Carolyn, last: Rosé}
-  - {first: C. P., last: Rose}
 - canonical: {first: Tony, last: Rose}
   variants:
-  - {first: T.G., last: Rose}
   - {first: Tony G., last: Rose}
 - canonical: {first: Alexandr, last: Rosen}
   variants:
   - {first: ALEXANDR, last: ROSEN}
-- canonical: {first: Ronald, last: Rosenfeld}
-  variants:
-  - {first: R., last: Rosenfeld}
 - canonical: {first: Stanley J., last: Rosenschein}
   variants:
   - {first: Stanley, last: Rosenschein}
 - canonical: {first: Michael, last: Rosner}
   variants:
   - {first: Mike, last: Rosner}
-  - {first: M., last: Rosner}
   - {first: Michael A., last: Rosner}
-  - {first: M.A., last: Rosner}
 - canonical: {first: Peter, last: Rossen Skadhauge}
   variants:
   - {first: Peter Rossen, last: Skadhauge}
-- canonical: {first: Sophie, last: Rosset}
-  variants:
-  - {first: S., last: Rosset}
 - canonical: {first: Gianluca De, last: Rossi}
   variants:
   - {first: Gianluca, last: Rossi}
-- canonical: {first: Piercarlo, last: Rossi}
-  variants:
-  - {first: P., last: Rossi}
 - canonical: {first: Stefano Dei, last: Rossi}
   variants:
   - {first: Stefano, last: Dei Rossi}
@@ -9263,12 +7975,7 @@
   - {first: Steven F., last: Roth}
 - canonical: {first: JACQUES, last: ROUAULT}
   variants:
-  - {first: J., last: ROUAULT}
   - {first: Jacques, last: Rouault}
-- canonical: {first: Salim, last: Roukos}
-  variants:
-  - {first: S., last: Roukos}
-  - {first: S, last: Roukos}
 - canonical: {first: François, last: Rousselot}
   variants:
   - {first: Francois, last: ROUSSELOT}
@@ -9276,10 +7983,6 @@
 - canonical: {first: Bryan R., last: Routledge}
   variants:
   - {first: Bryan, last: Routledge}
-- canonical: {first: Justus C., last: Roux}
-  variants:
-  - {first: J. C., last: Roux}
-  - {first: J.C., last: Roux}
 - canonical: {first: Adriana, last: Roventini}
   variants:
   - {first: Adriana, last: ROVENTINI}
@@ -9296,13 +7999,9 @@
 - canonical: {first: Raphael, last: Rubino}
   variants:
   - {first: Raphaël, last: Rubino}
-- canonical: {first: Antonio J., last: Rubio}
-  variants:
-  - {first: A.J., last: Rubio}
 - canonical: {first: Alexander, last: Rudnicky}
   variants:
   - {first: Alexander I., last: Rudnicky}
-  - {first: A., last: Rudnicky}
   - {first: Alex, last: Rudnicky}
 - canonical: {first: Björn, last: Rudzewitz}
   variants:
@@ -9319,16 +8018,9 @@
 - canonical: {first: Alexander M., last: Rush}
   variants:
   - {first: Alexander, last: Rush}
-- canonical: {first: Albert, last: Russel}
-  variants:
-  - {first: A., last: Russel}
 - canonical: {first: Graham, last: Russell}
   variants:
-  - {first: G.J., last: Russell}
   - {first: Graham J., last: Russell}
-- canonical: {first: Martin, last: Russell}
-  variants:
-  - {first: M., last: Russell}
 - canonical: {first: Natalia Kariaeva, last: Rutgers}
   variants:
   - {first: Natalia, last: Kariaeva}
@@ -9374,15 +8066,6 @@
 - canonical: {first: Paul, last: Sabatier}
   variants:
   - {first: PAUL, last: SABATIER}
-- canonical: {first: Victor, last: Sadler}
-  variants:
-  - {first: V., last: Sadler}
-- canonical: {first: Mehrnoosh, last: Sadrzadeh}
-  variants:
-  - {first: M., last: Sadrzadeh}
-- canonical: {first: Naomi, last: Sager}
-  variants:
-  - {first: N., last: Sager}
 - canonical: {first: Benoît, last: Sagot}
   variants:
   - {first: Benoit, last: Sagot}
@@ -9402,15 +8085,6 @@
 - canonical: {first: Suguru, last: Saitô}
   variants:
   - {first: Suguru, last: Saito}
-- canonical: {first: Rafa, last: Saiz}
-  variants:
-  - {first: R., last: Saiz}
-- canonical: {first: Maximiliano, last: Saiz-Noeda}
-  variants:
-  - {first: M., last: Saiz-Noeda}
-- canonical: {first: Satoshi, last: Sakai}
-  variants:
-  - {first: S., last: Sakai}
 - canonical: {first: Sebastián Peña, last: Saldarriaga}
   variants:
   - {first: Peña, last: Saldarriaga}
@@ -9427,15 +8101,9 @@
 - canonical: {first: Ansaf, last: Salleb-Aouissi}
   variants:
   - {first: Ansaf, last: Salleb-Aoussi}
-- canonical: {first: Gerard, last: Salton}
-  variants:
-  - {first: G., last: Salton}
 - canonical: {first: Giancarlo, last: Salton}
   variants:
   - {first: Giancarlo D., last: Salton}
-- canonical: {first: Madis, last: Saluveer}
-  variants:
-  - {first: M., last: Saluveer}
 - canonical: {first: Rasoul, last: Samad Zadeh Kaljahi}
   variants:
   - {first: Rasul, last: Samad Zadeh Kaljahi}
@@ -9445,9 +8113,6 @@
 - canonical: {first: Nagiza, last: Samatova}
   variants:
   - {first: Nagiza F., last: Samatova}
-- canonical: {first: Hossein, last: Sameti}
-  variants:
-  - {first: H., last: Sameti}
 - canonical: {first: Elyes, last: Sammouda}
   variants:
   - {first: Elyes, last: SAMMOUDA}
@@ -9490,25 +8155,17 @@
 - canonical: {first: Andrea, last: Sansò}
   variants:
   - {first: Andrea, last: Sanso}
-- canonical: {first: Beatrice, last: Santorini}
-  variants:
-  - {first: B., last: Santorini}
 - canonical: {first: Diana, last: Santos}
   variants:
   - {first: DIANA, last: SANTOS}
 - canonical: {first: Estela, last: Saquete}
   variants:
-  - {first: E., last: Saquete}
   - {first: Estela, last: Saquete Boro}
 - canonical: {first: Murat, last: Saraclar}
   variants:
   - {first: Murat, last: Saraçlar}
-- canonical: {first: Xabier, last: Saralegi}
-  variants:
-  - {first: X., last: Saralegi}
 - canonical: {first: Kepa, last: Sarasola}
   variants:
-  - {first: K, last: Sarasola}
   - {first: K., last: Sarasola}
 - canonical: {first: K, last: Saravanan}
   variants:
@@ -9539,7 +8196,6 @@
 - canonical: {first: Satoshi, last: Sato}
   variants:
   - {first: Satoshi, last: SATO}
-  - {first: S., last: Sato}
 - canonical: {first: Pavankumar, last: Satuluri}
   variants:
   - {first: Pavan Kumar, last: Satuluri}
@@ -9651,7 +8307,6 @@
 - canonical: {first: Richard, last: Schwartz}
   variants:
   - {first: Rich, last: Schwartz}
-  - {first: R., last: Schwartz}
 - canonical: {first: Ulrich, last: Schäfer}
   variants:
   - {first: Ulrich, last: Schafer}
@@ -9668,7 +8323,6 @@
   - {first: Hinrich, last: Schuetze}
 - canonical: {first: Donia, last: Scott}
   variants:
-  - {first: D, last: Scott}
   - {first: Donia R., last: Scott}
 - canonical: {first: Djamé, last: Seddah}
   variants:
@@ -9686,15 +8340,9 @@
   variants:
   - {first: Frederique, last: SEGOND}
   - {first: Frederique, last: Segond}
-- canonical: {first: Jérémie, last: Segouat}
-  variants:
-  - {first: J., last: Segouat}
 - canonical: {first: Isabel, last: Segura-Bedmar}
   variants:
   - {first: Isabel, last: Segura Bedmar}
-- canonical: {first: Corrado, last: Seidenari}
-  variants:
-  - {first: C., last: Seidenari}
 - canonical: {first: Satoshi, last: Sekine}
   variants:
   - {first: Satoshi, last: SEKINE}
@@ -9707,15 +8355,9 @@
 - canonical: {first: Jiří, last: Semecký}
   variants:
   - {first: Jirí, last: Semecky}
-- canonical: {first: Giovanni, last: Semeraro}
-  variants:
-  - {first: G., last: Semeraro}
 - canonical: {first: Nasredine, last: Semmar}
   variants:
   - {first: Nasredine, last: SEMMAR}
-- canonical: {first: Stephanie, last: Seneff}
-  variants:
-  - {first: S., last: Seneff}
 - canonical: {first: Hongsuck, last: Seo}
   variants:
   - {first: Paul Hongsuck, last: Seo}
@@ -9725,21 +8367,9 @@
 - canonical: {first: Jungyun, last: Seo}
   variants:
   - {first: Jung Yun, last: Seo}
-- canonical: {first: Luciano, last: Serafini}
-  variants:
-  - {first: L., last: Serafini}
 - canonical: {first: Iulian Vlad, last: Serban}
   variants:
   - {first: Iulian, last: Serban}
-- canonical: {first: Jean-Francois, last: Serignat}
-  variants:
-  - {first: J.F., last: Serignat}
-- canonical: {first: Christophe, last: Servan}
-  variants:
-  - {first: C., last: Servan}
-- canonical: {first: Andrea, last: Setzer}
-  variants:
-  - {first: A., last: Setzer}
 - canonical: {first: Jurica, last: Seva}
   variants:
   - {first: Jurica, last: Ševa}
@@ -9749,9 +8379,6 @@
 - canonical: {first: Binyam Ephrem, last: Seyoum}
   variants:
   - {first: Binyam, last: Ephrem}
-- canonical: {first: Petr, last: Sgall}
-  variants:
-  - {first: P., last: Sgall}
 - canonical: {first: Khaled, last: Shaban}
   variants:
   - {first: Khaled, last: Bashir Shaban}
@@ -9761,20 +8388,12 @@
 - canonical: {first: Ritesh, last: Shah}
   variants:
   - {first: Ritesh M., last: Shah}
-- canonical: {first: Mostafa, last: Shahin}
-  variants:
-  - {first: M., last: Shahin}
 - canonical: {first: Zoya M., last: Shalyapina}
   variants:
-  - {first: Z.M., last: Shalyapina}
-  - {first: Z. M., last: Shalyapina}
   - {first: Zoyn M., last: Shalyapina}
 - canonical: {first: Eli, last: Shamir}
   variants:
   - {first: Eli, last: SHAMIR}
-- canonical: {first: Stuart C., last: Shapiro}
-  variants:
-  - {first: S.C., last: Shapiro}
 - canonical: {first: Abdul-Baquee, last: Sharaf}
   variants:
   - {first: Abdul-Baquee M., last: Sharaf}
@@ -9790,10 +8409,6 @@
 - canonical: {first: Vishnu Dutt, last: Sharma}
   variants:
   - {first: Vishnu, last: Sharma}
-- canonical: {first: Richard A., last: Sharman}
-  variants:
-  - {first: R. A., last: Sharman}
-  - {first: R.A., last: Sharman}
 - canonical: {first: Lokendra, last: Shastri}
   variants:
   - {first: Lokendra, last: SHASTRI}
@@ -9815,9 +8430,6 @@
 - canonical: {first: Jia-Lin, last: Shen}
   variants:
   - {first: Jia-lin, last: Shen}
-- canonical: {first: David D., last: Sherertz}
-  variants:
-  - {first: D. D., last: Sherertz}
 - canonical: {first: Mohamed Ahmed, last: Sherif}
   variants:
   - {first: Mohamed, last: Sherif}
@@ -9840,15 +8452,9 @@
 - canonical: {first: Hideo, last: Shimazu}
   variants:
   - {first: Hideo, last: SHIMAZU}
-- canonical: {first: Katsumasa, last: Shimizu}
-  variants:
-  - {first: K., last: Shimizu}
 - canonical: {first: Tohru, last: Shimizu}
   variants:
   - {first: Toru, last: Shimizu}
-- canonical: {first: Mitsuo, last: Shimohata}
-  variants:
-  - {first: M., last: Shimohata}
 - canonical: {first: Jong-Hun, last: Shin}
   variants:
   - {first: Jong Hun, last: Shin}
@@ -9858,9 +8464,6 @@
 - canonical: {first: Hiroyuki, last: Shinnou}
   variants:
   - {first: Hiroyuki, last: SHINNOU}
-- canonical: {first: Katsuhiko, last: Shirai}
-  variants:
-  - {first: K., last: Shirai}
 - canonical: {first: Satoshi, last: Shirai}
   variants:
   - {first: Satosi, last: Shirai}
@@ -9876,9 +8479,6 @@
 - canonical: {first: Prajwol, last: Shrestha}
   variants:
   - {first: Prajol, last: Shrestha}
-- canonical: {first: Elizabeth, last: Shriberg}
-  variants:
-  - {first: E., last: Shriberg}
 - canonical: {first: Manish, last: Shrivastava}
   variants:
   - {first: Manish, last: Srivastava}
@@ -9929,7 +8529,6 @@
 - canonical: {first: Khalil, last: Sima’an}
   variants:
   - {first: Khalil, last: Simaan}
-  - {first: K., last: Sima’an}
 - canonical: {first: Katalin Ilona, last: Simkó}
   variants:
   - {first: Katalin, last: Simkó}
@@ -9939,7 +8538,6 @@
 - canonical: {first: Nathalie, last: SIMONIN}
   variants:
   - {first: Nathalie, last: Simonin}
-  - {first: N., last: SIMONIN}
 - canonical: {first: Dan, last: Simonson}
   variants:
   - {first: Daniel, last: Simonson}
@@ -9950,8 +8548,6 @@
 - canonical: {first: King Kui, last: Sin}
   variants:
   - {first: KingKui, last: Sin}
-  - {first: K. K., last: Sin}
-  - {first: K.K., last: Sin}
 - canonical: {first: Anil Kumar, last: Singh}
   variants:
   - {first: Anil, last: Kumar Singh}
@@ -9974,12 +8570,6 @@
 - canonical: {first: Raivis, last: Skadiņš}
   variants:
   - {first: Raivis, last: Skadins}
-- canonical: {first: Wojciech, last: Skalmowski}
-  variants:
-  - {first: W., last: Skalmowski}
-- canonical: {first: Romuald, last: Skiba}
-  variants:
-  - {first: R., last: Skiba}
 - canonical: {first: Steven, last: Skiena}
   variants:
   - {first: Steve, last: Skiena}
@@ -10060,9 +8650,6 @@
 - canonical: {first: Matthew, last: Snover}
   variants:
   - {first: Matthew G., last: Snover}
-- canonical: {first: Stephen, last: Soderland}
-  variants:
-  - {first: S., last: Soderland}
 - canonical: {first: Sylvana, last: Sofkova Hashemi}
   variants:
   - {first: Sylvana, last: Sofkova}
@@ -10078,9 +8665,6 @@
 - canonical: {first: Juan, last: Soler-Company}
   variants:
   - {first: Juan, last: Soler Company}
-- canonical: {first: Aitor, last: Sologaistoa}
-  variants:
-  - {first: A., last: Sologaistoa}
 - canonical: {first: Illés, last: Solt}
   variants:
   - {first: Illes, last: Solt}
@@ -10088,7 +8672,6 @@
   variants:
   - {first: Harold L., last: Somers}
   - {first: Harold L., last: SOMERS}
-  - {first: H.L., last: Somers}
 - canonical: {first: Norman K., last: Sondheimer}
   variants:
   - {first: Norman, last: Sondheimer}
@@ -10112,7 +8695,6 @@
   - {first: Jeffrey S., last: Sorensen}
 - canonical: {first: Aitor, last: Soroa}
   variants:
-  - {first: A., last: Soroa}
   - {first: Aitor, last: Soroa Etxabe}
 - canonical: {first: Ionut, last: Sorodoc}
   variants:
@@ -10123,9 +8705,6 @@
 - canonical: {first: David Cabrero, last: Souto}
   variants:
   - {first: David, last: Cabrero}
-- canonical: {first: Jackson, last: Souza}
-  variants:
-  - {first: J., last: Souza}
 - canonical: {first: Vinícius Mourão Alves de, last: Souza}
   variants:
   - {first: Vinícius Mourão Alves, last: de Souza}
@@ -10135,9 +8714,6 @@
 - canonical: {first: Irena, last: Spasić}
   variants:
   - {first: Irena, last: Spasic}
-- canonical: {first: Manuela, last: Speranza}
-  variants:
-  - {first: M., last: Speranza}
 - canonical: {first: Valentin I., last: Spitkovsky}
   variants:
   - {first: Valentin, last: Spitkovsky}
@@ -10149,16 +8725,12 @@
 - canonical: {first: Richard, last: Sproat}
   variants:
   - {first: Richard W., last: Sproat}
-- canonical: {first: Rachele, last: Sprugnoli}
-  variants:
-  - {first: R., last: Sprugnoli}
 - canonical: {first: Shannon L., last: Spruit}
   variants:
   - {first: Shannon, last: Spruit}
 - canonical: {first: Peter, last: Spyns}
   variants:
   - {first: PETER, last: SPYNS}
-  - {first: P., last: Spyns}
 - canonical: {first: Constantine D., last: Spyropoulos}
   variants:
   - {first: Constantine, last: Spyropoulos}
@@ -10169,7 +8741,6 @@
 - canonical: {first: Munirathnam, last: Srikanth}
   variants:
   - {first: Muirathnam, last: Srikanth}
-  - {first: M., last: Srikanth}
 - canonical: {first: Somayajulu, last: Sripada}
   variants:
   - {first: Somayajulu G., last: Sripada}
@@ -10186,7 +8757,6 @@
   - {first: Edward P., last: Stabler}
 - canonical: {first: Gregory, last: Stainhauer}
   variants:
-  - {first: G., last: Stainhauer}
   - {first: Gregory, last: Stainhaouer}
 - canonical: {first: Ieva, last: Staliūnaitė}
   variants:
@@ -10194,13 +8764,9 @@
 - canonical: {first: David, last: Stallard}
   variants:
   - {first: David G., last: Stallard}
-  - {first: D., last: Stallard}
 - canonical: {first: Bonnie Glover, last: Stalls}
   variants:
   - {first: Bonnie, last: Glover}
-- canonical: {first: Efstathios, last: Stamatatos}
-  variants:
-  - {first: E., last: Stamatatos}
 - canonical: {first: Ranka, last: Stanković}
   variants:
   - {first: Ranka, last: Stankoviæ}
@@ -10211,21 +8777,14 @@
 - canonical: {first: Ingrid, last: Starke}
   variants:
   - {first: Ingrid, last: STARKE}
-  - {first: I., last: Starke}
 - canonical: {first: Anatoli, last: Starostin}
   variants:
   - {first: Anatoly, last: Starostin}
-- canonical: {first: Mark, last: Steedman}
-  variants:
-  - {first: M., last: Steedman}
 - canonical: {first: Dan, last: Stefanescu}
   variants:
   - {first: Dan, last: Ştefănescu}
   - {first: Dan, last: Ştefanescu}
   - {first: Dan, last: Ştefǎnescu}
-- canonical: {first: Stefan, last: Steidl}
-  variants:
-  - {first: S., last: Steidl}
 - canonical: {first: Erich H., last: STEINER}
   variants:
   - {first: ERICH, last: STEINER}
@@ -10236,7 +8795,6 @@
   - {first: Egon W., last: Stemle}
 - canonical: {first: Amanda, last: Stent}
   variants:
-  - {first: A., last: Stent}
   - {first: Amanda J., last: Stent}
 - canonical: {first: Evgeny, last: Stepanov}
   variants:
@@ -10247,9 +8805,6 @@
 - canonical: {first: Richard M., last: Stern}
   variants:
   - {first: Richard, last: Stern}
-- canonical: {first: Rosemary, last: Stevenson}
-  variants:
-  - {first: R., last: Stevenson}
 - canonical: {first: Brandon M., last: Stewart}
   variants:
   - {first: Brandon, last: Stewart}
@@ -10259,9 +8814,6 @@
 - canonical: {first: Oliviero, last: Stock}
   variants:
   - {first: Oliviero, last: STOCK}
-- canonical: {first: Andreas, last: Stolcke}
-  variants:
-  - {first: A., last: Stolcke}
 - canonical: {first: Scott C., last: Stoness}
   variants:
   - {first: Scott, last: Stoness}
@@ -10277,9 +8829,6 @@
 - canonical: {first: Pavel, last: Straňák}
   variants:
   - {first: Pavel, last: Stranak}
-- canonical: {first: Helmer, last: Strik}
-  variants:
-  - {first: H., last: Strik}
 - canonical: {first: Lena, last: Stromback}
   variants:
   - {first: LENA, last: STROMBACK}
@@ -10291,16 +8840,12 @@
   variants:
   - {first: TOMEK, last: STRZALKOWSKI}
   - {first: Tomek, last: Strzalkowskl}
-  - {first: T., last: Strzalkowski}
 - canonical: {first: Sofia, last: Strönbergsson}
   variants:
   - {first: Sofia, last: Strömbergsson}
 - canonical: {first: Roland, last: Stuckardt}
   variants:
   - {first: Roland, last: STUCKARDT}
-- canonical: {first: Janienke, last: Sturm}
-  variants:
-  - {first: J., last: Sturm}
 - canonical: {first: Dean, last: Sturtevant}
   variants:
   - {first: Dean G., last: Sturtevant}
@@ -10340,12 +8885,6 @@
 - canonical: {first: David, last: Suendermann-Oeft}
   variants:
   - {first: David, last: Suendermann}
-- canonical: {first: Masakatsu, last: Sugimoto}
-  variants:
-  - {first: M., last: Sugimoto}
-- canonical: {first: Ryochi, last: Sugimura}
-  variants:
-  - {first: R., last: Sugimura}
 - canonical: {first: '', last: Sukhada}
   variants:
   - {first: Sukhada, last: Palkar}
@@ -10395,15 +8934,9 @@
 - canonical: {first: Masaru, last: Suzuki}
   variants:
   - {first: Masaru, last: SUZUKI}
-- canonical: {first: Armando, last: Suárez}
-  variants:
-  - {first: A., last: Suárez}
 - canonical: {first: Mari Carmen, last: Suárez-Figueroa}
   variants:
   - {first: M. Carmen, last: Suárez-Figueroa}
-- canonical: {first: Piergiorgio, last: Svaizer}
-  variants:
-  - {first: P., last: Svaizer}
 - canonical: {first: Lukáš, last: Svoboda}
   variants:
   - {first: Lukas, last: Svoboda}
@@ -10439,7 +8972,6 @@
 - canonical: {first: Jon, last: Sánchez}
   variants:
   - {first: Jon, last: Sanchez}
-  - {first: J., last: Sánchez}
 - canonical: {first: Víctor M., last: Sánchez-Cartagena}
   variants:
   - {first: Victor M., last: Sánchez-Cartagena}
@@ -10466,9 +8998,6 @@
 - canonical: {first: Anders, last: Søgaard}
   variants:
   - {first: Anders, last: Sogaard}
-- canonical: {first: Maite, last: Taboada}
-  variants:
-  - {first: M., last: Taboada}
 - canonical: {first: Martha Yifiru, last: Tachbelie}
   variants:
   - {first: Martha, last: Yifiru Tachbelie}
@@ -10517,15 +9046,9 @@
 - canonical: {first: Wai Lok, last: Tam}
   variants:
   - {first: Wailok, last: Tam}
-- canonical: {first: Fabio, last: Tamburini}
-  variants:
-  - {first: F., last: Tamburini}
 - canonical: {first: Aleš, last: Tamchyna}
   variants:
   - {first: Ales, last: Tamchyna}
-- canonical: {first: Noriyuki, last: Tamura}
-  variants:
-  - {first: N., last: Tamura}
 - canonical: {first: Chew Lim, last: Tan}
   variants:
   - {first: Chew-Lim, last: Tan}
@@ -10567,22 +9090,12 @@
 - canonical: {first: Mariona, last: Taulé}
   variants:
   - {first: Mariona, last: Taule}
-  - {first: M., last: Taulé}
-- canonical: {first: Miriam, last: Tavoni}
-  variants:
-  - {first: M., last: Tavoni}
 - canonical: {first: Sarah, last: Taylor}
   variants:
   - {first: Sarah M., last: Taylor}
 - canonical: {first: Suzanne Liebowitz, last: Taylor}
   variants:
   - {first: Suzanne, last: Liebowitz}
-- canonical: {first: William J., last: Teahan}
-  variants:
-  - {first: W. J., last: Teahan}
-- canonical: {first: João Paulo, last: Teixeira}
-  variants:
-  - {first: João P., last: Teixeira}
 - canonical: {first: Eric Sadit, last: Tellez}
   variants:
   - {first: Eric S., last: Tellez}
@@ -10598,9 +9111,6 @@
 - canonical: {first: Harry, last: Tennant}
   variants:
   - {first: Harry R., last: Tennant}
-- canonical: {first: Alexandre, last: Termier}
-  variants:
-  - {first: A., last: Termier}
 - canonical: {first: Egidio L., last: Terra}
   variants:
   - {first: Egidio, last: Terra}
@@ -10619,7 +9129,6 @@
 - canonical: {first: Mariët, last: Theune}
   variants:
   - {first: Mariet, last: Theune}
-  - {first: M., last: Theune}
 - canonical: {first: John C., last: Thomas}
   variants:
   - {first: John, last: Thomas}
@@ -10646,9 +9155,6 @@
 - canonical: {first: Laszlo, last: Tihanyi}
   variants:
   - {first: László, last: Tihanyi}
-- canonical: {first: Christoph, last: Tillmann}
-  variants:
-  - {first: C., last: Tillmann}
 - canonical: {first: Joëlle, last: Tilmanne}
   variants:
   - {first: Joelle, last: Tilmanne}
@@ -10658,10 +9164,6 @@
 - canonical: {first: Ismail, last: Timimi}
   variants:
   - {first: Ismaïl, last: Timimi}
-  - {first: I., last: Timimi}
-- canonical: {first: Neil, last: Tipper}
-  variants:
-  - {first: N, last: Tipper}
 - canonical: {first: Erik, last: Tjong Kim Sang}
   variants:
   - {first: Erik F., last: Tjong Kim Sang}
@@ -10690,10 +9192,6 @@
 - canonical: {first: Masaru, last: Tomita}
   variants:
   - {first: Masaru, last: TOMITA}
-  - {first: M., last: Tomita}
-- canonical: {first: Yoshihiro, last: Tomiyama}
-  variants:
-  - {first: Y., last: Tomiyama}
 - canonical: {first: Laura Mayfield, last: Tomokiyo}
   variants:
   - {first: Laura, last: Mayfield}
@@ -10792,9 +9290,6 @@
 - canonical: {first: Raphael, last: Troncy}
   variants:
   - {first: Raphaël, last: Troncy}
-- canonical: {first: Harald, last: Trost}
-  variants:
-  - {first: H., last: Trost}
 - canonical: {first: Thomas Alexander, last: Trost}
   variants:
   - {first: Thomas, last: Trost}
@@ -10830,9 +9325,6 @@
 - canonical: {first: Yuen-Hsien, last: Tseng}
   variants:
   - {first: Yuan-Hsien, last: Tseng}
-- canonical: {first: Pirros, last: Tsiakoulis}
-  variants:
-  - {first: P., last: Tsiakoulis}
 - canonical: {first: Benjamin K., last: Tsou}
   variants:
   - {first: B. K., last: T’sou}
@@ -10841,16 +9333,12 @@
   - {first: Benjamin, last: T’sou}
 - canonical: {first: Jun’ichi, last: Tsujii}
   variants:
-  - {first: J., last: Tsujii}
   - {first: Jun’ichi, last: TSUJII}
   - {first: Jun-ichi, last: Tsujii}
   - {first: Jun-Ichi, last: Tsujii}
   - {first: Jun-ichi, last: TSUJII}
   - {first: Junichi, last: Tsujii}
   - {first: Jun-ich, last: Tsujii}
-- canonical: {first: Junya, last: Tsutsumi}
-  variants:
-  - {first: J., last: Tsutsumi}
 - canonical: {first: Taijiro, last: Tsutsumi}
   variants:
   - {first: Taijiro, last: TSUTSUMI}
@@ -10874,13 +9362,9 @@
   - {first: Dan, last: Tufis}
   - {first: Dan, last: TUFIS}
   - {first: Dan, last: Tufiș}
-- canonical: {first: Giovanni, last: Tummarello}
-  variants:
-  - {first: G., last: Tummarello}
 - canonical: {first: Gokhan, last: Tur}
   variants:
   - {first: Gokhan, last: Tür}
-  - {first: G., last: Tur}
 - canonical: {first: Umit Deniz, last: Turan}
   variants:
   - {first: Ümit Deniz, last: Turan}
@@ -10890,12 +9374,6 @@
 - canonical: {first: Joseph, last: Turian}
   variants:
   - {first: Joseph P., last: Turian}
-- canonical: {first: Franco, last: Turini}
-  variants:
-  - {first: F., last: Turini}
-- canonical: {first: Jordi, last: Turmo}
-  variants:
-  - {first: J., last: Turmo}
 - canonical: {first: Peter, last: Turney}
   variants:
   - {first: Peter D., last: Turney}
@@ -10905,16 +9383,10 @@
 - canonical: {first: Agnès, last: Tutin}
   variants:
   - {first: Agnes, last: Tutin}
-- canonical: {first: Mark S., last: Tuttle}
-  variants:
-  - {first: M. S., last: Tuttle}
 - canonical: {first: Francis, last: Tyers}
   variants:
   - {first: Francis M., last: Tyers}
   - {first: Francis, last: M. Tyers}
-- canonical: {first: Evelyne, last: Tzoukermann}
-  variants:
-  - {first: E., last: Tzoukermann}
 - canonical: {first: Kiyotaka, last: Uchimoto}
   variants:
   - {first: Kiyotaka, last: UCHIMOTO}
@@ -10924,7 +9396,6 @@
 - canonical: {first: Yoshihiro, last: Ueda}
   variants:
   - {first: Yoshihiro, last: UEDA}
-  - {first: Y., last: Ueda}
 - canonical: {first: Shunsuke, last: Uemura}
   variants:
   - {first: Syunsuke, last: UEMURA}
@@ -10957,13 +9428,6 @@
 - canonical: {first: Zdenka, last: Uresova}
   variants:
   - {first: Zdeňka, last: Urešová}
-- canonical: {first: Ruben, last: Urizar}
-  variants:
-  - {first: R., last: Urizar}
-- canonical: {first: Miriam, last: Urkia}
-  variants:
-  - {first: M., last: Urkia}
-  - {first: M, last: Urkia}
 - canonical: {first: Cristian, last: Ursu}
   variants:
   - {first: Christian, last: Ursu}
@@ -11008,9 +9472,6 @@
 - canonical: {first: Andre, last: Valli}
   variants:
   - {first: André, last: Valli}
-- canonical: {first: Andoni, last: Valverde}
-  variants:
-  - {first: A., last: Valverde}
 - canonical: {first: M. Pilar, last: Valverde Ibáñez}
   variants:
   - {first: M. Pilar, last: Valverde-Ibanez}
@@ -11035,7 +9496,6 @@
   variants:
   - {first: Henk van den, last: Heuvel}
   - {first: Henk, last: Van den Heuvel}
-  - {first: H., last: van den Heuvel}
 - canonical: {first: Erik, last: van der Goot}
   variants:
   - {first: Erik, last: Van der Goot}
@@ -11084,7 +9544,6 @@
   - {first: Josef Van, last: Genabith}
   - {first: Josef, last: Van Genabith}
   - {first: Josef van, last: Genabith}
-  - {first: J., last: Van Genabith}
 - canonical: {first: Willem Robert, last: van Hage}
   variants:
   - {first: Willem Van, last: Hage}
@@ -11156,12 +9615,8 @@
   variants:
   - {first: Tristan, last: van Rullen}
   - {first: Tristan Van, last: Rullen}
-- canonical: {first: Jerome, last: Vapillon}
-  variants:
-  - {first: J., last: Vapillon}
 - canonical: {first: Dániel, last: Varga}
   variants:
-  - {first: D., last: Varga}
   - {first: Daniel, last: Varga}
 - canonical: {first: István, last: Varga}
   variants:
@@ -11170,33 +9625,19 @@
   variants:
   - {first: Giovanni B., last: Varile}
   - {first: Giovanni B., last: VARILE}
-  - {first: G.B., last: Varile}
 - canonical: {first: Dusan, last: Varis}
   variants:
   - {first: Dušan, last: Variš}
-- canonical: {first: Ioana, last: Vasilescu}
-  variants:
-  - {first: I., last: Vasilescu}
-- canonical: {first: Gunaranjan, last: Vasireddy}
-  variants:
-  - {first: G., last: Vasireddy}
 - canonical: {first: Andrejs, last: Vasiļjevs}
   variants:
   - {first: Andrejs, last: Vasiljevs}
 - canonical: {first: Alexander, last: Vasserman}
   variants:
   - {first: Alex, last: Vasserman}
-- canonical: {first: Dominique, last: Vaufreydaz}
-  variants:
-  - {first: D., last: Vaufreydaz}
 - canonical: {first: Bernard, last: Vauquois}
   variants:
   - {first: B., last: VAUQUOIS}
-  - {first: B., last: Vauquois}
   - {first: BERNARD, last: VAUQUOIS}
-- canonical: {first: Guillaume, last: Vauvert}
-  variants:
-  - {first: G., last: Vauvert}
 - canonical: {first: Eva Maria, last: Vecchi}
   variants:
   - {first: Eva, last: Vecchi}
@@ -11210,7 +9651,6 @@
 - canonical: {first: Paola, last: Velardi}
   variants:
   - {first: Paola, last: VELARDI}
-  - {first: P., last: Velardi}
 - canonical: {first: Patricia, last: Velazquez-Morales}
   variants:
   - {first: Patricia, last: Velázquez-Morales}
@@ -11245,20 +9685,12 @@
   - {first: Jose-Luis, last: Vicedo}
   - {first: Jose Luis, last: Vicedo}
   - {first: José L., last: Vicedo}
-  - {first: J.L., last: Vicedo}
-- canonical: {first: Enrique, last: Vidal}
-  variants:
-  - {first: E., last: Vidal}
 - canonical: {first: Renata, last: Vieira}
   variants:
   - {first: Renata, last: VIEIRA}
-  - {first: R., last: Vieira}
 - canonical: {first: Sarah, last: Vieweg}
   variants:
   - {first: Sarah E., last: Vieweg}
-- canonical: {first: Marina, last: Vigário}
-  variants:
-  - {first: M., last: Vigário}
 - canonical: {first: K., last: Vijay-Shanker}
   variants:
   - {first: K, last: Vijay-Shanker}
@@ -11273,7 +9705,6 @@
 - canonical: {first: Juan Miguel, last: Vilar}
   variants:
   - {first: Juan-Miguel, last: Vilar}
-  - {first: J. M., last: Vilar}
   - {first: Juan M., last: Vilar}
 - canonical: {first: Darnes, last: Vilariño}
   variants:
@@ -11281,9 +9712,6 @@
 - canonical: {first: Jorgen, last: Villadsen}
   variants:
   - {first: Jørgen, last: Villadsen}
-- canonical: {first: Jeanne, last: Villaneau}
-  variants:
-  - {first: J., last: Villaneau}
 - canonical: {first: Luís, last: Villarejo}
   variants:
   - {first: Luis, last: Villarejo}
@@ -11305,7 +9733,6 @@
   - {first: Nguyen, last: Ha Vo}
 - canonical: {first: Stephan, last: Vogel}
   variants:
-  - {first: S., last: Vogel}
   - {first: Stephen, last: Vogel}
 - canonical: {first: Maria das Graças, last: Volpe Nunes}
   variants:
@@ -11384,29 +9811,21 @@
 - canonical: {first: Stefan, last: Wagner}
   variants:
   - {first: Stefan, last: Wager}
-- canonical: {first: Wolfgang, last: Wahlster}
-  variants:
-  - {first: W., last: Wahlster}
 - canonical: {first: Alex, last: Waibel}
   variants:
   - {first: Alexander, last: Waibel}
-  - {first: A., last: Waibel}
 - canonical: {first: Hiromi, last: Wakaki}
   variants:
   - {first: Hiromi, last: WAKAKI}
 - canonical: {first: Shoko, last: Wakamiya}
   variants:
   - {first: Shoko, last: WAKAMIYA}
-- canonical: {first: Takahiro, last: Wakao}
-  variants:
-  - {first: T., last: Wakao}
 - canonical: {first: Christopher R., last: Walker}
   variants:
   - {first: Christopher, last: Walker}
 - canonical: {first: Marilyn, last: Walker}
   variants:
   - {first: Marilyn A., last: Walker}
-  - {first: M. A., last: Walker}
 - canonical: {first: Vern, last: Walker}
   variants:
   - {first: Vern R., last: Walker}
@@ -11419,16 +9838,9 @@
 - canonical: {first: Joel, last: Wallenberg}
   variants:
   - {first: Joel C., last: Wallenberg}
-- canonical: {first: Annalu, last: Waller}
-  variants:
-  - {first: A., last: Waller}
 - canonical: {first: Alan, last: Wallington}
   variants:
   - {first: Alan M., last: Wallington}
-  - {first: A.M., last: Wallington}
-- canonical: {first: David L., last: Waltz}
-  variants:
-  - {first: D. L., last: Waltz}
 - canonical: {first: Bo, last: Wang}
   variants:
   - {first: Bo, last: WANG}
@@ -11479,9 +9891,6 @@
 - canonical: {first: Sida I., last: Wang}
   variants:
   - {first: Sida, last: Wang}
-- canonical: {first: Wen, last: Wang}
-  variants:
-  - {first: W., last: Wang}
 - canonical: {first: Wen Ting, last: Wang}
   variants:
   - {first: WenTing, last: Wang}
@@ -11491,7 +9900,6 @@
 - canonical: {first: Xia, last: Wang}
   variants:
   - {first: Xia S., last: Wang}
-  - {first: X. S., last: Wang}
 - canonical: {first: Xiao-Long, last: Wang}
   variants:
   - {first: XiaoLong, last: Wang}
@@ -11508,7 +9916,6 @@
   - {first: Nigel G., last: Ward}
 - canonical: {first: Wayne, last: Ward}
   variants:
-  - {first: W., last: Ward}
   - {first: Wayne H., last: Ward}
 - canonical: {first: David H. D., last: Warren}
   variants:
@@ -11532,14 +9939,10 @@
 - canonical: {first: J. Angus, last: Webb}
   variants:
   - {first: Angus, last: Webb}
-- canonical: {first: Nick, last: Webb}
-  variants:
-  - {first: N., last: Webb}
 - canonical: {first: Bonnie, last: Webber}
   variants:
   - {first: Bonnie L., last: Webber}
   - {first: Bonnie Lynn, last: Webber}
-  - {first: B., last: Webber}
 - canonical: {first: HEINZ J., last: WEBER}
   variants:
   - {first: H-J., last: Weber}
@@ -11558,9 +9961,6 @@
 - canonical: {first: Xiangfeng, last: Wei}
   variants:
   - {first: XiangFeng, last: Wei}
-- canonical: {first: Robert, last: Weide}
-  variants:
-  - {first: R., last: Weide}
 - canonical: {first: Amy, last: Weinberg}
   variants:
   - {first: Amy S., last: Weinberg}
@@ -11572,19 +9972,14 @@
   - {first: Clifford, last: Weinstein}
 - canonical: {first: Mitch, last: Weintraub}
   variants:
-  - {first: M., last: Weintraub}
   - {first: Mitchel, last: Weintraub}
 - canonical: {first: David, last: Weir}
   variants:
   - {first: David J., last: Weir}
-  - {first: D. J., last: Weir}
   - {first: David, last: Wei}
 - canonical: {first: Ralph, last: Weischedel}
   variants:
   - {first: Ralph M., last: Weischedel}
-- canonical: {first: Davy, last: Weissenbacher}
-  variants:
-  - {first: D., last: Weissenbacher}
 - canonical: {first: Daniel S., last: Weld}
   variants:
   - {first: Daniel, last: Weld}
@@ -11613,16 +10008,11 @@
   - {first: Ryan, last: White}
 - canonical: {first: Pete, last: Whitelock}
   variants:
-  - {first: P., last: Whitelock}
-  - {first: P. J., last: Whitelock}
   - {first: Pete J., last: Whitelock}
   - {first: Pete, last: WHITELOCK}
 - canonical: {first: Edward W. D., last: Whittaker}
   variants:
   - {first: E.W.D., last: Whittaker}
-- canonical: {first: Steve, last: Whittaker}
-  variants:
-  - {first: S., last: Whittaker}
 - canonical: {first: Daniel, last: Whyatt}
   variants:
   - {first: Dan, last: Whyatt}
@@ -11630,20 +10020,12 @@
   variants:
   - {first: Janyce M., last: Wiebe}
   - {first: Jan, last: Wiebe}
-- canonical: {first: Colin W., last: Wightman}
-  variants:
-  - {first: C.W., last: Wightman}
-  - {first: C. W., last: Wightman}
-- canonical: {first: Graham, last: Wilcock}
-  variants:
-  - {first: G., last: Wilcock}
 - canonical: {first: John, last: Wilkerson}
   variants:
   - {first: John D., last: Wilkerson}
 - canonical: {first: Yorick, last: Wilks}
   variants:
   - {first: Yorick, last: WILKS}
-  - {first: Y., last: Wilks}
 - canonical: {first: Jason D., last: Williams}
   variants:
   - {first: Jason, last: Williams}
@@ -11674,9 +10056,6 @@
 - canonical: {first: Michael J., last: Witbrock}
   variants:
   - {first: Michael, last: Witbrock}
-- canonical: {first: Peter, last: Wittenburg}
-  variants:
-  - {first: P., last: Wittenburg}
 - canonical: {first: Billy T.M., last: Wong}
   variants:
   - {first: Billy T. M., last: Wong}
@@ -11689,7 +10068,6 @@
 - canonical: {first: Kam-Fai, last: Wong}
   variants:
   - {first: Kam-fai, last: Wong}
-  - {first: K.F., last: Wong}
 - canonical: {first: Ping Wai, last: Wong}
   variants:
   - {first: Percy Ping-Wai, last: WONG}
@@ -11701,19 +10079,11 @@
   - {first: GORDON R., last: WOOD}
 - canonical: {first: Mary McGee, last: Wood}
   variants:
-  - {first: M. McGee, last: Wood}
   - {first: Mary McGee, last: WOOD}
   - {first: Mary, last: McGee Wood}
-- canonical: {first: William A., last: Woods}
-  variants:
-  - {first: W. A., last: Woods}
 - canonical: {first: Karsten L., last: Worm}
   variants:
   - {first: Karsten, last: Worm}
-  - {first: K. L., last: Worm}
-- canonical: {first: Monika, last: Woszczyna}
-  variants:
-  - {first: M., last: Woszczyna}
 - canonical: {first: Klaus, last: Wothke}
   variants:
   - {first: K., last: WOTHKE}
@@ -11809,18 +10179,12 @@
 - canonical: {first: Tomohiro, last: YAMASAKI}
   variants:
   - {first: Tomohiro, last: Yamasaki}
-- canonical: {first: Yoichi, last: Yamashita}
-  variants:
-  - {first: Y., last: Yamashita}
 - canonical: {first: Charles, last: Yang}
   variants:
   - {first: Charles D., last: Yang}
 - canonical: {first: Dechuan, last: Yang}
   variants:
   - {first: De, last: Yang}
-- canonical: {first: Dong, last: Yang}
-  variants:
-  - {first: D., last: Yang}
 - canonical: {first: Eun-Suk, last: Yang}
   variants:
   - {first: Eunsuk, last: Yang}
@@ -11850,9 +10214,6 @@
 - canonical: {first: Jin-ge, last: Yao}
   variants:
   - {first: Jin-Ge, last: Yao}
-- canonical: {first: Mustafa, last: Yaseen}
-  variants:
-  - {first: M., last: Yaseen}
 - canonical: {first: Norihito, last: Yasuda}
   variants:
   - {first: Norihi, last: Yasuda}
@@ -11881,16 +10242,12 @@
 - canonical: {first: Wen-tau, last: Yih}
   variants:
   - {first: Scott Wen-tau, last: Yih}
-- canonical: {first: Matti, last: Ylilammi}
-  variants:
-  - {first: M, last: Ylilammi}
 - canonical: {first: Akio, last: Yokoo}
   variants:
   - {first: AKIO, last: YOKOO}
 - canonical: {first: Shoichi, last: Yokoyama}
   variants:
   - {first: Shoichi, last: YOKOYAMA}
-  - {first: S., last: Yokoyama}
 - canonical: {first: Aesun, last: Yoon}
   variants:
   - {first: Ae sun, last: Yoon}
@@ -11907,13 +10264,9 @@
 - canonical: {first: Sho, last: Yoshida}
   variants:
   - {first: Sho, last: YOSHIDA}
-- canonical: {first: Takehiko, last: Yoshimi}
-  variants:
-  - {first: T., last: Yoshimi}
 - canonical: {first: Kei, last: Yoshimoto}
   variants:
   - {first: Kei, last: YOSHIMOTO}
-  - {first: K., last: Yoshimoto}
 - canonical: {first: Yumiko, last: Yoshimura}
   variants:
   - {first: Yumiko, last: YOSHIMURA}
@@ -11970,9 +10323,6 @@
   - {first: Remi, last: ZAJAC}
   - {first: REMI, last: ZAJAC}
   - {first: Rémi, last: Zajac}
-- canonical: {first: Xabier, last: Zalbide}
-  variants:
-  - {first: X., last: Zalbide}
 - canonical: {first: Jordi Porta, last: Zamorano}
   variants:
   - {first: Jordi, last: Porta}
@@ -11981,30 +10331,19 @@
   - {first: Antonio, last: ZAMPOLLI}
   - {first: ANTONIO, last: ZAMPOLLI}
   - {first: A., last: ZAMPOLLI}
-  - {first: A., last: Zampolli}
 - canonical: {first: Hongying, last: Zan}
   variants:
   - {first: Hong-ying, last: Zan}
-- canonical: {first: Stefano, last: Zanobini}
-  variants:
-  - {first: S., last: Zanobini}
 - canonical: {first: Fabio Massimo, last: Zanzotto}
   variants:
   - {first: Fabio, last: Massimo Zanzotto}
   - {first: Fabio, last: Zanzotto}
-  - {first: F., last: Zanzotto}
 - canonical: {first: Carlos Mario, last: Zapata Jaramillo}
   variants:
   - {first: Carlos M., last: Zapata-Jaramillo}
 - canonical: {first: Haïfa, last: Zargayouna}
   variants:
   - {first: Haifa, last: Zargayouna}
-- canonical: {first: Gian Piero, last: Zarri}
-  variants:
-  - {first: G.P., last: Zarri}
-- canonical: {first: George, last: Zavaliagkos}
-  variants:
-  - {first: G., last: Zavaliagkos}
 - canonical: {first: Henk, last: Zeevat}
   variants:
   - {first: Henk, last: ZEEVAT}
@@ -12063,7 +10402,6 @@
   variants:
   - {first: Yao Zhong, last: Zhang}
   - {first: Yao-zhong, last: Zhang}
-  - {first: Y., last: Zhang}
 - canonical: {first: Ying, last: Zhang}
   variants:
   - {first: Joy Ying, last: Zhang}
@@ -12132,16 +10470,12 @@
 - canonical: {first: Tatiana, last: Zidraşco}
   variants:
   - {first: Tatiana, last: Zidrasco}
-- canonical: {first: Ute, last: Ziegenhain}
-  variants:
-  - {first: U., last: Ziegenhain}
 - canonical: {first: Šárka, last: Zikánová}
   variants:
   - {first: Sárka, last: Zikánová}
 - canonical: {first: Harald H., last: Zimmermann}
   variants:
   - {first: Harald, last: Zimmermann}
-  - {first: H., last: Zimmermann}
 - canonical: {first: Cäcilia, last: Zirn}
   variants:
   - {first: Caecilia, last: Zirn}
@@ -12154,23 +10488,12 @@
 - canonical: {first: Chengqing, last: Zong}
   variants:
   - {first: Cheng-qing, last: Zong}
-- canonical: {first: Enrico, last: Zovato}
-  variants:
-  - {first: E., last: Zovato}
-- canonical: {first: Richard, last: Zuber}
-  variants:
-  - {first: R., last: Zuber}
 - canonical: {first: Victor, last: Zue}
   variants:
   - {first: Victor W., last: Zue}
-  - {first: V., last: Zue}
 - canonical: {first: Geoffrey, last: Zweig}
   variants:
-  - {first: G., last: Zweig}
   - {first: Geoff, last: Zweig}
-- canonical: {first: Pierre, last: Zweigenbaum}
-  variants:
-  - {first: P., last: Zweigenbaum}
 - canonical: {first: Judit, last: Ács}
   variants:
   - {first: Judit, last: Acs}
@@ -12232,9 +10555,6 @@
 - canonical: {first: Jana, last: Šindlerová}
   variants:
   - {first: Jana, last: Sindlerova}
-- canonical: {first: Jan, last: Šnajder}
-  variants:
-  - {first: Jan, last: Snajder}
 - canonical: {first: Sanja, last: Štajner}
   variants:
   - {first: Sanja, last: Stajner}
@@ -12259,3 +10579,4 @@
 - canonical: {first: Lukáš, last: Žilka}
   variants:
   - {first: Lukas, last: Zilka}
+


### PR DESCRIPTION
Modify loading of XML so that if a first or last name has a `complete`  …
attribute, its value is used instead of the element's text. I don't know
if this is the most correct thing to do, but as far as I know, everything
that the code uses names for, it's preferable to use the `complete` version.

Besides making paper pages and BibTeX entries more informative (though less
faithful), this also allows us to discard thousands of name variants.