### PR TITLE
E12-1009 title: "BothWorlds" -> "Both Worlds"

### DIFF
--- a/data/xml/E12.xml
+++ b/data/xml/E12.xml
@@ -74,7 +74,7 @@
       <attachment>E12-1008.Attachment.zip</attachment>
     </paper>
     <paper id="9">
-      <title>The Best of <fixed-case>B</fixed-case>oth<fixed-case>W</fixed-case>orlds – A Graph-based Completion Model for Transition-based Parsers</title>
+      <title>The Best of Both Worlds – A Graph-based Completion Model for Transition-based Parsers</title>
       <author><first>Bernd</first><last>Bohnet</last></author>
       <author><first>Jonas</first><last>Kuhn</last></author>
       <pages>77–87</pages>


### PR DESCRIPTION
and remove incorrect fixed-case marking resulting from missing space.

space is present in PDF title.