### PR TITLE
removed TACL paper

### DIFF
--- a/data/xml/N19.xml
+++ b/data/xml/N19.xml
@@ -6060,22 +6060,6 @@
     <bibkey>pezeshkpour-tian-singh:2019:N19-1</bibkey>
   </paper>
 
-  <paper id="1338">
-    <title>Analysis Methods in Neural Language Processing: A Survey</title>
-    <author><first>Yonatan</first><last>Belinkov</last></author>
-    <author><first>James</first><last>Glass</last></author>
-    <booktitle>Proceedings of the 2019 Conference of the North <fixed-case>A</fixed-case>merican Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 1 (Long and Short Papers)</booktitle>
-    <month>June</month>
-    <year>2019</year>
-    <address>Minneapolis, Minnesota</address>
-    <publisher>Association for Computational Linguistics</publisher>
-    <pages>3348–3354</pages>
-    <abstract>The field of natural language processing has seen impressive progress in recent years, with neural network models replacing many of the traditional systems. A plethora of new models has been proposed, many of which are thought to be opaque compared to their feature-rich counterparts. This has led researchers to analyze, interpret, and evaluate neural networks in novel and more fine-grained ways. In this survey paper, we review analysis methods in neural language processing, categorize them according to prominent research trends, highlight existing limitations, and point to potential directions for future work.</abstract>
-    <url>http://www.aclweb.org/anthology/N19-1338</url>
-    <bibtype>inproceedings</bibtype>
-    <bibkey>belinkov-glass:2019:N19-1</bibkey>
-  </paper>
-
   <paper id="1339">
     <title>Transferable Neural Projection Representations</title>
     <author><first>Chinnadhurai</first><last>Sankar</last></author>


### PR DESCRIPTION
This TACL paper (https://www.mitpressjournals.org/doi/full/10.1162/tacl_a_00254)
was inadvertently added to the NAACL proceedings.