### PR TITLE
normalize_anth.py: find papers in nested volumes

### DIFF
--- a/bin/normalize_anth.py
+++ b/bin/normalize_anth.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
     if not root.tail:
         # lxml drops trailing newline
         root.tail = "\n"
-    for paper in root.findall('paper'):
+    for paper in root.findall('.//paper'):
         fullid = "{}-{}".format(root.attrib['id'], paper.attrib['id'])
         for oldnode in paper:
             location = "{}:{}".format(fullid, oldnode.tag)

--- a/bin/normalize_anth.py
+++ b/bin/normalize_anth.py
@@ -160,9 +160,11 @@ if __name__ == "__main__":
         # lxml drops trailing newline
         root.tail = "\n"
     for paper in root.findall('.//paper'):
-        fullid = "{}-{}".format(root.attrib['id'], paper.attrib['id'])
+        papernum = "{} vol {} paper {}".format(root.attrib['id'],
+                                               paper.getparent().attrib['id'],
+                                               paper.attrib['id'])
         for oldnode in paper:
-            location = "{}:{}".format(fullid, oldnode.tag)
+            location = "{}:{}".format(papernum, oldnode.tag)
             process(oldnode, informat=informat)
                 
     tree.write(args.outfile, encoding="UTF-8", xml_declaration=True)

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -15,7 +15,7 @@
       <month>May</month>
       <year>2006</year>
     </meta>
-    <frontmatter></frontmatter>
+    <frontmatter/>
     <paper id="1">
       <author><first>Nina</first><last>Grønnum</last></author>
       <title><fixed-case>D</fixed-case>an<fixed-case>PASS</fixed-case> - A <fixed-case>D</fixed-case>anish Phonetically Annotated Spontaneous Speech Corpus</title>
@@ -3678,7 +3678,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/809_pdf.pdf</url>
     </paper>
     <paper id="509">
-      <author><first>Benoı̂t</first><last>Sagot</last></author>
+      <author><first>Benoît</first><last>Sagot</last></author>
       <author><first>Lionel</first><last>Clément</last></author>
       <author><first>Éric</first><last>Villemonte de La Clergerie</last></author>
       <author><first>Pierre</first><last>Boullier</last></author>


### PR DESCRIPTION
L06.xml: restore fix to dotless i

#417 normalize_anth.py does contain code fixing dotless i with an accent.
latex_to_unicode.py mentions it as well.  What else needs to be fixed?
