### PR TITLE
new Makefile, copy static files from other directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,20 +17,12 @@ Icon
 # logfiles
 .philog.LOGFILE
 
+# backup files
+*~
+*#
+
 #######################################
 **/__pycache__
 
-# Hugo
-hugo/public
-hugo/content/papers/**/
-hugo/content/events/*.md
-hugo/content/people/**/
-hugo/content/sigs/*.md
-hugo/content/venues/*.md
-hugo/content/volumes/*.md
-!hugo/content/**/_index.md
-hugo/data/*.yaml
-hugo/data/papers/*.yaml
-hugo/data/people/*.yaml
-hugo/resources
-hugo/data-export
+# generated website
+/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
 script:
   - jing -c data/xml/schema.rnc data/xml/*.xml
   - jing data/xml/schema.rng data/xml/*.xml
-  - bin/build_hugo
+  - make

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Arne Köhn <arne@chark.eu>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL = /bin/sh
+ANTHOLOGYHOST := "https://aclweb.org"
+ANTHOLOGYDIR := anthology
+
+.PHONY: site
+site: static yaml hugo_pages bibtex mods endnote hugo
+
+.PHONY: all
+all: clean check site
+
+# copies all files that are not automatically generated
+# and creates empty directories as needed.
+.PHONY: static
+static:
+	mkdir -p build
+	cp -r hugo/* build
+	mkdir -p build/data-export
+	sed -i "s/ANTHOLOGYDIR/$(ANTHOLOGYDIR)/g" build/index.html
+
+.PHONY: yaml
+yaml:
+	python3 bin/create_hugo_yaml.py --clean
+
+.PHONY: hugo_pages
+hugo_pages:
+	python3 bin/create_hugo_pages.py --clean
+
+.PHONY: bibtex
+bibtex:
+	python3 bin/create_bibtex.py --clean
+
+.PHONY: mods
+mods:
+	@echo "INFO     Converting BibTeX files to MODS XML..."
+	if ! [ -x "`command -v tqdm`" ]; then \
+	  find build/data-export -name '*.bib' -print0 | \
+	      xargs -0 -n 1 -P 8 bin/bib2xml_wrapper >/dev/null; \
+	else \
+	  find build/data-export -name '*.bib' -print0 | \
+	      xargs -0 -n 1 -P 8 bin/bib2xml_wrapper | \
+	      tqdm --total `find build/data-export -name '*.bib' | wc -l` \
+               --unit files >/dev/null; \
+	fi
+
+.PHONY: endnote
+endnote:
+	@echo "INFO     Converting MODS XML files to EndNote..."
+	if ! [ -x "`command -v tqdm`" ]; then \
+	  find build/data-export -name '*.xml' -print0 | \
+	      xargs -0 -n 1 -P 8 bin/xml2end_wrapper >/dev/null; \
+	else \
+	  find build/data-export -name '*.xml' -print0 | \
+	      xargs -0 -n 1 -P 8 bin/xml2end_wrapper | \
+	      tqdm --total `find build/data-export -name '*.xml' | wc -l` \
+	           --unit files >/dev/null; \
+	fi
+
+.PHONY: hugo
+hugo:
+	@echo "INFO     Running Hugo... this may take a while."
+	cd build && \
+	    hugo -b $(ANTHOLOGYHOST)/$(ANTHOLOGYDIR) \
+	         -d $(ANTHOLOGYDIR) \
+	         --cleanDestinationDir \
+	         --minify
+
+.PHONY: clean
+clean:
+	rm -rf build
+
+.PHONY: check
+check:
+	jing -c data/xml/schema.rnc data/xml/*xml
+
+.PHONY: serve
+serve:
+	 cd build && python3 -m http.server 8000
+
+# this target does not use ANTHOLOGYDIR because the official website
+# only works if ANTHOLOGYDIR == anthology.
+.PHONY: upload
+upload:
+	rsync -azve ssh --delete build/anthology/ aclweb:anthology-static

--- a/README.md
+++ b/README.md
@@ -33,17 +33,14 @@ $ git clone https://github.com/acl-org/acl-anthology
 ### Generating
 
 Provided you have correctly installed all requirements, building the website
-should be as simple as calling the following command from the directory to which
-you cloned the repo:
+should be as simple running `make` from the directory to which
+you cloned the repo.
 
-```bash
-$ bin/build_hugo
-```
-
-The fully generated website will be in `hugo/public/` afterwards.  If any errors
+The fully generated website will be in `build/anthology` afterwards.  If any errors
 occur during this step, you can consult the [detailed
 README](README_detailed.md) for more information on the individual steps
-performed to build the site.
+performed to build the site.  You can see the resulting website by launching
+a local webserver with `make serve`, which will serve it at http://localhost:8000.
 
 Note that building the website is quite a resource-intensive process;
 particularly the last step, invoking Hugo, uses about 18~GB of system memory.

--- a/README_detailed.md
+++ b/README_detailed.md
@@ -8,7 +8,8 @@ seen on <https://aclweb.org/anthology/>.
 
 The Anthology website is generated using the [Hugo](https://gohugo.io) static
 site generator.  However, before we can actually invoke Hugo, we need to prepare
-the contents of the website.
+the contents of the website.  The following steps describe what happens
+behind the scenes.  All the steps have a corresponding `make` target as well.
 
 ### Step 1: Prepare the data for site generation
 

--- a/bin/bib2xml_wrapper
+++ b/bin/bib2xml_wrapper
@@ -14,5 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 bib2xml -nt $1 2>/dev/null > ${1%.bib}.xml
 echo 1

--- a/bin/create_bibtex.py
+++ b/bin/create_bibtex.py
@@ -21,7 +21,7 @@ Creates .bib files for all papers in the Hugo directory.
 
 Options:
   --importdir=DIR          Directory to import XML files from. [default: {scriptdir}/../data/]
-  --exportdir=DIR          Directory to write exported files to.   [default: {scriptdir}/../hugo/data-export/]
+  --exportdir=DIR          Directory to write exported files to.   [default: {scriptdir}/../build/data-export/]
   --debug                  Output debug-level log messages.
   -c, --clean              Delete existing files in target directory before generation.
   -h, --help               Display this helpful text.

--- a/bin/create_hugo_pages.py
+++ b/bin/create_hugo_pages.py
@@ -22,7 +22,7 @@ Creates page stubs for the full anthology based on the YAML data files.
 This script can only be run after create_hugo_yaml.py!
 
 Options:
-  --dir=DIR                Hugo project directory. [default: {scriptdir}/../hugo/]
+  --dir=DIR                Hugo project directory. [default: {scriptdir}/../build/]
   --debug                  Output debug-level log messages.
   -c, --clean              Delete existing files in target directory before generation.
   -h, --help               Display this helpful text.

--- a/bin/create_hugo_yaml.py
+++ b/bin/create_hugo_yaml.py
@@ -21,7 +21,7 @@ Creates YAML files containing all necessary Anthology data for the static websit
 
 Options:
   --importdir=DIR          Directory to import XML files from. [default: {scriptdir}/../data/]
-  --exportdir=DIR          Directory to write YAML files to.   [default: {scriptdir}/../hugo/data/]
+  --exportdir=DIR          Directory to write YAML files to.   [default: {scriptdir}/../build/data/]
   --debug                  Output debug-level log messages.
   -c, --clean              Delete existing files in target directory before generation.
   -n, --dry-run            Do not write YAML files (useful for debugging).

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -1,4 +1,3 @@
-baseURL = "http://aclweb.org/anthology/"
 languageCode = "en-us"
 title = "ACL Anthology"
 disablePathToLower = true

--- a/hugo/index.html
+++ b/hugo/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="0; url=http://localhost:8000/ANTHOLOGYDIR">
+        <script type="text/javascript">
+            window.location.href = "http://localhost:8000/ANTHOLOGYDIR"
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+        If you are not redirected automatically, follow this <a href='http://localhost:8000/ANTHOLOGYDIR'>link to the anthology</a>.
+    </body>
+</html>


### PR DESCRIPTION
Introduces a basic Makefile, as discussed in #316.

Files previously residing in hugo/ are now kept in hugo-src and copied
as part of the build process, so that rm -rf hugo cleans everything.

The Makefile consists of a set of phony targets, each building a part
of the site.

Relevant targets:
 - site: creates the site
 - all: cleans output, checks validity of XML and creates the site
 - serve: starts a web server on localhost:8000 to browse the site
 - upload: rsyncs the site to the aclweb webserver

This means: `make all serve` will rebuild the site from scratch and start a webserver,
`make all upload` will rebuild the site and upload it to the official web server.

Comments welcome!


