### PR TITLE
fixed warning: Page's .Hugo is deprecated and will be removed in a fu…

### DIFF
--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -13,7 +13,7 @@
     {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
     <title>{{ block "title" . }}{{ with .Params.Title }}{{ . }} - {{ end }}{{ .Site.Title }}{{ end }}</title>
 
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     <link href="{{ "aclicon.ico" | relURL }}" rel="shortcut icon" type="image/x-icon" />
 
     {{ $sass_options := (dict "includePaths" (slice "assets/css" "assets/css/vendor/bootstrap/scss")) }}


### PR DESCRIPTION
fixed warning: 

```Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.```

occurred with hugo version:

`Hugo Static Site Generator v0.55.3/extended linux/amd64 BuildDate: unknown`
