### PR TITLE
EMNLP 2014 and 2016 tutorial abstracts

### DIFF
--- a/data/xml/D14.xml
+++ b/data/xml/D14.xml
@@ -2129,4 +2129,106 @@
       <doi>10.3115/v1/D14-1226</doi>
     </paper>
   </volume>
+  <volume id="2">
+   <meta>
+    <booktitle>Proceedings of <fixed-case>EMNLP</fixed-case> 2014, Tutorial Abstracts</booktitle>
+    <url>P18-5</url>
+    <editor><first>Lucia</first><last>Specia</last></editor>
+    <editor><first>Xavier</first><last>Carreras</last></editor>
+    <publisher>Association for Computational Linguistics</publisher>
+    <address>Doha, Qatar</address>
+    <month>October</month>
+    <year>2014</year>
+   </meta>
+   <paper id="1">
+    <title>Sentiment Analysis of Social Media Texts</title>
+    <author><first>Saif M.</first><last>Mohammad</last></author>
+    <author><first>Xiaodan</first><last>Zhu</last></author>
+    <abstract>Automatically detecting sentiment of product reviews, blogs, tweets, and SMS messages has attracted extensive interest from both the academia and industry. It has a number of applications, including: tracking sentiment towards products, movies, politicians, etc.; improving customer relation models; detecting happiness and well-being; and improving automatic dialogue systems. In this tutorial, we will describe how you can create a state-of-the-art sentiment analysis system, with a focus on social media posts.
+
+We begin with an introduction to sentiment analysis and its various forms: term level, message level, document level, and aspect level. We will describe how sentiment analysis systems are evaluated, especially through recent SemEval shared tasks: Sentiment Analysis of Twitter (SemEval-2013 Task 2, SemEval 2014-Task 9) and Aspect Based Sentiment Analysis (SemEval-2014 Task 4).
+
+We will give an overview of the best sentiment analysis systems at this point of time, including those that are conventional statistical systems as well as those using deep learning approaches. We will describe in detail the NRC-Canada systems, which were the overall best performing systems in all three SemEval competitions listed above. These are simple lexical- and sentiment-lexicon features based systems, which are relatively easy to re-implement.
+
+We will discuss features that had the most impact (those derived from sentiment lexicons and negation handling). We will present how large tweet-specific sentiment lexicons can be automatically generated and evaluated. We will also show how negation impacts sentiment differently depending on whether the scope of the negation is positive or negative. Finally, we will flesh out limitations of current approaches and promising future directions.</abstract>
+    <url>D14-2001</url>
+   </paper>
+   <paper id="2">
+    <title>Spectral Learning Techniques for Weighted Automata, Transducers, and Grammars</title>
+    <author><first>Borja</first><last>Balle</last></author>
+    <author><first>Ariadna</first><last>Quattoni</last></author>
+    <author><first>Xavier</first><last>Carreras</last></author>
+    <abstract>In recent years we have seen the development of efficient and provably correct algorithms for learning weighted automata and closely related function classes such as weighted transducers and weighted context-free grammars. The common denominator of all these algorithms is the so-called spectral method, which gives an efficient and robust way to estimate recursively defined functions from empirical estimations of observable statistics. These algorithms are appealing because of the existence of theoretical guarantees (e.g. they are not susceptible to local minima) and because of their efficiency. However, despite their simplicity and wide applicability to real problems, their impact in NLP applications is still moderate. One of the goals of this tutorial is to remedy this situation.
+
+The contents that will be presented in this tutorial will offer a complementary perspective with respect to previous tutorials on spectral methods presented at ICML-2012, ICML-2013 and NAACL-2013. Rather than using the language of graphical models and signal processing, we tell the story from the perspective of formal languages and automata theory (without assuming a background in formal algebraic methods). Our presentation highlights the common intuitions lying behind different spectral algorithms by presenting them in a unified framework based on the concepts of low-rank factorizations and completions of Hankel matrices. In addition, we provide an interpretation of the method in terms of forward and backward recursions for automata and grammars. This provides extra intuitions about the method and stresses the importance of matrix factorization for learning automata and grammars. We believe that this complementary perspective might be appealing for an NLP audience and serve to put spectral learning in a wider and, perhaps for some, more familiar context. Our hope is that this will broaden the understanding of these methods by the NLP community and empower many researchers to apply these techniques to novel problems.
+
+The content of the tutorial will be divided into four blocks of 45 minutes each, as follows. The first block will introduce the basic definitions of weighted automata and Hankel matrices, and present a key connection between the fundamental theorem of weighted automata and learning. In the second block we will discuss the case of probabilistic automata in detail, touching upon all aspects from the underlying theory to the tricks required to achieve accurate and scalable learning algorithms. The third block will present extensions to related models, including sequence tagging models, finite-state transducers and weighted context-free grammars. The last block will describe a general framework for using spectral techniques in more general situations where a matrix completion pre-processing step is required; several applications of this approach will be described.</abstract>
+    <url>D14-2002</url>
+   </paper>
+   <paper id="3">
+    <title>Semantic Parsing with Combinatory Categorial Grammars</title>
+    <author><first>Yoav</first><last>Artzi</last></author>
+    <author><first>Nicholas</first><last>Fitzgerald</last></author>
+    <author><first>Luke</first><last>Zettlemoyer</last></author>
+    <abstract>Semantic parsers map natural language sentences to formal representations of their underlying meaning. Building accurate semantic parsers without prohibitive engineering costs is a long-standing, open research problem.
+
+The tutorial will describe general principles for building semantic parsers. The presentation will be divided into two main parts: learning and modeling. In the learning part, we will describe a unified approach for learning Combinatory Categorial Grammar (CCG) semantic parsers, that induces both a CCG lexicon and the parameters of a parsing model. The approach learns from data with labeled meaning representations, as well as from more easily gathered weak supervision. It also enables grounded learning where the semantic parser is used in an interactive environment, for example to read and execute instructions. The modeling section will include best practices for grammar design and choice of semantic representation. We will motivate our use of lambda calculus as a language for building and representing meaning with examples from several domains.
+
+The ideas we will discuss are widely applicable. The semantic modeling approach, while implemented in lambda calculus, could be applied to many other formal languages. Similarly, the algorithms for inducing CCG focus on tasks that are formalism independent, learning the meaning of words and estimating parsing parameters. No prior knowledge of CCG is required. The tutorial will be backed by implementation and experiments in the University of Washington Semantic Parsing Framework (UW SPF, http://yoavartzi.com/spf).</abstract>
+    <url>D14-2003</url>
+   </paper>
+   <paper id="4">
+    <title>Linear Programming Decoders in Natural Language Processing: From Integer Programming to Message Passing and Dual Decomposition</title>
+    <author><first>André F. T.</first><last>Martins</last></author>
+    <abstract>This tutorial will cover the theory and practice of linear programming decoders. This class of decoders encompasses a variety of techniques that have enjoyed great success in devising structured models for natural language processing (NLP). Along the tutorial, we provide a unified view of different algorithms and modeling techniques, including belief propagation, dual decomposition, integer linear programming, Markov logic, and constrained conditional models. Various applications in NLP will serve as a motivation.
+
+There is a long string of work using integer linear programming (ILP) formulations in NLP, for example in semantic role labeling, machine translation, summarization, dependency parsing, coreference resolution, and opinion mining, to name just a few. At the heart of these approaches is the ability to encode logic and budget constraints (common in NLP and information retrieval) as linear inequalities. Thanks to general purpose solvers (such as Gurobi, CPLEX, or GLPK), the practitioner can abstract away from the decoding algorithm and focus on developing a powerful model. A disadvantage, however, is that general solvers do not scale well to large problem instances, since they fail to exploit the structure of the problem.
+
+This is where graphical models come into play. In this tutorial, we show that most logic and budget constraints that arise in NLP can be cast in this framework. This opens the door for the use of message-passing algorithms, such as belief propagation and variants thereof. An alternative are algorithms based on dual decomposition, such as the subgradient method or AD3. These algorithms have achieved great success in a variety of applications, such as parsing, corpus-wide tagging, machine translation, summarization, joint coreference resolution and quotation attribution, and semantic role labeling. Interestingly, most decoders used in these works can be regarded as structure-aware solvers for addressing relaxations of integer linear programs. All these algorithms have a similar consensus-based architecture: they repeatedly perform certain "local" operations in the graph, until some form of local agreement is achieved. The local operations are performed at each factor, and they range between computing marginals, max-marginals, an optimal configuration, or a small quadratic problem, all of which are commonly tractable and efficient in a wide range of problems.
+
+As a companion of this tutorial, we provide an open-source implementation of some of the algorithms described above, available at http://www.ark.cs.cmu.edu/AD3.</abstract>
+    <url>D14-2004</url>
+   </paper>
+   <paper id="5">
+    <title>Syntax-Based Statistical Machine Translation</title>
+    <author><first>Philip</first><last>Williams</last></author>
+    <author><first>Philipp</first><last>Koehn</last></author>
+    <abstract>The tutorial explains in detail syntax-based statistical machine translation with synchronous context free grammars (SCFG). It is aimed at researchers who have little background in this area, and gives a comprehensive overview about the main models and methods.
+
+While syntax-based models in statistical machine translation have a long history, spanning back almost 20 years, they have only recently shown superior translation quality over the more commonly used phrase-based models, and are now considered state of the art for some language pairs, such as Chinese-English (since ISI's submission to NIST 2006), and English-German (since Edinburgh's submission to WMT 2012).
+
+While the field is very dynamic, there is a core set of methods that have become dominant. Such SCFG models are implemented in the open source machine translation toolkit Moses, and the tutors draw from the practical experience of its development.
+
+The tutorial focuses on explaining core established concepts in SCFG-based approaches, which are the most popular in this area. The main goal of the tutorial is for the audience to understand how these systems work end-to-end. We review as much relevant literature as necessary, but the tutorial is not a primarily research survey.
+
+The tutorial is rounded up with open problems and advanced topics, such as computational challenges, different formalisms for syntax-based models and inclusion of semantics.</abstract>
+    <url>D14-2005</url>
+   </paper>
+   <paper id="6">
+    <title>Embedding Methods for Natural Language Processing</title>
+    <author><first>Antoine</first><last>Bordes</last></author>
+    <author><first>Jason</first><last>Weston</last></author>
+    <abstract>Embedding-based models are popular tools in Natural Language Processing these days. In this tutorial, our goal is to provide an overview of the main advances in this domain. These methods learn latent representations of words, as well as database entries that can then be used to do semantic search, automatic knowledge base construction, natural language understanding, etc. Our current plan is to split the tutorial into 2 sessions of 90 minutes, with a 30 minutes coffee break in the middle, so that we can cover in a first session the basics of learning embeddings and advanced models in the second session. This is detailed in the following.
+
+Part 1: Unsupervised and Supervised Embeddings
+We introduce models that embed tokens (words, database entries) by representing them as low dimensional embedding vectors. Unsupervised and supervised methods will be discussed, including SVD, Word2Vec, Paragraph Vectors, SSI, Wsabie and others. A comparison between methods will be made in terms of applicability, type of loss function (ranking loss, reconstruction loss, classification loss), regularization, etc. The use of these models in several NLP tasks will be discussed, including question answering, frame identification, knowledge extraction and document retrieval.
+
+Part 2: Embeddings for Multi-relational Data
+This second part will focus mostly on the construction of embeddings for multi-relational data, that is when tokens can be interconnected in different ways in the data such as in knowledge bases for instance. Several methods based on tensor factorization, collective matrix factorization, stochastic block models or energy-based learning will be presented. The task of link prediction in a knowledge base will be used as an application example. Multiple empirical results on the use of embedding models to align textual information to knowledge bases will also be presented, together with some demos if time permits.</abstract>
+    <url>D14-2006</url>
+   </paper>
+   <paper id="7">
+    <title>Natural Language Processing of Arabic and its Dialects</title>
+    <author><first>Mona</first><last>Diab</last></author>
+    <author><first>Nizar</first><last>Habash</last></author>
+    <abstract>This tutorial introduces the different challenges and current solutions to the automatic processing of Arabic and its dialects. The tutorial has two parts: First, we present a discussion of generic issues relevant to Arabic NLP and detail dialectal linguistic issues and the challenges they pose for NLP. In the second part, we review the state-of-the-art in Arabic processing covering several enabling technologies and applications, e.g., dialect identification, morphological processing (analysis, disambiguation, tokenization, POS tagging), parsing, and machine translation.</abstract>
+    <url>D14-2007</url>
+   </paper>
+   <paper id="8">
+    <title>Text Quantification</title>
+    <author><first>Fabrizio</first><last>Sebastiani</last></author>
+    <abstract>In recent years it has been pointed out that, in a number of applications involving (text) classification, the final goal is not determining which class (or classes) individual unlabelled data items belong to, but determining the prevalence (or "relative frequency") of each class in the unlabelled data. The latter task is known as quantification. Assume a market research agency runs a poll in which they ask the question "What do you think of the recent ad campaign for product X?" Once the poll is complete, they may want to classify the resulting textual answers according to whether they belong or not to the class LovedTheCampaign. The agency is likely not interested in whether a specific individual belongs to the class LovedTheCampaign, but in knowing how many respondents belong to it, i.e., in knowing the prevalence of the class. In other words, the agency is interested not in classification, but in quantification. Essentially, quantification is classification tackled at the aggregate (rather than at the individual) level. The research community has recently shown a growing interest in tackling quantification as a task in its own right. One of the reasons is that, since the goal of quantification is different than that of classification, quantification requires evaluation measures different than for classification. A second, related reason is that using a method optimized for classification accuracy is suboptimal when quantification accuracy is the real goal. A third reason is the growing awareness that quantification is going to be more and more important; with the advent of big data, more and more application contexts are going to spring up in which we will simply be happy with analyzing data at the aggregate (rather than at the individual) level. The goal of this tutorial is to introduce the audience to the problem of quantification, to the techniques that have been proposed for solving it, to the metrics used to evaluate them, and to the problems that are still open in the area.</abstract>
+    <url>D14-2008</url>
+   </paper>
+  </volume>
 </collection>

--- a/data/xml/D14.xml
+++ b/data/xml/D14.xml
@@ -2130,70 +2130,65 @@
     </paper>
   </volume>
   <volume id="2">
-   <meta>
-    <booktitle>Proceedings of <fixed-case>EMNLP</fixed-case> 2014, Tutorial Abstracts</booktitle>
-    <url>P18-5</url>
-    <editor><first>Lucia</first><last>Specia</last></editor>
-    <editor><first>Xavier</first><last>Carreras</last></editor>
-    <publisher>Association for Computational Linguistics</publisher>
-    <address>Doha, Qatar</address>
-    <month>October</month>
-    <year>2014</year>
-   </meta>
-   <paper id="1">
-    <title>Sentiment Analysis of Social Media Texts</title>
-    <author><first>Saif M.</first><last>Mohammad</last></author>
-    <author><first>Xiaodan</first><last>Zhu</last></author>
-    <abstract>Automatically detecting sentiment of product reviews, blogs, tweets, and SMS messages has attracted extensive interest from both the academia and industry. It has a number of applications, including: tracking sentiment towards products, movies, politicians, etc.; improving customer relation models; detecting happiness and well-being; and improving automatic dialogue systems. In this tutorial, we will describe how you can create a state-of-the-art sentiment analysis system, with a focus on social media posts.
+    <meta>
+      <booktitle>Proceedings of <fixed-case>EMNLP</fixed-case> 2014, Tutorial Abstracts</booktitle>
+      <editor><first>Lucia</first><last>Specia</last></editor>
+      <editor><first>Xavier</first><last>Carreras</last></editor>
+      <publisher>Association for Computational Linguistics</publisher>
+      <address>Doha, Qatar</address>
+      <month>October</month>
+      <year>2014</year>
+    </meta>
+    <paper id="1">
+      <title>Sentiment Analysis of Social Media Texts</title>
+      <author><first>Saif M.</first><last>Mohammad</last></author>
+      <author><first>Xiaodan</first><last>Zhu</last></author>
+      <abstract>Automatically detecting sentiment of product reviews, blogs, tweets, and SMS messages has attracted extensive interest from both the academia and industry. It has a number of applications, including: tracking sentiment towards products, movies, politicians, etc.; improving customer relation models; detecting happiness and well-being; and improving automatic dialogue systems. In this tutorial, we will describe how you can create a state-of-the-art sentiment analysis system, with a focus on social media posts.
 
 We begin with an introduction to sentiment analysis and its various forms: term level, message level, document level, and aspect level. We will describe how sentiment analysis systems are evaluated, especially through recent SemEval shared tasks: Sentiment Analysis of Twitter (SemEval-2013 Task 2, SemEval 2014-Task 9) and Aspect Based Sentiment Analysis (SemEval-2014 Task 4).
 
 We will give an overview of the best sentiment analysis systems at this point of time, including those that are conventional statistical systems as well as those using deep learning approaches. We will describe in detail the NRC-Canada systems, which were the overall best performing systems in all three SemEval competitions listed above. These are simple lexical- and sentiment-lexicon features based systems, which are relatively easy to re-implement.
 
 We will discuss features that had the most impact (those derived from sentiment lexicons and negation handling). We will present how large tweet-specific sentiment lexicons can be automatically generated and evaluated. We will also show how negation impacts sentiment differently depending on whether the scope of the negation is positive or negative. Finally, we will flesh out limitations of current approaches and promising future directions.</abstract>
-    <url>D14-2001</url>
-   </paper>
-   <paper id="2">
-    <title>Spectral Learning Techniques for Weighted Automata, Transducers, and Grammars</title>
-    <author><first>Borja</first><last>Balle</last></author>
-    <author><first>Ariadna</first><last>Quattoni</last></author>
-    <author><first>Xavier</first><last>Carreras</last></author>
-    <abstract>In recent years we have seen the development of efficient and provably correct algorithms for learning weighted automata and closely related function classes such as weighted transducers and weighted context-free grammars. The common denominator of all these algorithms is the so-called spectral method, which gives an efficient and robust way to estimate recursively defined functions from empirical estimations of observable statistics. These algorithms are appealing because of the existence of theoretical guarantees (e.g. they are not susceptible to local minima) and because of their efficiency. However, despite their simplicity and wide applicability to real problems, their impact in NLP applications is still moderate. One of the goals of this tutorial is to remedy this situation.
+    </paper>
+    <paper id="2">
+      <title>Spectral Learning Techniques for Weighted Automata, Transducers, and Grammars</title>
+      <author><first>Borja</first><last>Balle</last></author>
+      <author><first>Ariadna</first><last>Quattoni</last></author>
+      <author><first>Xavier</first><last>Carreras</last></author>
+      <abstract>In recent years we have seen the development of efficient and provably correct algorithms for learning weighted automata and closely related function classes such as weighted transducers and weighted context-free grammars. The common denominator of all these algorithms is the so-called spectral method, which gives an efficient and robust way to estimate recursively defined functions from empirical estimations of observable statistics. These algorithms are appealing because of the existence of theoretical guarantees (e.g. they are not susceptible to local minima) and because of their efficiency. However, despite their simplicity and wide applicability to real problems, their impact in NLP applications is still moderate. One of the goals of this tutorial is to remedy this situation.
 
 The contents that will be presented in this tutorial will offer a complementary perspective with respect to previous tutorials on spectral methods presented at ICML-2012, ICML-2013 and NAACL-2013. Rather than using the language of graphical models and signal processing, we tell the story from the perspective of formal languages and automata theory (without assuming a background in formal algebraic methods). Our presentation highlights the common intuitions lying behind different spectral algorithms by presenting them in a unified framework based on the concepts of low-rank factorizations and completions of Hankel matrices. In addition, we provide an interpretation of the method in terms of forward and backward recursions for automata and grammars. This provides extra intuitions about the method and stresses the importance of matrix factorization for learning automata and grammars. We believe that this complementary perspective might be appealing for an NLP audience and serve to put spectral learning in a wider and, perhaps for some, more familiar context. Our hope is that this will broaden the understanding of these methods by the NLP community and empower many researchers to apply these techniques to novel problems.
 
 The content of the tutorial will be divided into four blocks of 45 minutes each, as follows. The first block will introduce the basic definitions of weighted automata and Hankel matrices, and present a key connection between the fundamental theorem of weighted automata and learning. In the second block we will discuss the case of probabilistic automata in detail, touching upon all aspects from the underlying theory to the tricks required to achieve accurate and scalable learning algorithms. The third block will present extensions to related models, including sequence tagging models, finite-state transducers and weighted context-free grammars. The last block will describe a general framework for using spectral techniques in more general situations where a matrix completion pre-processing step is required; several applications of this approach will be described.</abstract>
-    <url>D14-2002</url>
-   </paper>
-   <paper id="3">
-    <title>Semantic Parsing with Combinatory Categorial Grammars</title>
-    <author><first>Yoav</first><last>Artzi</last></author>
-    <author><first>Nicholas</first><last>Fitzgerald</last></author>
-    <author><first>Luke</first><last>Zettlemoyer</last></author>
-    <abstract>Semantic parsers map natural language sentences to formal representations of their underlying meaning. Building accurate semantic parsers without prohibitive engineering costs is a long-standing, open research problem.
+    </paper>
+    <paper id="3">
+      <title>Semantic Parsing with Combinatory Categorial Grammars</title>
+      <author><first>Yoav</first><last>Artzi</last></author>
+      <author><first>Nicholas</first><last>Fitzgerald</last></author>
+      <author><first>Luke</first><last>Zettlemoyer</last></author>
+      <abstract>Semantic parsers map natural language sentences to formal representations of their underlying meaning. Building accurate semantic parsers without prohibitive engineering costs is a long-standing, open research problem.
 
 The tutorial will describe general principles for building semantic parsers. The presentation will be divided into two main parts: learning and modeling. In the learning part, we will describe a unified approach for learning Combinatory Categorial Grammar (CCG) semantic parsers, that induces both a CCG lexicon and the parameters of a parsing model. The approach learns from data with labeled meaning representations, as well as from more easily gathered weak supervision. It also enables grounded learning where the semantic parser is used in an interactive environment, for example to read and execute instructions. The modeling section will include best practices for grammar design and choice of semantic representation. We will motivate our use of lambda calculus as a language for building and representing meaning with examples from several domains.
 
 The ideas we will discuss are widely applicable. The semantic modeling approach, while implemented in lambda calculus, could be applied to many other formal languages. Similarly, the algorithms for inducing CCG focus on tasks that are formalism independent, learning the meaning of words and estimating parsing parameters. No prior knowledge of CCG is required. The tutorial will be backed by implementation and experiments in the University of Washington Semantic Parsing Framework (UW SPF, http://yoavartzi.com/spf).</abstract>
-    <url>D14-2003</url>
-   </paper>
-   <paper id="4">
-    <title>Linear Programming Decoders in Natural Language Processing: From Integer Programming to Message Passing and Dual Decomposition</title>
-    <author><first>André F. T.</first><last>Martins</last></author>
-    <abstract>This tutorial will cover the theory and practice of linear programming decoders. This class of decoders encompasses a variety of techniques that have enjoyed great success in devising structured models for natural language processing (NLP). Along the tutorial, we provide a unified view of different algorithms and modeling techniques, including belief propagation, dual decomposition, integer linear programming, Markov logic, and constrained conditional models. Various applications in NLP will serve as a motivation.
+    </paper>
+    <paper id="4">
+      <title>Linear Programming Decoders in Natural Language Processing: From Integer Programming to Message Passing and Dual Decomposition</title>
+      <author><first>André F. T.</first><last>Martins</last></author>
+      <abstract>This tutorial will cover the theory and practice of linear programming decoders. This class of decoders encompasses a variety of techniques that have enjoyed great success in devising structured models for natural language processing (NLP). Along the tutorial, we provide a unified view of different algorithms and modeling techniques, including belief propagation, dual decomposition, integer linear programming, Markov logic, and constrained conditional models. Various applications in NLP will serve as a motivation.
 
 There is a long string of work using integer linear programming (ILP) formulations in NLP, for example in semantic role labeling, machine translation, summarization, dependency parsing, coreference resolution, and opinion mining, to name just a few. At the heart of these approaches is the ability to encode logic and budget constraints (common in NLP and information retrieval) as linear inequalities. Thanks to general purpose solvers (such as Gurobi, CPLEX, or GLPK), the practitioner can abstract away from the decoding algorithm and focus on developing a powerful model. A disadvantage, however, is that general solvers do not scale well to large problem instances, since they fail to exploit the structure of the problem.
 
 This is where graphical models come into play. In this tutorial, we show that most logic and budget constraints that arise in NLP can be cast in this framework. This opens the door for the use of message-passing algorithms, such as belief propagation and variants thereof. An alternative are algorithms based on dual decomposition, such as the subgradient method or AD3. These algorithms have achieved great success in a variety of applications, such as parsing, corpus-wide tagging, machine translation, summarization, joint coreference resolution and quotation attribution, and semantic role labeling. Interestingly, most decoders used in these works can be regarded as structure-aware solvers for addressing relaxations of integer linear programs. All these algorithms have a similar consensus-based architecture: they repeatedly perform certain "local" operations in the graph, until some form of local agreement is achieved. The local operations are performed at each factor, and they range between computing marginals, max-marginals, an optimal configuration, or a small quadratic problem, all of which are commonly tractable and efficient in a wide range of problems.
 
 As a companion of this tutorial, we provide an open-source implementation of some of the algorithms described above, available at http://www.ark.cs.cmu.edu/AD3.</abstract>
-    <url>D14-2004</url>
-   </paper>
-   <paper id="5">
-    <title>Syntax-Based Statistical Machine Translation</title>
-    <author><first>Philip</first><last>Williams</last></author>
-    <author><first>Philipp</first><last>Koehn</last></author>
-    <abstract>The tutorial explains in detail syntax-based statistical machine translation with synchronous context free grammars (SCFG). It is aimed at researchers who have little background in this area, and gives a comprehensive overview about the main models and methods.
+    </paper>
+    <paper id="5">
+      <title>Syntax-Based Statistical Machine Translation</title>
+      <author><first>Philip</first><last>Williams</last></author>
+      <author><first>Philipp</first><last>Koehn</last></author>
+      <abstract>The tutorial explains in detail syntax-based statistical machine translation with synchronous context free grammars (SCFG). It is aimed at researchers who have little background in this area, and gives a comprehensive overview about the main models and methods.
 
 While syntax-based models in statistical machine translation have a long history, spanning back almost 20 years, they have only recently shown superior translation quality over the more commonly used phrase-based models, and are now considered state of the art for some language pairs, such as Chinese-English (since ISI's submission to NIST 2006), and English-German (since Edinburgh's submission to WMT 2012).
 
@@ -2202,33 +2197,29 @@ While the field is very dynamic, there is a core set of methods that have become
 The tutorial focuses on explaining core established concepts in SCFG-based approaches, which are the most popular in this area. The main goal of the tutorial is for the audience to understand how these systems work end-to-end. We review as much relevant literature as necessary, but the tutorial is not a primarily research survey.
 
 The tutorial is rounded up with open problems and advanced topics, such as computational challenges, different formalisms for syntax-based models and inclusion of semantics.</abstract>
-    <url>D14-2005</url>
-   </paper>
-   <paper id="6">
-    <title>Embedding Methods for Natural Language Processing</title>
-    <author><first>Antoine</first><last>Bordes</last></author>
-    <author><first>Jason</first><last>Weston</last></author>
-    <abstract>Embedding-based models are popular tools in Natural Language Processing these days. In this tutorial, our goal is to provide an overview of the main advances in this domain. These methods learn latent representations of words, as well as database entries that can then be used to do semantic search, automatic knowledge base construction, natural language understanding, etc. Our current plan is to split the tutorial into 2 sessions of 90 minutes, with a 30 minutes coffee break in the middle, so that we can cover in a first session the basics of learning embeddings and advanced models in the second session. This is detailed in the following.
+    </paper>
+    <paper id="6">
+      <title>Embedding Methods for Natural Language Processing</title>
+      <author><first>Antoine</first><last>Bordes</last></author>
+      <author><first>Jason</first><last>Weston</last></author>
+      <abstract>Embedding-based models are popular tools in Natural Language Processing these days. In this tutorial, our goal is to provide an overview of the main advances in this domain. These methods learn latent representations of words, as well as database entries that can then be used to do semantic search, automatic knowledge base construction, natural language understanding, etc. Our current plan is to split the tutorial into 2 sessions of 90 minutes, with a 30 minutes coffee break in the middle, so that we can cover in a first session the basics of learning embeddings and advanced models in the second session. This is detailed in the following.
 
 Part 1: Unsupervised and Supervised Embeddings
 We introduce models that embed tokens (words, database entries) by representing them as low dimensional embedding vectors. Unsupervised and supervised methods will be discussed, including SVD, Word2Vec, Paragraph Vectors, SSI, Wsabie and others. A comparison between methods will be made in terms of applicability, type of loss function (ranking loss, reconstruction loss, classification loss), regularization, etc. The use of these models in several NLP tasks will be discussed, including question answering, frame identification, knowledge extraction and document retrieval.
 
 Part 2: Embeddings for Multi-relational Data
 This second part will focus mostly on the construction of embeddings for multi-relational data, that is when tokens can be interconnected in different ways in the data such as in knowledge bases for instance. Several methods based on tensor factorization, collective matrix factorization, stochastic block models or energy-based learning will be presented. The task of link prediction in a knowledge base will be used as an application example. Multiple empirical results on the use of embedding models to align textual information to knowledge bases will also be presented, together with some demos if time permits.</abstract>
-    <url>D14-2006</url>
-   </paper>
-   <paper id="7">
-    <title>Natural Language Processing of Arabic and its Dialects</title>
-    <author><first>Mona</first><last>Diab</last></author>
-    <author><first>Nizar</first><last>Habash</last></author>
-    <abstract>This tutorial introduces the different challenges and current solutions to the automatic processing of Arabic and its dialects. The tutorial has two parts: First, we present a discussion of generic issues relevant to Arabic NLP and detail dialectal linguistic issues and the challenges they pose for NLP. In the second part, we review the state-of-the-art in Arabic processing covering several enabling technologies and applications, e.g., dialect identification, morphological processing (analysis, disambiguation, tokenization, POS tagging), parsing, and machine translation.</abstract>
-    <url>D14-2007</url>
-   </paper>
-   <paper id="8">
-    <title>Text Quantification</title>
-    <author><first>Fabrizio</first><last>Sebastiani</last></author>
-    <abstract>In recent years it has been pointed out that, in a number of applications involving (text) classification, the final goal is not determining which class (or classes) individual unlabelled data items belong to, but determining the prevalence (or "relative frequency") of each class in the unlabelled data. The latter task is known as quantification. Assume a market research agency runs a poll in which they ask the question "What do you think of the recent ad campaign for product X?" Once the poll is complete, they may want to classify the resulting textual answers according to whether they belong or not to the class LovedTheCampaign. The agency is likely not interested in whether a specific individual belongs to the class LovedTheCampaign, but in knowing how many respondents belong to it, i.e., in knowing the prevalence of the class. In other words, the agency is interested not in classification, but in quantification. Essentially, quantification is classification tackled at the aggregate (rather than at the individual) level. The research community has recently shown a growing interest in tackling quantification as a task in its own right. One of the reasons is that, since the goal of quantification is different than that of classification, quantification requires evaluation measures different than for classification. A second, related reason is that using a method optimized for classification accuracy is suboptimal when quantification accuracy is the real goal. A third reason is the growing awareness that quantification is going to be more and more important; with the advent of big data, more and more application contexts are going to spring up in which we will simply be happy with analyzing data at the aggregate (rather than at the individual) level. The goal of this tutorial is to introduce the audience to the problem of quantification, to the techniques that have been proposed for solving it, to the metrics used to evaluate them, and to the problems that are still open in the area.</abstract>
-    <url>D14-2008</url>
-   </paper>
+    </paper>
+    <paper id="7">
+      <title>Natural Language Processing of Arabic and its Dialects</title>
+      <author><first>Mona</first><last>Diab</last></author>
+      <author><first>Nizar</first><last>Habash</last></author>
+      <abstract>This tutorial introduces the different challenges and current solutions to the automatic processing of Arabic and its dialects. The tutorial has two parts: First, we present a discussion of generic issues relevant to Arabic NLP and detail dialectal linguistic issues and the challenges they pose for NLP. In the second part, we review the state-of-the-art in Arabic processing covering several enabling technologies and applications, e.g., dialect identification, morphological processing (analysis, disambiguation, tokenization, POS tagging), parsing, and machine translation.</abstract>
+    </paper>
+    <paper id="8">
+      <title>Text Quantification</title>
+      <author><first>Fabrizio</first><last>Sebastiani</last></author>
+      <abstract>In recent years it has been pointed out that, in a number of applications involving (text) classification, the final goal is not determining which class (or classes) individual unlabelled data items belong to, but determining the prevalence (or "relative frequency") of each class in the unlabelled data. The latter task is known as quantification. Assume a market research agency runs a poll in which they ask the question "What do you think of the recent ad campaign for product X?" Once the poll is complete, they may want to classify the resulting textual answers according to whether they belong or not to the class LovedTheCampaign. The agency is likely not interested in whether a specific individual belongs to the class LovedTheCampaign, but in knowing how many respondents belong to it, i.e., in knowing the prevalence of the class. In other words, the agency is interested not in classification, but in quantification. Essentially, quantification is classification tackled at the aggregate (rather than at the individual) level. The research community has recently shown a growing interest in tackling quantification as a task in its own right. One of the reasons is that, since the goal of quantification is different than that of classification, quantification requires evaluation measures different than for classification. A second, related reason is that using a method optimized for classification accuracy is suboptimal when quantification accuracy is the real goal. A third reason is the growing awareness that quantification is going to be more and more important; with the advent of big data, more and more application contexts are going to spring up in which we will simply be happy with analyzing data at the aggregate (rather than at the individual) level. The goal of this tutorial is to introduce the audience to the problem of quantification, to the techniques that have been proposed for solving it, to the metrics used to evaluate them, and to the problems that are still open in the area.</abstract>
+    </paper>
   </volume>
 </collection>

--- a/data/xml/D16.xml
+++ b/data/xml/D16.xml
@@ -2690,4 +2690,83 @@
       <video href="https://vimeo.com/239243926" tag="video"/>
     </paper>
   </volume>
+  <volume id="2">
+    <meta>
+      <booktitle>Proceedings of <fixed-case>EMNLP</fixed-case> 2016, Tutorial Abstracts</booktitle>
+      <url>D16-2</url>
+      <editor><first>Bishan</first><last>Yang</last></editor>
+      <editor><first>Rebecca</first><last>Hwa</last></editor>
+      <publisher>Association for Computational Linguistics</publisher>
+      <address>Austin, Texas</address>
+      <month>November</month>
+      <year>2016</year>
+    </meta>
+    <paper id="1">
+      <title>Practical Neural Networks for NLP: From Theory to Code</title>
+      <author><first>Chris</first><last>Dyer</last></author>
+      <author><first>Yoav</first><last>Goldberg</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <url>D16-2001</url>
+      <abstract>This tutorial aims to bring NLP researchers up to speed with the current techniques in deep learning and neural networks, and show them how they can turn their ideas into practical implementations. We will start with simple classification models (logistic regression and multilayer perceptrons) and cover more advanced patterns that come up in NLP such as recurrent networks for sequence tagging and prediction problems, structured networks (e.g., compositional architectures based on syntax trees), structured output spaces (sequences and trees), attention for sequence-to-sequence transduction, and feature induction for complex algorithm states. A particular emphasis will be on learning to represent complex objects as recursive compositions of simpler objects. This representation will reflect characterize standard objects in NLP, such as the composition of characters and morphemes into words, and words into sentences and documents. In addition, new opportunities such as learning to embed "algorithm states" such as those used in transition-based parsing and other sequential structured prediction models (for which effective features may be difficult to engineer by hand) will be covered.
+
+Everything in the tutorial will be grounded in code — we will show how to program seemingly complex neural-net models using toolkits based on the computation-graph formalism. Computation graphs decompose complex computations into a DAG, with nodes representing inputs, target outputs, parameters, or (sub)differentiable functions (e.g., "tanh", "matrix multiply", and "softmax"), and edges represent data dependencies. These graphs can be run "forward" to make predictions and compute errors (e.g., log loss, squared error) and then "backward" to compute derivatives with respect to model parameters. In particular we'll cover the Python bindings of the CNN library. CNN has been designed from the ground up for NLP applications, dynamically structured NNs, rapid prototyping, and a transparent data and execution model.</abstract>
+    </paper>
+    <paper id="2">
+      <title>Advanced Markov Logic Techniques for Scalable Joint Inference in NLP</title>
+      <author><first>Deepak</first><last>Venugopal</last></author>
+      <author><first>Vibhav</first><last>Gogate</last></author>
+      <author><first>Vincent</first><last>Ng</last></author>
+      <url>D16-2002</url>
+      <abstract>In the early days of the statistical NLP era, many language processing tasks were tackled using the so-called pipeline architecture: the given task is broken into a series of sub-tasks such that the output of one sub-task is an input to the next sub-task in the sequence. The pipeline architecture is appealing for various reasons, including modularity, modeling convenience, and manageable computational complexity. However, it suffers from the error propagation problem: errors made in one sub-task are propagated to the next sub-task in the sequence, leading to poor accuracy on that sub-task, which in turn leads to more errors downstream. Another disadvantage associated with it is lack of feedback: errors made in a sub-task are often not corrected using knowledge uncovered while solving another sub-task down the pipeline.
+
+Realizing these weaknesses, researchers have turned to joint inference approaches in recent years. One such approach involves the use of Markov logic, which is defined as a set of weighted first-order logic formulas and, at a high level, unifies first-order logic with probabilistic graphical models. It is an ideal modeling language (knowledge representation) for compactly representing relational and uncertain knowledge in NLP. In a typical use case of MLNs in NLP, the application designer describes the background knowledge using a few first-order logic sentences and then uses software packages such as Alchemy, Tuffy, and Markov the beast to perform learning and inference (prediction) over the MLN. However, despite its obvious advantages, over the years, researchers and practitioners have found it difficult to use MLNs effectively in many NLP applications. The main reason for this is that it is hard to scale inference and learning algorithms for MLNs to large datasets and complex models, that are typical in NLP.
+
+In this tutorial, we will introduce the audience to recent advances in scaling up inference and learning in MLNs as well as new approaches to make MLNs a "black-box" for NLP applications (with only minor tuning required on the part of the user). Specifically, we will introduce attendees to a key idea that has emerged in the MLN research community over the last few years, lifted inference , which refers to inference techniques that take advantage of symmetries (e.g., synonyms), both exact and approximate, in the MLN . We will describe how these next-generation inference techniques can be used to perform effective joint inference. We will also present our new software package for inference and learning in MLNs, Alchemy 2.0, which is based on lifted inference, focusing primarily on how it can be used to scale up inference and learning in large models and datasets for applications such as semantic similarity determination, information extraction and question answering.</abstract>
+    </paper>
+    <paper id="3"> 
+      <title>Lifelong Machine Learning for Natural Language Processing</title>
+      <author><first>Zhiyuan</first><last>Chen</last></author>
+      <author><first>Bing</first><last>Liu</last></author>
+      <url>D16-2003</url>
+      <abstract>Machine learning (ML) has been successfully used as a prevalent approach to solving numerous NLP problems. However, the classic ML paradigm learns in isolation. That is, given a dataset, an ML algorithm is executed on the dataset to produce a model without using any related or prior knowledge. Although this type of isolated learning is very useful, it also has serious limitations as it does not accumulate knowledge learned in the past and use the knowledge to help future learning, which is the hallmark of human learning and human intelligence. Lifelong machine learning (LML) aims to achieve this capability. Specifically, it aims to design and develop computational learning systems and algorithms that learn as humans do, i.e., retaining the results learned in the past, abstracting knowledge from them, and using the knowledge to help future learning. In this tutorial, we will introduce the existing research of LML and to show that LML is very suitable for NLP tasks and has potential to help NLP make major progresses.</abstract>
+    </paper>
+    <paper id="4">
+      <title>Neural Networks for Sentiment Analysis</title>
+      <author><first>Yue</first><last>Zhang</last></author>
+      <author><first>Duy Tin</first><last>Vo</last></author>
+      <url>D16-2004</url>
+      <abstract>Sentiment analysis has been a major research topic in natural language processing (NLP). Traditionally, the problem has been attacked using discrete models and manually-defined sparse features. Over the past few years, neural network models have received increased research efforts in most sub areas of sentiment analysis, giving highly promising results. A main reason is the capability of neural models to automatically learn dense features that capture subtle semantic information over words, sentences and documents, which are difficult to model using traditional discrete features based on words and ngram patterns. This tutorial gives an introduction to neural network models for sentiment analysis, discussing the mathematics of word embeddings, sequence models and tree structured models and their use in sentiment analysis on the word, sentence and document levels, and fine-grained sentiment analysis. The tutorial covers a range of neural network models (e.g. CNN, RNN, RecNN, LSTM) and their extensions, which are employed in four main subtasks of sentiment analysis:
+Sentiment-oriented embeddings; 
+Sentence-level sentiment;
+Document-level sentiment;
+Fine-grained sentiment.
+
+The content of the tutorial is divided into 3 sections of 1 hour each. We assume that the audience is familiar with linear algebra and basic neural network structures, introduce the mathematical details of the most typical models. First, we will introduce the sentiment analysis task, basic concepts related to neural network models for sentiment analysis, and show detail approaches to integrate sentiment information into embeddings. Sentence-level models will be described in the second section. Finally, we will discuss neural network models use for document-level and fine-grained sentiment.</abstract>
+    </paper>
+    <paper id="5">
+      <title>Continuous Vector Spaces for Cross-language NLP Applications</title>
+      <author><first>Rafael E.</first><last>Banchs</last></author>
+      <url>D16-2005</url>
+      <abstract>The mathematical metaphor offered by the geometric concept of distance in vector spaces with respect to semantics and meaning has been proven to be useful in many monolingual natural language processing applications. There is also some recent and strong evidence that this paradigm can also be useful in the cross-language setting. In this tutorial, we present and discuss some of the most recent advances on exploiting the vector space model paradigm in specific cross-language natural language processing applications, along with a comprehensive review of the theoretical background behind them.
+
+First, the tutorial introduces some fundamental concepts of distributional semantics and vector space models. More specifically, the concepts of distributional hypothesis and term-document matrices are revised, followed by a brief discussion on linear and non-linear dimensionality reduction techniques and their implications to the parallel distributed approach to semantic cognition. Next, some classical examples of using vector space models in monolingual natural language processing applications are presented. Specific examples in the areas of information retrieval, related term identification and semantic compositionality are described.
+
+Then, the tutorial focuses its attention on the use of the vector space model paradigm in cross-language applications. To this end, some recent examples are presented and discussed in detail, addressing the specific problems of cross-language information retrieval, cross-language sentence matching, and machine translation. Some of the most recent developments in the area of Neural Machine Translation are also discussed.
+
+Finally, the tutorial concludes with a discussion about current and future research problems related to the use of vector space models in cross-language settings. Future avenues for scientific research are described, with major emphasis on the extension from vector and matrix representations to tensors, as well as the problem of encoding word position information into the vector-based representations.</abstract>
+    </paper>
+    <paper id="6">
+      <title>Methods and Theories for Large-scale Structured Prediction</title>
+      <author><first>Xu</first><last>Sun</last></author>
+      <author><first>Yansong</first><last>Feng</last></author>
+      <url>D16-2006</url>
+      <abstract>Many important NLP tasks are casted as structured prediction problems, and try to predict certain forms of structured output from the input. Examples of structured prediction include POS tagging, named entity recognition, PCFG parsing, dependency parsing, machine translation, and many others. When apply structured prediction to a specific NLP task, there are the following challenges:
+
+1. Model selection: Among various models/algorithms with different characteristics, which one should we choose for a specific NLP task?
+2. Training: How to train the model parameters effectively and efficiently?
+3. Overfitting: To achieve good accuracy on test data, it is important to control the overfitting from the training data. How to control the overfitting risk for structured prediction?
+
+This tutorial will provide a clear overview of recent advances in structured prediction methods and theories, and address the above issues when we apply structured prediction to NLP tasks. We will introduce large margin methods (e.g., perceptrons, MIRA), graphical models (e.g., CRFs), and deep learning methods (e.g., RNN, LSTM), and show the respective advantages and disadvantages for NLP applications. For the training algorithms, we will introduce online/ stochastic training methods, and we will introduce parallel online/stochastic learning algorithms and theories to speed up the training (e.g., the Hogwild algorithm). For controlling the overfitting from training data, we will introduce the weight regularization methods, structure regularization, and implicit regularization methods.</abstract>
+    </paper>
+   </volume>
 </collection>

--- a/data/xml/D16.xml
+++ b/data/xml/D16.xml
@@ -2693,7 +2693,6 @@
   <volume id="2">
     <meta>
       <booktitle>Proceedings of <fixed-case>EMNLP</fixed-case> 2016, Tutorial Abstracts</booktitle>
-      <url>D16-2</url>
       <editor><first>Bishan</first><last>Yang</last></editor>
       <editor><first>Rebecca</first><last>Hwa</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
@@ -2706,7 +2705,6 @@
       <author><first>Chris</first><last>Dyer</last></author>
       <author><first>Yoav</first><last>Goldberg</last></author>
       <author><first>Graham</first><last>Neubig</last></author>
-      <url>D16-2001</url>
       <abstract>This tutorial aims to bring NLP researchers up to speed with the current techniques in deep learning and neural networks, and show them how they can turn their ideas into practical implementations. We will start with simple classification models (logistic regression and multilayer perceptrons) and cover more advanced patterns that come up in NLP such as recurrent networks for sequence tagging and prediction problems, structured networks (e.g., compositional architectures based on syntax trees), structured output spaces (sequences and trees), attention for sequence-to-sequence transduction, and feature induction for complex algorithm states. A particular emphasis will be on learning to represent complex objects as recursive compositions of simpler objects. This representation will reflect characterize standard objects in NLP, such as the composition of characters and morphemes into words, and words into sentences and documents. In addition, new opportunities such as learning to embed "algorithm states" such as those used in transition-based parsing and other sequential structured prediction models (for which effective features may be difficult to engineer by hand) will be covered.
 
 Everything in the tutorial will be grounded in code — we will show how to program seemingly complex neural-net models using toolkits based on the computation-graph formalism. Computation graphs decompose complex computations into a DAG, with nodes representing inputs, target outputs, parameters, or (sub)differentiable functions (e.g., "tanh", "matrix multiply", and "softmax"), and edges represent data dependencies. These graphs can be run "forward" to make predictions and compute errors (e.g., log loss, squared error) and then "backward" to compute derivatives with respect to model parameters. In particular we'll cover the Python bindings of the CNN library. CNN has been designed from the ground up for NLP applications, dynamically structured NNs, rapid prototyping, and a transparent data and execution model.</abstract>
@@ -2716,7 +2714,6 @@ Everything in the tutorial will be grounded in code — we will show how to prog
       <author><first>Deepak</first><last>Venugopal</last></author>
       <author><first>Vibhav</first><last>Gogate</last></author>
       <author><first>Vincent</first><last>Ng</last></author>
-      <url>D16-2002</url>
       <abstract>In the early days of the statistical NLP era, many language processing tasks were tackled using the so-called pipeline architecture: the given task is broken into a series of sub-tasks such that the output of one sub-task is an input to the next sub-task in the sequence. The pipeline architecture is appealing for various reasons, including modularity, modeling convenience, and manageable computational complexity. However, it suffers from the error propagation problem: errors made in one sub-task are propagated to the next sub-task in the sequence, leading to poor accuracy on that sub-task, which in turn leads to more errors downstream. Another disadvantage associated with it is lack of feedback: errors made in a sub-task are often not corrected using knowledge uncovered while solving another sub-task down the pipeline.
 
 Realizing these weaknesses, researchers have turned to joint inference approaches in recent years. One such approach involves the use of Markov logic, which is defined as a set of weighted first-order logic formulas and, at a high level, unifies first-order logic with probabilistic graphical models. It is an ideal modeling language (knowledge representation) for compactly representing relational and uncertain knowledge in NLP. In a typical use case of MLNs in NLP, the application designer describes the background knowledge using a few first-order logic sentences and then uses software packages such as Alchemy, Tuffy, and Markov the beast to perform learning and inference (prediction) over the MLN. However, despite its obvious advantages, over the years, researchers and practitioners have found it difficult to use MLNs effectively in many NLP applications. The main reason for this is that it is hard to scale inference and learning algorithms for MLNs to large datasets and complex models, that are typical in NLP.
@@ -2727,14 +2724,12 @@ In this tutorial, we will introduce the audience to recent advances in scaling u
       <title>Lifelong Machine Learning for Natural Language Processing</title>
       <author><first>Zhiyuan</first><last>Chen</last></author>
       <author><first>Bing</first><last>Liu</last></author>
-      <url>D16-2003</url>
       <abstract>Machine learning (ML) has been successfully used as a prevalent approach to solving numerous NLP problems. However, the classic ML paradigm learns in isolation. That is, given a dataset, an ML algorithm is executed on the dataset to produce a model without using any related or prior knowledge. Although this type of isolated learning is very useful, it also has serious limitations as it does not accumulate knowledge learned in the past and use the knowledge to help future learning, which is the hallmark of human learning and human intelligence. Lifelong machine learning (LML) aims to achieve this capability. Specifically, it aims to design and develop computational learning systems and algorithms that learn as humans do, i.e., retaining the results learned in the past, abstracting knowledge from them, and using the knowledge to help future learning. In this tutorial, we will introduce the existing research of LML and to show that LML is very suitable for NLP tasks and has potential to help NLP make major progresses.</abstract>
     </paper>
     <paper id="4">
       <title>Neural Networks for Sentiment Analysis</title>
       <author><first>Yue</first><last>Zhang</last></author>
       <author><first>Duy Tin</first><last>Vo</last></author>
-      <url>D16-2004</url>
       <abstract>Sentiment analysis has been a major research topic in natural language processing (NLP). Traditionally, the problem has been attacked using discrete models and manually-defined sparse features. Over the past few years, neural network models have received increased research efforts in most sub areas of sentiment analysis, giving highly promising results. A main reason is the capability of neural models to automatically learn dense features that capture subtle semantic information over words, sentences and documents, which are difficult to model using traditional discrete features based on words and ngram patterns. This tutorial gives an introduction to neural network models for sentiment analysis, discussing the mathematics of word embeddings, sequence models and tree structured models and their use in sentiment analysis on the word, sentence and document levels, and fine-grained sentiment analysis. The tutorial covers a range of neural network models (e.g. CNN, RNN, RecNN, LSTM) and their extensions, which are employed in four main subtasks of sentiment analysis:
 Sentiment-oriented embeddings; 
 Sentence-level sentiment;
@@ -2746,7 +2741,6 @@ The content of the tutorial is divided into 3 sections of 1 hour each. We assume
     <paper id="5">
       <title>Continuous Vector Spaces for Cross-language NLP Applications</title>
       <author><first>Rafael E.</first><last>Banchs</last></author>
-      <url>D16-2005</url>
       <abstract>The mathematical metaphor offered by the geometric concept of distance in vector spaces with respect to semantics and meaning has been proven to be useful in many monolingual natural language processing applications. There is also some recent and strong evidence that this paradigm can also be useful in the cross-language setting. In this tutorial, we present and discuss some of the most recent advances on exploiting the vector space model paradigm in specific cross-language natural language processing applications, along with a comprehensive review of the theoretical background behind them.
 
 First, the tutorial introduces some fundamental concepts of distributional semantics and vector space models. More specifically, the concepts of distributional hypothesis and term-document matrices are revised, followed by a brief discussion on linear and non-linear dimensionality reduction techniques and their implications to the parallel distributed approach to semantic cognition. Next, some classical examples of using vector space models in monolingual natural language processing applications are presented. Specific examples in the areas of information retrieval, related term identification and semantic compositionality are described.
@@ -2759,7 +2753,6 @@ Finally, the tutorial concludes with a discussion about current and future resea
       <title>Methods and Theories for Large-scale Structured Prediction</title>
       <author><first>Xu</first><last>Sun</last></author>
       <author><first>Yansong</first><last>Feng</last></author>
-      <url>D16-2006</url>
       <abstract>Many important NLP tasks are casted as structured prediction problems, and try to predict certain forms of structured output from the input. Examples of structured prediction include POS tagging, named entity recognition, PCFG parsing, dependency parsing, machine translation, and many others. When apply structured prediction to a specific NLP task, there are the following challenges:
 
 1. Model selection: Among various models/algorithms with different characteristics, which one should we choose for a specific NLP task?
@@ -2768,5 +2761,5 @@ Finally, the tutorial concludes with a discussion about current and future resea
 
 This tutorial will provide a clear overview of recent advances in structured prediction methods and theories, and address the above issues when we apply structured prediction to NLP tasks. We will introduce large margin methods (e.g., perceptrons, MIRA), graphical models (e.g., CRFs), and deep learning methods (e.g., RNN, LSTM), and show the respective advantages and disadvantages for NLP applications. For the training algorithms, we will introduce online/ stochastic training methods, and we will introduce parallel online/stochastic learning algorithms and theories to speed up the training (e.g., the Hogwild algorithm). For controlling the overfitting from training data, we will introduce the weight regularization methods, structure regularization, and implicit regularization methods.</abstract>
     </paper>
-   </volume>
+  </volume>
 </collection>

--- a/data/xml/D18.xml
+++ b/data/xml/D18.xml
@@ -6151,4 +6151,66 @@
       <abstract>We present easy-to-use TensorFlow Hub sentence embedding models having good task transfer performance. Model variants allow for trade-offs between accuracy and compute resources. We report the relationship between model complexity, resources, and transfer performance. Comparisons are made with baselines without transfer learning and to baselines that incorporate word-level transfer. Transfer learning using sentence-level embeddings is shown to outperform models without transfer learning and often those that use only word-level transfer. We show good transfer task performance with minimal training data and obtain encouraging results on word embedding association tests (WEAT) of model bias.</abstract>
     </paper>
   </volume>
+  <volume id="3">
+   <meta>
+      <booktitle>Proceedings of <fixed-case>EMNLP</fixed-case> 2018, Tutorial Abstracts</booktitle>
+      <url>D18-3</url>
+      <editor><first /><last>Mausam</last></editor>
+      <editor><first>Lu</first><last>Wang</last></editor>
+      <publisher>Association for Computational Linguistics</publisher>
+      <address>Melbourne, Australia</address>
+      <month>October-November</month>
+      <year>2018</year>
+    </meta>
+    <paper id="1">
+      <title>Joint models for NLP</title>
+      <author><first>Yue</first><last>Zhang</last></author>
+      <url>D18-3001</url>
+      <abstract>Joint models have received much research attention in NLP, allowing relevant tasks to share common information while avoiding error propagation in multi-stage pepelines. Several main approaches have been taken by statistical joint modeling, while neural models allow parameter sharing and adversarial training. This tutorial reviews main approaches to joint modeling for both statistical and neural methods.</abstract>
+    </paper>
+    <paper id="2">
+      <title>Graph Formalisms for Meaning Representations</title>
+      <author><first>Adam</first><last>Lopez</last></author>
+      <author><first>Sorcha</first><last>Gilroy</last></author>
+      <url>D18-3002</url>
+      <abstract>In this tutorial we will focus on Hyperedge Replacement Languages (HRL; Drewes et al. 1997), a context-free graph rewriting system. HRL are one of the most popular graph formalisms to be studied in NLP (Chiang et al., 2013; Peng et al., 2015; Bauer and Rambow, 2016). We will discuss HRL by formally defining them, studying several examples, discussing their properties, and providing exercises for the tutorial. While HRL have been used in NLP in the past, there is some speculation that they are more expressive than is necessary for graphs representing natural language (Drewes, 2017). Part of our own research has been exploring what restrictions of HRL could yield languages that are more useful for NLP and also those that have desirable properties for NLP models, such as being closed under intersection. 
+
+With that in mind, we also plan to discuss Regular Graph Languages (RGL; Courcelle 1991), a subfamily of HRL which are closed under intersection. The definition of RGL is relatively simple after being introduced to HRL. We do not plan on discussing any proofs of why RGL are also a subfamily of MSOL, as described in Gilroy et al. (2017b). We will briefly mention the other formalisms shown in Figure 1 such as MSOL and DAGAL but this will focus on their properties rather than any formal definitions.</abstract>
+    </paper>
+    <paper id="3">
+      <title>Writing Code for NLP Research</title>
+      <author><first>Matt</first><last>Gardner</last></author>
+      <author><first>Mark</first><last>Neumann</last></author>
+      <author><first>Joel</first><last>Grus</last></author>
+      <author><first>Nicholas</first><last>Lourie</last></author>
+      <url>D18-3003</url>
+      <abstract>Doing modern NLP research requires writing code. Good code enables fast prototyping, easy debugging, controlled experiments, and accessible visualizations that help researchers understand what a model is doing. Bad code leads to research that is at best hard to reproduce and extend, and at worst simply incorrect. Indeed, there is a growing recognition of the importance of having good tools to assist good research in our field, as the upcoming workshop on open source software for NLP demonstrates. This tutorial aims to share best practices for writing code for NLP research, drawing on the instructors' experience designing the recently-released AllenNLP toolkit, a PyTorch-based library for deep learning NLP research. We will explain how a library with the right abstractions and components enables better code and better science, using models implemented in AllenNLP as examples. Participants will learn how to write research code in a way that facilitates good science and easy experimentation, regardless of what framework they use.</abstract>
+    </paper>
+    <paper id="4">
+      <title>Deep Latent Variable Models of Natural Language</title>
+      <author><first>Alexander</first><last>Rush</last></author>
+      <author><first>Yoon</first><last>Kim</last></author>
+      <author><first>Sam</first><last>Wiseman</last></author>
+      <url>D18-3004</url>
+      <abstract>The proposed tutorial will cover deep latent variable models both in the case where exact inference over the latent variables is tractable and when it is not. The former case includes neural extensions of unsupervised tagging and parsing models. Our discussion of the latter case, where inference cannot be performed tractably, will restrict itself to continuous latent variables. In particular, we will discuss recent developments both in neural variational inference (e.g., relating to Variational Auto-encoders) and in implicit density modeling (e.g., relating to Generative Adversarial Networks). We will highlight the challenges of applying these families of methods to NLP problems, and discuss recent successes and best practices.</abstract>
+    </paper>
+    <paper id="5">
+      <title>Standardized Tests as benchmarks for Artificial Intelligence</title>
+      <author><first>Mrinmaya</first><last>Sachan</last></author>
+      <author><first>Minjoon</first><last>Seo</last></author>
+      <author><first>Hannaneh</first><last>Hajishirzi</last></author>
+      <author><first>Eric</first><last>Xing</last></author>
+      <url>D18-3005</url>
+      <abstract>Standardized tests have recently been proposed as replacements to the Turing test as a driver for progress in AI (Clark, 2015). These include tests on understanding passages and stories and answering questions about them (Richardson et al., 2013; Rajpurkar et al., 2016a, inter alia), science question answering (Schoenick et al., 2016, inter alia), algebra word problems (Kushman et al., 2014, inter alia), geometry problems (Seo et al., 2015; Sachan et al., 2016), visual question answering (Antol et al., 2015), etc. Many of these tests require sophisticated understanding of the world, aiming to push the boundaries of AI. 
+
+For this tutorial, we broadly categorize these tests into two categories: open domain tests such as reading comprehensions and elementary school tests where the goal is to find the support for an answer from the student curriculum, and closed domain tests such as intermediate level math and science tests (algebra, geometry, Newtonian physics problems, etc.). Unlike open domain tests, closed domain tests require the system to have significant domain knowledge and reasoning capabilities. For example, geometry questions typically involve a number of geometry primitives (lines, quadrilaterals, circles, etc) and require students to use axioms and theorems of geometry (Pythagoras theorem, alternating angles, etc) to solve them. These closed domains often have a formal logical basis and the question can be mapped to a formal language by semantic parsing. The formal question representation can then provided as an input to an expert system to solve the question.</abstract>
+    </paper>
+    <paper id="6">
+      <title>Deep Chit-Chat: Deep Learning for ChatBots</title>
+      <author><first>Wei</first><last>Wu</last></author>
+      <author><first>Rui</first><last>Yan</last></author>
+      <url>D18-3006</url>
+      <abstract>The tutorial is based on the long-term efforts on building conversational models with deep learning approaches for chatbots. We will summarize the fundamental challenges in modeling open domain dialogues, clarify the difference from modeling goal-oriented dialogues, and give an overview of state-of-the-art methods for open domain conversation including both retrieval-based methods and generation-based methods. In addition to these, our tutorial will also cover some new trends of research of chatbots, such as how to design a reasonable evaluation system and how to "control" conversations from a chatbot with some specific information such as personas, styles, and emotions, etc.</abstract>
+    </paper>
+  </volume>
 </collection>

--- a/data/xml/D18.xml
+++ b/data/xml/D18.xml
@@ -6152,9 +6152,8 @@
     </paper>
   </volume>
   <volume id="3">
-   <meta>
+    <meta>
       <booktitle>Proceedings of <fixed-case>EMNLP</fixed-case> 2018, Tutorial Abstracts</booktitle>
-      <url>D18-3</url>
       <editor><first /><last>Mausam</last></editor>
       <editor><first>Lu</first><last>Wang</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
@@ -6165,14 +6164,12 @@
     <paper id="1">
       <title>Joint models for NLP</title>
       <author><first>Yue</first><last>Zhang</last></author>
-      <url>D18-3001</url>
       <abstract>Joint models have received much research attention in NLP, allowing relevant tasks to share common information while avoiding error propagation in multi-stage pepelines. Several main approaches have been taken by statistical joint modeling, while neural models allow parameter sharing and adversarial training. This tutorial reviews main approaches to joint modeling for both statistical and neural methods.</abstract>
     </paper>
     <paper id="2">
       <title>Graph Formalisms for Meaning Representations</title>
       <author><first>Adam</first><last>Lopez</last></author>
       <author><first>Sorcha</first><last>Gilroy</last></author>
-      <url>D18-3002</url>
       <abstract>In this tutorial we will focus on Hyperedge Replacement Languages (HRL; Drewes et al. 1997), a context-free graph rewriting system. HRL are one of the most popular graph formalisms to be studied in NLP (Chiang et al., 2013; Peng et al., 2015; Bauer and Rambow, 2016). We will discuss HRL by formally defining them, studying several examples, discussing their properties, and providing exercises for the tutorial. While HRL have been used in NLP in the past, there is some speculation that they are more expressive than is necessary for graphs representing natural language (Drewes, 2017). Part of our own research has been exploring what restrictions of HRL could yield languages that are more useful for NLP and also those that have desirable properties for NLP models, such as being closed under intersection. 
 
 With that in mind, we also plan to discuss Regular Graph Languages (RGL; Courcelle 1991), a subfamily of HRL which are closed under intersection. The definition of RGL is relatively simple after being introduced to HRL. We do not plan on discussing any proofs of why RGL are also a subfamily of MSOL, as described in Gilroy et al. (2017b). We will briefly mention the other formalisms shown in Figure 1 such as MSOL and DAGAL but this will focus on their properties rather than any formal definitions.</abstract>
@@ -6183,7 +6180,6 @@ With that in mind, we also plan to discuss Regular Graph Languages (RGL; Courcel
       <author><first>Mark</first><last>Neumann</last></author>
       <author><first>Joel</first><last>Grus</last></author>
       <author><first>Nicholas</first><last>Lourie</last></author>
-      <url>D18-3003</url>
       <abstract>Doing modern NLP research requires writing code. Good code enables fast prototyping, easy debugging, controlled experiments, and accessible visualizations that help researchers understand what a model is doing. Bad code leads to research that is at best hard to reproduce and extend, and at worst simply incorrect. Indeed, there is a growing recognition of the importance of having good tools to assist good research in our field, as the upcoming workshop on open source software for NLP demonstrates. This tutorial aims to share best practices for writing code for NLP research, drawing on the instructors' experience designing the recently-released AllenNLP toolkit, a PyTorch-based library for deep learning NLP research. We will explain how a library with the right abstractions and components enables better code and better science, using models implemented in AllenNLP as examples. Participants will learn how to write research code in a way that facilitates good science and easy experimentation, regardless of what framework they use.</abstract>
     </paper>
     <paper id="4">
@@ -6191,7 +6187,6 @@ With that in mind, we also plan to discuss Regular Graph Languages (RGL; Courcel
       <author><first>Alexander</first><last>Rush</last></author>
       <author><first>Yoon</first><last>Kim</last></author>
       <author><first>Sam</first><last>Wiseman</last></author>
-      <url>D18-3004</url>
       <abstract>The proposed tutorial will cover deep latent variable models both in the case where exact inference over the latent variables is tractable and when it is not. The former case includes neural extensions of unsupervised tagging and parsing models. Our discussion of the latter case, where inference cannot be performed tractably, will restrict itself to continuous latent variables. In particular, we will discuss recent developments both in neural variational inference (e.g., relating to Variational Auto-encoders) and in implicit density modeling (e.g., relating to Generative Adversarial Networks). We will highlight the challenges of applying these families of methods to NLP problems, and discuss recent successes and best practices.</abstract>
     </paper>
     <paper id="5">
@@ -6200,7 +6195,6 @@ With that in mind, we also plan to discuss Regular Graph Languages (RGL; Courcel
       <author><first>Minjoon</first><last>Seo</last></author>
       <author><first>Hannaneh</first><last>Hajishirzi</last></author>
       <author><first>Eric</first><last>Xing</last></author>
-      <url>D18-3005</url>
       <abstract>Standardized tests have recently been proposed as replacements to the Turing test as a driver for progress in AI (Clark, 2015). These include tests on understanding passages and stories and answering questions about them (Richardson et al., 2013; Rajpurkar et al., 2016a, inter alia), science question answering (Schoenick et al., 2016, inter alia), algebra word problems (Kushman et al., 2014, inter alia), geometry problems (Seo et al., 2015; Sachan et al., 2016), visual question answering (Antol et al., 2015), etc. Many of these tests require sophisticated understanding of the world, aiming to push the boundaries of AI. 
 
 For this tutorial, we broadly categorize these tests into two categories: open domain tests such as reading comprehensions and elementary school tests where the goal is to find the support for an answer from the student curriculum, and closed domain tests such as intermediate level math and science tests (algebra, geometry, Newtonian physics problems, etc.). Unlike open domain tests, closed domain tests require the system to have significant domain knowledge and reasoning capabilities. For example, geometry questions typically involve a number of geometry primitives (lines, quadrilaterals, circles, etc) and require students to use axioms and theorems of geometry (Pythagoras theorem, alternating angles, etc) to solve them. These closed domains often have a formal logical basis and the question can be mapped to a formal language by semantic parsing. The formal question representation can then provided as an input to an expert system to solve the question.</abstract>
@@ -6209,7 +6203,6 @@ For this tutorial, we broadly categorize these tests into two categories: open d
       <title>Deep Chit-Chat: Deep Learning for ChatBots</title>
       <author><first>Wei</first><last>Wu</last></author>
       <author><first>Rui</first><last>Yan</last></author>
-      <url>D18-3006</url>
       <abstract>The tutorial is based on the long-term efforts on building conversational models with deep learning approaches for chatbots. We will summarize the fundamental challenges in modeling open domain dialogues, clarify the difference from modeling goal-oriented dialogues, and give an overview of state-of-the-art methods for open domain conversation including both retrieval-based methods and generation-based methods. In addition to these, our tutorial will also cover some new trends of research of chatbots, such as how to design a reasonable evaluation system and how to "control" conversations from a chatbot with some specific information such as personas, styles, and emotions, etc.</abstract>
     </paper>
   </volume>

--- a/data/xml/P16.xml
+++ b/data/xml/P16.xml
@@ -3649,4 +3649,116 @@
       <doi>10.18653/v1/P16-4028</doi>
     </paper>
   </volume>
+  <volume id="5">
+    <meta>
+      <booktitle>Proceedings of <fixed-case>ACL</fixed-case> 2016, Tutorial Abstracts</booktitle>
+      <url>P16-5</url>
+      <editor><first>Alexandra</first><last>Birch</last></editor>
+      <editor><first>Willem</first><last>Zuidema</last></editor>
+      <publisher>Association for Computational Linguistics</publisher>
+      <address>Berlin, Germany</address>
+      <month>August</month>
+      <year>2016</year>
+    </meta>
+    <paper id="1">
+      <title>Multimodal Learning and Reasoning</title>
+      <author><first>Desmond</first><last>Elliott</last></author>
+      <author><first>Douwe</first><last>Kiela</last></author>
+      <author><first>Angeliki</first><last>Lazaridou</last></author>
+      <url>P16-5001</url>
+      <abstract>Natural Language Processing has broadened in scope to tackle more and more challenging language understanding and reasoning tasks. The core NLP tasks remain predominantly unimodal, focusing on linguistic input, despite the fact that we, humans, acquire and use language while communicating in perceptually rich environments. Moving towards human-level AI will require the integration and modeling of multiple modalities beyond language. With this tutorial, our aim is to introduce researchers to the areas of NLP that have dealt with multimodal signals. The key advantage of using multimodal signals in NLP tasks is the complementarity of the data in different modalities. For example, we are less likely to nd descriptions of yellow bananas or wooden chairs in text corpora, but these visual attributes can be readily extracted directly from images. Multimodal signals, such as visual, auditory or olfactory data, have proven useful for models of word similarity and relatedness, automatic image and video description, and even predicting the associated smells of words. Finally, multimodality offers a practical opportunity to study and apply multitask learning, a general machine learning paradigm that improves generalization performance of a task by using training signals of other related tasks.
+
+All material associated to the tutorial will be available at http://multimodalnlp.github.io/</abstract>
+    </paper>
+    <paper id="2">
+      <title>NLP Approaches to Computational Argumentation</title>
+      <author><first>Noam</first><last>Slonim</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
+      <author><first>Chris</first><last>Reed</last></author>
+      <author><first>Benno</first><last>Stein</last></author>
+      <url>P16-5002</url>
+      <abstract>Argumentation and debating represent primary intellectual activities of the human mind. People in all societies argue and debate, not only to convince others of their own opinions but also in order to explore the differences between multiple perspectives and conceptualizations, and to learn from this exploration. The process of reaching a resolution on controversial topics typically does not follow a simple sequence of purely logical steps. Rather it involves a wide variety of complex and interwoven actions. Presumably, pros and cons are identified, considered, and weighed, via cognitive processes that often involve persuasion and emotions, which are inherently harder to formalize from a computational perspective.
+
+This wide range of conceptual capabilities and activities, have only in part been studied in fields like CL and NLP, and typically within relatively small sub-communities that overlap the ACL audience. The new field of Computational Argumentation has very recently seen significant expansion within the CL and NLP community as new techniques and datasets start to become available, allowing for the first time investigation of the computational aspects of human argumentation in a holistic manner. 
+
+The main goal of this tutorial would be to introduce this rapidly evolving field to the CL community. Specifically, we will aim to review recent advances in the field and to outline the challenging research questions - that are most relevant to the ACL audience - that naturally arise when trying to model human argumentation.
+
+We will further emphasize the practical value of this line of study, by considering real-world CL and NLP applications that are expected to emerge from this research, and to impact various industries, including legal, finance, healthcare, media, and education, to name just a few examples.
+
+The first part of the tutorial will provide introduction to the basics of argumentation and rhetoric. Next, we will cover fundamental analysis tasks in Computational Argumentation, including argumentation mining, revealing argument relations, assessing arguments quality, stance classification, polarity analysis, and more. After the coffee break, we will first review existing resources and recently introduced benchmark data. In the following part we will cover basic synthesis tasks in Computational Argumentation, including the relation to NLG and dialogue systems, and the evolving area of Debate Technologies, defined as technologies developed directly to enhance, support, and engage with human debating. Finally, we will present relevant demos, review potential applications, and discuss the future of this emerging field.</abstract>
+    </paper>
+    <paper id="3"> 
+      <title>Computer Aided Translation</title>
+      <author><first>Philipp</first><last>Koehn</last></author>
+      <url>P16-5003</url>
+      <abstract>Moving beyond post-editing machine translation, a number of recent research efforts have advanced computer aided translation methods that allow for more interactivity, richer information such as confidence scores, and the completed feedback loop of instant adaptation of machine translation models to user translations. 
+
+This tutorial will explain the main techniques for several aspects of computer aided translation: confidence measures;
+interactive machine translation (interactive translation prediction);
+bilingual concordancers;
+translation option display;
+paraphrasing (alternative translation suggestions);
+visualization of word alignment;
+online adaptation;
+automatic reviewing;
+integration of translation memory;
+eye tracking, logging, and cognitive user models;
+
+For each of these, the state of the art and open challenges are presented. The tutorial will also look under the hood of the open source CASMACAT toolkit that is based on MATECAT, and available as a "Home Edition" to be installed on a desktop machine. The target audience of this tutorials are researchers interested in computer aided machine translation and practitioners who want to use or deploy advanced CAT technology.</abstract>
+    </paper>
+    <paper id="4">
+      <title>Semantic Representations of Word Senses and Concepts</title>
+      <author><first>José</first><last>Camacho-Collados</last></author>
+      <author><first>Ignacio</first><last>Iacobacci</last></author>
+      <author><first>Chris</first><last>Navigli</last></author>
+      <author><first>Roberto</first><last>Taher Pilehvar</last></author>
+      <url>P16-5004</url>
+      <abstract>Representing the semantics of linguistic items in a machine ­interpretable form has been a major goal of Natural Language Processing since its earliest days. Among the range of different linguistic items, words have attracted the most research attention. However, word representations have an important limitation: they conflate different meanings of a word into a single vector. Representations of word senses have the potential to overcome this inherent limitation. Indeed, the representation of individual word senses and concepts has recently gained in popularity with several experimental results showing that a considerable performance improvement can be achieved across different NLP applications upon moving from word level to the deeper sense and concept levels. Another interesting point regarding the representation of concepts and word senses is that these models can be seamlessly applied to other linguistic items, such as words, phrases, sentences, etc.
+
+This tutorial will first provide a brief overview of the recent literature concerning word representation (both count based and neural network based). It will then describe the advantages of moving from the word level to the deeper level of word senses and concepts, providing an extensive review of state ­of ­the ­art systems. Approaches covered will not only include those which draw upon knowledge resources such as WordNet, Wikipedia, BabelNet or FreeBase as reference, but also the so ­called multi ­prototype approaches which learn sense distinctions by using different clustering techniques. Our tutorial will discuss the advantages and potential limitations of all approaches, showing their most successful applications to date. We will conclude by presenting current open problems and lines of future work.</abstract>
+    </paper>
+    <paper id="5">
+      <title>Neural Machine Translation</title>
+      <author><first>Thang</first><last>Luong</last></author>
+      <author><first>Kyunghyun</first><last>Cho</last></author>
+      <author><first>Christopher D.</first><last>Manning</last></author>
+      <url>P16-5005</url>
+      <abstract>Neural Machine Translation (NMT) is a simple new architecture for getting machines to learn to translate. Despite being relatively new (Kalchbrenner and Blunsom, 2013; Cho et al., 2014; Sutskever et al., 2014), NMT has already shown promising results, achieving state-of-the-art performances for various language pairs (Luong et al, 2015a; Jean et al, 2015; Luong et al, 2015b; Sennrich et al., 2016; Luong and Manning, 2016). While many of these NMT papers were presented to the ACL community, research and practice of NMT are only at their beginning stage. This tutorial would be a great opportunity for the whole community of machine translation and natural language processing to learn more about a very promising new approach to MT. This tutorial has four parts.
+
+In the first part, we start with an overview of MT approaches, including: (a) traditional methods that have been dominant over the past twenty years and (b) recent hybrid models with the use of neural network components. From these, we motivate why an end-to-end approach like neural machine translation is needed. The second part introduces a basic instance of NMT. We start out with a discussion of recurrent neural networks, including the back-propagation-through-time algorithm and stochastic gradient descent optimizers, as these are the foundation on which NMT builds. We then describe in detail the basic sequence-to-sequence architecture of NMT (Cho et al., 2014; Sutskever et al., 2014), the maximum likelihood training approach, and a simple beam-search decoder to produce translations.
+
+The third part of our tutorial describes techniques to build state-of-the-art NMT. We start with approaches to extend the vocabulary coverage of NMT (Luong et al., 2015a; Jean et al., 2015; Chitnis and DeNero, 2015). We then introduce the idea of jointly learning both translations and alignments through an attention mechanism (Bahdanau et al., 2015); other variants of attention (Luong et al., 2015b; Tu et al., 2016) are discussed too. We describe a recent trend in NMT, that is to translate at the sub-word level (Chung et al., 2016; Luong and Manning, 2016; Sennrich et al., 2016), so that language variations can be effectively handled. We then give tips on training and testing NMT systems such as batching and ensembling. In the final part of the tutorial, we briefly describe promising approaches, such as (a) how to combine multiple tasks to help translation (Dong et al., 2015; Luong et al., 2016; Firat et al., 2016; Zoph and Knight, 2016) and (b) how to utilize monolingual corpora (Sennrich et al., 2016). Lastly, we conclude with challenges remained to be solved for future NMT.
+
+PS: we would also like to acknowledge the very first paper by Forcada and Ñeco (1997) on sequence-to-sequence models for translation!</abstract> 
+    </paper>
+    <paper id="6">
+      <title>Game Theory and Natural Language: Origin, Evolution and Processing</title>
+      <author><first>Rocco</first><last>Tripodi</last></author>
+      <author><first>Marcello</first><last>Pelillo</last></author>
+      <url>P16-5006</url>
+      <abstract>The development of game theory in the early 1940's by John von Neumann was a reaction against the then dominant view that problems in economic theory can be formulated using standard methods from optimization theory. Indeed, most real-world economic problems involve conflicting interactions among decision-making agents that cannot be adequately captured by a single (global) objective function. The main idea behind game theory is to shift the emphasis from optimality criteria to equilibrium conditions. Game theory provides a framework to model complex scenarios, with applications in economics and social science but also in different fields of information technology. With the recent development of algorithmic game theory, it has been used to solve problems in computer vision, pattern recognition, machine learning and natural language processing.
+
+Game-theoretic frameworks have been used in different ways to study language origin and evolution. Furthermore, the so-called game metaphor has been used by philosophers and linguists to explain how language evolved and how it works. Ludwig Wittgenstein, for example, famously introduced the concept of a language game to explain the conventional nature of language, and put forward the idea of the spontaneous formation of a common language that gradually emerges from the interactions among the speakers within a population.
+
+This concept opens the way to the interpretation of language as a complex adaptive system composed of linguistic units and their interactions, which gives rise to the emergence of structural properties. It is the core part of many computational models of language that are based on classical game theory and evolutionary game theory. With the former it is possible to model how speakers form a signaling system in which the ambiguity of the symbols is minimized; with the latter it is possible to model how speakers coordinate their linguistic choices according to the satisfaction that they have about the outcome of a communication act, converging to a common language. In the same vein, many other attempts have been proposed to explain how other characteristics of language follow similar dynamics.
+
+Game theory, and in particular evolutionary game theory, thanks to their ability to model interactive situations and to integrate information from multiple sources, have also been used to solve specific problems in natural language processing and information retrieval, such as language generation, word sense disambiguation and document and text clustering.
+
+The goal of this tutorial is to offer an introduction to the basic concepts of game theory and to show its main applications in the study of language, from different perspectives. We shall assume no pre-existing knowledge of game theory by the audience, thereby making the tutorial self-contained and understandable by a non-expert.</abstract>
+    </paper>
+    <paper id="7">
+      <title>Understanding Short Texts</title>
+      <author><first>Zhongyuan</first><last>Wang</last></author>
+      <author><first>Haixun</first><last>Wang</last></author>
+      <url>P16-5007</url>
+      <abstract>Billions of short texts are produced every day, in the form of search queries, ad keywords, tags, tweets, messenger conversations, social network posts, etc. Unlike documents, short texts have some unique characteristics which make them difficult to handle. First, short texts, especially search queries, do not always observe the syntax of a written language. This means traditional NLP techniques, such as syntactic parsing, do not always apply to short texts. Second, short texts contain limited context. The majority of search queries contain less than 5 words, and tweets can have no more than 140 characters. Because of the above reasons, short texts give rise to a significant amount of ambiguity, which makes them extremely difficult to handle. On the other hand, many applications, including search engines, ads, automatic question answering, online advertising, recommendation systems, etc., rely on short text understanding. In all these applications, the necessary first step is to transform an input text into a machine-interpretable representation, namely to "understand" the short text. A growing number of approaches leverage external knowledge to address the issue of inadequate contextual information that accompanies the short texts. These approaches can be classified into two categories: Explicit Representation Model (ERM) and Implicit Representation Model (IRM). In this tutorial, we will present a comprehensive overview of short text understanding based on explicit semantics (knowledge graph representation, acquisition, and reasoning) and implicit semantics (embedding and deep learning). Specifically, we will go over various techniques in knowledge acquisition, representation, and inferencing has been proposed for text understanding, and we will describe massive structured and semi-structured data that have been made available in the recent decade that directly or indirectly encode human knowledge, turning the knowledge representation problems into a computational grand challenge with feasible solutions insight.</abstract>
+    </paper>
+    <paper id="8">
+      <title>MetaNet: Repository, Identification System, and Applications</title>
+      <author><first>Miriam R L</first><last>Petruck</last></author>
+      <author><first>Ellen K</first><last>Dodge</last></author>
+      <url>P16-5008</url>
+      <abstract>The ubiquity of metaphor in language (Lakoff and Johnson 1980) has served as impetus for cognitive linguistic approaches to the study of language, mind, and the study of mind (e.g. Thibodeau &amp; Boroditsky 2011). While native speakers use metaphor naturally and easily, the treatment and interpretation of metaphor in computational systems remains challenging because such systems have not succeeded in developing ways to recognize the semantic elements that define metaphor. This tutorial demonstrates MetaNet's frame-based semantic analyses, and their informing of MetaNet's automatic metaphor identification system. Participants will gain a complete understanding of the theoretical basis and the practical workings of MetaNet, and acquire relevant information about the Frame Semantics basis of that knowledge base and the way that FrameNet handles the widespread phenomenon of metaphor in language. The tutorial is geared to researchers and practitioners of language technology, not necessarily experts in metaphor analysis or knowledgeable about either FrameNet or MetaNet, but who are interested in natural language processing tasks that involve automatic metaphor processing, or could benefit from exposure to tools and resources that support frame-based deep semantic, analyses of language, including metaphor as a widespread phenomenon in human language.</abstract>
+    </paper>
+   </volume>
 </collection>

--- a/data/xml/P16.xml
+++ b/data/xml/P16.xml
@@ -3652,7 +3652,6 @@
   <volume id="5">
     <meta>
       <booktitle>Proceedings of <fixed-case>ACL</fixed-case> 2016, Tutorial Abstracts</booktitle>
-      <url>P16-5</url>
       <editor><first>Alexandra</first><last>Birch</last></editor>
       <editor><first>Willem</first><last>Zuidema</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
@@ -3665,7 +3664,6 @@
       <author><first>Desmond</first><last>Elliott</last></author>
       <author><first>Douwe</first><last>Kiela</last></author>
       <author><first>Angeliki</first><last>Lazaridou</last></author>
-      <url>P16-5001</url>
       <abstract>Natural Language Processing has broadened in scope to tackle more and more challenging language understanding and reasoning tasks. The core NLP tasks remain predominantly unimodal, focusing on linguistic input, despite the fact that we, humans, acquire and use language while communicating in perceptually rich environments. Moving towards human-level AI will require the integration and modeling of multiple modalities beyond language. With this tutorial, our aim is to introduce researchers to the areas of NLP that have dealt with multimodal signals. The key advantage of using multimodal signals in NLP tasks is the complementarity of the data in different modalities. For example, we are less likely to nd descriptions of yellow bananas or wooden chairs in text corpora, but these visual attributes can be readily extracted directly from images. Multimodal signals, such as visual, auditory or olfactory data, have proven useful for models of word similarity and relatedness, automatic image and video description, and even predicting the associated smells of words. Finally, multimodality offers a practical opportunity to study and apply multitask learning, a general machine learning paradigm that improves generalization performance of a task by using training signals of other related tasks.
 
 All material associated to the tutorial will be available at http://multimodalnlp.github.io/</abstract>
@@ -3676,7 +3674,6 @@ All material associated to the tutorial will be available at http://multimodalnl
       <author><first>Iryna</first><last>Gurevych</last></author>
       <author><first>Chris</first><last>Reed</last></author>
       <author><first>Benno</first><last>Stein</last></author>
-      <url>P16-5002</url>
       <abstract>Argumentation and debating represent primary intellectual activities of the human mind. People in all societies argue and debate, not only to convince others of their own opinions but also in order to explore the differences between multiple perspectives and conceptualizations, and to learn from this exploration. The process of reaching a resolution on controversial topics typically does not follow a simple sequence of purely logical steps. Rather it involves a wide variety of complex and interwoven actions. Presumably, pros and cons are identified, considered, and weighed, via cognitive processes that often involve persuasion and emotions, which are inherently harder to formalize from a computational perspective.
 
 This wide range of conceptual capabilities and activities, have only in part been studied in fields like CL and NLP, and typically within relatively small sub-communities that overlap the ACL audience. The new field of Computational Argumentation has very recently seen significant expansion within the CL and NLP community as new techniques and datasets start to become available, allowing for the first time investigation of the computational aspects of human argumentation in a holistic manner. 
@@ -3690,7 +3687,6 @@ The first part of the tutorial will provide introduction to the basics of argume
     <paper id="3"> 
       <title>Computer Aided Translation</title>
       <author><first>Philipp</first><last>Koehn</last></author>
-      <url>P16-5003</url>
       <abstract>Moving beyond post-editing machine translation, a number of recent research efforts have advanced computer aided translation methods that allow for more interactivity, richer information such as confidence scores, and the completed feedback loop of instant adaptation of machine translation models to user translations. 
 
 This tutorial will explain the main techniques for several aspects of computer aided translation: confidence measures;
@@ -3712,7 +3708,6 @@ For each of these, the state of the art and open challenges are presented. The t
       <author><first>Ignacio</first><last>Iacobacci</last></author>
       <author><first>Chris</first><last>Navigli</last></author>
       <author><first>Roberto</first><last>Taher Pilehvar</last></author>
-      <url>P16-5004</url>
       <abstract>Representing the semantics of linguistic items in a machine ­interpretable form has been a major goal of Natural Language Processing since its earliest days. Among the range of different linguistic items, words have attracted the most research attention. However, word representations have an important limitation: they conflate different meanings of a word into a single vector. Representations of word senses have the potential to overcome this inherent limitation. Indeed, the representation of individual word senses and concepts has recently gained in popularity with several experimental results showing that a considerable performance improvement can be achieved across different NLP applications upon moving from word level to the deeper sense and concept levels. Another interesting point regarding the representation of concepts and word senses is that these models can be seamlessly applied to other linguistic items, such as words, phrases, sentences, etc.
 
 This tutorial will first provide a brief overview of the recent literature concerning word representation (both count based and neural network based). It will then describe the advantages of moving from the word level to the deeper level of word senses and concepts, providing an extensive review of state ­of ­the ­art systems. Approaches covered will not only include those which draw upon knowledge resources such as WordNet, Wikipedia, BabelNet or FreeBase as reference, but also the so ­called multi ­prototype approaches which learn sense distinctions by using different clustering techniques. Our tutorial will discuss the advantages and potential limitations of all approaches, showing their most successful applications to date. We will conclude by presenting current open problems and lines of future work.</abstract>
@@ -3722,7 +3717,6 @@ This tutorial will first provide a brief overview of the recent literature conce
       <author><first>Thang</first><last>Luong</last></author>
       <author><first>Kyunghyun</first><last>Cho</last></author>
       <author><first>Christopher D.</first><last>Manning</last></author>
-      <url>P16-5005</url>
       <abstract>Neural Machine Translation (NMT) is a simple new architecture for getting machines to learn to translate. Despite being relatively new (Kalchbrenner and Blunsom, 2013; Cho et al., 2014; Sutskever et al., 2014), NMT has already shown promising results, achieving state-of-the-art performances for various language pairs (Luong et al, 2015a; Jean et al, 2015; Luong et al, 2015b; Sennrich et al., 2016; Luong and Manning, 2016). While many of these NMT papers were presented to the ACL community, research and practice of NMT are only at their beginning stage. This tutorial would be a great opportunity for the whole community of machine translation and natural language processing to learn more about a very promising new approach to MT. This tutorial has four parts.
 
 In the first part, we start with an overview of MT approaches, including: (a) traditional methods that have been dominant over the past twenty years and (b) recent hybrid models with the use of neural network components. From these, we motivate why an end-to-end approach like neural machine translation is needed. The second part introduces a basic instance of NMT. We start out with a discussion of recurrent neural networks, including the back-propagation-through-time algorithm and stochastic gradient descent optimizers, as these are the foundation on which NMT builds. We then describe in detail the basic sequence-to-sequence architecture of NMT (Cho et al., 2014; Sutskever et al., 2014), the maximum likelihood training approach, and a simple beam-search decoder to produce translations.
@@ -3735,7 +3729,6 @@ PS: we would also like to acknowledge the very first paper by Forcada and Ñeco 
       <title>Game Theory and Natural Language: Origin, Evolution and Processing</title>
       <author><first>Rocco</first><last>Tripodi</last></author>
       <author><first>Marcello</first><last>Pelillo</last></author>
-      <url>P16-5006</url>
       <abstract>The development of game theory in the early 1940's by John von Neumann was a reaction against the then dominant view that problems in economic theory can be formulated using standard methods from optimization theory. Indeed, most real-world economic problems involve conflicting interactions among decision-making agents that cannot be adequately captured by a single (global) objective function. The main idea behind game theory is to shift the emphasis from optimality criteria to equilibrium conditions. Game theory provides a framework to model complex scenarios, with applications in economics and social science but also in different fields of information technology. With the recent development of algorithmic game theory, it has been used to solve problems in computer vision, pattern recognition, machine learning and natural language processing.
 
 Game-theoretic frameworks have been used in different ways to study language origin and evolution. Furthermore, the so-called game metaphor has been used by philosophers and linguists to explain how language evolved and how it works. Ludwig Wittgenstein, for example, famously introduced the concept of a language game to explain the conventional nature of language, and put forward the idea of the spontaneous formation of a common language that gradually emerges from the interactions among the speakers within a population.
@@ -3750,15 +3743,13 @@ The goal of this tutorial is to offer an introduction to the basic concepts of g
       <title>Understanding Short Texts</title>
       <author><first>Zhongyuan</first><last>Wang</last></author>
       <author><first>Haixun</first><last>Wang</last></author>
-      <url>P16-5007</url>
       <abstract>Billions of short texts are produced every day, in the form of search queries, ad keywords, tags, tweets, messenger conversations, social network posts, etc. Unlike documents, short texts have some unique characteristics which make them difficult to handle. First, short texts, especially search queries, do not always observe the syntax of a written language. This means traditional NLP techniques, such as syntactic parsing, do not always apply to short texts. Second, short texts contain limited context. The majority of search queries contain less than 5 words, and tweets can have no more than 140 characters. Because of the above reasons, short texts give rise to a significant amount of ambiguity, which makes them extremely difficult to handle. On the other hand, many applications, including search engines, ads, automatic question answering, online advertising, recommendation systems, etc., rely on short text understanding. In all these applications, the necessary first step is to transform an input text into a machine-interpretable representation, namely to "understand" the short text. A growing number of approaches leverage external knowledge to address the issue of inadequate contextual information that accompanies the short texts. These approaches can be classified into two categories: Explicit Representation Model (ERM) and Implicit Representation Model (IRM). In this tutorial, we will present a comprehensive overview of short text understanding based on explicit semantics (knowledge graph representation, acquisition, and reasoning) and implicit semantics (embedding and deep learning). Specifically, we will go over various techniques in knowledge acquisition, representation, and inferencing has been proposed for text understanding, and we will describe massive structured and semi-structured data that have been made available in the recent decade that directly or indirectly encode human knowledge, turning the knowledge representation problems into a computational grand challenge with feasible solutions insight.</abstract>
     </paper>
     <paper id="8">
       <title>MetaNet: Repository, Identification System, and Applications</title>
       <author><first>Miriam R L</first><last>Petruck</last></author>
       <author><first>Ellen K</first><last>Dodge</last></author>
-      <url>P16-5008</url>
       <abstract>The ubiquity of metaphor in language (Lakoff and Johnson 1980) has served as impetus for cognitive linguistic approaches to the study of language, mind, and the study of mind (e.g. Thibodeau &amp; Boroditsky 2011). While native speakers use metaphor naturally and easily, the treatment and interpretation of metaphor in computational systems remains challenging because such systems have not succeeded in developing ways to recognize the semantic elements that define metaphor. This tutorial demonstrates MetaNet's frame-based semantic analyses, and their informing of MetaNet's automatic metaphor identification system. Participants will gain a complete understanding of the theoretical basis and the practical workings of MetaNet, and acquire relevant information about the Frame Semantics basis of that knowledge base and the way that FrameNet handles the widespread phenomenon of metaphor in language. The tutorial is geared to researchers and practitioners of language technology, not necessarily experts in metaphor analysis or knowledgeable about either FrameNet or MetaNet, but who are interested in natural language processing tasks that involve automatic metaphor processing, or could benefit from exposure to tools and resources that support frame-based deep semantic, analyses of language, including metaphor as a widespread phenomenon in human language.</abstract>
     </paper>
-   </volume>
+  </volume>
 </collection>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -3739,7 +3739,7 @@
     <meta>
       <booktitle>Proceedings of the 3rd Workshop on Arabic Corpus Linguistics</booktitle>
       <url>W19-56</url>
-      <editor><first>Mahmoud</first><last>El-haj</last></editor>
+      <editor><first>Mahmoud</first><last>El-Haj</last></editor>
       <editor><first>Paul</first><last>Rayson</last></editor>
       <editor><first>Eric</first><last>Atwell</last></editor>
       <editor><first>Lama</first><last>Alsudias</last></editor>


### PR DESCRIPTION
Added EMNLP 2018 tutorial abstracts from conf. webpages. Minor spell-/formatting- errors are also fixed. 
Also, looks like tutorials were not part of EMNLP prior to 2014. So, I can't find any information about tutorials in EMNLP 2010-2013.
