### PR TITLE
Add pubChairs to editors list as agreed with WANLP General Chair

### DIFF
--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -7432,6 +7432,8 @@
       <booktitle>Proceedings of the Fourth Arabic Natural Language Processing Workshop</booktitle>
       <url>W19-46</url>
       <editor><first>Wassim</first><last>El-Hajj</last></editor>
+	  <editor><first>Mahmoud</first><last>El-Haj</last></editor>
+	  <editor><first>Nadi</first><last>Tomeh</last></editor>
       <editor><first>Lamia Hadrich</first><last>Belguith</last></editor>
       <editor><first>Fethi</first><last>Bougares</last></editor>
       <editor><first>Walid</first><last>Magdy</last></editor>


### PR DESCRIPTION
The editors list of the Proceedings of the Fourth Arabic Natural Language Processing Workshop (WANLP) was missing the publication chairs names. I contacted the General Chair of the 4th WANLP to clarify this error. General Chair agreed to open a pull request on GitHub to fix this error. 4th WANLP General Chair: Wassim El-Hajj. Pub chairs names: Mahmoud El-Haj (Pull Request creator) and Nadi Tomeh as shown on the 4th WANLP website: https://sites.google.com/view/wanlp-2019/home
