### PR TITLE
Use and update venv inside Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
 
 install:
   - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
-  - pip install -r bin/requirements.txt
   - sudo apt-get install -y jing bibutils
 
 script:


### PR DESCRIPTION
Also checks whether the python version is new enough.  No more
handling the virtualenv by hand anymore.

Possible downside: it assumes that the system-wide python3 is the one
that should be used for building the site.  I don't think that this is
a real problem.