### PR TITLE
Check for correct hugo version in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,16 @@ ifeq ($(PYTHON_VERSION_OK),0)
 endif
 # end python check
 #######################################################
+
+# hugo version check
+HUGO_VERSION_MIN=58
+HUGO_VERSION=$(shell hugo version | sed 's/.*Generator v0.\(..\).*/\1/')
+HUGO_VERSION_TOO_LOW:=$(shell [ $(HUGO_VERSION_MIN) -gt $(HUGO_VERSION) ] && echo true)
+ifeq ($(HUGO_VERSION_TOO_LOW),true)
+  $(error "incorrect hugo version installed! Need hugo 0.$(HUGO_VERSION_MIN), but only found hugo 0.$(HUGO_VERSION)!")
+endif
+
+
 VENV := "venv/bin/activate"
 
 .PHONY: site


### PR DESCRIPTION
Just noticed that I was running 0.55 instead of 0.58; this is my automated check for the future.  Confirmed that it work pre- and post-update of hugo :-)