### PR TITLE
remove abstracts from volume and anthology files

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -235,7 +235,7 @@ class Paper:
         else:
             return default
 
-    def as_bibtex(self):
+    def as_bibtex(self, concise=False):
         """Return the BibTeX entry for this paper."""
         # Build BibTeX entry
         bibkey = self.bibkey
@@ -278,7 +278,7 @@ class Paper:
                 entries.append((entry, self.get(entry)))
         if "pages" in self.attrib:
             entries.append(("pages", self.get("pages").replace("–", "--")))
-        if "xml_abstract" in self.attrib:
+        if "xml_abstract" in self.attrib and not concise:
             entries.append(("abstract", self.get_abstract(form="latex")))
 
         # Serialize it

--- a/bin/create_bibtex.py
+++ b/bin/create_bibtex.py
@@ -64,9 +64,10 @@ def create_bibtex(anthology, trgdir, clean=False):
                     ) as file_paper:
                         contents = paper.as_bibtex()
                         file_paper.write(contents)
-                        file_volume.write(contents)
+                        concise_contents = paper.as_bibtex(concise=True)
+                        file_volume.write(concise_contents)
                         file_volume.write("\n")
-                        file_full.write(contents)
+                        file_full.write(concise_contents)
                         file_full.write("\n")
 
 


### PR DESCRIPTION
This PR removes abstracts from volumes BibTeX files and from the complete Anthology export. I think this is the right thing to do and at least a compromise on #243. For example, it shaves about 25% of the size from the complete Anthology export.