### PR TITLE
Slightly increase width of button row in paper lists

### DIFF
--- a/hugo/assets/css/_papers.scss
+++ b/hugo/assets/css/_papers.scss
@@ -117,5 +117,5 @@ dd.acl-button-row .btn {
 }
 
 .list-button-row {
-  min-width: 6rem;
+  min-width: 6.3rem;
 }


### PR DESCRIPTION
I confirmed that the spacing of paper lists is slightly off on some browsers/systems, as mentioned by @mjpost in https://github.com/acl-org/acl-anthology/pull/443#issuecomment-512897195. It looks similar for me on Chrome on Windows 10, for example.

Slightly increasing the minimum width should fix this and won't disturb the layout much on any system.