### PR TITLE
GH publish action: no verbose logging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 
 on:
   push:
-    branch:
+    branches:
       - master
 
 jobs:
@@ -34,4 +34,4 @@ jobs:
       env:
         PUBLISH_TARGET: ${{ secrets.PUBLISH_TARGET }}
       run: |
-        echo rsync -aze "ssh -o StrictHostKeyChecking=accept-new" --delete build/anthology/ $PUBLISH_TARGET
+        rsync -aze "ssh -o StrictHostKeyChecking=accept-new" --delete build/anthology/ $PUBLISH_TARGET

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,4 @@ jobs:
       env:
         PUBLISH_TARGET: ${{ secrets.PUBLISH_TARGET }}
       run: |
-        rsync -aze "ssh -o StrictHostKeyChecking=accept-new" --delete build/anthology/ $PUBLISH_TARGET
+        echo rsync -aze "ssh -o StrictHostKeyChecking=accept-new" --delete build/anthology/ $PUBLISH_TARGET

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,4 @@ jobs:
       env:
         PUBLISH_TARGET: ${{ secrets.PUBLISH_TARGET }}
       run: |
-        rsync -azve "ssh -o StrictHostKeyChecking=accept-new" --delete build/anthology/ $PUBLISH_TARGET
+        rsync -aze "ssh -o StrictHostKeyChecking=accept-new" --delete build/anthology/ $PUBLISH_TARGET


### PR DESCRIPTION
Just deletes the -v so we have shorter logs.
