### PR TITLE
reorg of C69

### DIFF
--- a/data/xml/C69.xml
+++ b/data/xml/C69.xml
@@ -1,830 +1,573 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <volume id="C69">
- <paper id="0100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 1</title>
- </paper>
-
- <paper id="0101">
- <title>TREE GRAMMARS (= Δ-GRAMMARS)</title>
- <author id="igor-melcuk"><last>Mel’čuk</last><first>I. A.</first></author>
- <author><last>Gladky</last><first>A. V.</first></author>
-</paper>
-
- <paper id="0200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 2</title>
-</paper>
-
- <paper id="0201">
- <title>A CONCEPTUAL DEPENDENCY PARSER FOR NATURAL LANGUAGE</title>
- <author><first>Roger C.</first><last>Schank</last></author>
- <author><first>Larry</first><last>Tesler</last></author>
-</paper>
-
- <paper id="0300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 3</title>
-</paper>
-
- <paper id="0301">
- <title>NEXUS A LINGUISTIC TECHNIQUE FOR PRECOORDINATION</title>
- <author><first>R. A.</first><last>Benson</last></author>
-</paper>
-
- <paper id="0400">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 4</title>
-</paper>
-
- <paper id="0401">
- <title>Automatic Processing of Foreign Language Documents</title>
- <author id="gerard-salton"><first>G.</first><last>Salton</last></author>
-</paper>
-
- <paper id="0500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 5</title>
-</paper>
-
- <paper id="0501">
- <title>AN APPLICATION OF COMPUTER PROGRAMMING TO THE RECONSTRUCTION OF A PROTO-LANGUAGE</title>
- <author><first>Stanton P.</first><last>Durham</last></author>
- <author><first>David Ellis</first><last>Rogers</last></author>
-</paper>
-
- <paper id="0600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 6</title>
-</paper>
-
- <paper id="0601">
- <title>Some formal properties of phonological redundancy rules</title>
- <author><first>Stephan</first><last>Braun</last></author>
-</paper>
-
- <paper id="0700">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 7</title>
-</paper>
-
- <paper id="0701">
- <title>Automatic error-correction in natural languages</title>
- <author><first>A.J.</first><last>Szanser</last></author>
-</paper>
-
- <paper id="0800">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 8</title>
-</paper>
-
- <paper id="0801">
- <title>INTERACTIVE SEMANTIC ANALYSIS OF ENGLISH PARAGRAPHS</title>
- <author><first>Yorick</first><last>Wilks</last></author>
-</paper>
-
- <paper id="0900">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 9</title>
-</paper>
-
- <paper id="0901">
- <title>AUTOMATIC SIMULATION OF HISTORICAL CHANGE</title>
- <author><first>Raoul N.</first><last>Smith</last></author>
-</paper>
-
- <paper id="1000">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 10</title>
-</paper>
-
- <paper id="1001">
- <title>STRUCTURAL PATTERNS OF CHINESE CHARACTERS</title>
- <author><first>Osamu</first><last>Fujimura</last></author>
- <author><first>Ryohei</first><last>Kagaya</last></author>
-</paper>
-
- <paper id="1100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 11</title>
-</paper>
-
- <paper id="1101">
- <title>AUTOMATED PROCESSING OF MEDICAL ENGLISH</title>
- <author><first>Arnold W.</first><last>Pratt</last></author>
- <author><first>Milos G.</first><last>Pacak</last></author>
-</paper>
-
- <paper id="1200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 12</title>
-</paper>
-
- <paper id="1201">
- <title>QUANTITATIVE APPROXIMATIONS TO THE WORD</title>
- <author><first>Edward</first><last>Gammon</last></author>
-</paper>
-
- <paper id="1300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 13</title>
-</paper>
-
- <paper id="1301">
- <title>A DIRECTED RANDOM PARAGRAPH GENERATOR</title>
- <author><first>Stanley Y.W.</first><last>Su</last></author>
- <author><first>Kenneth E.</first><last>Harper</last></author>
-</paper>
-
- <paper id="1400">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 14</title>
-</paper>
-
- <paper id="1401">
- <title>Applications of a Computer System for Transformational Grammar</title>
- <author><first>Joyce</first><last>Friedman</last></author>
-</paper>
-
- <paper id="1500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 15</title>
-</paper>
-
- <paper id="1501">
- <title>Syntactic Analysis by Alternating Computation and Inspection</title>
- <author><first>Gustav</first><last>Leunbach</last></author>
-</paper>
-
- <paper id="1600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 16</title>
-</paper>
-
- <paper id="1601">
- <title>COMPUTATIONAL ANALYSIS OF INTERFERENCE PHENOMENA ON THE LEXICAL LEVEL</title>
- <author id="wojciech-skalmowski"><first>W.</first><last>Skalmowski</last></author>
- <author><first>M. Van</first><last>Overbeke</last></author>
-</paper>
-
- <paper id="1700">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 17</title>
-</paper>
-
- <paper id="1701">
- <title>UNE NOTATION DES TEXTES HORS DES CONTRAINTES MORPHOLOGIQUES ET SYNTAXIQUES DE L’EXPRESSION</title>
- <author id="bernard-vauquois"><first>B.</first><last>Vauquois</last></author>
- <author id="gerard-veillon"><first>G.</first><last>Veillon</last></author>
- <author id="nicolas-nedobejkine"><first>N.</first><last>Nedobejkine</last></author>
- <author><first>C.</first><last>Bourguignon</last></author>
-</paper>
-
- <paper id="1800">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 18</title>
-</paper>
-
- <paper id="1801">
- <title>An Application of an Extended Generative Semantic Model of Language to Man-machine Interaction</title>
- <author><first>Robert I.</first><last>Binnick</last></author>
-</paper>
-
- <paper id="1900">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 19</title>
-</paper>
-
- <paper id="1901">
- <title>DIALECTOLOGY BY  COMPUTER</title>
- <author><first>Gordon R.</first><last>Wood</last></author>
-</paper>
-
- <paper id="2000">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 20</title>
-</paper>
-
- <paper id="2001">
- <title>ON THE PRESERVATION OF CONTEXT-FREE LANGUAGES IN A LEVEL-BASED SYSTEM</title>
- <author><first>Jacob</first><last>Mey</last></author>
-</paper>
-
- <paper id="2100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 21</title>
-</paper>
-
- <paper id="2101">
- <title>MONTE CARLO SIMULATION OF LANGUAGE CHANGE IN TIKOPIA &amp; MAORI</title>
- <author><first>Sheldon</first><last>Klein</last></author>
- <author><first>Michael A.</first><last>Kuppin</last></author>
- <author><first>Kirby A.</first><last>Meives</last></author>
-</paper>
-
- <paper id="2200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 22</title>
-</paper>
-
- <paper id="2201">
- <title>Semantics and the Syntactic Classification of Words</title>
- <author><first>Ernst</first><last>von Glasersfeld</last></author>
-</paper>
-
- <paper id="2300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 23</title>
-</paper>
-
- <paper id="2301">
- <title>UBER ZEITKEFERENZ UND TEMPUS</title>
- <author><first>Dieter</first><last>Wunderlich</last></author>
-</paper>
-
- <paper id="2400">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 24</title>
-</paper>
-
- <paper id="2401">
- <title>Total or Selected Content Analysis</title>
- <author><first>Julius</first><last>Laffal</last></author>
-</paper>
-
- <paper id="2500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 25</title>
-</paper>
-
- <paper id="2501">
- <title>ORGANIZATION AND PROGRAMMING OF THE MULTISTORE PARSER</title>
- <author><first>Pier Paolo</first><last>Pisani</last></author>
-</paper>
-
- <paper id="2600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 26</title>
-</paper>
-
- <paper id="2601">
- <title>Computers in the Yugoslav <fixed-case>S</fixed-case>erbo-Croat/<fixed-case>E</fixed-case>nglish Contrastive Analysis Project</title>
- <author><first>Zeljko</first><last>Bujas</last></author>
-</paper>
-
- <paper id="2700">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 27</title>
-</paper>
-
- <paper id="2701">
- <title>QUELQUES APPLICATIONS DE LA LOGIQUE A LA SEMANTIQUE DES LANGUES NATURELLES</title>
- <author id="jacques-rouault"><first>J.</first><last>ROUAULT</last></author>
-</paper>
-
- <paper id="2800">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 28</title>
-</paper>
-
- <paper id="2801">
- <title>On the Use of Linguistic Quantifying Operators in the Logico-Semantic Structure Representation of Utterances</title>
- <author><first>Irena</first><last>Bellert</last></author>
-</paper>
-
- <paper id="2900">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 29</title>
-</paper>
-
- <paper id="2901">
- <title>TOWARDS A COMPUTATIONAL FORMALIZATION OF NATURAL LANGUAGE SEMANTICS</title>
- <author><first>Robert M.</first><last>Schwarcz</last></author>
-</paper>
-
- <paper id="3000">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 30</title>
-</paper>
-
- <paper id="3001">
- <title>Empirical Investigation of <fixed-case>G</fixed-case>erman Word Derivation with the Aid of a Computer</title>
- <author><first>Karl Dieter</first><last>Bunting</last></author>
-</paper>
-
- <paper id="3100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 31</title>
-</paper>
-
- <paper id="3101">
- <title>Disambiguating Verbs with Multiple Meaning in the <fixed-case>MT</fixed-case>-System of <fixed-case>IBM</fixed-case> <fixed-case>G</fixed-case>ermany</title>
- <author id="istvan-batori"><first>I.</first><last>Batori</last></author>
-</paper>
-
- <paper id="3200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 32</title>
-</paper>
-
- <paper id="3201">
- <title>SEMANTICS OF PREPOSITIONAL CONSTRUCTS IN RUSSIAN: TENTATIVE APPROACH</title>
- <author><first>Adam G.</first><last>Woyna</last></author>
-</paper>
-
- <paper id="3300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 33</title>
-</paper>
-
- <paper id="3301">
- <title>AUTOMATIC RECOGNITION OF SPEECH SOUNDS BY A DIGITAL COMPUTER</title>
- <author><first>A.</first><last>Iivonen</last></author>
-</paper>
-
- <paper id="3400">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 34</title>
-</paper>
-
- <paper id="3401">
- <title>A Rapidly Extensible Language System (The Rel Language Processor)</title>
- <author><first>Peter C.</first><last>Lockemann</last></author>
- <author><first>Frederick B.</first><last>Thompson</last></author>
-</paper>
-
- <paper id="3500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 35</title>
-</paper>
-
- <paper id="3501">
- <title>A RAPIDLY EXTENSIBLE LANGUAGE SYSTEM (REL ENGLISH)</title>
- <author><first>Bozena</first><last>Dostert</last></author>
- <author><first>Frederick B. </first><last>Thompson</last></author>
-</paper>
-
- <paper id="3600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 36</title>
-</paper>
-
- <paper id="3601">
- <title>THE LEXICON: A SYSTEM OF MATRICES OF LEXICAL UNITS AND THEIR PROPERTIES</title>
- <author><first>HARRY H.</first><last>JOSSELSON</last></author>
-</paper>
-
- <paper id="3700">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 37</title>
-</paper>
-
- <paper id="3701">
- <title>AUTOMATIC TEXT GENERATION</title>
- <author><first>G. H.</first><last>Woolley</last></author>
-</paper>
-
- <paper id="3800">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 38</title>
-</paper>
-
- <paper id="3801">
- <title>A PRAGMATIC APPROACH TO MACHINE TRANSLATION FROM CHINESE TO ENGLISH</title>
- <author><first>Ching-Yi</first><last>Dougherty</last></author>
-</paper>
-
- <paper id="3900">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 39</title>
-</paper>
-
- <paper id="3901">
- <title>HOBBES’ CALCULUS OF WORDS</title>
- <author><first>P. A.</first><last>Verburg</last></author>
-</paper>
-
- <paper id="4000">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 40</title>
-</paper>
-
- <paper id="4001">
- <title>A PROGRESS REPORT ON THE USE OF ENGLISH IN INFORMATION RETRIEVAL</title>
- <author><first>J. A.</first><last>MOYNE</last></author>
-</paper>
-
- <paper id="4100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 41</title>
-</paper>
-
- <paper id="4101">
- <title>LINGUISTICS AND AUTOMATED LANGUAGE PROCESSING</title>
- <author><first>Christine A.</first><last>Montgomery</last></author>
-</paper>
-
- <paper id="4200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 42</title>
-</paper>
-
- <paper id="4201">
- <title>A UNIVERSAL GRAPHIC CHARACTER WRITER</title>
- <author><first>Shou-chuan</first><last>Yang</last></author>
- <author><first>Charlotte W.</first><last>Yang</last></author>
-</paper>
-
- <paper id="4300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 43</title>
-</paper>
-
- <paper id="4301">
- <title>GRAMMAIRE <fixed-case>I</fixed-case> DESCRIPTION TRANSFORMATIONNELLE D’ UN SOUS-ENSEMBLE DU FRANCAIS</title>
- <author><first>Antonio A.M.</first><last>Querido</last></author>
-</paper>
-
- <paper id="4400">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 44</title>
-</paper>
-
- <paper id="4401">
- <title>SYNTACTIC PATTERNS IN A SAMPLE OF TECHNICAL ENGLISH</title>
- <author><first>Victor J.</first><last>Streeter</last></author>
-</paper>
-
- <paper id="4500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 45</title>
-</paper>
-
- <paper id="4501">
- <title>THE USE OF CONTEXT-SENSITIVE RULES IN IMMEDIATE CONSTITUENT ANALYSIS</title>
- <author><first>Stanley</first><last>Peters</last></author>
-</paper>
-
- <paper id="4600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 46</title>
-</paper>
-
- <paper id="4601">
- <title>STRUCTURE, EFFECTIVENESS, AND USES OF THE CITATION IDENTIFIER</title>
- <author><first>Casimir</first><last>Borkowski</last></author>
-</paper>
-
- <paper id="4700">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 47</title>
-</paper>
-
- <paper id="4701">
- <title>PROPERTIES OF FORMAL GRAMMARS WITH MIXED TYPE OF RULES AND THEIR LINGUISTIC RELEVANCE</title>
- <author><first>Aravind K.</first><last>Joshi</last></author>
-</paper>
-
- <paper id="4800">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 48</title>
-</paper>
-
- <paper id="4801">
- <title>CONTEXTUAL GRAMMARS</title>
- <author><first>Solomon</first><last>Marcus</last></author>
-</paper>
-
- <paper id="4900">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 49</title>
-</paper>
-
- <paper id="4901">
- <title>SIMULATION OF WORD-MEANING STOCHASTIC PROCESSES</title>
- <author><first>David</first><last>Sankoff</last></author>
-</paper>
-
- <paper id="5000">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 50</title>
-</paper>
-
- <paper id="5001">
- <title>ON THE PROBLEMS OF CO-TEXTUAL ANALYSIS OF TEXTS</title>
- <author><first>Janos S.</first><last>Petofi</last></author>
-</paper>
-
- <paper id="5100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 51</title>
-</paper>
-
- <paper id="5101">
- <title>A SEARCH ALGORITHM AND DATA STRUCTURE FOR AN EFFICIENT INFORMATION SYSTEM</title>
- <author><first>Shou-chuan</first><last>Yang</last></author>
-</paper>
-
- <paper id="5200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 52</title>
-</paper>
-
- <paper id="5201">
- <title>COMPUTER-PRODUCED REPRESENTATION OF DIALECTAL VARIATION: INITLAL FRICATIVES IN SOUTHERN BRITISH ENGLISH</title>
- <author><first>W. Nelson</first><last>Francis</last></author>
- <author><first>Jan</first><last>Svartvik</last></author>
- <author><first>Gerald M.</first><last>Rubin</last></author>
-</paper>
-
- <paper id="5300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 53</title>
-</paper>
-
-
- <paper id="5301">
- <title>AN INTERACTIVE PHONOLOGICAL RULE TESTING SYSTEM</title>
- <author><first>Victoria A.</first><last>Fromkin</last></author>
- <author><first>D. Lloyd</first><last>Rice</last></author>
-</paper>
-
- <paper id="5400">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 54</title>
-</paper>
-
- <paper id="5401">
- <title>NETWORK OF BINARY RELATIONS IN NATURAL LANGUAGE</title>
- <author><first>Adrian</first><last>Birbanescu</last></author>
-</paper>
-
- <paper id="5500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 55</title>
-</paper>
-
- <paper id="5501">
- <title>LE PROJET DE TRADUCTION AUTOMATIQUE A L’UNIVERSITE DE MONTREAL</title>
- <author><first>Andre</first><last>Dugas</last></author>
- <author><first>Myrna</first><last>Gopnik</last></author>
- <author><first>Brian</first><last>Harris</last></author>
- <author><first>Jean-Pierre</first><last>Paillet</last></author>
-</paper>
-
- <paper id="5600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 56</title>
-</paper>
-
- <paper id="5601">
- <title>MATHEMATICAL MODELS FOR BALKAN PHONOLOGICAL CONVERGENCE</title>
- <author><first>Evangelos A.</first><last>Afendras</last></author>
-</paper>
-
- <paper id="5700">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 57</title>
-</paper>
-
- <paper id="5701">
- <title>THE MEASUREMENT OF PHONETIC SIMILARITY</title>
- <author><first>Peter</first><last>Ladefoged</last></author>
-</paper>
-
- <paper id="5800">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 58</title>
-</paper>
-
- <paper id="5801">
- <title>COMPUTER AIDED RESEARCH ON SYNONYMY AND ANTONYMY</title>
- <author><first>H. P.</first><last>Edmundson</last></author>
- <author><first>Martin N.</first><last>Epstein</last></author>
-</paper>
-
- <paper id="5900">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 59</title>
-</paper>
-
- <paper id="5901">
- <title>SOME PROBLEMS OF WORD-FORMATION WITHIN THE FRAMEWORK OF A GENERATIVE GRAMMAR</title>
- <author><first>Szabo</first><last>Zoltan</last></author>
-</paper>
-
- <paper id="6000">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 60</title>
-</paper>
-
- <paper id="6001">
- <title>THE ‘TIME CATEGORY’ IN NATURAL LANGUAGES AND ITS SEMANTIC INTERPRETATION</title>
- <author><first>E.</first><last>Vasiliu</last></author>
-</paper>
-
- <paper id="6100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 61</title>
-</paper>
-
- <paper id="6101">
- <title>PROBLEM OF IMPROVING THE EFFICIENCY OF PARSING SYSTEMS</title>
- <author id="daniel-varga"><first>D.</first><last>Varga</last></author>
-</paper>
-
- <paper id="6200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 62: COLLECTION OF ABSTRACTS OF PAPERS</title>
-</paper>
-
- <paper id="6201">
- <title>Constructional Potentiality:  Priscianic grammar as a disambiguation technique in the automatic recognition of <fixed-case>L</fixed-case>atin syntax</title>
- <author><first>R. R.</first><last>Dyer</last></author>
-</paper>
-
- <paper id="6202">
- <title>ON SATURATED PARTITIONS</title>
- <author><first>Stephan-Ylan</first><last>Solomon</last></author>
-</paper>
-
- <paper id="6203">
- <title>Problems of <fixed-case>G</fixed-case>erman-<fixed-case>E</fixed-case>nglish Automatic Translation</title>
- <author><first>Paul O.</first><last>Samuelsdorff</last></author>
-</paper>
-
- <paper id="6204">
- <title>Stylistic Analysis of Poetry</title>
- <author><first>Irene R.</first><last>Fairley</last></author>
-</paper>
-
- <paper id="6205">
- <title>The machine realization of the periphrasing system and the results of the experiment</title>
- <author><first>N. G.</first><last>Arsentyeva</last></author>
-</paper>
-
- <paper id="6206">
- <title>A NEW APPROACH TO SYNTAX</title>
- <author><first>B. J.</first><last>Dasher</last></author>
-</paper>
-
- <paper id="6207">
- <title>On Semantics of Some Verbal Categories in <fixed-case>E</fixed-case>nglish</title>
- <author><first>Eva</first><last>Hajicova</last></author>
-</paper>
-
- <paper id="6208">
- <title>Sur quelques preprietes communes des catagories semantiques et des procedures generatrices de trois modeles de synthese dans le processus de la <fixed-case>TA</fixed-case> (resume)</title>
- <author><first>A.</first><last>Ludskanov</last></author>
-</paper>
-
- <paper id="6209">
- <title>Towards an automatic morphological segmentation</title>
- <author><first>Josse De</first><last>Kock</last></author>
- <author><first>Walter</first><last>Bossaert</last></author>
-</paper>
-
- <paper id="6210">
- <title>The structure, and semantics of the verbal government</title>
- <author><first>Jacob</first><last>Mathe</last></author>
-</paper>
-
- <paper id="6211">
- <title>Machine Transcoding</title>
- <author><first>T. R.</first><last>Hofmann</last></author>
- <author><first>Brian</first><last>Harris</last></author>
-</paper>
-
- <paper id="6212">
- <title>Analyse structurelle automatique de grouses nominaux anglais</title>
- <author><first>L.</first><last>Moessner</last></author>
-</paper>
-
- <paper id="6213">
- <title>Ein Programm zur automatischen Synthese englischer Satze</title>
- <author><first>Klaus</first><last>Detering</last></author>
-</paper>
-
- <paper id="6214">
- <title>AN APPLICATION OF COMPUTER TECHNIQUES TO ANALYSIS OF THE VERB PHRASE IN HINDI AND ENGLISH: A Preliminary Report</title>
- <author><first>L. M.</first><last>Khubohandani</last></author>
- <author><first>W. W.</first><last>Glover</last></author>
-</paper>
-
- <paper id="6215">
- <title>Computational Studies in Terminology</title>
- <author><first>Reinhart</first><last>Herzog</last></author>
-</paper>
-
- <paper id="6300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 63</title>
-</paper>
-
- <paper id="6301">
- <title>COMPUTATIONAL LINGUISTIC TECHNIQUES IN AN ON-LINE SYSTEM FOR TEXTUAL ANALYSIS</title>
- <author><first>Donald E.</first><last>Walker</last></author>
-</paper>
-
- <paper id="6400">
-  <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 64</title>
-</paper>
-
- <paper id="6401">
- <title>A PROGRESS REPORT ON THE USE OF SLANT GRAMMAR CALCULUS FOR AUTOMATIC ANALYSIS</title>
- <author><first>Ferenc</first><last>Kiefer</last></author>
-</paper>
-
- <paper id="6500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 65</title>
-</paper>
-
- <paper id="6501">
- <title>DISKONTINUIERLICHE KONSTITUENTEN</title>
- <author><first>H.</first><last>Eggers</last></author>
- <author><first>A.</first><last>Rothkegel-Schramm</last></author>
- <author id="wolfgang-klein"><first>W.</first><last>Klein</last></author>
- <author><first>H-J.</first><last>Weber</last></author>
- <author id="harald-h-zimmermann"><first>H.</first><last>Zimmermann</last></author>
-</paper>
-
- <paper id="6600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 66</title>
-</paper>
-
- <paper id="6601">
- <title>AN INTUITVE REPRESENTATION OF CONTEXT-FREE LANGUAGES</title>
- <author><first>Laszlo</first><last>Kalmar</last></author>
-</paper>
-
- <paper id="6700">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 67</title>
-</paper>
-
- <paper id="6701">
- <title>DIE SEMANTISCHE SYNTAX DER KOMMUNIKATIVEN GRAMMATIK AUF EDV-ANLAGEN</title>
- <author><first>Alfred</first><last>Hoppe</last></author>
-</paper>
-
- <paper id="6800">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 68</title>
-</paper>
-
- <paper id="6801">
- <title>MULTI-INDEX SYNTACTICAL CALCULUS</title>
- <author><first>Hans</first><last>Karlgren</last></author>
-</paper>
-
- <paper id="6900">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 69: COLLECTION OF ABSTRACTS OF PAPERS</title>
-</paper>
-
- <paper id="6901">
- <title>The Book of Isaiah: Morphological Clustering and Disputed Authorship</title>
- <author><first>Asa</first><last>Kasher</last></author>
-</paper>
-
- <paper id="6902">
- <title>DISCOURSE REFERENTS</title>
- <author><first>Lauri</first><last>Karttunen</last></author>
-</paper>
-
- <paper id="6903">
- <title>ADOUT THE VECTORIAL CALCULUS OF THE RELATION BETWEEN THE SEMANTIC AND SYTACTIC MARKERS OF THE LEXICAL ENTRY</title>
- <author><first>Paul</first><last>Schveiger</last></author>
-</paper>
-
- <paper id="6904">
- <title>Project <fixed-case>DOC</fixed-case></title>
- <author><first>William S-Y.</first><last>Wang</last></author>
-</paper>
-
- <paper id="7000">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 70</title>
-</paper>
-
- <paper id="7001">
- <title>DISCOURSE REFERENTS</title>
- <author><first>Lauri</first><last>Karttunen</last></author>
-</paper>
-
- <paper id="7100">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 71</title>
-</paper>
-
- <paper id="7101">
- <title>PROJECT DOC: ITS METHODOLOGICAL BASIS</title>
- <author><first>William S-Y.</first><last>Wang</last></author>
-</paper>
-
- <paper id="7200">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969</title>
-</paper>
-
- <paper id="7201">
- <title>DIE MALARINSELN UND IHRE SEHENSWURDIGKEITEN</title>
-</paper>
-
- <paper id="7300">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969</title>
-</paper>
-
- <paper id="7301">
- <title><fixed-case>PROGRAM</fixed-case> Declarations and Instructions</title>
-</paper>
-
- <paper id="7400">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969</title>
-</paper>
-
- <paper id="7401">
- <title>Half COMPUTERIZED LINGUISTICS: A Half COMMENTARY</title>
- <author><first>Martin</first><last>Minow</last></author>
-</paper>
-
- <paper id="7500">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969</title>
-</paper>
-
- <paper id="7501">
- <title>SOME REMARKS ON J. L. MEY’s PAPER (Preprint No. 20)</title>
- <author id="petr-sgall"><first>P.</first><last>Sgall</last></author>
- <author id="eva-hajicova"><first>E.</first><last>Hajicova</last></author>
-</paper>
-
- <paper id="7600">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Post-print <fixed-case>I</fixed-case></title>
-</paper>
-
- <paper id="7601">
- <title>A Note on Morpheme Structure in Generative Phonology</title>
- <author><first>Frances</first><last>Kartunnen</last></author>
-</paper>
-
- <paper id="7602">
- <title>METAPRINT 3 (METAPRINT 1) Responses to “COMPUTERIZED LINGUISTICS: HALF A COMMENTARY”</title>
- <author><first>Martin</first><last>Minow</last></author>
-</paper>
-
- <paper id="7603">
- <title>Alphabetic List of Contributors of papers to the Conference and Identification Code</title>
-</paper>
-
- <paper id="7604">
- <title>STATISTICAL METHODS IN LEXICOLOGICAL RESEARCH IN THE BALTIC STATES</title>
- <author><first>HILDA</first><last>RADZIN</last></author>
-</paper>
-
- <paper id="7605">
- <title>Diverse corrigenda and addenda to the pre-prints</title>
- </paper>
-
- <paper id="7701">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Index to Preprints</title>
-</paper>
-
- <paper id="7801">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: BULLETIN MONDAY, SEPTEMBER 1, 1969</title>
-</paper>
-
- <paper id="7901">
- <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: BULLETIN WEDNESDAY, SEPTEMBER 3, 1969</title>
-</paper>
+  <paper id="1000">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS <fixed-case>COLING</fixed-case> 1969</title>
+    <month>September</month>
+    <year>1969</year>
+    <address>Sånga Säby, Sweden</address>
+  </paper>
+
+  <paper id="1001">
+    <title>TREE GRAMMARS (= Δ-GRAMMARS)</title>
+    <author id="igor-melcuk"><last>Mel’čuk</last><first>I. A.</first></author>
+    <author><last>Gladky</last><first>A. V.</first></author>
+  </paper>
+
+  <paper id="1002">
+    <title>A CONCEPTUAL DEPENDENCY PARSER FOR NATURAL LANGUAGE</title>
+    <author><first>Roger C.</first><last>Schank</last></author>
+    <author><first>Larry</first><last>Tesler</last></author>
+  </paper>
+
+  <paper id="1003">
+    <title>NEXUS A LINGUISTIC TECHNIQUE FOR PRECOORDINATION</title>
+    <author><first>R. A.</first><last>Benson</last></author>
+  </paper>
+
+  <paper id="1004">
+    <title>Automatic Processing of Foreign Language Documents</title>
+    <author id="gerard-salton"><first>G.</first><last>Salton</last></author>
+  </paper>
+
+  <paper id="1005">
+    <title>AN APPLICATION OF COMPUTER PROGRAMMING TO THE RECONSTRUCTION OF A PROTO-LANGUAGE</title>
+    <author><first>Stanton P.</first><last>Durham</last></author>
+    <author><first>David Ellis</first><last>Rogers</last></author>
+  </paper>
+
+  <paper id="1006">
+    <title>Some formal properties of phonological redundancy rules</title>
+    <author><first>Stephan</first><last>Braun</last></author>
+  </paper>
+
+  <paper id="1007">
+    <title>Automatic error-correction in natural languages</title>
+    <author><first>A.J.</first><last>Szanser</last></author>
+  </paper>
+
+  <paper id="1008">
+    <title>INTERACTIVE SEMANTIC ANALYSIS OF ENGLISH PARAGRAPHS</title>
+    <author><first>Yorick</first><last>Wilks</last></author>
+  </paper>
+
+  <paper id="1009">
+    <title>AUTOMATIC SIMULATION OF HISTORICAL CHANGE</title>
+    <author><first>Raoul N.</first><last>Smith</last></author>
+  </paper>
+
+  <paper id="1010">
+    <title>STRUCTURAL PATTERNS OF CHINESE CHARACTERS</title>
+    <author><first>Osamu</first><last>Fujimura</last></author>
+    <author><first>Ryohei</first><last>Kagaya</last></author>
+  </paper>
+
+  <paper id="1011">
+    <title>AUTOMATED PROCESSING OF MEDICAL ENGLISH</title>
+    <author><first>Arnold W.</first><last>Pratt</last></author>
+    <author><first>Milos G.</first><last>Pacak</last></author>
+  </paper>
+
+  <paper id="1012">
+    <title>QUANTITATIVE APPROXIMATIONS TO THE WORD</title>
+    <author><first>Edward</first><last>Gammon</last></author>
+  </paper>
+
+  <paper id="1013">
+    <title>A DIRECTED RANDOM PARAGRAPH GENERATOR</title>
+    <author><first>Stanley Y.W.</first><last>Su</last></author>
+    <author><first>Kenneth E.</first><last>Harper</last></author>
+  </paper>
+
+  <paper id="1014">
+    <title>Applications of a Computer System for Transformational Grammar</title>
+    <author><first>Joyce</first><last>Friedman</last></author>
+  </paper>
+
+  <paper id="1015">
+    <title>Syntactic Analysis by Alternating Computation and Inspection</title>
+    <author><first>Gustav</first><last>Leunbach</last></author>
+  </paper>
+
+  <paper id="1016">
+    <title>COMPUTATIONAL ANALYSIS OF INTERFERENCE PHENOMENA ON THE LEXICAL LEVEL</title>
+    <author id="wojciech-skalmowski"><first>W.</first><last>Skalmowski</last></author>
+    <author><first>M. Van</first><last>Overbeke</last></author>
+  </paper>
+
+  <paper id="1017">
+    <title>UNE NOTATION DES TEXTES HORS DES CONTRAINTES MORPHOLOGIQUES ET SYNTAXIQUES DE L’EXPRESSION</title>
+    <author id="bernard-vauquois"><first>B.</first><last>Vauquois</last></author>
+    <author id="gerard-veillon"><first>G.</first><last>Veillon</last></author>
+    <author id="nicolas-nedobejkine"><first>N.</first><last>Nedobejkine</last></author>
+    <author><first>C.</first><last>Bourguignon</last></author>
+  </paper>
+
+  <paper id="1018">
+    <title>An Application of an Extended Generative Semantic Model of Language to Man-machine Interaction</title>
+    <author><first>Robert I.</first><last>Binnick</last></author>
+  </paper>
+
+  <paper id="1019">
+    <title>DIALECTOLOGY BY  COMPUTER</title>
+    <author><first>Gordon R.</first><last>Wood</last></author>
+  </paper>
+
+  <paper id="1020">
+    <title>ON THE PRESERVATION OF CONTEXT-FREE LANGUAGES IN A LEVEL-BASED SYSTEM</title>
+    <author><first>Jacob</first><last>Mey</last></author>
+  </paper>
+
+  <paper id="1021">
+    <title>MONTE CARLO SIMULATION OF LANGUAGE CHANGE IN TIKOPIA &amp; MAORI</title>
+    <author><first>Sheldon</first><last>Klein</last></author>
+    <author><first>Michael A.</first><last>Kuppin</last></author>
+    <author><first>Kirby A.</first><last>Meives</last></author>
+  </paper>
+
+  <paper id="1022">
+    <title>Semantics and the Syntactic Classification of Words</title>
+    <author><first>Ernst</first><last>von Glasersfeld</last></author>
+  </paper>
+
+  <paper id="1023">
+    <title>UBER ZEITKEFERENZ UND TEMPUS</title>
+    <author><first>Dieter</first><last>Wunderlich</last></author>
+  </paper>
+
+  <paper id="1024">
+    <title>Total or Selected Content Analysis</title>
+    <author><first>Julius</first><last>Laffal</last></author>
+  </paper>
+
+  <paper id="1025">
+    <title>ORGANIZATION AND PROGRAMMING OF THE MULTISTORE PARSER</title>
+    <author><first>Pier Paolo</first><last>Pisani</last></author>
+  </paper>
+
+  <paper id="1026">
+    <title>Computers in the Yugoslav <fixed-case>S</fixed-case>erbo-Croat/<fixed-case>E</fixed-case>nglish Contrastive Analysis Project</title>
+    <author><first>Zeljko</first><last>Bujas</last></author>
+  </paper>
+
+  <paper id="1027">
+    <title>QUELQUES APPLICATIONS DE LA LOGIQUE A LA SEMANTIQUE DES LANGUES NATURELLES</title>
+    <author id="jacques-rouault"><first>J.</first><last>ROUAULT</last></author>
+  </paper>
+
+  <paper id="1028">
+    <title>On the Use of Linguistic Quantifying Operators in the Logico-Semantic Structure Representation of Utterances</title>
+    <author><first>Irena</first><last>Bellert</last></author>
+  </paper>
+
+  <paper id="1029">
+    <title>TOWARDS A COMPUTATIONAL FORMALIZATION OF NATURAL LANGUAGE SEMANTICS</title>
+    <author><first>Robert M.</first><last>Schwarcz</last></author>
+  </paper>
+
+  <paper id="1030">
+    <title>Empirical Investigation of <fixed-case>G</fixed-case>erman Word Derivation with the Aid of a Computer</title>
+    <author><first>Karl Dieter</first><last>Bunting</last></author>
+  </paper>
+
+  <paper id="1031">
+    <title>Disambiguating Verbs with Multiple Meaning in the <fixed-case>MT</fixed-case>-System of <fixed-case>IBM</fixed-case> <fixed-case>G</fixed-case>ermany</title>
+    <author id="istvan-batori"><first>I.</first><last>Batori</last></author>
+  </paper>
+
+  <paper id="1032">
+    <title>SEMANTICS OF PREPOSITIONAL CONSTRUCTS IN RUSSIAN: TENTATIVE APPROACH</title>
+    <author><first>Adam G.</first><last>Woyna</last></author>
+  </paper>
+
+  <paper id="1033">
+    <title>AUTOMATIC RECOGNITION OF SPEECH SOUNDS BY A DIGITAL COMPUTER</title>
+    <author><first>A.</first><last>Iivonen</last></author>
+  </paper>
+
+  <paper id="1034">
+    <title>A Rapidly Extensible Language System (The Rel Language Processor)</title>
+    <author><first>Peter C.</first><last>Lockemann</last></author>
+    <author><first>Frederick B.</first><last>Thompson</last></author>
+  </paper>
+
+  <paper id="1035">
+    <title>A RAPIDLY EXTENSIBLE LANGUAGE SYSTEM (REL ENGLISH)</title>
+    <author><first>Bozena</first><last>Dostert</last></author>
+    <author><first>Frederick B. </first><last>Thompson</last></author>
+  </paper>
+
+  <paper id="1036">
+    <title>THE LEXICON: A SYSTEM OF MATRICES OF LEXICAL UNITS AND THEIR PROPERTIES</title>
+    <author><first>HARRY H.</first><last>JOSSELSON</last></author>
+  </paper>
+
+  <paper id="1037">
+    <title>AUTOMATIC TEXT GENERATION</title>
+    <author><first>G. H.</first><last>Woolley</last></author>
+  </paper>
+
+  <paper id="1038">
+    <title>A PRAGMATIC APPROACH TO MACHINE TRANSLATION FROM CHINESE TO ENGLISH</title>
+    <author><first>Ching-Yi</first><last>Dougherty</last></author>
+  </paper>
+
+  <paper id="1039">
+    <title>HOBBES’ CALCULUS OF WORDS</title>
+    <author><first>P. A.</first><last>Verburg</last></author>
+  </paper>
+
+  <paper id="1040">
+    <title>A PROGRESS REPORT ON THE USE OF ENGLISH IN INFORMATION RETRIEVAL</title>
+    <author><first>J. A.</first><last>MOYNE</last></author>
+  </paper>
+
+  <paper id="1041">
+    <title>LINGUISTICS AND AUTOMATED LANGUAGE PROCESSING</title>
+    <author><first>Christine A.</first><last>Montgomery</last></author>
+  </paper>
+
+  <paper id="1042">
+    <title>A UNIVERSAL GRAPHIC CHARACTER WRITER</title>
+    <author><first>Shou-chuan</first><last>Yang</last></author>
+    <author><first>Charlotte W.</first><last>Yang</last></author>
+  </paper>
+
+  <paper id="1043">
+    <title>GRAMMAIRE <fixed-case>I</fixed-case> DESCRIPTION TRANSFORMATIONNELLE D’ UN SOUS-ENSEMBLE DU FRANCAIS</title>
+    <author><first>Antonio A.M.</first><last>Querido</last></author>
+  </paper>
+
+  <paper id="1044">
+    <title>SYNTACTIC PATTERNS IN A SAMPLE OF TECHNICAL ENGLISH</title>
+    <author><first>Victor J.</first><last>Streeter</last></author>
+  </paper>
+
+  <paper id="1045">
+    <title>THE USE OF CONTEXT-SENSITIVE RULES IN IMMEDIATE CONSTITUENT ANALYSIS</title>
+    <author><first>Stanley</first><last>Peters</last></author>
+  </paper>
+
+  <paper id="1046">
+    <title>STRUCTURE, EFFECTIVENESS, AND USES OF THE CITATION IDENTIFIER</title>
+    <author><first>Casimir</first><last>Borkowski</last></author>
+  </paper>
+
+  <paper id="1047">
+    <title>PROPERTIES OF FORMAL GRAMMARS WITH MIXED TYPE OF RULES AND THEIR LINGUISTIC RELEVANCE</title>
+    <author><first>Aravind K.</first><last>Joshi</last></author>
+  </paper>
+
+  <paper id="1048">
+    <title>CONTEXTUAL GRAMMARS</title>
+    <author><first>Solomon</first><last>Marcus</last></author>
+  </paper>
+
+  <paper id="1049">
+    <title>SIMULATION OF WORD-MEANING STOCHASTIC PROCESSES</title>
+    <author><first>David</first><last>Sankoff</last></author>
+  </paper>
+
+  <paper id="1050">
+    <title>ON THE PROBLEMS OF CO-TEXTUAL ANALYSIS OF TEXTS</title>
+    <author><first>Janos S.</first><last>Petofi</last></author>
+  </paper>
+
+  <paper id="1051">
+    <title>A SEARCH ALGORITHM AND DATA STRUCTURE FOR AN EFFICIENT INFORMATION SYSTEM</title>
+    <author><first>Shou-chuan</first><last>Yang</last></author>
+  </paper>
+
+  <paper id="1052">
+    <title>COMPUTER-PRODUCED REPRESENTATION OF DIALECTAL VARIATION: INITLAL FRICATIVES IN SOUTHERN BRITISH ENGLISH</title>
+    <author><first>W. Nelson</first><last>Francis</last></author>
+    <author><first>Jan</first><last>Svartvik</last></author>
+    <author><first>Gerald M.</first><last>Rubin</last></author>
+  </paper>
+
+  <paper id="1053">
+    <title>AN INTERACTIVE PHONOLOGICAL RULE TESTING SYSTEM</title>
+    <author><first>Victoria A.</first><last>Fromkin</last></author>
+    <author><first>D. Lloyd</first><last>Rice</last></author>
+  </paper>
+
+  <paper id="1054">
+    <title>NETWORK OF BINARY RELATIONS IN NATURAL LANGUAGE</title>
+    <author><first>Adrian</first><last>Birbanescu</last></author>
+  </paper>
+
+  <paper id="1055">
+    <title>LE PROJET DE TRADUCTION AUTOMATIQUE A L’UNIVERSITE DE MONTREAL</title>
+    <author><first>Andre</first><last>Dugas</last></author>
+    <author><first>Myrna</first><last>Gopnik</last></author>
+    <author><first>Brian</first><last>Harris</last></author>
+    <author><first>Jean-Pierre</first><last>Paillet</last></author>
+  </paper>
+
+  <paper id="1056">
+    <title>MATHEMATICAL MODELS FOR BALKAN PHONOLOGICAL CONVERGENCE</title>
+    <author><first>Evangelos A.</first><last>Afendras</last></author>
+  </paper>
+
+  <paper id="1057">
+    <title>THE MEASUREMENT OF PHONETIC SIMILARITY</title>
+    <author><first>Peter</first><last>Ladefoged</last></author>
+  </paper>
+
+  <paper id="1058">
+    <title>COMPUTER AIDED RESEARCH ON SYNONYMY AND ANTONYMY</title>
+    <author><first>H. P.</first><last>Edmundson</last></author>
+    <author><first>Martin N.</first><last>Epstein</last></author>
+  </paper>
+
+  <paper id="1059">
+    <title>SOME PROBLEMS OF WORD-FORMATION WITHIN THE FRAMEWORK OF A GENERATIVE GRAMMAR</title>
+    <author><first>Szabo</first><last>Zoltan</last></author>
+  </paper>
+
+  <paper id="1060">
+    <title>THE ‘TIME CATEGORY’ IN NATURAL LANGUAGES AND ITS SEMANTIC INTERPRETATION</title>
+    <author><first>E.</first><last>Vasiliu</last></author>
+  </paper>
+
+  <paper id="1061">
+    <title>PROBLEM OF IMPROVING THE EFFICIENCY OF PARSING SYSTEMS</title>
+    <author id="daniel-varga"><first>D.</first><last>Varga</last></author>
+  </paper>
+
+  <paper id="1063">
+    <title>COMPUTATIONAL LINGUISTIC TECHNIQUES IN AN ON-LINE SYSTEM FOR TEXTUAL ANALYSIS</title>
+    <author><first>Donald E.</first><last>Walker</last></author>
+  </paper>
+
+  <paper id="1064">
+    <title>A PROGRESS REPORT ON THE USE OF SLANT GRAMMAR CALCULUS FOR AUTOMATIC ANALYSIS</title>
+    <author><first>Ferenc</first><last>Kiefer</last></author>
+  </paper>
+
+  <paper id="1065">
+    <title>DISKONTINUIERLICHE KONSTITUENTEN</title>
+    <author><first>H.</first><last>Eggers</last></author>
+    <author><first>A.</first><last>Rothkegel-Schramm</last></author>
+    <author id="wolfgang-klein"><first>W.</first><last>Klein</last></author>
+    <author><first>H-J.</first><last>Weber</last></author>
+    <author id="harald-h-zimmermann"><first>H.</first><last>Zimmermann</last></author>
+  </paper>
+
+  <paper id="1066">
+    <title>AN INTUITVE REPRESENTATION OF CONTEXT-FREE LANGUAGES</title>
+    <author><first>Laszlo</first><last>Kalmar</last></author>
+  </paper>
+
+  <paper id="1067">
+    <title>DIE SEMANTISCHE SYNTAX DER KOMMUNIKATIVEN GRAMMATIK AUF EDV-ANLAGEN</title>
+    <author><first>Alfred</first><last>Hoppe</last></author>
+  </paper>
+
+  <paper id="1068">
+    <title>MULTI-INDEX SYNTACTICAL CALCULUS</title>
+    <author><first>Hans</first><last>Karlgren</last></author>
+  </paper>
+
+  <paper id="1070">
+    <title>DISCOURSE REFERENTS</title>
+    <author><first>Lauri</first><last>Karttunen</last></author>
+  </paper>
+
+  <paper id="1071">
+    <title>PROJECT DOC: ITS METHODOLOGICAL BASIS</title>
+    <author><first>William S-Y.</first><last>Wang</last></author>
+  </paper>
+
+  <paper id="1072">
+    <title>DIE MALARINSELN UND IHRE SEHENSWURDIGKEITEN</title>
+  </paper>
+
+  <paper id="1073">
+    <title><fixed-case>PROGRAM</fixed-case>: Declarations and Instructions</title>
+    <pages>1–48</pages>
+  </paper>
+
+  <paper id="1074">
+    <title>Index to Preprints</title>
+  </paper>
+
+  <paper id="2000">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 62: COLLECTION OF ABSTRACTS OF PAPERS</title>
+  </paper>
+
+  <paper id="2001">
+    <title>Constructional Potentiality:  Priscianic grammar as a disambiguation technique in the automatic recognition of <fixed-case>L</fixed-case>atin syntax</title>
+    <author><first>R. R.</first><last>Dyer</last></author>
+    <pages>1</pages>
+  </paper>
+
+  <paper id="2002">
+    <title>ON SATURATED PARTITIONS</title>
+    <author><first>Stephan-Ylan</first><last>Solomon</last></author>
+    <pages>3</pages>
+  </paper>
+
+  <paper id="2003">
+    <title>Problems of <fixed-case>G</fixed-case>erman-<fixed-case>E</fixed-case>nglish Automatic Translation</title>
+    <author><first>Paul O.</first><last>Samuelsdorff</last></author>
+    <pages>4</pages>
+  </paper>
+
+  <paper id="2004">
+    <title>Stylistic Analysis of Poetry</title>
+    <author><first>Irene R.</first><last>Fairley</last></author>
+    <pages>5</pages>
+  </paper>
+
+  <paper id="2005">
+    <title>The machine realization of the periphrasing system and the results of the experiment</title>
+    <author><first>N. G.</first><last>Arsentyeva</last></author>
+    <pages>6</pages>
+  </paper>
+
+  <paper id="2006">
+    <title>A NEW APPROACH TO SYNTAX</title>
+    <author><first>B. J.</first><last>Dasher</last></author>
+    <pages>7</pages>
+  </paper>
+
+  <paper id="2007">
+    <title>On Semantics of Some Verbal Categories in <fixed-case>E</fixed-case>nglish</title>
+    <author><first>Eva</first><last>Hajicova</last></author>
+    <pages>8</pages>
+  </paper>
+
+  <paper id="2008">
+    <title>Sur quelques preprietes communes des catagories semantiques et des procedures generatrices de trois modeles de synthese dans le processus de la <fixed-case>TA</fixed-case> (resume)</title>
+    <author><first>A.</first><last>Ludskanov</last></author>
+    <pages>9</pages>
+  </paper>
+
+  <paper id="2009">
+    <title>Towards an automatic morphological segmentation</title>
+    <author><first>Josse De</first><last>Kock</last></author>
+    <author><first>Walter</first><last>Bossaert</last></author>
+    <pages>10–11</pages>
+  </paper>
+
+  <paper id="2010">
+    <title>The structure, and semantics of the verbal government</title>
+    <author><first>Jacob</first><last>Mathe</last></author>
+    <pages>12</pages>
+  </paper>
+
+  <paper id="2011">
+    <title>Machine Transcoding</title>
+    <author><first>T. R.</first><last>Hofmann</last></author>
+    <author><first>Brian</first><last>Harris</last></author>
+    <pages>13–14</pages>
+  </paper>
+
+  <paper id="2012">
+    <title>Analyse structurelle automatique de grouses nominaux anglais</title>
+    <author><first>L.</first><last>Moessner</last></author>
+    <pages>15–17</pages>
+  </paper>
+
+  <paper id="2013">
+    <title>Ein Programm zur automatischen Synthese englischer Satze</title>
+    <author><first>Klaus</first><last>Detering</last></author>
+    <pages>18</pages>
+  </paper>
+
+  <paper id="2014">
+    <title>AN APPLICATION OF COMPUTER TECHNIQUES TO ANALYSIS OF THE VERB PHRASE IN HINDI AND ENGLISH: A Preliminary Report</title>
+    <author><first>L. M.</first><last>Khubohandani</last></author>
+    <author><first>W. W.</first><last>Glover</last></author>
+    <pages>19</pages>
+  </paper>
+
+  <paper id="2015">
+    <title>Computational Studies in Terminology</title>
+    <author><first>Reinhart</first><last>Herzog</last></author>
+    <pages>20</pages>
+  </paper>
+
+  <paper id="3000">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Preprint No. 69: COLLECTION OF ABSTRACTS OF PAPERS</title>
+  </paper>
+
+  <paper id="3001">
+    <title>The Book of Isaiah: Morphological Clustering and Disputed Authorship</title>
+    <author><first>Asa</first><last>Kasher</last></author>
+  </paper>
+
+  <paper id="3002">
+    <title>DISCOURSE REFERENTS</title>
+    <author><first>Lauri</first><last>Karttunen</last></author>
+  </paper>
+
+  <paper id="3003">
+    <title>ADOUT THE VECTORIAL CALCULUS OF THE RELATION BETWEEN THE SEMANTIC AND SYTACTIC MARKERS OF THE LEXICAL ENTRY</title>
+    <author><first>Paul</first><last>Schveiger</last></author>
+  </paper>
+
+  <paper id="3004">
+    <title>Project <fixed-case>DOC</fixed-case></title>
+    <author><first>William S-Y.</first><last>Wang</last></author>
+  </paper>
+
+  <paper id="4000">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Meta-prints</title>
+  </paper>
+
+  <paper id="4001">
+    <title>Computerized Linguistics: half a commentary</title>
+    <author><first>Martin</first><last>Minow</last></author>
+  </paper>
+
+  <paper id="4002">
+    <title>SOME REMARKS ON J. L. MEY’s PAPER (Preprint No. 20)</title>
+    <author id="petr-sgall"><first>P.</first><last>Sgall</last></author>
+    <author id="eva-hajicova"><first>E.</first><last>Hajicova</last></author>
+  </paper>
+
+  <paper id="5000">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: Post-print</title>
+  </paper>
+
+  <paper id="5001">
+    <title>A Note on Morpheme Structure in Generative Phonology</title>
+    <author><first>Frances</first><last>Kartunnen</last></author>
+    <pages>1–10</pages>
+  </paper>
+
+  <paper id="5002">
+    <title>METAPRINT 3 (METAMETAPRINT 1) Responses to “COMPUTERIZED LINGUISTICS: HALF A COMMENTARY”</title>
+    <author><first>Martin</first><last>Minow</last></author>
+    <pages>11–23</pages>
+  </paper>
+
+  <paper id="5003">
+    <title>Alphabetic List of Contributors of papers to the Conference and Identification Code</title>
+    <pages>24</pages>
+  </paper>
+
+  <paper id="5004">
+    <title>STATISTICAL METHODS IN LEXICOLOGICAL RESEARCH IN THE BALTIC STATES</title>
+    <author><first>HILDA</first><last>RADZIN</last></author>
+    <pages>25</pages>
+  </paper>
+
+  <paper id="5005">
+    <title>Diverse corrigenda and addenda to the pre-prints</title>
+    <pages>26–28</pages>
+  </paper>
+
+  <paper id="6000">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: BULLETINS</title>
+  </paper>
+
+  <paper id="6001">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: BULLETIN MONDAY, SEPTEMBER 1, 1969</title>
+  </paper>
+
+  <paper id="6002">
+    <title>INTERNATIONAL CONFERENCE ON COMPUTATIONAL LINGUISTICS COLING 1969: BULLETIN WEDNESDAY, SEPTEMBER 3, 1969</title>
+  </paper>
 </volume>


### PR DESCRIPTION
In a fit of frustration trying to nest this conference, I manually reorganized it. This is long overdue (#147). Comments welcome. The conference structure wasn't perfectly clear, but I organized it as:

- C69-1: preprints, including both abstracts and articles
- C69-2: preprint 62, which was a collection of abstracts
- C69-3: preprint 69, another collection of abstracts
- C69-4: metaprints (articles about preprints)
- C69-5: post prints (responses to the conference, I think)
- C69-6: two bulletins that were sent out

This will break all old links, but I don't think they're worth keeping. I haven't reorganized the PDFs yet.