### PR TITLE
Add banner class to fix spacing in topmost banner

### DIFF
--- a/hugo/assets/css/main.scss
+++ b/hugo/assets/css/main.scss
@@ -91,3 +91,8 @@ ul ul, ul ol, ol ul, ol ol {
     text-transform: unset !important;
   }
 }
+
+/* Fix spacing issues with warning banner on the top of each page.*/
+.banner {
+  padding-top: 15px;
+}

--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -28,7 +28,7 @@
     {{ block "header" . }}{{ partialCached "header_navbar.html" .}}{{ end }}
 
     <!-- Draft alert -->
-    <div class="container">
+    <div class="container banner">
       <aside class="alert alert-warning text-center py-1 mt-n3 mt-md-n4 mt-xl-n5" role="alert">
         You're viewing the latest version of the ACL Anthology.
         <a class="btn btn-warning mx-2" href="https://github.com/acl-org/acl-anthology/issues/170">Give feedback</a>


### PR DESCRIPTION
Added a simple banner class to the main.scss file and appended that class to the warning banner that sits on the top of every page. This improves the visual spacing on each page of the anthology.