### PR TITLE
Display author comments and similar names

### DIFF
--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -49,6 +49,7 @@ class AnthologyIndex:
         self.id_to_used = defaultdict(set)  # maps ids to all names actually used
         self.name_to_ids = defaultdict(list)  # maps canonical/variant names to ids
         self.coauthors = defaultdict(Counter)  # maps ids to co-author ids
+        self.comments = {}  # maps ids to comments (used for distinguishing authors with same name)
         self.id_to_papers = defaultdict(lambda: defaultdict(list))  # id -> role -> papers
         self.name_to_papers = defaultdict(lambda: defaultdict(list))  # name -> (explicit id?) -> papers; used only for error checking
         if srcdir is not None:
@@ -94,6 +95,8 @@ class AnthologyIndex:
                         )
                         continue
                     self.add_variant_name(id_, variant)
+                if "comment" in entry:
+                    self.comments[id_] = entry["comment"]
 
     def _is_stopword(self, word, paper):
         """Determines if a given word should be considered a stopword for

--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -50,6 +50,7 @@ class AnthologyIndex:
         self.name_to_ids = defaultdict(list)  # maps canonical/variant names to ids
         self.coauthors = defaultdict(Counter)  # maps ids to co-author ids
         self.comments = {}  # maps ids to comments (used for distinguishing authors with same name)
+        self.similar = defaultdict(set)
         self.id_to_papers = defaultdict(lambda: defaultdict(list))  # id -> role -> papers
         self.name_to_papers = defaultdict(lambda: defaultdict(list))  # name -> (explicit id?) -> papers; used only for error checking
         if srcdir is not None:
@@ -66,6 +67,13 @@ class AnthologyIndex:
                     canonical = entry["canonical"]
                     canonical = PersonName.from_dict(canonical)
                     self.set_canonical_name(id_, canonical)
+            # Automatically add people with same canonical name to similar list
+            for name, ids in self.name_to_ids.items():
+                if len(ids) > 1:
+                    for id1 in ids:
+                        for id2 in ids:
+                            if id2 != id1:
+                                self.similar[id1].add(id2)
             for entry in name_list:
                 try:
                     canonical = entry["canonical"]
@@ -97,6 +105,8 @@ class AnthologyIndex:
                     self.add_variant_name(id_, variant)
                 if "comment" in entry:
                     self.comments[id_] = entry["comment"]
+                if "similar" in entry:
+                    self.similar[id_].update(entry["similar"])
 
     def _is_stopword(self, word, paper):
         """Determines if a given word should be considered a stopword for

--- a/bin/create_hugo_yaml.py
+++ b/bin/create_hugo_yaml.py
@@ -76,6 +76,8 @@ def export_anthology(anthology, outdir, clean=False, dryrun=False):
         log.debug("export_anthology: processing person '{}'".format(repr(name)))
         data = name.as_dict()
         data["slug"] = id_
+        if id_ in anthology.people.comments:
+            data["comment"] = anthology.people.comments[id_]
         data["papers"] = sorted(
             anthology.people.get_papers(id_),
             key=lambda p: anthology.papers.get(p).get("year"),

--- a/bin/create_hugo_yaml.py
+++ b/bin/create_hugo_yaml.py
@@ -78,6 +78,8 @@ def export_anthology(anthology, outdir, clean=False, dryrun=False):
         data["slug"] = id_
         if id_ in anthology.people.comments:
             data["comment"] = anthology.people.comments[id_]
+        if id_ in anthology.people.similar:
+            data["similar"] = sorted(anthology.people.similar[id_])
         data["papers"] = sorted(
             anthology.people.get_papers(id_),
             key=lambda p: anthology.papers.get(p).get("year"),

--- a/data/xml/L02.xml
+++ b/data/xml/L02.xml
@@ -2695,7 +2695,7 @@
   </paper>
   <paper id="1223" href="http://www.lrec-conf.org/proceedings/lrec2002/pdf/223.pdf">
     <author id="peter-wittenburg"><first>P.</first><last>Wittenburg</last></author>
-    <author id="stephen-levinson"><first>St.</first><last>Levinson</last></author>
+    <author id="stephen-c-levinson"><first>St.</first><last>Levinson</last></author>
     <author id="sotaro-kita"><first>S.</first><last>Kita</last></author>
     <author id="hennie-brugman"><first>H.</first><last>Brugman</last></author>
     <title>Multimodal Annotations in Gesture and Sign Language Studies</title>

--- a/data/xml/P05.xml
+++ b/data/xml/P05.xml
@@ -1892,7 +1892,7 @@
         <author><first>Robert</first><last>Knippen</last></author>
         <author><first>Seok B.</first><last>Jang</last></author>
         <author><first>Anna</first><last>Rumshisky</last></author>
-        <author><first>John</first><last>Phillips</last></author>
+        <author id="jon-phillips"><first>John</first><last>Phillips</last></author>
         <author><first>James</first><last>Pustejovsky</last></author>
         <booktitle>Proceedings of the <fixed-case>ACL</fixed-case> Interactive Poster and Demonstration Sessions</booktitle>
         <month>June</month>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -163,10 +163,15 @@
 - canonical: {first: Zoltán, last: Alexin}
   id: zoltan-alexin
 - canonical: {first: James, last: Allan}
+  comment: UMass Amherst
   id: james-allan
+  similar: [james-allen]
 - canonical: {first: James, last: Allen}
+  id: james-allen
+  comment: Rochester
   variants:
   - {first: James F., last: Allen}
+  similar: [james-allan]
 - canonical: {first: Jonathan, last: Allen}
   variants:
   - {first: Jonathan, last: All}
@@ -284,9 +289,11 @@
 - canonical: {first: Alexandre, last: Andreewsky}
   id: alexandre-andreewsky
   comment: LIMSI
+  similar: [alexander-andreyewsky]
 - canonical: {first: Alexander, last: Andreyewsky}
   id: alexander-andreyewsky
   comment: IBM
+  similar: [alexandre-andreewsky]
 - canonical: {first: Antonella De, last: Angeli}
   variants:
   - {first: Antonella, last: DeAngeli}
@@ -685,6 +692,12 @@
   - {first: Jose Miguel, last: Benedi Ruiz}
   - {first: José Miguel, last: Benedí Ruíz}
   - {first: José-M., last: Benedí}
+- canonical: {first: Andrew, last: Bennett}
+  id: andrew-bennett
+  similar: andrew-bennetts
+- canonical: {first: Andrew, last: Bennetts}
+  id: andrew-bennetts
+  similar: andrew-bennett
 - canonical: {first: Paul, last: Bennett}
   variants:
   - {first: Paul N., last: Bennett}
@@ -745,9 +758,16 @@
 - canonical: {first: Irshad, last: Bhat}
   variants:
   - {first: Irshad A., last: Bhat}
+- canonical: {first: Rajesh, last: Bhat}
+  id: rajesh-bhat
+  similar: rajesh-bhatt
 - canonical: {first: Riyaz Ahmad, last: Bhat}
   variants:
   - {first: Riyaz A., last: Bhat}
+- canonical: {first: Rajesh, last: Bhatt}
+  id: rajesh-bhatt
+  comment: UMass Amherst
+  similar: rajesh-bhat
 - canonical: {first: Virendrakumar, last: Bhavsar}
   variants:
   - {first: Virendra, last: Bhavsar}
@@ -940,6 +960,12 @@
   id: helene-bonneau-maynard
   variants:
   - {first: Hélène, last: Maynard}
+- canonical: {first: Kalina, last: Bontcheva}
+  id: kalina-bontcheva
+  similar: [katina-bontcheva]
+- canonical: {first: Katina, last: Bontcheva}
+  id: katina-bontcheva
+  similar: [kalina-bontcheva]
 - canonical: {first: German, last: Bordel}
   id: german-bordel
   variants:
@@ -1137,9 +1163,11 @@
 - canonical: {first: John D., last: Burger}
   comment: MITRE
   id: john-d-burger
+  similar: [john-f-burger]
 - canonical: {first: John F., last: Burger}
   comment: System Development Corporation
   id: john-f-burger
+  similar: [john-d-burger]
 - canonical: {first: Christopher J.C., last: Burges}
   variants:
   - {first: Chris J.C., last: Burges}
@@ -1299,12 +1327,16 @@
   - {first: SANDRA, last: CARBERRY}
   - {first: M. Sandra, last: Carberry}
 - canonical: {first: Jaime G., last: Carbonell}
+  id: jaime-g-carbonell
   comment: CMU
   variants:
   - {first: Jaime, last: Carbonell}
   - {first: Jaime G., last: Carbonell Jr}
+  similar: [jaime-r-carbonell]
 - canonical: {first: Jaime R., last: Carbonell}
+  id: jaime-r-carbonell
   comment: BBN; d. 1973
+  similar: [jaime-g-carbonell]
 - canonical: {first: Antonio, last: Cardenal}
   variants:
   - {first: Antonio, last: Cardenal-Lopez}
@@ -1339,11 +1371,15 @@
   variants:
   - {first: Jeremy, last: Carroll}
 - canonical: {first: John A., last: Carroll}
+  id: john-a-carroll
   comment: Cambridge, Sussex
   variants:
   - {first: John, last: CARROLL}
   - {first: John, last: Carroll}
+  similar: [john-b-carroll]
 - canonical: {first: John B., last: Carroll}
+  id: john-b-carroll
+  similar: [john-a-carroll]
   comment: UNC
 - canonical: {first: Julie, last: Carson-Berndsen}
   variants:
@@ -6013,12 +6049,14 @@
 - canonical: {first: Lori, last: Levin}
   variants:
   - {first: Lori S., last: Levin}
-- canonical: {first: Stephen, last: Levinson}
+- canonical: {first: Stephen C., last: Levinson}
   comment: Max-Planck-Institute for Psycholinguistics
-  id: stephen-levinson
+  id: stephen-c-levinson
+  similar: [stephen-e-levinson]
 - canonical: {first: Stephen E., last: Levinson}
   comment: Bell Labs
   id: stephen-e-levinson
+  similar: [stephen-c-levinson]
 - canonical: {first: Gina-Anne, last: Levow}
   variants:
   - {first: Gina, last: Levow}
@@ -6935,8 +6973,11 @@
   id: david-d-mcdonald
   variants:
   - {first: David D., last: MCDONALD}
+  similar: [david-w-mcdonald]
 - canonical: {first: David W., last: McDonald}
+  id: david-w-mcdonald
   comment: Univ. of Washington
+  similar: [david-d-mcdonald]
 - canonical: {first: Joyce, last: McDowell}
   id: joyce-mcdowell
 - canonical: {first: Tony, last: McEnery}
@@ -7032,9 +7073,11 @@
   id: robert-e-mercer
   variants:
   - {first: Robert E., last: MERCER}
+  similar: [robert-l-mercer]
 - canonical: {first: Robert L., last: Mercer}
   comment: IBM
   id: robert-l-mercer
+  similar: [robert-e-mercer]
 - canonical: {first: Roberta H., last: Merchant}
   variants:
   - {first: Roberta, last: Merchant}
@@ -7337,14 +7380,17 @@
   id: antonio-moreno-ortiz
   variants:
   - {first: Antonio, last: Moreno Ortiz}
+  similar: [antonio-moreno-ribas, antonio-moreon-sandoval]
 - canonical: {first: Antonio, last: Moreno Ribas}
   comment: Univ. Rovira i Virgili
   id: antonio-moreno-ribas
+  similar: [antonio-moreno-ortiz, antonio-moreon-sandoval]
 - canonical: {first: Antonio, last: Moreno-Sandoval}
   comment: NYU, Univ. Autónoma de Madrid
   id: antonio-moreno-sandoval
   variants:
   - {first: Antonio Moreno, last: Sandoval}
+  similar: [antonio-moreno-ortiz, antonio-moreno-ribas]
 - canonical: {first: Elliott, last: Moreton}
   variants:
   - {first: Elliot, last: Moreton}
@@ -7685,10 +7731,8 @@
   variants:
   - {first: Huy-Tien, last: Nguyen}
 - canonical: {first: Long, last: Nguyen}
-  comment: BBN
   id: long-nguyen
 - canonical: {first: Minh Le, last: Nguyen}
-  comment: JAIST
   id: minh-le-nguyen
   variants:
   - {first: Minh-Le, last: Nguyen}
@@ -8337,6 +8381,14 @@
 - canonical: {first: Tuoi Thi, last: Phan}
   variants:
   - {first: Tuoi, last: T. Phan}
+- canonical: {first: John, last: Phillips}
+  id: john-phillips
+  comment: Univ. of Manchester
+  similar: jon-phillips
+- canonical: {first: Jon, last: Phillips}
+  id: jon-phillips
+  comment: Georgetown, MITRE
+  similar: john-phillips
 - canonical: {first: Michael, last: Phillips}
   id: michael-phillips
 - canonical: {first: Robert, last: Phillips}
@@ -9031,8 +9083,12 @@
   - {first: Raphaël, last: Rubino}
 - canonical: {first: Antonio J., last: Rubio}
   id: antonio-j-rubio
+- canonical: {first: Alex, last: Rudnick}
+  id: alex-rudnick
+  similar: alexander-rudnicky
 - canonical: {first: Alexander, last: Rudnicky}
   id: alexander-rudnicky
+  similar: alex-rudnick
   variants:
   - {first: Alexander I., last: Rudnicky}
   - {first: Alex, last: Rudnicky}

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -694,10 +694,10 @@
   - {first: José-M., last: Benedí}
 - canonical: {first: Andrew, last: Bennett}
   id: andrew-bennett
-  similar: andrew-bennetts
+  similar: [andrew-bennetts]
 - canonical: {first: Andrew, last: Bennetts}
   id: andrew-bennetts
-  similar: andrew-bennett
+  similar: [andrew-bennett]
 - canonical: {first: Paul, last: Bennett}
   variants:
   - {first: Paul N., last: Bennett}
@@ -760,14 +760,14 @@
   - {first: Irshad A., last: Bhat}
 - canonical: {first: Rajesh, last: Bhat}
   id: rajesh-bhat
-  similar: rajesh-bhatt
+  similar: [rajesh-bhatt]
 - canonical: {first: Riyaz Ahmad, last: Bhat}
   variants:
   - {first: Riyaz A., last: Bhat}
 - canonical: {first: Rajesh, last: Bhatt}
   id: rajesh-bhatt
   comment: UMass Amherst
-  similar: rajesh-bhat
+  similar: [rajesh-bhat]
 - canonical: {first: Virendrakumar, last: Bhavsar}
   variants:
   - {first: Virendra, last: Bhavsar}
@@ -7069,7 +7069,6 @@
   - {first: Helen M., last: Meng}
 - canonical: {first: Robert E., last: Mercer}
   comment: Univ. of Western Ontario
-    Robert Mercer
   id: robert-e-mercer
   variants:
   - {first: Robert E., last: MERCER}
@@ -7380,11 +7379,11 @@
   id: antonio-moreno-ortiz
   variants:
   - {first: Antonio, last: Moreno Ortiz}
-  similar: [antonio-moreno-ribas, antonio-moreon-sandoval]
+  similar: [antonio-moreno-ribas, antonio-moreno-sandoval]
 - canonical: {first: Antonio, last: Moreno Ribas}
   comment: Univ. Rovira i Virgili
   id: antonio-moreno-ribas
-  similar: [antonio-moreno-ortiz, antonio-moreon-sandoval]
+  similar: [antonio-moreno-ortiz, antonio-moreno-sandoval]
 - canonical: {first: Antonio, last: Moreno-Sandoval}
   comment: NYU, Univ. Autónoma de Madrid
   id: antonio-moreno-sandoval
@@ -8384,11 +8383,11 @@
 - canonical: {first: John, last: Phillips}
   id: john-phillips
   comment: Univ. of Manchester
-  similar: jon-phillips
+  similar: [jon-phillips]
 - canonical: {first: Jon, last: Phillips}
   id: jon-phillips
   comment: Georgetown, MITRE
-  similar: john-phillips
+  similar: [john-phillips]
 - canonical: {first: Michael, last: Phillips}
   id: michael-phillips
 - canonical: {first: Robert, last: Phillips}
@@ -9085,10 +9084,10 @@
   id: antonio-j-rubio
 - canonical: {first: Alex, last: Rudnick}
   id: alex-rudnick
-  similar: alexander-rudnicky
+  similar: [alexander-rudnicky]
 - canonical: {first: Alexander, last: Rudnicky}
   id: alexander-rudnicky
-  similar: alex-rudnick
+  similar: [alex-rudnick]
   variants:
   - {first: Alexander I., last: Rudnicky}
   - {first: Alex, last: Rudnicky}

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -283,6 +283,7 @@
   - {first: Elisabeth, last: André}
 - canonical: {first: Alexandre, last: Andreewsky}
   id: alexandre-andreewsky
+  comment: LIMSI
 - canonical: {first: Alexander, last: Andreyewsky}
   id: alexander-andreyewsky
   comment: IBM
@@ -1298,10 +1299,12 @@
   - {first: SANDRA, last: CARBERRY}
   - {first: M. Sandra, last: Carberry}
 - canonical: {first: Jaime G., last: Carbonell}
-  comment: Different from Jaime R. Carbonell
+  comment: CMU
   variants:
   - {first: Jaime, last: Carbonell}
   - {first: Jaime G., last: Carbonell Jr}
+- canonical: {first: Jaime R., last: Carbonell}
+  comment: BBN; d. 1973
 - canonical: {first: Antonio, last: Cardenal}
   variants:
   - {first: Antonio, last: Cardenal-Lopez}
@@ -1340,6 +1343,8 @@
   variants:
   - {first: John, last: CARROLL}
   - {first: John, last: Carroll}
+- canonical: {first: John B., last: Carroll}
+  comment: UNC
 - canonical: {first: Julie, last: Carson-Berndsen}
   variants:
   - {first: Julie, last: CARSON}
@@ -6237,7 +6242,7 @@
   comment: "刘洋; ICT, Tsinghua"
   id: yang-liu-ict
 - canonical: {first: Yang, last: Liu}
-  comment: "Not yet disambiguated"
+  comment: "May refer to several people"
   id: yang-liu
 - canonical: {first: Andrej, last: Ljolje}
   id: andrej-ljolje
@@ -7022,7 +7027,7 @@
   variants:
   - {first: Helen M., last: Meng}
 - canonical: {first: Robert E., last: Mercer}
-  comment: Western Ontario
+  comment: Univ. of Western Ontario
     Robert Mercer
   id: robert-e-mercer
   variants:
@@ -7328,16 +7333,15 @@
   - {first: Julian, last: Moreno-Schneider}
   - {first: Julián, last: Moreno-Schneider}
 - canonical: {first: Antonio, last: Moreno-Ortiz}
-  comment: University of Málaga
-    with another Antonio Moreno
+  comment: Univ. of Málaga
   id: antonio-moreno-ortiz
   variants:
   - {first: Antonio, last: Moreno Ortiz}
 - canonical: {first: Antonio, last: Moreno Ribas}
-  comment: Universitat Rovira i Virgili
+  comment: Univ. Rovira i Virgili
   id: antonio-moreno-ribas
 - canonical: {first: Antonio, last: Moreno-Sandoval}
-  comment: NYU, Universidad Autónoma de Madrid
+  comment: NYU, Univ. Autónoma de Madrid
   id: antonio-moreno-sandoval
   variants:
   - {first: Antonio Moreno, last: Sandoval}
@@ -7706,7 +7710,6 @@
   variants:
   - {first: Thuy Linh, last: Nguyen}
 - canonical: {first: Toan Q., last: Nguyen}
-  comment: Notre Dame
   variants:
   - {first: Toan, last: Nguyen}
 - canonical: {first: Tri-Thanh, last: Nguyen}

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -18,6 +18,15 @@
     {{ end }}
   </p>
   {{ end }}
+  {{ with $person.similar }}
+  <p class="font-weight-light text-muted">
+    <span class="font-italic">Other people with similar names:</span>
+    {{ $len := (len .) }}
+    {{ range $index, $sim_id := . }}
+    {{ trim (partial "author_link.html" (dict "ctx" $ "person" (dict "id" $sim_id))) " \n" | safeHTML }}{{ if ne (add $index 1) $len }}, {{ end }}
+    {{ end }}
+  </p>
+  {{ end }}
   <hr />
 
   <div class="row">

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -23,7 +23,8 @@
     <span class="font-italic">Other people with similar names:</span>
     {{ $len := (len .) }}
     {{ range $index, $sim_id := . }}
-    {{ trim (partial "author_link.html" (dict "ctx" $ "person" (dict "id" $sim_id))) " \n" | safeHTML }}{{ if ne (add $index 1) $len }}, {{ end }}
+    {{ trim (partial "author_link.html" (dict "ctx" $ "person" (dict "id" $sim_id))) " \n" | safeHTML }}
+    {{ $sim_person := index $.Site.Data.people (slicestr $sim_id 0 1) $sim_id }}{{ with $sim_person.comment }}({{.}}){{ end }}{{ if ne (add $index 1) $len }}, {{ end }}
     {{ end }}
   </p>
   {{ end }}

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -6,6 +6,9 @@
     <!-- {{- .Title -}} -->
     <span class="font-weight-normal">{{ $person.first }}</span> <span class="font-weight-bold">{{ $person.last }}</span>
   </h2>
+  {{ with $person.comment }}
+  <p class="font-weight-light text-muted">{{.}}</p>
+  {{ end }}
   {{ with $person.variant_entries }}
   <p class="font-weight-light text-muted">
     <span class="font-italic">Published also as:</span>


### PR DESCRIPTION
The typical form of the comment is semicolon separated values, all optional:
- Name in another script (so far only Chinese)
- Affiliations, separated by commas
- `d. 1973` (for `anthology/people/j/jaime-r-carbonell/`, to make it really clear that it's not CMU Jaime, because they were both at BBN at one point).

For an author name which is known to be ambiguous (e.g., `anthology/people/y/yang-liu`), the comment is "May refer to several people". Changes in wording welcome.
