### PR TITLE
name variant {James,Jim} Rogers

### DIFF
--- a/data/xml/W13.xml
+++ b/data/xml/W13.xml
@@ -7985,7 +7985,7 @@
    <paper id="3007">
         <title>Learning Subregular Classes of Languages with Factored Deterministic Automata</title>
         <author><first>Jeffrey</first><last>Heinz</last></author>
-        <author><first>Jim</first><last>Rogers</last></author>
+        <author><first>James</first><last>Rogers</last></author>
         <booktitle>Proceedings of the 13th Meeting on the Mathematics of Language (<fixed-case>M</fixed-case>o<fixed-case>L</fixed-case> 13)</booktitle>
         <month>August</month>
         <year>2013</year>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -8957,6 +8957,9 @@
 - canonical: {first: Ina, last: Roesiger}
   variants:
   - {first: Ina, last: Rösiger}
+- canonical: {first: James, last: Rogers}
+  variants:
+  - {first: Jim, last: Rogers}
 - canonical: {first: U., last: Rohini}
   variants:
   - {first: Rohini, last: U}


### PR DESCRIPTION
In fact, the only occurrence of "Jim Rogers" in the anthology (`W13-3007`) is only in the BibTex (the paper says James). However, he published as "Jim Rogers" elsewhere, e.g.: https://link.springer.com/article/10.1007/s10849-011-9134-0
