### PR TITLE
added open graph headers (closes #403)

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -67,8 +67,6 @@ class Paper:
         if paper.is_volume or is_journal(paper.full_id):
             del paper.attrib['xml_booktitle']
 
-        paper.attrib['booktitle'] = paper.get('booktitle')
-
         # Expand URLs with paper ID
         for tag in ('revision', 'erratum'):
             if tag in paper.attrib:
@@ -95,8 +93,7 @@ class Paper:
                 "url": data.ANTHOLOGY_URL.format( "{}v1".format(paper.full_id)) } )
 
         paper.attrib["title"] = paper.get_title("plain")
-        if "booktitle" in paper.attrib:
-            paper.attrib["booktitle"] = paper.get_booktitle("plain")
+        paper.attrib["booktitle"] = paper.get_booktitle("plain")
 
         if "editor" in paper.attrib:
             if paper.is_volume:
@@ -226,7 +223,7 @@ class Paper:
         """
         return self.formatter(self.get("xml_abstract"), form, allow_url=True)
 
-    def get_booktitle(self, form="xml"):
+    def get_booktitle(self, form="xml", default=''):
         """Returns the booktitle, optionally formatting it.
 
         See `get_title()` for details.
@@ -235,6 +232,8 @@ class Paper:
             return self.formatter(self.get("xml_booktitle"), form)
         elif self.parent_volume is not None:
             return self.parent_volume.get('title')
+        else:
+            return default
 
     def as_bibtex(self):
         """Return the BibTeX entry for this paper."""

--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -118,6 +118,12 @@ class Paper:
                 paper._interpret_pages()
             else:
                 del paper.attrib["pages"]
+
+        if 'author' in paper.attrib:
+            # for x in paper.attrib['author']:
+            #     print('X', x[0].full)
+            paper.attrib["author_string"] = ', '.join([x[0].full for x in paper.attrib["author"]])
+
         return paper
 
     def _interpret_pages(self):

--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -67,6 +67,8 @@ class Paper:
         if paper.is_volume or is_journal(paper.full_id):
             del paper.attrib['xml_booktitle']
 
+        paper.attrib['booktitle'] = paper.get('booktitle')
+
         # Expand URLs with paper ID
         for tag in ('revision', 'erratum'):
             if tag in paper.attrib:
@@ -229,7 +231,10 @@ class Paper:
 
         See `get_title()` for details.
         """
-        return self.formatter(self.get("xml_booktitle"), form)
+        if 'xml_booktitle' in self.attrib:
+            return self.formatter(self.get("xml_booktitle"), form)
+        elif self.parent_volume is not None:
+            return self.parent_volume.get('title')
 
     def as_bibtex(self):
         """Return the BibTeX entry for this paper."""

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -25,7 +25,7 @@
 {{ with $paper.doi }}<meta content="{{ . }}" name="citation_doi" >{{ end }}
   <meta property="og:title" content="{{ $paper.title }}" />
   {{ with $paper.thumbnail }}
-  <meta property="og:image" content="{{ . }}"
+  <meta property="og:image" content="{{ . }}" />
   {{ end }}
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="ACL Anthology" />

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -23,6 +23,14 @@
 {{ with $paper.page_first }}<meta content="{{ . }}" name="citation_firstpage" >{{ end }}
 {{ with $paper.page_last }}<meta content="{{ . }}" name="citation_lastpage" >{{ end }}
 {{ with $paper.doi }}<meta content="{{ . }}" name="citation_doi" >{{ end }}
+
+  <meta property="og:title" content="{{ $paper.title }}" />
+  <!-- would be cool to set this as a generated image of the paper's first page -->
+  <meta property="og:image" content="https://www.aclweb.org/anthology/images/acl-logo.svg" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="ACL Anthology" />
+  <meta property="og:url" content="{{ $paper.url }}" />
+  <meta property="og:description" content="{{ $paper.author_string }}. {{ $paper.booktitle }}. {{ $paper.year }}" />
 {{ end }}
 
 {{ define "javascript" }}

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -23,10 +23,10 @@
 {{ with $paper.page_first }}<meta content="{{ . }}" name="citation_firstpage" >{{ end }}
 {{ with $paper.page_last }}<meta content="{{ . }}" name="citation_lastpage" >{{ end }}
 {{ with $paper.doi }}<meta content="{{ . }}" name="citation_doi" >{{ end }}
-
   <meta property="og:title" content="{{ $paper.title }}" />
-  <!-- would be cool to set this as a generated image of the paper's first page -->
-  <meta property="og:image" content="https://www.aclweb.org/anthology/images/acl-logo.svg" />
+  {{ with $paper.thumbnail }}
+  <meta property="og:image" content="{{ . }}"
+  {{ end }}
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="ACL Anthology" />
   <meta property="og:url" content="{{ $paper.url }}" />


### PR DESCRIPTION
This adds open graph headers. One effect is that when Anthology papers are shared in locations such as Slack, a nice summary is displayed:

<img width="564" alt="image" src="https://user-images.githubusercontent.com/455256/65824096-9ce3e780-e230-11e9-9cd2-8041c81c94eb.png">