### PR TITLE
Change canonical URLs of volume pages (resolves #430)

### DIFF
--- a/bin/create_hugo_pages.py
+++ b/bin/create_hugo_pages.py
@@ -113,7 +113,12 @@ def create_volumes(srcdir, clean=False):
                 {
                     "anthology_id": anthology_id,
                     "title": entry["title"],
-                    "slug": slugify(entry["title"]),
+                    "aliases": [
+                        slugify(entry["title"]),
+                        "/papers/{}/{}/{}/".format(
+                            anthology_id[0], anthology_id[:3], anthology_id
+                        ),
+                    ],
                 },
                 default_flow_style=False,
                 stream=f,


### PR DESCRIPTION
This PR changes the canonical URL of volume pages to be their ID instead of a slug of their title.

This means that, for example, S12-1 would have the canonical URL:

+ `https://aclweb.org/anthology/volumes/S12-1/`

In addition, the current title slug is retained as an alias, and another alias is set for the logically equivalent `/papers/` URL, so the following two will both work & redirect to the canonical URL:

+ `https://aclweb.org/anthology/volumes/sem-2012-the-first-joint-conference-on-lexical-and-computational-semantics-volume-1-proceedings-of-the-main-conference-and-the-shared-task-and-volume-2-proceedings-of-the-sixth-international-workshop-on-semantic-evaluation-semeval-2012/`
+ `https://aclweb.org/anthology/papers/S/S12/S12-1/`
