### PR TITLE
Move feedback button to sidebar, remove banner

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -8,5 +8,5 @@ staticDir = ["static", "data-export"]
 
   [[menu.footer]]
     identifier = "issues"
-    name = "Issues"
+    name = "Report Issues"
     url = "https://github.com/acl-org/acl-anthology/issues/"

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -1,10 +1,8 @@
 ---
 Title: ACL Anthology
-date: "2019-05-05"
+date: "0001-01-01"
 css_container: container-fluid
 ---
-
-We have recently added hundreds of videos, and expanded the early years of the Computational Linguistics Journal.
 
 The Anthology can archive your poster or presentation!
 Please submit them in PDF format by [filling out this form](https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAAMAABqTSThUN0I2VEdZMTk4Sks3S042MVkxUEZQUVdOUS4u).

--- a/hugo/content/_index.md
+++ b/hugo/content/_index.md
@@ -4,6 +4,9 @@ date: "0001-01-01"
 css_container: container-fluid
 ---
 
+<!-- To disable printing a date for the MOTD, set the "date" field above to some
+value before 2019. -->
+
 The Anthology can archive your poster or presentation!
 Please submit them in PDF format by [filling out this form](https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAAMAABqTSThUN0I2VEdZMTk4Sks3S042MVkxUEZQUVdOUS4u).
 Attachments will be distributed under the terms of the [CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/).

--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -28,14 +28,6 @@
   <body>
     {{ block "header" . }}{{ partialCached "header_navbar.html" .}}{{ end }}
 
-    <!-- Draft alert -->
-    <div class="container pt-3">
-      <aside class="alert alert-warning text-center py-1 mt-n3 mt-md-n4 mt-xl-n5" role="alert">
-        You're viewing the latest version of the ACL Anthology.
-        <a class="btn btn-warning mx-2" href="https://github.com/acl-org/acl-anthology/issues/170">Give feedback</a>
-      </aside>
-    </div>
-
     <div id="main-container" class="{{ default "container" (index .Params "css_container") }}">
       {{ block "main" . }}{{ end }}
     </div>

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -36,7 +36,9 @@
 
     <aside class="alert alert-info acl-news mb-3" role="alert">
       <!-- The news message pulls from content/_index.md -->
+      {{ if (gt (time .PublishDate).Year 2018) }}
       <div class="acl-news-date">{{ .PublishDate.Format "January 2006" }}</div>
+      {{ end }}
       {{ .Content }}
     </aside>
 

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -40,9 +40,17 @@
       {{ .Content }}
     </aside>
 
-    {{ if (fileExists "/data-export/anthology.bib.gz") }}
-    <a class="btn btn-block btn-info" href="{{ "/anthology.bib.gz" | relURL }}">Full Anthology as BibTeX ({{ printf "%.2f MB" (div (os.Stat "/data-export/anthology.bib.gz").Size 1000000.0) }})</a>
-    {{ end }}
+    <div class="row mb-3">
+      {{ if (fileExists "/data-export/anthology.bib.gz") }}
+      <div class="col-6 col-xl-12 mb-2">
+        <a class="btn btn-block btn-info" href="{{ "/anthology.bib.gz" | relURL }}">Full Anthology as BibTeX ({{ printf "%.2f MB" (div (os.Stat "/data-export/anthology.bib.gz").Size 1000000.0) }})</a>
+      </div>
+      {{ end }}
+      <div class="col-6 col-xl-12 mb-2">
+        <a class="btn btn-block btn-warning" href="https://github.com/acl-org/acl-anthology/issues/170">Give feedback
+        </a>
+      </div>
+    </div>
   </div><div class="col-12 col-xl-10 col-xl-width-auto">
     <main aria-role="main">
     <h6>ACL Events</h6>


### PR DESCRIPTION
This PR removes the feedback banner from the top of every page, and adds a feedback button to the landing page sidebar like this:

![image](https://user-images.githubusercontent.com/11348502/61706958-b3118b00-ad49-11e9-9af7-e9b1868b3263.png)

Alternative suggestions are welcome, but I do think it's time to get rid of the top banner for ACL :)