### PR TITLE
Update Q19.xml

### DIFF
--- a/data/xml/Q19.xml
+++ b/data/xml/Q19.xml
@@ -160,7 +160,7 @@
       <url>Q19-1014</url>
     </paper>
     <paper id="15">
-      <title>Neural Sequence-to-Sequence Models from Weak Feedback with Bipolar Ramp Loss</title>
+      <title>Learning Neural Sequence-to-Sequence Models from Weak Feedback with Bipolar Ramp Loss</title>
       <author><first>Laura</first><last>Jehl</last></author>
       <author><first>Carolin</first><last>Lawrence</last></author>
       <author><first>Stefan</first><last>Riezler</last></author>


### PR DESCRIPTION
Lillian Lee pointed out that we have a paper title missing a word. The error was propagated from the MIT Press XML data; they've since corrected this.