### PR TITLE
Add spacing to warning banner.

### DIFF
--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -28,7 +28,7 @@
     {{ block "header" . }}{{ partialCached "header_navbar.html" .}}{{ end }}
 
     <!-- Draft alert -->
-    <div class="container">
+    <div class="container pt-3">
       <aside class="alert alert-warning text-center py-1 mt-n3 mt-md-n4 mt-xl-n5" role="alert">
         You're viewing the latest version of the ACL Anthology.
         <a class="btn btn-warning mx-2" href="https://github.com/acl-org/acl-anthology/issues/170">Give feedback</a>


### PR DESCRIPTION
The yellow warning banner is always too close to the page. This will add a little space. This time, it uses bootstrap utilities without adding new classes.


