### PR TITLE
Update LREC metadata

### DIFF
--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -2,7 +2,18 @@
 <collection id="L08">
   <volume id="1">
     <meta>
-      <booktitle>LREC 2008</booktitle>
+      <booktitle>Proceedings of the Sixth International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>'08)</booktitle>
+      <editor><first>Nicoletta</first><last>Calzolari</last></editor>
+      <editor><first>Khalid</first><last>Choukri</last></editor>
+      <editor><first>Bente</first><last>Maegaard</last></editor>
+      <editor><first>Joseph</first><last>Mariani</last></editor>
+      <editor><first>Jan</first><last>Odijk</last></editor>
+      <editor><first>Stelios</first><last>Piperidis</last></editor>
+      <editor><first>Daniel</first><last>Tapias</last></editor>
+      <publisher>European Languages Resources Association (ELRA)</publisher>
+      <address>Marrakech, Morocco</address>
+      <month>May</month>
+      <year>2008</year>
     </meta>
     <frontmatter/>
     <paper id="1">

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -2,7 +2,7 @@
 <collection id="L10">
   <volume id="1">
     <meta>
-      <booktitle>Proceedings of the Seventh conference on International Language Resources and Evaluation (<fixed-case>LREC</fixed-case>’10)</booktitle>
+      <booktitle>Proceedings of the Seventh International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>'10)</booktitle>
       <editor><first>Nicoletta</first><last>Calzolari</last></editor>
       <editor><first>Khalid</first><last>Choukri</last></editor>
       <editor><first>Bente</first><last>Maegaard</last></editor>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -2,13 +2,14 @@
 <collection id="L12">
   <volume id="1">
     <meta>
-      <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>-2012)</booktitle>
+      <booktitle>Proceedings of the Eighth International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>'12)</booktitle>
       <editor><first>Nicoletta</first><last>Calzolari</last></editor>
       <editor><first>Khalid</first><last>Choukri</last></editor>
       <editor><first>Thierry</first><last>Declerck</last></editor>
       <editor><first>Mehmet Uğur</first><last>Doğan</last></editor>
       <editor><first>Bente</first><last>Maegaard</last></editor>
       <editor><first>Joseph</first><last>Mariani</last></editor>
+      <editor><first>Asuncion</first><last>Moreno</last></editor>
       <editor><first>Jan</first><last>Odijk</last></editor>
       <editor><first>Stelios</first><last>Piperidis</last></editor>
       <publisher>European Languages Resources Association (ELRA)</publisher>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -2,7 +2,7 @@
 <collection id="L14">
   <volume id="1">
     <meta>
-      <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>-2014)</booktitle>
+      <booktitle>Proceedings of the Ninth International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>'14)</booktitle>
       <editor><first>Nicoletta</first><last>Calzolari</last></editor>
       <editor><first>Khalid</first><last>Choukri</last></editor>
       <editor><first>Thierry</first><last>Declerck</last></editor>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -2,7 +2,7 @@
 <collection id="L16">
   <volume id="1">
     <meta>
-      <booktitle>Proceedings of the Tenth International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case> 2016)</booktitle>
+      <booktitle>Proceedings of the Tenth International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>'16)</booktitle>
       <editor><first>Nicoletta</first><last>Calzolari</last></editor>
       <editor><first>Khalid</first><last>Choukri</last></editor>
       <editor><first>Thierry</first><last>Declerck</last></editor>

--- a/data/xml/L18.xml
+++ b/data/xml/L18.xml
@@ -2,22 +2,22 @@
 <collection id="L18">
   <volume id="1">
     <meta>
-      <booktitle>Proceedings of the Eleventh International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case>-2018)</booktitle>
+      <booktitle>Proceedings of the Eleventh International Conference on Language Resources and Evaluation (<fixed-case>LREC</fixed-case> 2018)</booktitle>
       <url>L18-1</url>
       <editor><first>Nicoletta</first><last>Calzolari</last></editor>
       <editor><first>Khalid</first><last>Choukri</last></editor>
       <editor><first>Christopher</first><last>Cieri</last></editor>
       <editor><first>Thierry</first><last>Declerck</last></editor>
+      <editor><first>Sara</first><last>Goggi</last></editor>
       <editor><first>Koiti</first><last>Hasida</last></editor>
       <editor><first>Hitoshi</first><last>Isahara</last></editor>
       <editor><first>Bente</first><last>Maegaard</last></editor>
       <editor><first>Joseph</first><last>Mariani</last></editor>
+      <editor><first>Hélène</first><last>Mazo</last></editor>
       <editor><first>Asuncion</first><last>Moreno</last></editor>
       <editor><first>Jan</first><last>Odijk</last></editor>
       <editor><first>Stelios</first><last>Piperidis</last></editor>
       <editor><first>Takenobu</first><last>Tokunaga</last></editor>
-      <editor><first>Sara</first><last>Goggi</last></editor>
-      <editor><first>Hélène</first><last>Mazo</last></editor>
       <publisher>European Languages Resources Association (ELRA)</publisher>
       <address>Miyazaki, Japan</address>
       <month>May</month>


### PR DESCRIPTION
LREC 2008 currently has no metadata, so I went along and added it according to the official BibTeX entries on their website.

I also went through LREC 2010–2018 to make the spelling match their official metadata and, in a few cases, fix editor lists.

There seems to be no official BibTeX for LREC 2006 and older, so I didn't touch those.