### PR TITLE
ACL2019 workshop sigs

### DIFF
--- a/data/yaml/sigs/sigann.yaml
+++ b/data/yaml/sigs/sigann.yaml
@@ -2,6 +2,8 @@ Name: Special Interest Group for Annotation (SIGANN)
 ShortName: SIGANN
 URL: http://www.cs.vassar.edu/sigann/
 Meetings: 
+  - 2019:
+    - W19-40 # LAW XIII
   - 2018:
     - W18-49 # LAW-MWE-CxG-2018
   - 2017:

--- a/data/yaml/sigs/sigbiomed.yaml
+++ b/data/yaml/sigs/sigbiomed.yaml
@@ -1,7 +1,9 @@
 Name: Special Interest Group on Biomedical Natural Language Processing
 ShortName: SIGBIOMED
 URL: http://www.sigbiomed.org/
-Meetings: 
+Meetings:
+  - 2019:
+    - W19-50 # BioNLP
   - 2017:
     - W17-23 # BioNLP
   - 2016:

--- a/data/yaml/sigs/sigedu.yaml
+++ b/data/yaml/sigs/sigedu.yaml
@@ -2,6 +2,8 @@ Name: Special Interest Group for Building Educational Applications
 ShortName: SIGEDU
 URL: https://sig-edu.org/
 Meetings:
+  - 2019:
+    - W19-44
   - 2018:
     - W18-05
     - W18-71

--- a/data/yaml/sigs/siglex.yaml
+++ b/data/yaml/sigs/siglex.yaml
@@ -5,6 +5,7 @@ Meetings:
   - 2019:
     - S19-1 # *SEM
     - S19-2 # SemEval
+    - W19-51 # Joint Workshop on Multiword Expressions and Wordnet
   - 2018:
     - S18-1 # SemEval
     - S18-2 # *Sem

--- a/data/yaml/sigs/sigmorphon.yaml
+++ b/data/yaml/sigs/sigmorphon.yaml
@@ -2,6 +2,9 @@ Name: Special Interest Group on Computational Morphology and Phonology (SIGMORPH
 ShortName: SIGMORPHON
 URL: https://sigmorphon.github.io/
 Meetings:
+  - 2019:
+    - W19-49 # TypNLP
+    - W19-42 # SIGMORPHON
   - 2018:
     - W18-58 # 15th SIGMORPHON Workshop on Computational Research in Phonetics, Phonology, and Morphology
   - 2016:

--- a/data/yaml/sigs/sigrep.yaml
+++ b/data/yaml/sigs/sigrep.yaml
@@ -1,0 +1,12 @@
+Name: Special Interest Group on Representation Learning
+ShortName: SIGREP
+URL: http://www.sigrep.org
+Meetings:
+  - 2019:
+    - W19-43 # RepL4NLP
+  - 2018:
+    - W18-30 # RepL4NLP
+  - 2017:
+    - W17-26 # RepL4NLP
+  - 2016:
+    - W16-16 # RepL4NLP

--- a/data/yaml/sigs/sigslav.yaml
+++ b/data/yaml/sigs/sigslav.yaml
@@ -2,6 +2,8 @@ Name: Special Interest Group on Slavic Natural Language Processing
 ShortName: SIGSLAV
 URL: http://sigslav.cs.helsinki.fi/
 Meetings:
+  - 2019:
+    - W19-37 # Proceedings of the 7th Workshop on Balto-Slavic Natural Language Processing
   - 2017:
     - W17-14 # Proceedings of the 6th Workshop on Balto-Slavic Natural Language Processing
   - 2015:


### PR DESCRIPTION
Added missing SIGs.

What I'd really like is for this to be added as a new tag in the ACLPUB XML, so that it could be automatically ingested (https://github.com/acl-org/ACLPUB/issues/15).