### PR TITLE
update metadata on John P. Lalor for consistency

### DIFF
--- a/data/xml/D16.xml
+++ b/data/xml/D16.xml
@@ -650,7 +650,7 @@
     </paper>
     <paper id="62">
       <title>Building an Evaluation Scale using Item Response Theory</title>
-      <author><first>John</first> <last>Lalor</last></author>
+      <author><first>John P.</first> <last>Lalor</last></author>
       <author><first>Hao</first> <last>Wu</last></author>
       <author><first>Hong</first> <last>Yu</last></author>
       <pages>648–657</pages>

--- a/data/xml/D18.xml
+++ b/data/xml/D18.xml
@@ -5804,7 +5804,7 @@
     </paper>
     <paper id="500">
       <title>Understanding Deep Learning Performance through an Examination of Test Set Difficulty: A Psychometric Case Study</title>
-      <author><first>John</first><last>Lalor</last></author>
+      <author><first>John P.</first><last>Lalor</last></author>
       <author><first>Hao</first><last>Wu</last></author>
       <author><first>Tsendsuren</first><last>Munkhdalai</last></author>
       <author><first>Hong</first><last>Yu</last></author>

--- a/data/xml/W16.xml
+++ b/data/xml/W16.xml
@@ -11013,7 +11013,7 @@
     <paper id="9">
       <title>Citation Analysis with Neural Attention Models</title>
       <author><first>Tsendsuren</first> <last>Munkhdalai</last></author>
-      <author><first>John</first> <last>Lalor</last></author>
+      <author><first>John P.</first> <last>Lalor</last></author>
       <author><first>Hong</first> <last>Yu</last></author>
       <pages>69–77</pages>
       <url>W16-6109</url>


### PR DESCRIPTION
Right now I have two ACL Anthology pages because my name shows up in the metadata in two different ways:

- John Lalor
- John P. Lalor

This pull request updates the metadata to replace "John Lalor" with "John P. Lalor" on a few files so that my papers all roll up to a single author file.