### PR TITLE
Ingestion of IWPT 1989

### DIFF
--- a/data/xml/W89.xml
+++ b/data/xml/W89.xml
@@ -543,7 +543,7 @@
       <url>W89-0243</url>
     </paper>
     <paper id="44">
-      <title>A Broad-Coverage Natural Language Analysis 5ystem</title>
+      <title>A Broad-Coverage Natural Language Analysis System</title>
       <author><first>Karen</first><last>Jensen</last></author>
       <pages>425–441</pages>
       <abstract/>

--- a/data/xml/W89.xml
+++ b/data/xml/W89.xml
@@ -425,7 +425,7 @@
     </paper>
     <paper id="29">
       <title>Finite State Machines from Feature Grammars</title>
-      <author><first>Alan W.</first><last>Black</last></author>
+      <author><first>Alan W</first><last>Black</last></author>
       <pages>277–285</pages>
       <abstract>This paper describes the conversion of a set of feature grammar rules into a deterministic finite state machine that accepts the same language (or at least a well-defined related language). First the reasoning behind why this is an interesting thing to do within the Edinburgh speech recogniser project, is discussed. Then details about the compilation algorithm are given. Finally, there is some discussion of the advantages and disadvantages of this method of implementing feature based grammar formalisms.</abstract>
       <url>W89-0229</url>
@@ -449,7 +449,7 @@
     </paper>
     <paper id="32">
       <title>The Parallel Expert Parser: A Meaning-Oriented, Lexically-Guided, Parallel-Interactive Model of Natural Language Understanding</title>
-      <author><first>Geert</first><last>Adriaens</last></author>
+      <author id="geert-adriaens"><first>G.</first><last>Adriaens</last></author>
       <pages>309–319</pages>
       <abstract>The Parallel Expert Parser (PEP) is a natural language analysis model belonging to the interactive model paradigm that stresses the parallel interaction of relatively small distributed knowledge components to arrive at the meaning of a fragment of text. It borrows the idea of words as basic dynamic entities triggering a set of interactive processes from the Word Expert Parser (Small 1980), but tries to improve on the clarity of interactive processes and on the organization of lexically-distributed knowledge. As of now, especially the procedural aspects have received attention: instead of having wild-running uncontrollable interactions, PEP restricts the interactions to explicit communications on a structured blackboard; the communication protocols are a compromise betwenn maximum parallelism and controllability. At the same time, it is no longer just words that trigger processes; words create larger units (constituents), that are in turn interacting entities on a higher level. Lexical experts contribute their associated knowledge, create higher-level experts, and die away. The linguists define the levels to be considered, and write expert processes in a language that tries to hide the procedural aspects of the parallel-interactive model from them. Problems include the possiblity of deadlock situations when processes wait infinitely for each other, the way to efficiently pursue different alternatives (as of now, the system just uses don’t-care determinism), and testing whether the protocols allow linguists to fully express their needs. PEP has been implemented in Flat Concurrent Prolog, using the Logix programming environment. Current research is oriented more towards the problem of distributed knowledge representation. Abstractions and generalizations across lexical experts could be made using principles from object-oriented programming (introducing generic, prototypical experts; cp. Hahn 1987). Thoughts also go in the direction of an integration of the coarse-grained parallelism with knowledge representation in a fine-grained parallel (connectionist) way.</abstract>
       <url>W89-0232</url>
@@ -551,7 +551,7 @@
     </paper>
     <paper id="45">
       <title>Pseudo Parsing Swift-Answer Algorithm</title>
-      <author><first>S. Pal</first><last>Asija</last></author>
+      <author><first>S Pal</first><last>Asija</last></author>
       <pages>442–447</pages>
       <abstract/>
       <url>W89-0245</url>
@@ -565,7 +565,7 @@
     </paper>
     <paper id="47">
       <title>Parsing Generalized Phrase Structure Grammar with Dynamic Expansion</title>
-      <author><first>Navin</first><last>Rudhiraja</last></author>
+      <author><first>Navin</first><last>Budhiraja</last></author>
       <author><first>Subrata</first><last>Mitra</last></author>
       <author><first>Harish</first><last>Karnick</last></author>
       <author><first>Rajeev</first><last>Sangal</last></author>

--- a/data/xml/W89.xml
+++ b/data/xml/W89.xml
@@ -210,7 +210,7 @@
       <pages>i–vii</pages>
     </frontmatter>
     <paper id="1">
-      <title>Unificabon and Classification: An Experiment in Information-Based Parsing</title>
+      <title>Unification and Classification: An Experiment in Information-Based Parsing</title>
       <author><first>Robert T.</first><last>Kasper</last></author>
       <pages>1–7</pages>
       <abstract>When dealing with a phenomenon as vast and com plex as natural language, an experimental approach is often the best way to discover new computational methods and determine their usefulness. The experimental process includes designing and selecting new experiments, carrying out the experiments, and evaluating the experiments. Most conference presentations are about finished experiments, completed theoretical results, or the evaluation of systems already in use. In this workshop setting, I would like to depart from this tendency to discuss some experiments that we are beginning to perform, and the reasons for investigating a particular approach to parsing. This approach builds on recent work in unification-based parsing and classification-based knowledge representation, developing an architecture that brings together the capabilities of these related frameworks.</abstract>
@@ -321,7 +321,7 @@
       <url>W89-0214</url>
     </paper>
     <paper id="15">
-      <title>Probalistic Methods in Dependency Grammar Parsing</title>
+      <title>Probabilistic Methods in Dependency Grammar Parsing</title>
       <author><first>Job M.</first><last>van Zuijlen</last></author>
       <pages>142–151</pages>
       <abstract>Authentic text as found in corpora cannot be described completely by a formal system, such as a set of grammar rules. As robust parsing is a prerequisite for any practical natural language processing system, there is certainly a need for techniques that go beyond merely formal approaches. Various possibilities, such as the use of simulated annealing, have been proposed recently and we have looked at their suitability for the parse process of the DLT machine translation system, which will use a large structured bilingual corpus as its main linguistic knowledge source. Our findings are that parsing is not the type of task that should be tackled solely through simulated annealing or similar stochastic optimization techniques but that a controlled application of probabilistic methods is essential for the performance of a corpus-based parser. On the basis of our explorative research we have planned a number of small-scale implementations in the near future.</abstract>

--- a/data/xml/W89.xml
+++ b/data/xml/W89.xml
@@ -195,4 +195,383 @@
       <url>W89-0130</url>
     </paper>
   </volume>
+  <volume id="2">
+    <meta>
+      <booktitle>Proceedings of the First International Workshop on Parsing Technologies</booktitle>
+      <editor><first>Masaru</first><last>Tomita</last></editor>
+      <publisher>Carnegy Mellon University</publisher>
+      <address>Pittsburgh, Pennsylvania, USA</address>
+      <month>August</month>
+      <year>1989</year>
+      <url>W89-02</url>
+    </meta>
+    <frontmatter>
+      <url>W89-0200</url>
+      <pages>i–vii</pages>
+    </frontmatter>
+    <paper id="1">
+      <title>Unificabon and Classification: An Experiment in Information-Based Parsing</title>
+      <author><first>Robert T.</first><last>Kasper</last></author>
+      <pages>1–7</pages>
+      <abstract>When dealing with a phenomenon as vast and com plex as natural language, an experimental approach is often the best way to discover new computational methods and determine their usefulness. The experimental process includes designing and selecting new experiments, carrying out the experiments, and evaluating the experiments. Most conference presentations are about finished experiments, completed theoretical results, or the evaluation of systems already in use. In this workshop setting, I would like to depart from this tendency to discuss some experiments that we are beginning to perform, and the reasons for investigating a particular approach to parsing. This approach builds on recent work in unification-based parsing and classification-based knowledge representation, developing an architecture that brings together the capabilities of these related frameworks.</abstract>
+      <url>W89-0201</url>
+    </paper>
+    <paper id="2">
+      <title>Using Restriction to Optimize Unification Parsing</title>
+      <author><first>Dale</first><last>Gerdemann</last></author>
+      <pages>8–17</pages>
+      <abstract/>
+      <url>W89-0202</url>
+    </paper>
+    <paper id="3">
+      <title>An Overview of Disjunctive Constraint Satisfaction</title>
+      <author><first>John T.</first><last>Maxwell III</last></author>
+      <author><first>Ronald M.</first><last>Kaplan</last></author>
+      <pages>18–27</pages>
+      <abstract/>
+      <url>W89-0203</url>
+    </paper>
+    <paper id="4">
+      <title>A Uniform Formal Framework for Parsing</title>
+      <author><first>Bernard</first><last>Lang</last></author>
+      <pages>28–42</pages>
+      <abstract/>
+      <url>W89-0204</url>
+    </paper>
+    <paper id="5">
+      <title>Head-Driven Bidirectional Parsing: A Tabular Method</title>
+      <author><first>Giorgio</first><last>Satta</last></author>
+      <author><first>Oliviero</first><last>Stock</last></author>
+      <pages>43–51</pages>
+      <abstract/>
+      <url>W89-0205</url>
+    </paper>
+    <paper id="6">
+      <title>Head-Driven Parsing</title>
+      <author><first>Martin</first><last>Kay</last></author>
+      <pages>52–62</pages>
+      <abstract/>
+      <url>W89-0206</url>
+    </paper>
+    <paper id="7">
+      <title>Parsing with Principles: Predicting a Phrasal Node Before Its Head Appears</title>
+      <author><first>Edward</first><last>Gibson</last></author>
+      <pages>63–74</pages>
+      <abstract/>
+      <url>W89-0207</url>
+    </paper>
+    <paper id="8">
+      <title>The Computational Implementation of Principle-Based Parsers</title>
+      <author><first>Sandiway</first><last>Fong</last></author>
+      <author><first>Robert C.</first><last>Berwick</last></author>
+      <pages>75–84</pages>
+      <abstract>This paper addresses the issue of how to organize linguistic principles for efficient processing. Based on the general characterization of principles in terms of purely computational properties, the effects of principle-ordering on parser performance are investigated. A novel parser that exploits the possible variation in principle-ordering to dynamically re-order principles is described. Heuristics for minimizing the amount of unnecessary work performed during the parsing process are also discussed.</abstract>
+      <url>W89-0208</url>
+    </paper>
+    <paper id="9">
+      <title>Probabilistic Parsing Method for Sentence Disambiguation</title>
+      <author><first>T.</first><last>Fujisaki</last></author>
+      <author id="frederick-jelinek"><first>F.</first><last>Jelinek</last></author>
+      <author><first>J.</first><last>Cocke</last></author>
+      <author id="ezra-black"><first>E.</first><last>Black</last></author>
+      <author><first>T.</first><last>Nishino</last></author>
+      <pages>85–94</pages>
+      <abstract/>
+      <url>W89-0209</url>
+    </paper>
+    <paper id="10">
+      <title>A Sequential Truncation Parsing Algorithm Based on the Score Function</title>
+      <author><first>Keh-Yih</first><last>Su</last></author>
+      <author><first>Jong-Nae</first><last>Wang</last></author>
+      <author><first>Mei-Hui</first><last>Su</last></author>
+      <author><first>Jing-Shin</first><last>Chang</last></author>
+      <pages>95–104</pages>
+      <abstract>In a natural language processing system, a large amount of ambiguity and a large branching factor are hindering factors in obtaining the desired analysis for a given sentence in a short time. In this paper, we are proposing a sequential truncation parsing algorithm to reduce the searching space and thus lowering the parsing time. The algorithm is based on a score function which takes the advantages of probabilistic characteristics of syntactic information in the sentences. A preliminary test on this algorithm was conducted with a special version of our machine translation system, the ARCHTRAN, and an encouraging result was observed.</abstract>
+      <url>W89-0210</url>
+    </paper>
+    <paper id="11">
+      <title>Probabilistic LR Parsing for Speech Recognition</title>
+      <author><first>J. H.</first><last>Wright</last></author>
+      <author><first>E. N.</first><last>Wrigley</last></author>
+      <pages>105–114</pages>
+      <abstract>An LR parser for probabilistic context-free grammars is described. Each of the standard versions of parser generator (SLR, canonical and LALR) may be applied. A graph-structured stack permits action conflicts and allows the parser to be used with uncertain input, typical of speech recognition applications. The sentence uncertainty is measured using entropy and is significantly lower for the grammar than for a first-order Markov model.</abstract>
+      <url>W89-0211</url>
+    </paper>
+    <paper id="12">
+      <title>Parsing Speech for Structure and Prominence</title>
+      <author><first>Dieter</first><last>Huber</last></author>
+      <pages>115–125</pages>
+      <abstract/>
+      <url>W89-0212</url>
+    </paper>
+    <paper id="13">
+      <title>Parsing Continuous Speech by HMM-LR Method</title>
+      <author><first>Kenji</first><last>Kita</last></author>
+      <author><first>Takeshi</first><last>Kawabata</last></author>
+      <author><first>Hiroaki</first><last>Saito</last></author>
+      <pages>126–131</pages>
+      <abstract>This paper describes a speech parsing method called HMM-LR. In HMM-LR, an LR parsing table is used to predict phones in speech input, and the system drives an HMM-based speech recognizer directly without any intervening structures such as a phone lattice. Very accurate, efficient speech parsing is achieved through the integrated processes of speech recognition and language analysis. The HMM-LR m ethod is applied to large-vocabulary speaker-dependent Japanese phrase recognition. The recognition rate is 87.1% for the top candidates and 97.7% for the five best candidates.</abstract>
+      <url>W89-0213</url>
+    </paper>
+    <paper id="14">
+      <title>Parsing Japanese Spoken Sentences Based on HPSG</title>
+      <author><first>Kiyoshi</first><last>Kogure</last></author>
+      <pages>132–141</pages>
+      <abstract>An analysis method for Japanese spoken sentences based on HPSG has been developed. Any analysis module for the interpreting telephony task requires the following capabilities: (i) the module must be able to treat spoken-style sentences; and, (ii) the module must be able to take, as its input, lattice-like structures which include both correct and incorrect constituent candidates of a speech recognition module. To satisfy these requirements, an analysis method has been developed, which consists of a grammar designed for treating spoken-style Japanese sentences and a parser designed for taking as its input speech recognition output lattices. The analysis module based on this method is used as part of the NADINE (Natural Dialogue Interpretation Expert) system and the SL-TRANS (Spoken Language Translation) system.</abstract>
+      <url>W89-0214</url>
+    </paper>
+    <paper id="15">
+      <title>Probalistic Methods in Dependency Grammar Parsing</title>
+      <author><first>Job M.</first><last>van Zuijlen</last></author>
+      <pages>142–151</pages>
+      <abstract>Authentic text as found in corpora cannot be described completely by a formal system, such as a set of grammar rules. As robust parsing is a prerequisite for any practical natural language processing system, there is certainly a need for techniques that go beyond merely formal approaches. Various possibilities, such as the use of simulated annealing, have been proposed recently and we have looked at their suitability for the parse process of the DLT machine translation system, which will use a large structured bilingual corpus as its main linguistic knowledge source. Our findings are that parsing is not the type of task that should be tackled solely through simulated annealing or similar stochastic optimization techniques but that a controlled application of probabilistic methods is essential for the performance of a corpus-based parser. On the basis of our explorative research we have planned a number of small-scale implementations in the near future.</abstract>
+      <url>W89-0215</url>
+    </paper>
+    <paper id="16">
+      <title>Predictive Normal Forms for Composition in Categorical Grammars</title>
+      <author><first>Robert E.</first><last>Wall</last></author>
+      <author><first>Kent</first><last>Wittenburg</last></author>
+      <pages>152–161</pages>
+      <abstract>Extensions to Categorial Grammars proposed to account for nonconstitutent conjunction and long-distance dependencies introduce the problem of equivalent derivations, an issue we have characterized as spurious ambiguity from the parsing perspective. In Wittenburg (1987) a proposal was made for compiling Categorial Grammars into predictive forms in order to solve the spurious ambiguity problem. This paper investigates formal properties o f grammars that use predictive versions of function composition. Among our results are (1) that grammars with predictive composition are in general equivalent to the originals if and only if a restriction on predictive rules is applied, (2) that modulo this restriction, the predictive grammars have indeed eliminated the problem of spurious ambiguity, and (3) that the issue o f equivalence is decidable, i.e., for any particular grammar, whether one needs to apply the restriction or not to ensure equivalence is a decidable question.</abstract>
+      <url>W89-0216</url>
+    </paper>
+    <paper id="17">
+      <title>Parsing Spoken Language Using Combinatory Grammars</title>
+      <author><first>Mark</first><last>Steedman</last></author>
+      <pages>162–171</pages>
+      <abstract/>
+      <url>W89-0217</url>
+    </paper>
+    <paper id="18">
+      <title>Recognition of Combinatory Categorial Grammars and Linear Indexed Grammars</title>
+      <author><first>K.</first><last>Vijay-Shanker</last></author>
+      <author><first>David J.</first><last>Weir</last></author>
+      <pages>172–181</pages>
+      <abstract/>
+      <url>W89-0218</url>
+    </paper>
+    <paper id="19">
+      <title>Handling of Ill-Designed Grammars in Tomita’s Parsing Algorithm</title>
+      <author><first>Rohman</first><last>Nozohoor-Farshi</last></author>
+      <pages>182–192</pages>
+      <abstract>In this paper, we show that some non-cyclic context-free grammars with <tex-math>\varepsilon</tex-math>-rules cannot be handled by Tomita’s algorithm properly. We describe a modified version of the algorithm which remedies the problem.</abstract>
+      <url>W89-0219</url>
+    </paper>
+    <paper id="20">
+      <title>Analysis of Tomita’s Algorithm for General Context-Free Parsing</title>
+      <author><first>James R.</first><last>Kipps</last></author>
+      <pages>193–202</pages>
+      <abstract>A variation on Tomita’s algorithm is analyzed in regards to its time and space complexity. It is shown to have a general time bound of <tex-math>0(n^{\tilde{\rho}+1})</tex-math>, where <tex-math>n</tex-math> is the length of the input string and <tex-math>\rho</tex-math> is the length of the longest production. A modified algorithm is presented in which the time bound is reduced to <tex-math>0(n^3)</tex-math>. The space complexity of Tomita’s algorithm is shown to be proportional to <tex-math>n^2</tex-math> in the worst case and is changed by at most a constant factor with the modification. Empirical results are used to illustrate the trade off between time and space on a simple example. A discussion of two subclasses of context-free grammars that can be recognized in <tex-math>0(n^2)</tex-math> and <tex-math>O(n)</tex-math> is also included.</abstract>
+      <url>W89-0220</url>
+    </paper>
+    <paper id="21">
+      <title>The Computational Complexity of Tomita’s Algorithm</title>
+      <author><first>Mark</first><last>Johnson</last></author>
+      <pages>203–208</pages>
+      <abstract/>
+      <url>W89-0221</url>
+    </paper>
+    <paper id="22">
+      <title>Probabilistic Parsing for Spoken Language Applications</title>
+      <author><first>Stephanie</first><last>Seneff</last></author>
+      <pages>209–218</pages>
+      <abstract>A new natural language system, TINA, has been developed for applications involving spoken language tasks, which integrate key ideas from context free grammars, Augmented Transition Networks (ATN’s) [6], and Lexical Functional Grammars (LFG’s) [1]. The parser uses a best-first strategy, with probability assignments on all arcs obtained automatically from a set of example sentences. An initial context-free grammar, derived from the example sentences, is first converted to a probabilistic network structure. Control includes both top-down and bottom-up cycles, and key parameters are passed among nodes to deal with long-distance movement, agreement, and semantic constraints. The probabilities provide a natural mechanism for exploring more common grammatical constructions first. One novel feature of TINA is that it provides an atuomatic sentence generation capability, which has been very effective for identifying overgeneration problems. A fully integrated spoken language system using this parser is under development.</abstract>
+      <url>W89-0222</url>
+    </paper>
+    <paper id="23">
+      <title>Connectionist Models of Language</title>
+      <author><first>James L.</first><last>McClelland</last></author>
+      <pages>219–220</pages>
+      <abstract/>
+      <url>W89-0223</url>
+    </paper>
+    <paper id="24">
+      <title>A Connectionist Parser Aimed at Spoken Language</title>
+      <author><first>Ajay</first><last>Jain</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <pages>221–229</pages>
+      <abstract>We describe a connectionist model which learns to parse single sentences from sequential word input. A parse in the connectionist network contains information about role assignment, prepositional attachment, relative clause structure, and subordinate clause structure. The trained network displays several interesting types of behavior. These include predictive ability, tolerance to certain corruptions of input word sequences, and some generalization capability. We report on experiments in which a small number of sentence types have been successfully learned by a network. Work is in progress on a larger database. Application of this type of connectionist model to the area of spoken language processing is discussed.</abstract>
+      <url>W89-0224</url>
+    </paper>
+    <paper id="25">
+      <title>Massively Parallel Parsing in <tex-math>\Phi</tex-math>DmDialog: Integrated Architecture for Parsing Speech Inputs</title>
+      <author><first>Hiroaki</first><last>Kitano</last></author>
+      <author><first>Teruko</first><last>Mitamura</last></author>
+      <author><first>Masaru</first><last>Tomita</last></author>
+      <pages>230–239</pages>
+      <abstract>This paper describes the parsing scheme in the <tex-math>\Phi</tex-math>DmDialog speech-to-speech dialog translation system, with special emphasis on the integration of speech and natural language processing. We propose an integrated architecture for parsing speech inputs based on a parallel marker-passing scheme and attaining dynamic participation of knowledge from the phonological-level to the discourse-level. At the phonological level, we employ a stochastic model using a transition matrix and a confusion matrix and markers which carry a probability measure. At a higher level, syntactic/semantic and discourse processing, we integrate a case-based and constraint-based scheme in a consistent manner so that a priori probability and constraints, which reflect linguistic and discourse factors, are provided to the phonological level of processing. A probability/cost-based scheme in our model enables ambiguity resolution at various levels using one uniform principle.</abstract>
+      <url>W89-0225</url>
+    </paper>
+    <paper id="26">
+      <title>Parallel Parsing Strategies in Natural Language Processing</title>
+      <author><first>Anton</first><last>Nijholt</last></author>
+      <pages>240–253</pages>
+      <abstract>We present a concise survey of approaches to the context-free parsing problem of natural languages in parallel environments. The discussion includes parsing schemes which use more than one traditional parser, schemes where separate processes are assigned to the ‘non-deterministic’ choices during parsing, schemes where the number of processes depends on the length of the sentence being parsed, and schemes where the number of processes depends on the grammar size rather than on the input length. In addition we discuss a connectionist approach to the parsing problem.</abstract>
+      <url>W89-0226</url>
+    </paper>
+    <paper id="27">
+      <title>Complexity and Decidability in Left-Associative Grammar</title>
+      <author><first>Roland</first><last>Hausser</last></author>
+      <pages>254–263</pages>
+      <abstract/>
+      <url>W89-0227</url>
+    </paper>
+    <paper id="28">
+      <title>The selection of a parsing strategy for an on-line machine translation system in a sublanguage domain. A new practical comparison</title>
+      <author><first>Patrick</first><last>Shann</last></author>
+      <pages>264–276</pages>
+      <abstract/>
+      <url>W89-0228</url>
+    </paper>
+    <paper id="29">
+      <title>Finite State Machines from Feature Grammars</title>
+      <author><first>Alan W.</first><last>Black</last></author>
+      <pages>277–285</pages>
+      <abstract>This paper describes the conversion of a set of feature grammar rules into a deterministic finite state machine that accepts the same language (or at least a well-defined related language). First the reasoning behind why this is an interesting thing to do within the Edinburgh speech recogniser project, is discussed. Then details about the compilation algorithm are given. Finally, there is some discussion of the advantages and disadvantages of this method of implementing feature based grammar formalisms.</abstract>
+      <url>W89-0229</url>
+    </paper>
+    <paper id="30">
+      <title>An Effective Enumeration Algorithm of Parses for Ambiguous CFL</title>
+      <author><first>Nariyoshi</first><last>Yamai</last></author>
+      <author><first>Tadashi</first><last>Seko</last></author>
+      <author><first>Noboru</first><last>Kubo</last></author>
+      <author><first>Toru</first><last>Kawata</last></author>
+      <pages>286–296</pages>
+      <abstract>An efficient algorithm that enumerates parses of ambiguous context-free languages is described, and its time and space complexities are discussed. When context-free parsers are used for natural language parsing, pattern recognition, and so forth, there may be a great number of parses for a sentence. One common strategy for efficient enumeration of parses is to assign an appropriate weight to each production, and to enumerate parses in the order of the total weight of all applied production. However, the existing algorithms taking this strategy can be applied only to the problems of limited areas such as regular languages; in the other areas only inefficient exhaustive searches are known. In this paper, we first introduce a hierarchical graph suitable for enumeration. Using this graph, enumeration of parses in the order of acceptablity is equivalent to finding paths of this graph in the order of length. Then, we present an efficient enumeration algorithm with this graph, which can be applied to arbitrary context-free grammars. For enumeration of <tex-math>k</tex-math> parses in the order of the total weight of all applied productions, the time and space complexities of our algorithm are <tex-math>0(n^3 + kn^2)</tex-math> and <tex-math>0(n^3 + kn)</tex-math>, respectively.</abstract>
+      <url>W89-0230</url>
+    </paper>
+    <paper id="31">
+      <title>A Morphological Parser for Linguistic Exploration</title>
+      <author><first>David</first><last>Weber</last></author>
+      <pages>297–308</pages>
+      <abstract/>
+      <url>W89-0231</url>
+    </paper>
+    <paper id="32">
+      <title>The Parallel Expert Parser: A Meaning-Oriented, Lexically-Guided, Parallel-Interactive Model of Natural Language Understanding</title>
+      <author><first>Geert</first><last>Adriaens</last></author>
+      <pages>309–319</pages>
+      <abstract>The Parallel Expert Parser (PEP) is a natural language analysis model belonging to the interactive model paradigm that stresses the parallel interaction of relatively small distributed knowledge components to arrive at the meaning of a fragment of text. It borrows the idea of words as basic dynamic entities triggering a set of interactive processes from the Word Expert Parser (Small 1980), but tries to improve on the clarity of interactive processes and on the organization of lexically-distributed knowledge. As of now, especially the procedural aspects have received attention: instead of having wild-running uncontrollable interactions, PEP restricts the interactions to explicit communications on a structured blackboard; the communication protocols are a compromise betwenn maximum parallelism and controllability. At the same time, it is no longer just words that trigger processes; words create larger units (constituents), that are in turn interacting entities on a higher level. Lexical experts contribute their associated knowledge, create higher-level experts, and die away. The linguists define the levels to be considered, and write expert processes in a language that tries to hide the procedural aspects of the parallel-interactive model from them. Problems include the possiblity of deadlock situations when processes wait infinitely for each other, the way to efficiently pursue different alternatives (as of now, the system just uses don’t-care determinism), and testing whether the protocols allow linguists to fully express their needs. PEP has been implemented in Flat Concurrent Prolog, using the Logix programming environment. Current research is oriented more towards the problem of distributed knowledge representation. Abstractions and generalizations across lexical experts could be made using principles from object-oriented programming (introducing generic, prototypical experts; cp. Hahn 1987). Thoughts also go in the direction of an integration of the coarse-grained parallelism with knowledge representation in a fine-grained parallel (connectionist) way.</abstract>
+      <url>W89-0232</url>
+    </paper>
+    <paper id="33">
+      <title>Chart Parsing for Loosely Coupled Parallel Systems</title>
+      <author><first>Henry S.</first><last>Thompson</last></author>
+      <pages>320–328</pages>
+      <abstract/>
+      <url>W89-0233</url>
+    </paper>
+    <paper id="34">
+      <title>Parallel Generalized LR Parsing based on Logic Programming</title>
+      <author><first>Hozumi</first><last>Tanaka</last></author>
+      <author><first>Hiroaki</first><last>Numazaki</last></author>
+      <pages>329–338</pages>
+      <abstract>A generalized LR parsing algorithm, which has been developed by Tomita [Tomita 86], can treat a context free grammar. His algorithm makes use of breadth first strategy when a conflict occcurs in a LR parsing table. It is well known that the breadth first strategy is suitable for parallel processing. This paper presents an algorithm of a parallel parsing system (PLR) based on a generalized LR parsing. PLR is implemented in GHC [Ueda 85] that is a concurrent logic programming language developed by Japanese 5th generation computer project. The feature of PLR is as follows: Each entry of a LR parsing table is regarded as a process which handles shift and reduce operations. If a process discovers a conflict in a LR parsing table, it activates subprocesses which conduct shift and reduce operations. These subprocesses run in parallel and simulate breadth first strategy. There is no need to make some subprocesses synchronize during parsing. Stack information is sent to each subprocesses from their parent process. A simple experiment for parsing a sentence revealed the fact that PLR runs faster than PAX [Matsumoto 87][Matsumoto 89] that has been known as the best parallel parser.</abstract>
+      <url>W89-0234</url>
+    </paper>
+    <paper id="35">
+      <title>The Relevance of Lexicalization to Parsing</title>
+      <author><first>Yves</first><last>Schabes</last></author>
+      <author><first>Aravind K.</first><last>Joshi</last></author>
+      <pages>339–349</pages>
+      <abstract>In this paper, we investigate the processing of the so-called ‘lexicalized’ grammar. In ‘lexicalized’ grammars (Schabes, Abeille and Joshi, 1988), each elementary structure is systema tically associated with a lexical ‘head’. These structures specify extended domains of locality (as compared to CFGs) over which constraints can be stated. The ‘grammar’ consists of a lexicon where each lexical item is associated with a finite number of structures for which that item is the ‘head’ . There are no separate grammar rules. There are, of course, ‘rules’ which tell us how these structures are combined. A general two-pass parsing strategy for ‘lexicalized’ grammars follows naturally. In the first stage, the parser selects a set of elementary structures associated with the lexical items in the input sentence, and in the second stage the sentence is parsed with respect to this set. We evaluate this strategy with respect to two characteristics. First, the amount of filtering on the entire grammar is evaluated: once the first pass is performed, the parser uses only a subset of the grammar. Second, we evaluate the use of non-local information: the structures selected during the first pass encode the morphological value (and therefore the position in the string) of their ‘head’; this enables the parser to use non-local in form ation to guide its search. We take Lexicalized Tree Adjoining Grammars as an in stance of lexicalized grammar. We illustrate the organization of the grammar. Then we show how a general Earley-type TAG parser (Schabes and Joshi, 1988) can take advantage of lexicalization. Empirical data show that the filtering of the grammar and the non-local in formation provided by the two-pass strategy improve the performance of the parser. We explain how constraints over the elementary structures expressed by unification equations can be parsed by a simple extension of the Earley-type TAG parser. Lexicalization guarantees termination of the algorithm without special devices such as restrictors.</abstract>
+      <url>W89-0235</url>
+    </paper>
+    <paper id="36">
+      <title>A Framework for the Development of Natural Language Grammars</title>
+      <author><first>Massimo</first><last>Marino</last></author>
+      <pages>350–360</pages>
+      <abstract>This paper describes a parsing system used in a framework for the development of Natural Language grammars. It is an interactive environment suitable for writing robust NL applications generally. Its heart is the SAIL parsing algorithm that uses a Phrase-Structure Grammar with extensive augmentations. Furthermore, some particular parsing tools are embedded in the system, and provide a powerful environment for developing grammars, even of large coverage.</abstract>
+      <url>W89-0236</url>
+    </paper>
+    <paper id="37">
+      <title>An Efficient Method for Parsing Erroneous Input</title>
+      <author><first>Stuart</first><last>Malone</last></author>
+      <author><first>Sue</first><last>Felshin</last></author>
+      <pages>361–368</pages>
+      <abstract>In a natural language processing system designed for language learners, it is necessary to accept both well-formed and ill-formed input. This paper describes a method of maintaining parsing efficiency for well-formed sentences while still accepting a wide range of ill-formed input.</abstract>
+      <url>W89-0237</url>
+    </paper>
+    <paper id="38">
+      <title>Analysis Techniques for Korean Sentences Based on Lexical Functional Grammar</title>
+      <author><first>Deok Ho</first><last>Yoon</last></author>
+      <author><first>Yung Taek</first><last>Kim</last></author>
+      <pages>369–378</pages>
+      <abstract>The Unification-based Grammars seem to be adequate for the analysis of agglutinative languages such as Korean, etc. In this paper, the merits of Lexical Functional Grammar is analyzed and the structure of Korean Syntactic Analyzer is described. Verbal complex category is used for the analysis of several linguistic phenomena and a new attribute of UNKNOWN is defined for the analysis of grammatical relations.</abstract>
+      <url>W89-0238</url>
+    </paper>
+    <paper id="39">
+      <title>Learning Cooccurrences by using a Parser</title>
+      <author><first>Kazunori</first><last>Matsumoto</last></author>
+      <author><first>Hiroshi</first><last>Sakaki</last></author>
+      <author><first>Shingo</first><last>Kuroiwa</last></author>
+      <pages>379–388</pages>
+      <abstract>This paper describes two methods for the acquisition and utilization of lexical cooccurrence relationships. Under these method, cooccurrence relationships are obtained from two kinds of inputs: example sentences and the corresponding correct syntactic structure. The first of the two methods treats a set of governors each element of which is bound to a element of sister nodes set in a syntactic structure under consideration, as a cooccurrence relationship. In the second method, a cooccurrence relationship name and affiliated attribute names are manually given in the description of augmented rewriting rules. Both methods discriminate correctness of cooccurrence by the use of the correct syntactic structure mentioned above. Experiment is made for both methods to find if thus obtained cooccurrence relationship is useful for the correct analysis.</abstract>
+      <url>W89-0239</url>
+    </paper>
+    <paper id="40">
+      <title>Parsing, Word Associations and Typical Predicate-Argument Relations</title>
+      <author><first>Kenneth</first><last>Church</last></author>
+      <author><first>William</first><last>Gale</last></author>
+      <author><first>Patrick</first><last>Hanks</last></author>
+      <author><first>Donald</first><last>Hindle</last></author>
+      <pages>389–398</pages>
+      <abstract>There are a number of collocational constraints in natural languages that ought to play a more important role in natural language parsers. Thus, for example, it is hard for most parsers to take advantage of the fact that wine is typically drunk, produced, and sold, but (probably) not pruned. So too, it is hard for a parser to know which verbs go with which prepositions (e.g., set up) and which nouns fit together to form compound noun phrases (e.g., computer programmer). This paper will attempt to show that many of these types of concerns can be addressed with syntactic methods (symbol pushing), and need not require explicit semantic interpretation. We have found that it is possible to identify many of these interesting co-occurrence relations by computing simple summary statistics over millions of words of text. This paper will summarize a number of experiments carried out by various subsets of the authors over the last few years. The term collocation will be used quite broadly to include constraints on SVO (subject verb object) triples, phrasal verbs, compound noun phrases, and psychoiinguistic notions of word association (e.g., doctor/nurse).</abstract>
+      <url>W89-0240</url>
+    </paper>
+    <paper id="41">
+      <title>An Efficient, Primarily Bottom-Up Parser for Unification Grammars</title>
+      <author><first>Neil K.</first><last>Simpkins</last></author>
+      <author><first>Peter J.</first><last>Hancox</last></author>
+      <pages>399–400</pages>
+      <abstract>The search for efficient parsing strategies has a long history, dating back to at least the Cocke/Younger/Kusami parser of the early sixties. The publication of the Earley parser in 1970 has had a significant influence on context-free (CF) parsing for natural language processing, evidenced by the interest in the variety of chart parsers implemented since then. The development of unification grammars (with their complex feature structures) has put new life into the discussion of efficient parsing strategies, and there has been some debate on the use of essentially bottom-up or top-down strategies, the efficacy of top-down filtering and so on. The approacn to parsing described here is suitable for complex category, unification-based grammars. The concentration here is on a unification grammar which has a context-free backbone, Lexical-Functional Grammer (LFG). The parser is designed primarily for simplicity, efficiency and practical application. The parser outlined here results in a high-level, but still efficient, language system without making a requirement on the grammar/lexicon writer to understand its implementation details. The parsing algorithm operates in a systematic bottom-up (BU) fashion, thus taking earliest advantage of LFQ’s concentration of information in the lexicon and also making use of unrestricted feature structures to realize LFG’s Top-Down (TD) predictive potential. While LFG can make special use of its CF backbone, the algorithm employed is not restricted to grammars having a CF backbone and is equally suited to complex-feature-based formalisms. Additionally, the algorithm described (which is a systematic left-to-right (left comer) parsing algorithm) allows us to take full advantage of both BU and TD aspects of a unificatin-based grammar without incurring prohibitive overheads such as feature-structure comparison or subsumption checking. The use of TD prediction, which in the Earley algorithm is allowed to hypothesize new parse paths, is here restricted to confirming initial parses produced BU, and specializing these according to future (feature) expectations.</abstract>
+      <url>W89-0241</url>
+    </paper>
+    <paper id="42">
+      <title>PREMO: Parsing by Conspicuous Lexical Consumption</title>
+      <author><first>Brian M.</first><last>Slator</last></author>
+      <author><first>Yorick</first><last>Wilks</last></author>
+      <pages>401–413</pages>
+      <abstract>PREMO is a knowledge-based Preference Semantics parser with access to a large, lexical semantic knowledge base and organized along the lines of an operating system. The state of every partial parse is captured in a structure called a language object, and the control structure of the preference machine is a priority queue of these language objects. The language object at the front of the queue has the highest score as computed by a preference metric that weighs grammatical predictions, semantic type matching, and pragmatic coherence. The highest priority language object is the intermediate reading that is currently most preferred (the others are still “alive,” but not actively pursued); in this way the preference machine avoids combinatorial explosion by following a “best-first” strategy for parsing. The system has clear extensions into parallel processing.</abstract>
+      <url>W89-0242</url>
+    </paper>
+    <paper id="43">
+      <title>Parsing 2-Dimensional Language</title>
+      <author><first>Masaru</first><last>Tomita</last></author>
+      <pages>414–424</pages>
+      <abstract>2-Dimensional Context-Free Grammar (2D-CFG) for 2-dimensional input text is introduced and efficient parsing algorithms for 2D-CFG are presented. In 2D-CFG, a grammar rule’s right hand side symbols can be placed not only horizontally but also vertically. Terminal symbols in a 2-dimensional input text are combined to form a rectangular region, and regions are combined to form a larger region using a 2-dimensional phrase structure rule. The parsing algorithms presented in this paper are the 2D-Ear1ey algorithm and 2D-LR algorithm, which are 2-dimensionally extended versions of Earley’s algorithm and the LR(O) algorithm, respectively.</abstract>
+      <url>W89-0243</url>
+    </paper>
+    <paper id="44">
+      <title>A Broad-Coverage Natural Language Analysis 5ystem</title>
+      <author><first>Karen</first><last>Jensen</last></author>
+      <pages>425–441</pages>
+      <abstract/>
+      <url>W89-0244</url>
+    </paper>
+    <paper id="45">
+      <title>Pseudo Parsing Swift-Answer Algorithm</title>
+      <author><first>S. Pal</first><last>Asija</last></author>
+      <pages>442–447</pages>
+      <abstract/>
+      <url>W89-0245</url>
+    </paper>
+    <paper id="46">
+      <title>A Dependency-Based Parser for Topic and Focus</title>
+      <author><first>Eva</first><last>Hajičová</last></author>
+      <pages>448–457</pages>
+      <abstract/>
+      <url>W89-0246</url>
+    </paper>
+    <paper id="47">
+      <title>Parsing Generalized Phrase Structure Grammar with Dynamic Expansion</title>
+      <author><first>Navin</first><last>Rudhiraja</last></author>
+      <author><first>Subrata</first><last>Mitra</last></author>
+      <author><first>Harish</first><last>Karnick</last></author>
+      <author><first>Rajeev</first><last>Sangal</last></author>
+      <pages>458–467</pages>
+      <abstract>A parser is described here based on the Cocke-Young-Kassami algorithm which uses immediate dominance and linear precedence rules together with various feature inheritance conventions. The meta rules in the grammar are not applied beforehand but only when needed. This ensures that the rule set is kept to a minimum. At the same time, determining what rule to expand by applying which meta-rule is done in an efficient manner using the meta-rule reference table. Since this table is generated during “compilation” stage, its generation does not add to parsing time.</abstract>
+      <url>W89-0247</url>
+    </paper>
+  </volume>
 </collection>

--- a/data/xml/W89.xml
+++ b/data/xml/W89.xml
@@ -290,7 +290,7 @@
       <url>W89-0210</url>
     </paper>
     <paper id="11">
-      <title>Probabilistic LR Parsing for Speech Recognition</title>
+      <title>Probabilistic <fixed-case>LR</fixed-case> Parsing for Speech Recognition</title>
       <author><first>J. H.</first><last>Wright</last></author>
       <author><first>E. N.</first><last>Wrigley</last></author>
       <pages>105–114</pages>
@@ -305,7 +305,7 @@
       <url>W89-0212</url>
     </paper>
     <paper id="13">
-      <title>Parsing Continuous Speech by HMM-LR Method</title>
+      <title>Parsing Continuous Speech by <fixed-case>HMM</fixed-case>-<fixed-case>LR</fixed-case> Method</title>
       <author><first>Kenji</first><last>Kita</last></author>
       <author><first>Takeshi</first><last>Kawabata</last></author>
       <author><first>Hiroaki</first><last>Saito</last></author>
@@ -314,7 +314,7 @@
       <url>W89-0213</url>
     </paper>
     <paper id="14">
-      <title>Parsing Japanese Spoken Sentences Based on HPSG</title>
+      <title>Parsing <fixed-case>J</fixed-case>apanese Spoken Sentences Based on <fixed-case>HPSG</fixed-case></title>
       <author><first>Kiyoshi</first><last>Kogure</last></author>
       <pages>132–141</pages>
       <abstract>An analysis method for Japanese spoken sentences based on HPSG has been developed. Any analysis module for the interpreting telephony task requires the following capabilities: (i) the module must be able to treat spoken-style sentences; and, (ii) the module must be able to take, as its input, lattice-like structures which include both correct and incorrect constituent candidates of a speech recognition module. To satisfy these requirements, an analysis method has been developed, which consists of a grammar designed for treating spoken-style Japanese sentences and a parser designed for taking as its input speech recognition output lattices. The analysis module based on this method is used as part of the NADINE (Natural Dialogue Interpretation Expert) system and the SL-TRANS (Spoken Language Translation) system.</abstract>
@@ -431,7 +431,7 @@
       <url>W89-0229</url>
     </paper>
     <paper id="30">
-      <title>An Effective Enumeration Algorithm of Parses for Ambiguous CFL</title>
+      <title>An Effective Enumeration Algorithm of Parses for Ambiguous <fixed-case>CFL</fixed-case></title>
       <author><first>Nariyoshi</first><last>Yamai</last></author>
       <author><first>Tadashi</first><last>Seko</last></author>
       <author><first>Noboru</first><last>Kubo</last></author>
@@ -462,7 +462,7 @@
       <url>W89-0233</url>
     </paper>
     <paper id="34">
-      <title>Parallel Generalized LR Parsing based on Logic Programming</title>
+      <title>Parallel Generalized <fixed-case>LR</fixed-case> Parsing based on Logic Programming</title>
       <author><first>Hozumi</first><last>Tanaka</last></author>
       <author><first>Hiroaki</first><last>Numazaki</last></author>
       <pages>329–338</pages>
@@ -493,7 +493,7 @@
       <url>W89-0237</url>
     </paper>
     <paper id="38">
-      <title>Analysis Techniques for Korean Sentences Based on Lexical Functional Grammar</title>
+      <title>Analysis Techniques for <fixed-case>K</fixed-case>orean Sentences Based on Lexical Functional Grammar</title>
       <author><first>Deok Ho</first><last>Yoon</last></author>
       <author><first>Yung Taek</first><last>Kim</last></author>
       <pages>369–378</pages>
@@ -528,7 +528,7 @@
       <url>W89-0241</url>
     </paper>
     <paper id="42">
-      <title>PREMO: Parsing by Conspicuous Lexical Consumption</title>
+      <title><fixed-case>PREMO</fixed-case>: Parsing by Conspicuous Lexical Consumption</title>
       <author><first>Brian M.</first><last>Slator</last></author>
       <author><first>Yorick</first><last>Wilks</last></author>
       <pages>401–413</pages>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -55,6 +55,7 @@
   id: geert-adriaens
   variants:
   - {first: GEERT, last: ADRIAENS}
+  - {first: G., last: Adriaens}
 - canonical: {first: Itziar, last: Aduriz}
   id: itziar-aduriz
 - canonical: {first: Rodrigo, last: Agerri}

--- a/data/yaml/sigs/sigparse.yaml
+++ b/data/yaml/sigs/sigparse.yaml
@@ -44,6 +44,4 @@ Meetings:
     - Name: 'IWPT 1991' # 13-15 February 1991 - Cancun
       URL: http://hmi.ewi.utwente.nl/sigparse/iwpt91_toc.html
   - 1989:
-    - Name: 'IWPT 1989' # 28-31 August 1989 - Pittsburg, PA
-      URL: http://hmi.ewi.utwente.nl/sigparse/iwpt89_toc.html
-
+     - W89-02 # IWPT 1989


### PR DESCRIPTION
Ingestion of IWPT 1989. Closes #382. PDFs can be found [here](https://wwwtcs.inf.tu-dresden.de/~kilian/assets/W89-02.tar.gz). Just about 50% of the papers have abstracts. Thanks again to CMU Library for providing the scan.

If someone is keen on double-checking the spelling of authors and titles, this would not be a bad thing, as both the website as well as the OCR from which the information is derived contained errors. I did quite a few manual corrections, but there might be something I missed.