### PR TITLE
W01-18XX: ingestion of IWPT 2001 (see #286)

### DIFF
--- a/data/xml/W01.xml
+++ b/data/xml/W01.xml
@@ -1520,5 +1520,434 @@
     <bibtype>inproceedings</bibtype>
     <bibkey>wilcock:2001:NODALIDA</bibkey>
   </paper>
+  
+  <paper id="1800">
+    <title>Proceedings of the Seventh International Workshop on Parsing Technologies</title>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1800</url>
+    <bibtype>book</bibtype>
+    <pages>i–xii</pages>
+  </paper>
 
+  <paper id="1801">
+    <title>Issues in Extracting Information from the Web</title>
+    <author><first>William W.</first><last>Cohen</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1801</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>3</pages>
+  </paper>
+  
+  <paper id="1802">
+    <title>Parameter Estimation for Statistical Parsing Models: Theory and Practice of</title>
+    <author><first>Michael</first><last>Collins</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1802</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>4–15</pages>
+  </paper>
+  
+  <paper id="1803">
+    <title>The <fixed-case>XTAG</fixed-case> Project at <fixed-case>P</fixed-case>enn</title>
+    <author><first>Aravind K.</first><last>Joshi</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1803</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>16–27</pages>
+  </paper>
+  
+  <paper id="1804">
+    <title>Probabilistic Modelling of Island-Driven Parsing</title>
+    <author><first>Alicia</first><last>Ageno</last></author>
+    <author><first>Horacio</first><last>Rodríguez</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1804</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>31–41</pages>
+  </paper>
+  
+  <paper id="1805">
+    <title>Bidirectional Automata for Tree Adjoining Grammars</title>
+    <author><first>Miguel A.</first><last>Alonso</last></author>
+    <author><first>Víctor J.</first><last>Díaz</last></author>
+    <author><first>Manuel</first><last>Vilares</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1805</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>42–53</pages>
+  </paper>
+
+  <paper id="1806">
+    <title>Bidirectional Ascendant Parsing for Natural Language Processing</title>
+    <author><first>Ştefan</first><last>Andrei</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1806</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>54–65</pages>
+  </paper>
+
+  <paper id="1807">
+    <title>On the Complexity of Some Extensions of <fixed-case>RCG</fixed-case> Parsing</title>
+    <author><first>Eberhard</first><last>Bertsch</last></author>
+    <author><first>Mark-Jan</first><last>Nederhof</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1807</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>66–77</pages>
+  </paper>
+
+  <paper id="1808">
+    <title>High Precision Extraction of Grammatical Relations</title>
+    <author><first>John</first><last>Carrol</last></author>
+    <author><first>Ted</first><last>Briscoe</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1808</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>78–89</pages>
+  </paper>
+
+  <paper id="1809">
+    <title>On Compilation of the Quick-Check Filter for Feature Structure Unification</title>
+    <author><first>Liviu</first><last>Ciortuz</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1809</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>90–100</pages>
+  </paper>
+
+  <paper id="1810">
+    <title>Generalized <tex-math>\varepsilon</tex-math>-Skip Discriminating-Reverse Parsing on Graph-Structured Stack</title>
+    <author><first>José</first><last>Fortes Gálvez</last></author> 
+    <author><first>Jacques</first><last>Farré</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1810</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>101–111</pages>
+  </paper>
+
+  <paper id="1811">
+    <title>Grammar Induction by <fixed-case>MDL</fixed-case>-Based Distributional Classification</title>
+    <author><first>Yikun</first><last>Guo</last></author>
+    <author><first>Fuliang</first><last>Weng</last></author>
+    <author><first>Lide</first><last>Wu</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1811</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>112–122</pages>
+  </paper>
+
+  <paper id="1812">
+    <title>Parsing and Hypergraphs</title>
+    <author><first>Dan</first><last>Klein</last></author>
+    <author><first>Christopher D.</first><last>Manning</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1812</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>123–134</pages>
+  </paper>
+
+  <paper id="1813">
+    <title>Automatic Detection of Prosody Phrase Boundaries for Text-to-Speech System</title>
+    <author><first>Xin</first><last>Lv</last></author>
+    <author><first>Tie-jun</first><last>Zhao</last></author>
+    <author><first>Zhan-yi</first><last>Liu</last></author>
+    <author><first>Mu-yun</first><last>Yang</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1813</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>135–141</pages>
+  </paper>
+
+  <paper id="1814">
+    <title>A Minimalist Implementation of Verb Subcategorization</title>
+    <author><first>Sourabh</first><last>Niyogi</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1814</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>142–153</pages>
+  </paper>
+
+  <paper id="1815">
+    <title>Unsupervised <fixed-case>POS</fixed-case>-Tagging Improves Parsing Accuracy and Parsing Efficiency</title>
+    <author><first>Robbert</first><last>Prins</last></author>
+    <author><first>Gertjan</first><last>van Noord</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1815</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>154–165</pages>
+  </paper>
+  
+  <paper id="1816">
+    <title>Parsing the <fixed-case>CHILDES</fixed-case> Database: Methodology and Lessons Learned</title>
+    <author><first>Kenji</first><last>Sagae</last></author>
+    <author><first>Alon</first><last>Lavie</last></author>
+    <author><first>Brian</first><last>MacWhinney</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1816</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>166–176</pages>
+  </paper>
+
+  <paper id="1817">
+    <title>Robust Data Oriented Parsing of Speech Utterances</title>
+    <author><first>Khalil</first><last>Sima’an</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1817</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>177–188</pages>
+  </paper>
+
+  <paper id="1818">
+    <title>A Novel Probabilistic Model for Link Unification Grammar</title>
+    <author><first>Fuliang</first><last>Weng</last></author>
+    <author><first>Naiyong</first><last>Jin</last></author>
+    <author><first>Jie</first><last>Meng</last></author>
+    <author><first>Yujia</first><last>Zhu</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1818</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>189–198</pages>
+  </paper>
+
+  <paper id="1819">
+    <title>A Multi-Input Dependency Parser</title>
+    <author><first>Salah</first><last>Aït-Mokhtar</last></author>
+    <author><first>Jean-Pierre</first><last>Chanod</last></author>
+    <author><first>Claude</first><last>Roux</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1819</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>201–204</pages>
+  </paper>
+  
+  <paper id="1820">
+    <title>Property Grammars: A Flexible Constraint-Based Approach to Parsing</title>
+    <author><first>Philippe</first><last>Blache</last></author>
+    <author><first>Jean-Marie</first><last>Balfourier</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1820</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>205-208</pages>
+  </paper>
+
+  <paper id="1821">
+    <title>On Specialised Compilation of Rules in Unification Grammars</title>
+    <author><first>Liviu</first><last>Ciortuz</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1821</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>209–212</pages>
+  </paper>
+
+  <paper id="1822">
+    <title>An Approach to Parsing <fixed-case>V</fixed-case>ietnamese Noun Compounds</title>
+    <author><first>Dinh</first><last>Dien</last></author>
+    <author><first>Hoang</first><last>Kiem</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1822</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>213–216</pages>
+  </paper>
+
+  <paper id="1823">
+    <title>The Implementation Process of a Statistical Parser for <fixed-case>B</fixed-case>razilian <fixed-case>P</fixed-case>ortuguese</title>
+    <author><first>Andréia</first><last>Gentil Bonfante</last></author>
+    <author><first>Maria</first><last>das Graças Volpe Nunes</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1823</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>217–220</pages>
+  </paper>
+
+  <paper id="1824">
+    <title>Efficient Sentence Parsing with Language Specific Features: A Case Study of <fixed-case>C</fixed-case>zech</title>
+    <author><first>Aleš</first><last>Horák</last></author>
+    <author><first>Pavel</first><last>Smrž</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1824</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>221–224</pages>
+  </paper>
+
+  <paper id="1825">
+    <title>Efficient Incremental Dependency Parsing</title>
+    <author><first>Yoshihide</first><last>Kato</last></author>
+    <author><first>Shigeki</first><last>Matsubara</last></author>
+    <author><first>Katsuhiko</first><last>Toyama</last></author>
+    <author><first>Yasuyoshi</first><last>Inagaki</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1825</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>225–228</pages>
+  </paper>
+
+  <paper id="1826">
+    <title>Automatic Grammar Partitioning for Syntactic Parsing</title>
+    <author><first>Po Chui</first><last>Luk</last></author>
+    <author><first>Fuliang</first><last>Weng</last></author>
+    <author><first>Helen</first><last>Meng</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1826</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>229–232</pages>
+  </paper>
+
+  <paper id="1827">
+    <title>Direct Bottom-Up Chart Parsing Using Abbreviated Context-Free Grammars</title>
+    <author><first>Guido</first><last>Minnen</last></author>
+    <author><first>William</first><last>Thompson</last></author>
+    <author><first>Harry</first><last>Bliss</last></author>
+    <author><first>Dale</first><last>Russell</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1827</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>233–236</pages>
+  </paper>
+  
+  <paper id="1828">
+    <title>Word-Order Relaxations &amp; Restrictions within a Dependency Grammar</title>
+    <author><first>Martin</first><last>Plátek</last></author>
+    <author><first>Tomáš</first><last>Holan</last></author>
+    <author><first>Vladislav</first><last>Kuboň</last></author>
+    <author><first>Karel</first><last>Oliva</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1828</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>237–240</pages>
+  </paper>
+  
+  <paper id="1829">
+    <title>Inside-Outside Estimation Meets Dynamic <fixed-case>EM</fixed-case></title>
+    <author><first>Detlef</first><last>Prescher</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1829</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>241–244</pages>
+  </paper>
+  
+  <paper id="1830">
+    <title>Knowledge Acquisition from a Text by a Linguistic and Statistical Method</title>
+    <author><first>Jean-David</first><last>Sta</last></author>
+    <author><first>Yun-Chuang</first><last>Chiao</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1830</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>245–248</pages>
+  </paper>
+  
+  <paper id="1831">
+    <title>Buffered Shift-Reduce Parsing</title>
+    <author><first>Bing</first><last>Swen</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1831</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>249–252</pages>
+  </paper>
+  
+  <paper id="1832">
+    <title>How Much Will a <fixed-case>RE</fixed-case>-Based Preprocessor Help a Statistical Parser?</title>
+    <author><first>Daniel</first><last>Zeman</last></author>
+    <booktitle>Proceedings of the Seventh International Workshop on Parsing Technologies</booktitle>
+    <month>October</month>
+    <year>2001</year>
+    <address>Beijing, China</address>
+    <url>http://www.aclweb.org/anthology/W01-1832</url>
+    <bibtype>inproceedings</bibtype>
+    <pages>253–256</pages>
+  </paper>
 </volume>

--- a/data/yaml/sigs/sigparse.yaml
+++ b/data/yaml/sigs/sigparse.yaml
@@ -19,16 +19,15 @@ Meetings:
   - 2010:
     - W10-1400 # Statistical Parsing of Morpho Rich Languages
   - 2009:
-    - W09-3800 # IPWT 2009
+    - W09-3800 # IWPT 2009
   - 2007:
-    - W07-2200 # IPWT 2007
+    - W07-2200 # IWPT 2007
   - 2005:
-    - W05-1500 # IPWT 2005
+    - W05-1500 # IWPT 2005
   - 2003:
-    - W03-3000 # IPWT 2003
+    - W03-3000 # IWPT 2003
   - 2001:
-    - Name: 'IWPT 2001' # 17-19 October 2001 - Beijing (China)
-      URL: http://www.icl.pku.edu.cn/iwpt2001
+    - W01-1800 # IWPT 2001
   - 2000:
     - Name: 'IWPT 2000' # 23-25 February 2000- Trento (Italy)
       URL: http://tcc.itc.it/events/iwpt2000.html


### PR DESCRIPTION
I prepared IWPT2001 for ingestion. An archive with the pdfs is at
http://blog.gebhardt.xyz/assets/IWPT2001-anthology.zip

`W01-1800.pdf` currently only contains the front matter. The indiviual papers do not have an imprint. 

If someone gives me a pointer where this functionality is hidden in aclpub I may compile a single pdf (including the author index) and pdfs with imprint as well.