### PR TITLE
Corrected paper title

### DIFF
--- a/data/xml/P10.xml
+++ b/data/xml/P10.xml
@@ -1980,7 +1980,7 @@
       <url>P10-4003</url>
     </paper>
     <paper id="4">
-      <title><fixed-case>G</fixed-case>ern<fixed-case>E</fixed-case>di<fixed-case>T</fixed-case> - A Graphical Tool for <fixed-case>G</fixed-case>erma<fixed-case>N</fixed-case>et Development</title>
+      <title><fixed-case>G</fixed-case>ern<fixed-case>E</fixed-case>di<fixed-case>T</fixed-case>: A Graphical Tool for <fixed-case>G</fixed-case>erma<fixed-case>N</fixed-case>et Development</title>
       <author><first>Verena</first><last>Henrich</last></author>
       <author><first>Erhard</first><last>Hinrichs</last></author>
       <pages>19–24</pages>

--- a/data/xml/P10.xml
+++ b/data/xml/P10.xml
@@ -1980,7 +1980,7 @@
       <url>P10-4003</url>
     </paper>
     <paper id="4">
-      <title><fixed-case>G</fixed-case>ern<fixed-case>E</fixed-case>di<fixed-case>T</fixed-case> - The <fixed-case>G</fixed-case>erma<fixed-case>N</fixed-case>et Editing Tool</title>
+      <title><fixed-case>G</fixed-case>ern<fixed-case>E</fixed-case>di<fixed-case>T</fixed-case> - A Graphical Tool for <fixed-case>G</fixed-case>erma<fixed-case>N</fixed-case>et Development</title>
       <author><first>Verena</first><last>Henrich</last></author>
       <author><first>Erhard</first><last>Hinrichs</last></author>
       <pages>19–24</pages>


### PR DESCRIPTION
Paper title of P10-4004 is given as "GernEdiT: A Graphical Tool for GermaNet Development" in the PDF, but metadata and proceedings TOC give it as "GernEdiT - The GermaNet Editing Tool". This causes confusion with L10-1180, which is also titled "GernEdiT – The GermaNet Editing Tool". I therefore propose to use the PDF's title in the metadata.
