### PR TITLE
Fix some overcapitalization

### DIFF
--- a/data/xml/H93.xml
+++ b/data/xml/H93.xml
@@ -2,7 +2,7 @@
 <collection id="H93">
   <volume id="1">
     <meta>
-      <booktitle><fixed-case>HUMAN</fixed-case> <fixed-case>LANGUAGE</fixed-case> <fixed-case>TECHNOLOGY</fixed-case>: Proceedings of a Workshop Held at Plainsboro, New Jersey, March 21-24, 1993</booktitle>
+      <booktitle>Human Language Technology: Proceedings of a Workshop Held at Plainsboro, New Jersey, March 21-24, 1993</booktitle>
     </meta>
     <frontmatter>
       <url>H93-1000</url>
@@ -13,12 +13,12 @@
       <url>H93-1001</url>
     </paper>
     <paper id="2">
-      <title>SESSION 1: SPOKEN LANGUAGE SYSTEMS</title>
+      <title>Session 1: Spoken Language Systems</title>
       <author><first>Alexander I.</first><last>Rudnicky</last></author>
       <url>H93-1002</url>
     </paper>
     <paper id="3">
-      <title>BENCHMARK TESTS FOR THE DARPA SPOKEN LANGUAGE PROGRAM</title>
+      <title>Benchmark Tests for the <fixed-case>DARPA</fixed-case> Spoken Language Program</title>
       <author><first>David S.</first><last>Pallett</last></author>
       <author id="jonathan-g-fiscus"><first>Johathan G.</first><last>Fiscus</last></author>
       <author><first>William M.</first><last>Fisher</last></author>
@@ -40,7 +40,7 @@
       <url>H93-1004</url>
     </paper>
     <paper id="5">
-      <title>THE HCRC MAP TASK CORPUS: NATURAL DIALOGUE FOR SPEECH RECOGNITION</title>
+      <title>The <fixed-case>HCRC</fixed-case> <fixed-case>M</fixed-case>ap <fixed-case>T</fixed-case>ask Corpus: Natural Dialogue for Speech Recognition</title>
       <author><first>Henry S.</first><last>Thompson</last></author>
       <author><first>Anne</first><last>Anderson</last></author>
       <author><first>Ellen Gurman</first><last>Bard</last></author>
@@ -374,25 +374,25 @@
       <url>H93-1048</url>
     </paper>
     <paper id="49">
-      <title>HYPOTHESIZING WORD ASSOCIATION FROM UNTAGGED TEXT</title>
+      <title>Hypothesizing Word Association from Untagged Text</title>
       <author><first>Tomoyoshi</first><last>Matsukawa</last></author>
       <url>H93-1049</url>
     </paper>
     <paper id="50">
-      <title>SMOOTHING OF AUTOMATICALLY GENERATED SELECTIONAL CONSTRAINTS</title>
+      <title>Smoothing of Automatically Generated Selectional Constraints</title>
       <author><first>Ralph</first><last>Grishman</last></author>
       <author><first>John</first><last>Sterling</last></author>
       <url>H93-1050</url>
     </paper>
     <paper id="51">
-      <title>CORPUS-BASED STATISTICAL SENSE RESOLUTION</title>
+      <title>Corpus-Based Statistical Sense Resolution</title>
       <author><first>Claudia</first><last>Leacock</last></author>
       <author><first>Geoffrey</first><last>Towell</last></author>
       <author><first>Ellen</first><last>Voorhees</last></author>
       <url>H93-1051</url>
     </paper>
     <paper id="52">
-      <title>ONE SENSE PER COLLOCATION</title>
+      <title>One Sense Per Collocation</title>
       <author><first>David</first><last>Yarowsky</last></author>
       <url>H93-1052</url>
     </paper>


### PR DESCRIPTION
H93 has a lot of text in all-caps. I fixed a bit of this by hand. It's probably a WIP overall, but this particular commit is a good start. I think it's better to do this bit-by-bit, opportunistically.