### PR TITLE
Added a missing check to ensure that the executable for xml2end exists

### DIFF
--- a/bin/build_hugo
+++ b/bin/build_hugo
@@ -23,6 +23,10 @@ if ! [ -x "$(command -v bib2xml)" ]; then
     >&2 echo "ERROR    Couldn't find bib2xml -- did you install bibutils?"
     exit 1
 fi
+if ! [ -x "$(command -v xml2end)" ]; then
+    >&2 echo "ERROR    Couldn't find xml2end -- did you install bibutils?"
+    exit 1
+fi
 if ! [ -x "$(command -v hugo)" ]; then
     >&2 echo "ERROR    Couldn't find hugo"
     exit 1


### PR DESCRIPTION
As a result of PR #270 incorporating the EndNote citation format, we should now ensure that `xml2end` exists in the system. This PR adds that one check, as suggested in the PR discussion.