### PR TITLE
Add build information to front page footer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo apt-get update
 
 install:
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_extended_0.58.3_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
   - sudo apt-get install -y jing bibutils
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo apt-get update
 
 install:
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.58.3/hugo_extended_0.58.3_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.54.0/hugo_extended_0.54.0_Linux-64bit.deb && sudo dpkg -i hugo_extended*.deb
   - sudo apt-get install -y jing bibutils
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ build/.static: $(shell find hugo -type f)
 	@mkdir -p build/data-export
 	@perl -pi -e "s/ANTHOLOGYDIR/$(ANTHOLOGYDIR)/g" build/index.html
 	@touch build/.static
+	cat build/config.toml
 
 .PHONY: yaml
 yaml: build/.yaml

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ build/.static: $(shell find hugo -type f)
 	@mkdir -p build/data-export
 	@perl -pi -e "s/ANTHOLOGYDIR/$(ANTHOLOGYDIR)/g" build/index.html
 	@touch build/.static
-	cat build/config.toml
 
 .PHONY: yaml
 yaml: build/.yaml

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ HUGO_ENV ?= production
 
 sourcefiles=$(shell find data -type f '(' -name "*.yaml" -o -name "*.xml" ')')
 
+timestamp=$(shell date +"%d %B %Y at %H:%M %Z")
+githash=$(shell git rev-parse HEAD)
+githashshort=$(shell git rev-parse --short HEAD)
+
 #######################################################
 # check whether the correct python version is available
 ifeq (, $(shell which python3 ))
@@ -69,6 +73,11 @@ build/.static: $(shell find hugo -type f)
 	@echo "INFO     Creating and populating build directory..."
 	@mkdir -p build
 	@cp -r hugo/* build
+	@echo >> build/config.toml
+	@echo "[params]" >> build/config.toml
+	@echo "  githash = \"${githash}\"" >> build/config.toml
+	@echo "  githashshort = \"${githashshort}\"" >> build/config.toml
+	@echo "  timestamp = \"${timestamp}\"" >> build/config.toml
 	@mkdir -p build/data-export
 	@perl -pi -e "s/ANTHOLOGYDIR/$(ANTHOLOGYDIR)/g" build/index.html
 	@touch build/.static
@@ -121,7 +130,7 @@ build/.endnote: build/.mods
 .PHONY: hugo
 hugo: build/.hugo
 
-build/.hugo: build/.pages build/.bibtex build/.mods build/.endnote
+build/.hugo: build/layouts/partials/footer.html
 	@echo "INFO     Running Hugo... this may take a while."
 	@cd build && \
 	    hugo -b $(ANTHOLOGYHOST)/$(ANTHOLOGYDIR) \

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ build/.endnote: build/.mods
 .PHONY: hugo
 hugo: build/.hugo
 
-build/.hugo: build/layouts/partials/footer.html
+build/.hugo: build/.pages build/.bibtex build/.mods build/.endnote
 	@echo "INFO     Running Hugo... this may take a while."
 	@cd build && \
 	    hugo -b $(ANTHOLOGYHOST)/$(ANTHOLOGYDIR) \

--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -20,5 +20,9 @@
       <a href="http://www.comp.nus.edu.sg/~kanmy/">Min-Yen Kan</a> (Editor, 2008&ndash;2018) |
       <a href="http://stevenbird.net/">Steven Bird</a> (Editor, 2001&ndash;2007)
     </p>
+
+    <p class="text-muted small px=1">
+      <i>Site last built on {{ .Site.Params.timestamp }} with <a href="https://github.com/acl-org/acl-anthology/tree/{{ .Site.Params.githash }}">build {{ .Site.Params.githashshort }}</a>.</i>
+    </p>
   </div>
 </footer>


### PR DESCRIPTION
This PR adds build time and github stamp to the footer of the main page.

![image](https://user-images.githubusercontent.com/455256/65350907-c8bdf800-dbb4-11e9-9d1c-9a84c0bf4353.png)

Hugo has variables for this, but I spent an hour trying to get it to format dates correctly, and it also didn't seem to be able to compute git hashes.