### PR TITLE
reimported CoNLL (addresses #612)

### DIFF
--- a/data/xml/K19.xml
+++ b/data/xml/K19.xml
@@ -87,7 +87,7 @@
       <doi>10.18653/v1/K19-1007</doi>
     </paper>
     <paper id="8">
-      <title>Say Anything: Automatic Semantic Infelicity Detection in <fixed-case>L</fixed-case>2 <fixed-case>E</fixed-case>nglish Indefinite Pronouns</title>
+      <title>Say Anything: Automatic Semantic Infelicity Detection in <fixed-case>L2</fixed-case> <fixed-case>E</fixed-case>nglish Indefinite Pronouns</title>
       <author><first>Ella</first><last>Rabinovich</last></author>
       <author><first>Julia</first><last>Watson</last></author>
       <author><first>Barend</first><last>Beekhuizen</last></author>
@@ -203,7 +203,6 @@
       <abstract>Universal Conceptual Cognitive Annotation (UCCA; Abend and Rappoport, 2013) is a typologically-informed, broad-coverage semantic annotation scheme that describes coarse-grained predicate-argument structure but currently lacks semantic roles. We argue that lexicon-free annotation of the semantic roles marked by prepositions, as formulated by Schneider et al. (2018), is complementary and suitable for integration within UCCA. We show empirically for English that the schemes, though annotated independently, are compatible and can be combined in a single semantic graph. A comparison of several approaches to parsing the integrated representation lays the groundwork for future research on this task.</abstract>
       <url>K19-1017</url>
       <attachment type="supplementary-material">K19-1017.Supplementary_Material.pdf</attachment>
-      <attachment>K19-1017.Attachment.pdf</attachment>
       <doi>10.18653/v1/K19-1017</doi>
     </paper>
     <paper id="18">
@@ -525,12 +524,11 @@
       <pages>493–503</pages>
       <abstract>Automated fact-checking based on machine learning is a promising approach to identify false information distributed on the web. In order to achieve satisfactory performance, machine learning methods require a large corpus with reliable annotations for the different tasks in the fact-checking process. Having analyzed existing fact-checking corpora, we found that none of them meets these criteria in full. They are either too small in size, do not provide detailed annotations, or are limited to a single domain. Motivated by this gap, we present a new substantially sized mixed-domain corpus with annotations of good quality for the core fact-checking tasks: document retrieval, evidence extraction, stance detection, and claim validation. To aid future corpus construction, we describe our methodology for corpus creation and annotation, and demonstrate that it results in substantial inter-annotator agreement. As baselines for future research, we perform experiments on our corpus with a number of model architectures that reach high performance in similar problem settings. Finally, to support the development of future models, we provide a detailed error analysis for each of the tasks. Our results show that the realistic, multi-domain setting defined by our data poses new challenges for the existing models, providing opportunities for considerable improvement by future systems.</abstract>
       <url>K19-1046</url>
-      <attachment>K19-1046.Attachment.pdf</attachment>
       <attachment type="supplementary-material">K19-1046.Supplementary_Material.pdf</attachment>
       <doi>10.18653/v1/K19-1046</doi>
     </paper>
     <paper id="47">
-      <title>Detecting Frames in News Headlines and Its Application to Analyzing News Framing Trends Surrounding <fixed-case>U</fixed-case>.<fixed-case>S</fixed-case>. Gun Violence</title>
+      <title>Detecting Frames in News Headlines and Its Application to Analyzing News Framing Trends Surrounding <fixed-case>U.S.</fixed-case> Gun Violence</title>
       <author><first>Siyi</first><last>Liu</last></author>
       <author><first>Lei</first><last>Guo</last></author>
       <author><first>Kate</first><last>Mays</last></author>
@@ -551,7 +549,6 @@
       <abstract>Named entity recognition (NER) identifies typed entity mentions in raw text. While the task is well-established, there is no universally used tagset: often, datasets are annotated for use in downstream applications and accordingly only cover a small set of entity types relevant to a particular task. For instance, in the biomedical domain, one corpus might annotate genes, another chemicals, and another diseases—despite the texts in each corpus containing references to all three types of entities. In this paper, we propose a deep structured model to integrate these “partially annotated” datasets to jointly identify all entity types appearing in the training corpora. By leveraging multiple datasets, the model can learn robust input representations; by building a joint structured model, it avoids potential conflicts caused by combining several models’ predictions at test time. Experiments show that the proposed model significantly outperforms strong multi-task learning baselines when training on multiple, partially annotated datasets and testing on datasets that contain tags from more than one of the training corpora.</abstract>
       <url>K19-1048</url>
       <attachment type="supplementary-material">K19-1048.Supplementary_Material.pdf</attachment>
-      <attachment>K19-1048.Attachment.pdf</attachment>
       <doi>10.18653/v1/K19-1048</doi>
     </paper>
     <paper id="49">
@@ -569,7 +566,7 @@
       <doi>10.18653/v1/K19-1049</doi>
     </paper>
     <paper id="50">
-      <title><fixed-case>C</fixed-case>ogni<fixed-case>V</fixed-case>al: A Framework for Cognitive Word Embedding Evaluation</title>
+      <title><fixed-case>CogniVal</fixed-case>: A Framework for Cognitive Word Embedding Evaluation</title>
       <author><first>Nora</first><last>Hollenstein</last></author>
       <author><first>Antonio</first><last>de la Torre</last></author>
       <author><first>Nicolas</first><last>Langer</last></author>
@@ -577,12 +574,11 @@
       <pages>538–549</pages>
       <abstract>An interesting method of evaluating word representations is by how much they reflect the semantic representations in the human brain. However, most, if not all, previous works only focus on small datasets and a single modality. In this paper, we present the first multi-modal framework for evaluating English word representations based on cognitive lexical semantics. Six types of word embeddings are evaluated by fitting them to 15 datasets of eye-tracking, EEG and fMRI signals recorded during language processing. To achieve a global score over all evaluation hypotheses, we apply statistical significance testing accounting for the multiple comparisons problem. This framework is easily extensible and available to include other intrinsic and extrinsic evaluation methods. We find strong correlations in the results between cognitive datasets, across recording modalities and to their performance on extrinsic NLP tasks.</abstract>
       <url>K19-1050</url>
-      <attachment type="supplementary-material">K19-1050.Supplementary_Material.zip</attachment>
       <attachment>K19-1050.Attachment.zip</attachment>
       <doi>10.18653/v1/K19-1050</doi>
     </paper>
     <paper id="51">
-      <title><fixed-case>K</fixed-case>now<fixed-case>S</fixed-case>em<fixed-case>LM</fixed-case>: A Knowledge Infused Semantic Language Model</title>
+      <title><fixed-case>KnowSemLM</fixed-case>: A Knowledge Infused Semantic Language Model</title>
       <author><first>Haoruo</first><last>Peng</last></author>
       <author><first>Qiang</first><last>Ning</last></author>
       <author><first>Dan</first><last>Roth</last></author>
@@ -616,7 +612,7 @@
       <doi>10.18653/v1/K19-1053</doi>
     </paper>
     <paper id="54">
-      <title><fixed-case>B</fixed-case>eam<fixed-case>S</fixed-case>eg: A Joint Model for Multi-Document Segmentation and Topic Identification</title>
+      <title><fixed-case>BeamSeg</fixed-case>: A Joint Model for Multi-Document Segmentation and Topic Identification</title>
       <author><first>Pedro</first><last>Mota</last></author>
       <author><first>Maxine</first><last>Eskenazi</last></author>
       <author><first>Luísa</first><last>Coheur</last></author>
@@ -626,7 +622,7 @@
       <doi>10.18653/v1/K19-1054</doi>
     </paper>
     <paper id="55">
-      <title><fixed-case>M</fixed-case>r<fixed-case>M</fixed-case>ep: Joint Extraction of Multiple Relations and Multiple Entity Pairs Based on Triplet Attention</title>
+      <title><fixed-case>MrMep</fixed-case>: Joint Extraction of Multiple Relations and Multiple Entity Pairs Based on Triplet Attention</title>
       <author><first>Jiayu</first><last>Chen</last></author>
       <author><first>Caixia</first><last>Yuan</last></author>
       <author><first>Xiaojie</first><last>Wang</last></author>
@@ -667,7 +663,6 @@
       <abstract>Recent developments in Named Entity Recognition (NER) have resulted in better and better models. However, is there a glass ceiling? Do we know which types of errors are still hard or even impossible to correct? In this paper, we present a detailed analysis of the types of errors in state-of-the-art machine learning (ML) methods. Our study illustrates weak and strong points of the Stanford, CMU, FLAIR, ELMO and BERT models, as well as their shared limitations. We also introduce new techniques for improving annotation, training process, and for checking model quality and stability.</abstract>
       <url>K19-1058</url>
       <attachment>K19-1058.Attachment.pdf</attachment>
-      <attachment type="supplementary-material">K19-1058.Supplementary_Material.pdf</attachment>
       <doi>10.18653/v1/K19-1058</doi>
     </paper>
     <paper id="59">
@@ -700,7 +695,6 @@
       <abstract>Event trigger extraction is an information extraction task of practical utility, yet it is challenging due to the difficulty of disambiguating word sense meaning. Previous approaches rely extensively on hand-crafted language-specific features and are applied mainly to English for which annotated datasets and Natural Language Processing (NLP) tools are available. However, the availability of such resources varies from one language to another. Recently, contextualized Bidirectional Encoder Representations from Transformers (BERT) models have established state-of-the-art performance for a variety of NLP tasks. However, there has not been much effort in exploring language transfer using BERT for event extraction. In this work, we treat event trigger extraction as a sequence tagging problem and propose a cross-lingual framework for training it without any hand-crafted features. We experiment with different flavors of transfer learning from high-resourced to low-resourced languages and compare the performance of different multilingual embeddings for event trigger extraction. Our results show that training in a multilingual setting outperforms language-specific models for both English and Chinese. Our work is the first to experiment with two event architecture variants in a cross-lingual setting, to show the effectiveness of contextualized embeddings obtained using BERT, and to explore and analyze its performance on Arabic.</abstract>
       <url>K19-1061</url>
       <attachment>K19-1061.Attachment.pdf</attachment>
-      <attachment type="supplementary-material">K19-1061.Supplementary_Material.pdf</attachment>
       <doi>10.18653/v1/K19-1061</doi>
     </paper>
     <paper id="62">
@@ -711,7 +705,7 @@
       <author><first>Aram</first><last>Galstyan</last></author>
       <author><first>Ralph</first><last>Weischedel</last></author>
       <author><first>Nanyun</first><last>Peng</last></author>
-      <pages>666–106</pages>
+      <pages>666–676</pages>
       <abstract>We propose a novel deep structured learning framework for event temporal relation extraction. The model consists of 1) a recurrent neural network (RNN) to learn scoring functions for pair-wise relations, and 2) a structured support vector machine (SSVM) to make joint predictions. The neural network automatically learns representations that account for long-term contexts to provide robust features for the structured model, while the SSVM incorporates domain knowledge such as transitive closure of temporal relations as constraints to make better globally consistent decisions. By jointly training the two components, our model combines the benefits of both data-driven learning and knowledge exploitation. Experimental results on three high-quality event temporal relation datasets (TCR, MATRES, and TB-Dense) demonstrate that incorporated with pre-trained contextualized embeddings, the proposed model achieves significantly better performances than the state-of-the-art methods on all three datasets. We also provide thorough ablation studies to investigate our model.</abstract>
       <url>K19-1062</url>
       <doi>10.18653/v1/K19-1062</doi>
@@ -745,12 +739,11 @@
       <pages>696–707</pages>
       <abstract>Remarkable success has been achieved in the last few years on some limited machine reading comprehension (MRC) tasks. However, it is still difficult to interpret the predictions of existing MRC models. In this paper, we focus on extracting evidence sentences that can explain or support the answers of multiple-choice MRC tasks, where the majority of answer options cannot be directly extracted from reference documents. Due to the lack of ground truth evidence sentence labels in most cases, we apply distant supervision to generate imperfect labels and then use them to train an evidence sentence extractor. To denoise the noisy labels, we apply a recently proposed deep probabilistic logic learning framework to incorporate both sentence-level and cross-sentence linguistic indicators for indirect supervision. We feed the extracted evidence sentences into existing MRC models and evaluate the end-to-end performance on three challenging multiple-choice MRC datasets: MultiRC, RACE, and DREAM, achieving comparable or better performance than the same models that take as input the full reference document. To the best of our knowledge, this is the first work extracting evidence sentences for multiple-choice MRC.</abstract>
       <url>K19-1065</url>
-      <attachment type="supplementary-material">K19-1065.Supplementary_Material.pdf</attachment>
       <attachment>K19-1065.Attachment.pdf</attachment>
       <doi>10.18653/v1/K19-1065</doi>
     </paper>
     <paper id="66">
-      <title><fixed-case>S</fixed-case>im<fixed-case>V</fixed-case>ecs: Similarity-Based Vectors for Utterance Representation in Conversational <fixed-case>AI</fixed-case> Systems</title>
+      <title><fixed-case>SimVecs</fixed-case>: Similarity-Based Vectors for Utterance Representation in Conversational <fixed-case>AI</fixed-case> Systems</title>
       <author><first>Ashraf</first><last>Mahgoub</last></author>
       <author><first>Youssef</first><last>Shahin</last></author>
       <author><first>Riham</first><last>Mansour</last></author>
@@ -784,7 +777,7 @@
       <doi>10.18653/v1/K19-1068</doi>
     </paper>
     <paper id="69">
-      <title><fixed-case>T</fixed-case>riple<fixed-case>N</fixed-case>et: Triple Attention Network for Multi-Turn Response Selection in Retrieval-Based Chatbots</title>
+      <title><fixed-case>TripleNet</fixed-case>: Triple Attention Network for Multi-Turn Response Selection in Retrieval-Based Chatbots</title>
       <author><first>Wentao</first><last>Ma</last></author>
       <author><first>Yiming</first><last>Cui</last></author>
       <author><first>Nan</first><last>Shao</last></author>
@@ -923,7 +916,7 @@
       <doi>10.18653/v1/K19-1080</doi>
     </paper>
     <paper id="81">
-      <title><fixed-case>BIO</fixed-case>fid Dataset: Publishing a <fixed-case>G</fixed-case>erman Gold Standard for Named Entity Recognition in Historical Biodiversity Literature</title>
+      <title><fixed-case>BIOfid</fixed-case> Dataset: Publishing a <fixed-case>G</fixed-case>erman Gold Standard for Named Entity Recognition in Historical Biodiversity Literature</title>
       <author><first>Sajawel</first><last>Ahmed</last></author>
       <author><first>Manuel</first><last>Stoeckel</last></author>
       <author><first>Christine</first><last>Driller</last></author>
@@ -967,7 +960,6 @@
       <abstract>Standard autoregressive seq2seq models are easily trained by max-likelihood, but tend to show poor results under small-data conditions. We introduce a class of seq2seq models, GAMs (Global Autoregressive Models), which combine an autoregressive component with a log-linear component, allowing the use of global <i>a priori</i> features to compensate for lack of data. We train these models in two steps. In the first step, we obtain an <i>unnormalized</i> GAM that maximizes the likelihood of the data, but is improper for fast inference or evaluation. In the second step, we use this GAM to train (by distillation) a second autoregressive model that approximates the <i>normalized</i> distribution associated with the GAM, and can be used for fast inference and evaluation. Our experiments focus on language modelling under synthetic conditions and show a strong perplexity reduction of using the second autoregressive model over the standard one.</abstract>
       <url>K19-1084</url>
       <attachment>K19-1084.Attachment.pdf</attachment>
-      <attachment type="supplementary-material">K19-1084.Supplementary_Material.pdf</attachment>
       <doi>10.18653/v1/K19-1084</doi>
     </paper>
     <paper id="85">
@@ -998,7 +990,6 @@
       <pages>929–939</pages>
       <abstract>In this paper, we focus on quantifying model stability as a function of random seed by investigating the effects of the induced randomness on model performance and the robustness of the model in general. We specifically perform a controlled study on the effect of random seeds on the behaviour of attention, gradient-based and surrogate model based (LIME) interpretations. Our analysis suggests that random seeds can adversely affect the consistency of models resulting in counterfactual interpretations. We propose a technique called Aggressive Stochastic Weight Averaging (ASWA) and an extension called Norm-filtered Aggressive Stochastic Weight Averaging (NASWA) which improves the stability of models over random seeds. With our ASWA and NASWA based optimization, we are able to improve the robustness of the original model, on average reducing the standard deviation of the model’s performance by 72%.</abstract>
       <url>K19-1087</url>
-      <attachment type="supplementary-material">K19-1087.Supplementary_Material.zip</attachment>
       <attachment>K19-1087.Attachment.zip</attachment>
       <doi>10.18653/v1/K19-1087</doi>
     </paper>
@@ -1049,7 +1040,7 @@
       <doi>10.18653/v1/K19-1091</doi>
     </paper>
     <paper id="92">
-      <title>Multi-Level Sentiment Analysis of <fixed-case>P</fixed-case>ol<fixed-case>E</fixed-case>mo 2.0: Extended Corpus of Multi-Domain Consumer Reviews</title>
+      <title>Multi-Level Sentiment Analysis of <fixed-case>PolEmo</fixed-case> 2.0: Extended Corpus of Multi-Domain Consumer Reviews</title>
       <author><first>Jan</first><last>Kocoń</last></author>
       <author><first>Piotr</first><last>Miłkowski</last></author>
       <author><first>Monika</first><last>Zaśko-Zielińska</last></author>
@@ -1068,7 +1059,6 @@
       <abstract>In this paper, we look beyond the traditional population-level sentiment modeling and consider the individuality in a person’s expressions by discovering both textual and contextual information. In particular, we construct a hierarchical neural network that leverages valuable information from a person’s past expressions, and offer a better understanding of the sentiment from the expresser’s perspective. Additionally, we investigate how a person’s sentiment changes over time so that recent incidents or opinions may have more effect on the person’s current sentiment than the old ones. Psychological studies have also shown that individual variation exists in how easily people change their sentiments. In order to model such traits, we develop a modified attention mechanism with Hawkes process applied on top of a recurrent network for a user-specific design. Implemented with automatically labeled Twitter data, the proposed model has shown positive results employing different input formulations for representing the concerned information.</abstract>
       <url>K19-1093</url>
       <attachment>K19-1093.Attachment.zip</attachment>
-      <attachment type="supplementary-material">K19-1093.Supplementary_Material.zip</attachment>
       <doi>10.18653/v1/K19-1093</doi>
     </paper>
     <paper id="94">
@@ -1122,7 +1112,7 @@
       <editor><first>Jan</first><last>Hajic</last></editor>
       <editor><first>Daniel</first><last>Hershcovich</last></editor>
       <editor><first>Marco</first><last>Kuhlmann</last></editor>
-      <editor><first>Tim</first><last>O’Gorman</last></editor>
+      <editor><first>Tim</first><last>O'Gorman</last></editor>
       <editor><first>Nianwen</first><last>Xue</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Hong Kong</address>
@@ -1165,7 +1155,7 @@
       <author><first>Stephan</first><last>Oepen</last></author>
       <author><first>Dan</first><last>Flickinger</last></author>
       <pages>40–44</pages>
-      <abstract>The English Resource Grammar (ERG) is a broad-coverage computational grammar of English that outputs underspecified logical-form representations of meaning in a framework dubbed English Resource Semantics (ERS). Two of the target representations in the the 2019 Shared Task on Cross-Framework Meaning Representation Parsing (MRP 2019) derive graph-based simplifications of ERS, viz. Elementary Dependency Structures (EDS) and DELPH-IN MRS Bi-Lexical Dependencies (DM). As a point of reference outside the official MRP competition, we parsed the evaluation strings using the ERG and converted the resulting meaning representations to EDS and DM. These graphs yield higher evaluation scores than the purely data-driven parsers in the actual shared task, suggesting that the general-purpose linguistic knowledge about English grammar encoded in the ERG can add value when parsing into these meaning representations.</abstract>
+      <abstract>The English Resource Grammar (ERG) is a broad-coverage computational grammar of English that outputs underspecified logical-form representations of meaning in a framework dubbed English Resource Semantics (ERS). Two of the target representations in the the 2019 Shared Task on Cross-Framework Meaning Representation Parsing (MRP~2019) derive graph-based simplifications of ERS, viz. Elementary Dependency Structures (EDS) and DELPH-IN MRS Bi-Lexical Dependencies (DM). As a point of reference outside the official MRP competition, we parsed the evaluation strings using the ERG and converted the resulting meaning representations to EDS and DM. These graphs yield higher evaluation scores than the purely data-driven parsers in the actual shared task, suggesting that the general-purpose linguistic knowledge about English grammar encoded in the ERG can add value when parsing into these meaning representations.</abstract>
       <url>K19-2003</url>
       <doi>10.18653/v1/K19-2003</doi>
     </paper>


### PR DESCRIPTION
I reimported this. The fixed-case handling is much easier to read, but I'm actually not sure which is correct. There is also still something of a mess with attachments; they're not labeled, and are sometimes double-imported.