### PR TITLE
Change volumes aliases to the correct URL slug (re #446)

### DIFF
--- a/bin/create_hugo_pages.py
+++ b/bin/create_hugo_pages.py
@@ -114,7 +114,7 @@ def create_volumes(srcdir, clean=False):
                     "anthology_id": anthology_id,
                     "title": entry["title"],
                     "aliases": [
-                        slugify(entry["title"]),
+                        "/volumes/{}/".format(slugify(entry["title"])),
                         "/papers/{}/{}/{}/".format(
                             anthology_id[0], anthology_id[:3], anthology_id
                         ),


### PR DESCRIPTION
Looks like I made a pretty nasty mistake when addressing #430 — the alias for the old volume URLs, unlike the main URL slug, apparently needs to be specified with absolute paths...

This will resolve #446.
