### PR TITLE
hotfix: revisions were not being displayed

### DIFF
--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -53,7 +53,7 @@ RewriteRule ^papers/[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
 
 # PDF link (e.g., P17-1069.pdf loads P/P17/P17-1069.pdf)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
+RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(v[0-9])?.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
 
 # Revisions and errata (e.g., P17-1069v2)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -52,10 +52,7 @@ RewriteRule ^papers/[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0
 # Volume URLs (e.g., P17-1 loads P/P17/P17-1.pdf)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
 
-# PDF link (e.g., P17-1069.pdf loads P/P17/P17-1069.pdf)
-#RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
-
-# Revisions and errata (e.g., P17-1069v2)
+# PDF link, revisions, and errata (P17-1069[v2].pdf loads P/P17/P17-1069[v2].pdf --- with "v2" optional)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)?\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
 
 # Attachments (e.g., P17-1069.Poster.pdf loads /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -52,10 +52,7 @@ RewriteRule ^papers/[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0
 # Volume URLs (e.g., P17-1 loads P/P17/P17-1.pdf)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
 
-# PDF link (e.g., P17-1069.pdf loads P/P17/P17-1069.pdf)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(v[0-9])?.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
-
-# Revisions and errata (e.g., P17-1069v2)
+# PDFs, including revisions and errata (e.g., P17-1069[v2].pdf loads P/P17/P17-1069[v2].pdf --- v2 is optional)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
 
 # Attachments (e.g., P17-1069.Poster.pdf loads /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -52,8 +52,11 @@ RewriteRule ^papers/[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0
 # Volume URLs (e.g., P17-1 loads P/P17/P17-1.pdf)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
 
-# PDFs, including revisions and errata (e.g., P17-1069[v2].pdf loads P/P17/P17-1069[v2].pdf --- v2 is optional)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
+# PDF link (e.g., P17-1069.pdf loads P/P17/P17-1069.pdf)
+#RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9]).pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
+
+# Revisions and errata (e.g., P17-1069v2)
+RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)?\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
 
 # Attachments (e.g., P17-1069.Poster.pdf loads /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)
 RewriteRule ^attachments/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]


### PR DESCRIPTION
Links to revisions (https://www.aclweb.org/anthology/D14-1096v2.pdf) were not being displayed. This fixes that and closes #554.

This is already live. If someone (@akoehn) can approve this and merge it before 8 PM EST tonight, I would appreciate it (that's when the site gets auto-rebuilt from master).