### PR TITLE
added invisible PDF link (closes #377)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 SHELL = /bin/sh
-ANTHOLOGYHOST := "https://aclweb.org"
+ANTHOLOGYHOST := "https://www.aclweb.org"
 ANTHOLOGYDIR := anthology
 
 sourcefiles=$(shell find data -type f '(' -name "*.yaml" -o -name "*.xml" ')')

--- a/hugo/layouts/papers/list-entry.html
+++ b/hugo/layouts/papers/list-entry.html
@@ -18,7 +18,9 @@
     <a class="badge badge-primary align-middle mr-1" href="{{ . }}" data-toggle="tooltip" data-placement="top" title="Open PDF">
       pdf
     </a>
+      {{- if eq . (strings.TrimSuffix ".pdf" .) -}}
     <a style="display: none" href="{{ . }}.pdf" title="Hidden link to PDF with extension">pdf</a>
+      {{- end -}}
     {{- end -}}
   {{- end -}}
     {{- $bibfile := printf "/papers/%s/%s/%s.bib" (slicestr $volume_id 0 1) $volume_id .Params.anthology_id -}}

--- a/hugo/layouts/papers/list-entry.html
+++ b/hugo/layouts/papers/list-entry.html
@@ -18,6 +18,7 @@
     <a class="badge badge-primary align-middle mr-1" href="{{ . }}" data-toggle="tooltip" data-placement="top" title="Open PDF">
       pdf
     </a>
+    <a style="display: none" href="{{ . }}.pdf" title="Hidden link to PDF with extension">pdf</a>
     {{- end -}}
   {{- end -}}
     {{- $bibfile := printf "/papers/%s/%s/%s.bib" (slicestr $volume_id 0 1) $volume_id .Params.anthology_id -}}

--- a/hugo/layouts/papers/list-entry.html
+++ b/hugo/layouts/papers/list-entry.html
@@ -18,7 +18,7 @@
     <a class="badge badge-primary align-middle mr-1" href="{{ . }}" data-toggle="tooltip" data-placement="top" title="Open PDF">
       pdf
     </a>
-      {{- if and (hasPrefix . .Site.BaseURL) (eq . (strings.TrimSuffix ".pdf" .)) -}}
+      {{- if and (hasPrefix . $.Site.Params.baseURL) (eq . (strings.TrimSuffix ".pdf" .)) -}}
     <a style="display: none" href="{{ . }}.pdf" title="Hidden link to PDF with extension">pdf</a>
       {{- end -}}
     {{- end -}}

--- a/hugo/layouts/papers/list-entry.html
+++ b/hugo/layouts/papers/list-entry.html
@@ -18,7 +18,7 @@
     <a class="badge badge-primary align-middle mr-1" href="{{ . }}" data-toggle="tooltip" data-placement="top" title="Open PDF">
       pdf
     </a>
-      {{- if eq . (strings.TrimSuffix ".pdf" .) -}}
+      {{- if and (hasPrefix . .Site.BaseURL) (eq . (strings.TrimSuffix ".pdf" .)) -}}
     <a style="display: none" href="{{ . }}.pdf" title="Hidden link to PDF with extension">pdf</a>
       {{- end -}}
     {{- end -}}

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -15,6 +15,12 @@ ErrorDocument 404 /anthology/404.html
 
 RewriteEngine On
 
+#
+# EXTERNAL REDIRECTIONS
+#
+# These rules contain external redirections: to HTTPS, to the canonical URLs, and others.
+#
+
 # Redirect non-canonical URL bases to https://aclweb.org/anthology/
 RewriteCond %{HTTP_HOST} ^anthology\.aclweb\.org$ [OR]
 RewriteCond %{HTTP_HOST} ^www\.anthology\.aclweb\.org$
@@ -26,11 +32,21 @@ RewriteRule ^/?(.*) https://www.aclweb.org/anthology/$1 [R=301,L]
 RewriteCond %{HTTPS} !=on
 RewriteRule ^(.*)$ https://%{SERVER_NAME}/anthology/$1 [R=301,L]
 
-## Old paths
+## PDF paths
 # Redirect old canonical paths (e.g., P/P17/P17-1069.pdf -> https://www.aclweb.org/anthology/P17-1069)
 # Note that since capture patterns can't be reused in the capture portion of the string, this is a leaky match
 # that will also redirect X/Z19/P17-1069.pdf -> /anthology-files/pdf/P/P17/1-69.pdf
 RewriteRule ^[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(.pdf)?$ https://www.aclweb.org/anthology/$1$2-$3 [R=301,L]
+
+# Redirect URLS with an explicit ".pdf" to the bare canonical version
+RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ https://www.aclweb.org/anthology/$1$2-$3 [R=301,L]
+
+#
+# INTERNAL REDIRECTIONS
+#
+# These rules take valid external URLS (which are often virtual targets) and retrieve their target.
+# They are invisible to the outside.
+#
 
 ## PDF redirection
 # Canonical URL (a plain ACL ID with no file extension, e.g., P17-1069 -> P/P17/P17-1069.pdf)


### PR DESCRIPTION
This adds an invisible link to papers with a `.pdf` extension, which should fix TPMS crawling of author pages.