### PR TITLE
IWPT 2003

### DIFF
--- a/data/xml/W03.xml
+++ b/data/xml/W03.xml
@@ -5621,7 +5621,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
-    <abstract>A large part of wide coverage Tree Adjoining Grammars (TAG) is formed by trees that satisfy the restrictions imposed by Tree Insertion Grammars (TIG). This characteristic can be used to reduce the practical complexity of TAG parsing, applying the standard adjunction operation only in those cases in which the simpler cubic-time TIG adjunction cannot be applied. In this paper, we describe a parsing algorithm managing simultaneous adjunctions in TAG and TIG.</abstract>
+    <abstract>Le traitement automatique du langage naturel est un axe de recherche qui connaît chaque jour de nouvelles théories et approches. Les systèmes d’analyse automatique qui sont fondés sur une approche séquentielle présentent plusieurs inconvénients. Afin de pallier ces limites, nous nous sommes intéressés à la réalisation d’un système d’analyse syntaxique de textes arabes basé sur l’approche multi-agent : MASPAR « Multi-Agent System for Parsing ARabic ».</abstract>
     <url>https://www.aclweb.org/anthology/W03-3002</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3002</bibkey>
@@ -5645,6 +5645,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>This paper presents a technique for the representation and the implementation of interaction relations between different domains of linguistic analysis. This solution relies on the localization of the linguistic objects in the context. The relations are then implemented by means of interaction constraints, each domain information being expressed independently.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3004</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3004</bibkey>
@@ -5656,6 +5657,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>In this paper, we present a method which may speed up Earley parsers in practice. A first pass called a guiding parser builds an intermediate structure called a guide which is used by a second pass, an Earley parser, called a guided parser whose Predictor phase is slightly modified in such a way that it selects an initial item only if this item is in the guide. This approach is validated by practical experiments preformed on a large test set with an English context-free grammar.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3005</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3005</bibkey>
@@ -5667,6 +5669,10 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>We present a novel approach to supertagging w.r.t. some lexicalized grammar G. It differs from previous approaches in several ways:
+- These supertaggers rely only on structural information: they do not need any training phase;
+- These supertaggers do not compute the “best“ supertag for each word, but rather a set of supertags. These sets of supertags do not exclude any supertag that will eventually be used in a valid complete derivation (i.e., we have a recall score of 100%);
+- These supertaggers are in fact true parsers which accept supersets of L(G) that can be more efficiently parsed than the sentences of L(G).</abstract>
     <url>https://www.aclweb.org/anthology/W03-3006</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3006</bibkey>
@@ -5678,6 +5684,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>Integration of two stochastic context-free grammars can be useful in two pass approaches used, for example, in speech recognition and understanding. Based on an algorithm proposed by [Nederhof and Satta, 2002] for the non-probabilistic case, left-to-right strategies for the search for the best solution based on CKY and Earley parsers are discussed. The restriction that one of the two grammars must be non recursive does not represent a problem in the considered applications.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3007</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3007</bibkey>
@@ -5690,6 +5697,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>Visual language editors should provide a user-friendly environment where users are supported in an effective way in the construction of visual sentences. In this paper, we propose an approach for the construction of syntax-directed visual language editors by integrating incremental parsers into freehand editors. The approach combines the LR-based techniques for parsing visual languages with the more general incremental Generalized LR parsing techniques developed for string languages.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3008</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3008</bibkey>
@@ -5702,6 +5710,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>Within a grammar formalism that treats syntax analysis as a global optimization problem, methods are investigated to improve parsing performance by recombining the solutions of smaller and easier subproblems. The robust nature of the formalism allows the application of this technique with little change to the original grammar.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3009</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3009</bibkey>
@@ -5713,6 +5722,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>In this paper, we present a definition of unification of weighted feature structures designed to deal with constraint relaxation. The application of phrase structure rules in a unification-based Natural Language Processing system is adapted such that inconsistent values do not lead to failure, but are penalised. These penalties are based on the signature and the shape of the feature structures, and thus realise an elegant and general approach to relaxation.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3010</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3010</bibkey>
@@ -5724,6 +5734,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>We propose two statistical left-corner parsers and investigate their accuracy at varying speeds. The parser based on a generative probability model achieves state-of-the-art accuracy when sufficient time is available, but when high speed is required the parser based on a discriminative probability model performs better. Neural network probability estimation is used to handle conditioning on both the unbounded parse histories and the unbounded lookahead strings.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3011</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3011</bibkey>
@@ -5736,6 +5747,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>The paper introduces PACE — a parser comparison and evaluation system for the syntactic processing of natural languages. The analysis is based on context free grammar with contextual extensions (constraints). The system is able to manage very large and extremely ambiguous CF grammars. It is independent of the parsing algorithm used. The tool can solve the contextual constraints on the resulting CF structure, select the best parsing trees according to their probabilities, or combine them. We discuss the advantages and disadvantages of our modular design as well as how efficiently it processes the standard evaluation grammars.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3012</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3012</bibkey>
@@ -5749,6 +5761,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>In this paper, we propose a new probabilistic GLR parsing method that can solve the problems of conventional methods. Our proposed Conditional Action Model uses Surface Phrasal Types (SPTs) encoding the functional word sequences of the sub-trees for describing structural characteristics of the partial parse. And, the proposed GLR model outperforms the previous methods by about 6~8%.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3013</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3013</bibkey>
@@ -5761,6 +5774,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>In this paper, we describe an approach to analysis for spoken language translation that combines phrase-level grammar-based parsing and automatic domain action classification. The job of the analyzer is to transform utterances into a shallow semantic task-oriented interlingua representation. The goal of our hybrid approach is to provide accurate real-time analyses and to improve robustness and portability to new domains and languages.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3014</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3014</bibkey>
@@ -5773,6 +5787,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>Parser does the part of speech (POS) identification in a sentence, which is required for Machine Translation (MT). An intelligent parser is a parser, which takes care of semantics along with the POS in a sentence. Use of such intelligent parser will reduce the complexity in semantics during MT apriori.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3015</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3015</bibkey>
@@ -5785,6 +5800,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>We show that a well-known algorithm to compute the intersection of a context-fre language and a regular language can be extended to apply to a probabilistic context-free grammar and a probabilistic finite automaton, provided the two probabilistic models are combined through multiplication. The result is a probabilistic context-free grammar that contains joint information about the original grammar and automaton.</abstract>
     <pages>137-148</pages>
     <url>https://www.aclweb.org/anthology/W03-3016</url>
     <bibtype>inproceedings</bibtype>
@@ -5796,6 +5812,8 @@
     <booktitle>Proceedings of the Eighth International Workshop on Parsing Technologies (IWPT</booktitle>
     <month>April</month>
     <year>2003</year>
+    <address>Nancy, France</address>
+    <abstract>This paper presents a deterministic parsing algorithm for projective dependency grammar. The running time of the algorithm is linear in the length of the input string, and the dependency graph produced is guaranteed to be projective and acyclic. The algorithm has been experimentally evaluated in parsing unrestricted Swedish text, achieving an accuracy above 85% with a very simple grammar.</abstract>
     <pages>149–160</pages>
     <url>https://www.aclweb.org/anthology/W03-3017</url>
     <bibtype>inproceedings</bibtype>
@@ -5808,6 +5826,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>In this paper an efficient algorithm for dependency parsing is described in which ambiguous dependency structure of a sentence is represented in the form of a graph. The idea of the algorithm is shortly outlined and some issues as to its time complexity are discussed.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3018</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3018</bibkey>
@@ -5820,6 +5839,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>We investigate an aspect of the relationship between parsing and corpus-based methods in NLP that has received relatively little attention: coverage augmentation in rule-based parsers. In the specific task of determining grammatical relations (such as subjects and objects) in transcribed spoken language, we show that a combination of rule-based and corpus-based approaches, where a rule-based system is used as the teacher (or an automatic data annotator) to a corpus-based system, outperforms either system in isolation.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3019</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3019</bibkey>
@@ -5833,6 +5853,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>We present a new formalism, partially ordered multiset context-free grammars (poms-CFG), along with an Earley-style parsing algorithm. The formalism, which can be thought of as a generalization of context-free grammars with partially ordered right-hand sides, is of interest in its own right, and also as infrastructure for obtaining tighter complexity bounds for more expressive context-free formalisms intended to express free or multiple word-order, such as ID/LP grammars. We reduce ID/LP grammars to poms-grammars, thereby getting finer-grained bounds on the parsing complexity of ID/LP grammars. We argue that in practice, the width of attested ID/LP grammars is small, yielding effectively polynomial time complexity for ID/LP grammar parsing.</abstract>
     <pages>171–182</pages>
     <url>https://www.aclweb.org/anthology/W03-3020</url>
     <bibtype>inproceedings</bibtype>
@@ -5845,6 +5866,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>Given a probabilistic parsing model and an evaluation metric for scoring the match between parse-trees, e.g., PARSEVAL [Black et al., 1991], this paper addresses the problem of how to select the on average best scoring parse-tree for an input sentence. Common wisdom dictates that it is optimal to select the parse with the highest probability, regardless of the evaluation metric. In contrast, the Maximizing Metrics (MM) method [Goodman, 1998, Stolcke et al., 1997] proposes that an algorithm that optimizes the evaluation metric itself constitutes the optimal choice. We study the MM method within parsing. We observe that the MM does not always hold for tree-bank models, and that optimizing weak metrics is not interesting for semantic processing. Subsequently, we state an alternative proposition: the optimal algorithm must maximize the metric that scores parse-trees according to linguistically relevant features. We present new algorithms that optimize metrics that take into account increasingly more linguistic features, and exhibit experiments in support of our claim.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3021</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3021</bibkey>
@@ -5854,8 +5876,8 @@
     <author><first>So-Young</first><last>Park</last></author>
     <author><first>Yong-Jae</first><last>Kwak</last></author>
     <author><first>Hoo-Jung</first><last>Chung</last></author>
-    <author><first /><last>Hwang, Young-Sook</last></author>
-    <author><first>Hae-Chang</first><last>Rïm</last></author>
+    <author><first>Young-Sook</first><last>Hwang</last></author>
+    <author><first>Hae-Chang</first><last>Rim</last></author>
     <booktitle>Proceedings of the Eighth International Conference on Parsing Technologies</booktitle>
     <month>April</month>
     <year>2003</year>
@@ -5872,6 +5894,7 @@
     <month>April</month>
     <year>2003</year>
     <address>Nancy, France</address>
+    <abstract>In this paper, we propose a method for analyzing word-word dependencies using deterministic bottom-up manner using Support Vector machines. We experimented with dependency trees converted from Penn treebank data, and achieved over 90% accuracy of word-word dependency. Though the result is little worse than the most up-to-date phrase structure based parsers, it looks satisfactorily accurate considering that our parser uses no information from phrase structures.</abstract>
     <url>https://www.aclweb.org/anthology/W03-3023</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3023</bibkey>

--- a/data/xml/W03.xml
+++ b/data/xml/W03.xml
@@ -5607,16 +5607,17 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>A large part of wide coverage Tree Adjoining Grammars (TAG) is formed by trees that satisfy the restrictions imposed by Tree Insertion Grammars (TIG). This characteristic can be used to reduce the practical complexity of TAG parsing, applying the standard adjunction operation only in those cases in which the simpler cubic-time TIG adjunction cannot be applied. In this paper, we describe a parsing algorithm managing simultaneous adjunctions in TAG and TIG.</abstract>
+    <pages>19–30</pages>
     <url>https://www.aclweb.org/anthology/W03-3001</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3001</bibkey>
   </paper>
   <paper id="3002">
     <title>Implémentation du système MASPAR selon une approche multi-agent</title>
-    <author><first>Souha Hammami</first><last>Mezghani</last></author>
     <author><first>Chafik</first><last>Aloulou</last></author>
-    <author><first>Lamia Hadrich</first><last>Belguith</last></author>
-    <author><first>Ahmed Hadj</first><last>Kacem</last></author>
+    <author><first>Lamia</first><last>Hadrich Belguith</last></author>
+    <author><first>Ahmed</first><last>Hadj Kacem</last></author>
+    <author><first>Souha</first><last>Hammami Mezghani</last></author>
     <booktitle>Proceedings of the Eighth International Conference on Parsing Technologies</booktitle>
     <month>April</month>
     <year>2003</year>
@@ -5634,6 +5635,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>The paper describes an incremental parsing algorithm for natural languages that uses normalized interfaces of modules of proof-nets. This algorithm produces at each step the different possible partial syntactical analyses of the first words of a sentence. Thus, it can analyze texts on the fly leaving partially analyzed sentences.</abstract>
+    <pages>31–42</pages>
     <url>https://www.aclweb.org/anthology/W03-3003</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3003</bibkey>
@@ -5658,6 +5660,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>In this paper, we present a method which may speed up Earley parsers in practice. A first pass called a guiding parser builds an intermediate structure called a guide which is used by a second pass, an Earley parser, called a guided parser whose Predictor phase is slightly modified in such a way that it selects an initial item only if this item is in the guide. This approach is validated by practical experiments preformed on a large test set with an English context-free grammar.</abstract>
+    <pages>43–54</pages>
     <url>https://www.aclweb.org/anthology/W03-3005</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3005</bibkey>
@@ -5673,6 +5676,7 @@
 - These supertaggers rely only on structural information: they do not need any training phase;
 - These supertaggers do not compute the “best“ supertag for each word, but rather a set of supertags. These sets of supertags do not exclude any supertag that will eventually be used in a valid complete derivation (i.e., we have a recall score of 100%);
 - These supertaggers are in fact true parsers which accept supersets of L(G) that can be more efficiently parsed than the sentences of L(G).</abstract>
+    <pages>55–65</pages>
     <url>https://www.aclweb.org/anthology/W03-3006</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3006</bibkey>
@@ -5698,6 +5702,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>Visual language editors should provide a user-friendly environment where users are supported in an effective way in the construction of visual sentences. In this paper, we propose an approach for the construction of syntax-directed visual language editors by integrating incremental parsers into freehand editors. The approach combines the LR-based techniques for parsing visual languages with the more general incremental Generalized LR parsing techniques developed for string languages.</abstract>
+    <pages>78–90</pages>
     <url>https://www.aclweb.org/anthology/W03-3008</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3008</bibkey>
@@ -5711,6 +5716,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>Within a grammar formalism that treats syntax analysis as a global optimization problem, methods are investigated to improve parsing performance by recombining the solutions of smaller and easier subproblems. The robust nature of the formalism allows the application of this technique with little change to the original grammar.</abstract>
+    <pages>91–102</pages>
     <url>https://www.aclweb.org/anthology/W03-3009</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3009</bibkey>
@@ -5723,6 +5729,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>In this paper, we present a definition of unification of weighted feature structures designed to deal with constraint relaxation. The application of phrase structure rules in a unification-based Natural Language Processing system is adapted such that inconsistent values do not lead to failure, but are penalised. These penalties are based on the signature and the shape of the feature structures, and thus realise an elegant and general approach to relaxation.</abstract>
+    <pages>103–114</pages>
     <url>https://www.aclweb.org/anthology/W03-3010</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3010</bibkey>
@@ -5735,6 +5742,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>We propose two statistical left-corner parsers and investigate their accuracy at varying speeds. The parser based on a generative probability model achieves state-of-the-art accuracy when sufficient time is available, but when high speed is required the parser based on a discriminative probability model performs better. Neural network probability estimation is used to handle conditioning on both the unbounded parse histories and the unbounded lookahead strings.</abstract>
+    <pages>115–126</pages>
     <url>https://www.aclweb.org/anthology/W03-3011</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3011</bibkey>
@@ -5748,6 +5756,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>The paper introduces PACE — a parser comparison and evaluation system for the syntactic processing of natural languages. The analysis is based on context free grammar with contextual extensions (constraints). The system is able to manage very large and extremely ambiguous CF grammars. It is independent of the parsing algorithm used. The tool can solve the contextual constraints on the resulting CF structure, select the best parsing trees according to their probabilities, or combine them. We discuss the advantages and disadvantages of our modular design as well as how efficiently it processes the standard evaluation grammars.</abstract>
+    <pages>211–212</pages>
     <url>https://www.aclweb.org/anthology/W03-3012</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3012</bibkey>
@@ -5762,6 +5771,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>In this paper, we propose a new probabilistic GLR parsing method that can solve the problems of conventional methods. Our proposed Conditional Action Model uses Surface Phrasal Types (SPTs) encoding the functional word sequences of the sub-trees for describing structural characteristics of the partial parse. And, the proposed GLR model outperforms the previous methods by about 6~8%.</abstract>
+    <pages>213–214</pages>
     <url>https://www.aclweb.org/anthology/W03-3013</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3013</bibkey>
@@ -5775,6 +5785,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>In this paper, we describe an approach to analysis for spoken language translation that combines phrase-level grammar-based parsing and automatic domain action classification. The job of the analyzer is to transform utterances into a shallow semantic task-oriented interlingua representation. The goal of our hybrid approach is to provide accurate real-time analyses and to improve robustness and portability to new domains and languages.</abstract>
+    <pages>127–136</pages>
     <url>https://www.aclweb.org/anthology/W03-3014</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3014</bibkey>
@@ -5867,6 +5878,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>Given a probabilistic parsing model and an evaluation metric for scoring the match between parse-trees, e.g., PARSEVAL [Black et al., 1991], this paper addresses the problem of how to select the on average best scoring parse-tree for an input sentence. Common wisdom dictates that it is optimal to select the parse with the highest probability, regardless of the evaluation metric. In contrast, the Maximizing Metrics (MM) method [Goodman, 1998, Stolcke et al., 1997] proposes that an algorithm that optimizes the evaluation metric itself constitutes the optimal choice. We study the MM method within parsing. We observe that the MM does not always hold for tree-bank models, and that optimizing weak metrics is not interesting for semantic processing. Subsequently, we state an alternative proposition: the optimal algorithm must maximize the metric that scores parse-trees according to linguistically relevant features. We present new algorithms that optimize metrics that take into account increasingly more linguistic features, and exhibit experiments in support of our claim.</abstract>
+    <pages>183–194</pages>
     <url>https://www.aclweb.org/anthology/W03-3021</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3021</bibkey>
@@ -5895,6 +5907,7 @@
     <year>2003</year>
     <address>Nancy, France</address>
     <abstract>In this paper, we propose a method for analyzing word-word dependencies using deterministic bottom-up manner using Support Vector machines. We experimented with dependency trees converted from Penn treebank data, and achieved over 90% accuracy of word-word dependency. Though the result is little worse than the most up-to-date phrase structure based parsers, it looks satisfactorily accurate considering that our parser uses no information from phrase structures.</abstract>
+    <pages>195–206</pages>
     <url>https://www.aclweb.org/anthology/W03-3023</url>
     <bibtype>inproceedings</bibtype>
     <bibkey>W03-3023</bibkey>


### PR DESCRIPTION
Provides abstracts for all available IWPT 2003 papers.
Page numbers where extracted from citations of the papers if available.
Spelling and ordering of the authors was adjusted according to the first page of the pdf files.
