### PR TITLE
Make sure that wheels are installed

### DIFF
--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,3 +1,4 @@
+wheel>=0.33.4
 docopt>=0.6.0
 latexcodec>=1.0.7
 lxml>=4.2.0


### PR DESCRIPTION
This fixes an error when installing the dependencies
using pip3 install -r requirements.txt and not having
wheels installed system-wide.

Noticed it because the stop words package threw an error
not finding bdist_wheel.