### PR TITLE
SIGFSM: link to FSMNLP 2017

### DIFF
--- a/data/yaml/sigs/sigfsm.yaml
+++ b/data/yaml/sigs/sigfsm.yaml
@@ -2,6 +2,8 @@ Name: Special Interest Group on Finite-State Methods (SIGFSM)
 ShortName: SIGFSM
 URL: https://kitwiki.csc.fi/twiki/bin/view/KitWiki/SIGFSM
 Meetings:
+  - 2017:
+    - W17-4000 # Proceedings of the 13th International Conference on Finite-State Methods and Natural Language Processing 2017
   - 2016:
     - W16-2400 # SIGFSM Workshop on Statistical NLP and Weighted Automata
     - W16-3300 # Proceedings of the 12th International Workshop on Tree Adjoining Grammars and Related Formalisms (TAG+12)


### PR DESCRIPTION
added missing link to FSMNLP 2017 on the page of SIGFSM