### PR TITLE
scanned ACL 2002 frontmatter (#571)

### DIFF
--- a/data/xml/P02.xml
+++ b/data/xml/P02.xml
@@ -4,11 +4,16 @@
     <meta>
       <booktitle>Proceedings of the 40th Annual Meeting of the Association for Computational Linguistics</booktitle>
       <publisher>Association for Computational Linguistics</publisher>
+      <editor><first>Pierre</first><last>Isabelle</last></editor>
+      <editor><first>Eugene</first><last>Charniak</last></editor>
+      <editor><first>Dekang</first><last>Lin</last></editor>
       <address>Philadelphia, Pennsylvania, USA</address>
       <month>July</month>
       <year>2002</year>
     </meta>
-    <frontmatter/>
+    <frontmatter>
+      <url>P02-1000</url>
+    </frontmatter>
     <paper id="1">
       <title>Parameter Estimation for Probabilistic Finite-State Transducers</title>
       <author><first>Jason</first><last>Eisner</last></author>


### PR DESCRIPTION
[The PDF](https://aclweb.org/anthology/P02-1000.pdf) is in place. 

(2-page author index!)