### PR TITLE
Use canonical URL in venues as URL instead PDF, link PDF at bottom

### DIFF
--- a/hugo/layouts/volumes/single.html
+++ b/hugo/layouts/volumes/single.html
@@ -67,7 +67,7 @@
       <dt>Publisher:</dt>
       <dd>{{ with $paper.publisher }}{{ . }}{{ end }}</dd>
       <dt>URL:</dt>
-      <dd>{{ with $paper.pdf }}<a href="{{ . }}">{{ . }}</a>{{ end }}</dd>
+      <dd><a href="{{ $paper.url }}">{{ $paper.url }}</a></dd>
       <dt>DOI:</dt>
       <dd>{{ with $paper.doi }}<a href="http://dx.doi.org/{{ . }}" title="To the current version of the paper by DOI">{{ . }}</a>{{ end }}</dd>
       <!--
@@ -91,6 +91,9 @@
         <a class="btn btn-secondary btn-sm" href="{{ $endfile | relURL }}">EndNote</a>
       {{ end }}
       </dd>
+      {{ with $paper.pdf }}
+      <dt>PDF:</dt><dd><a href="{{ . }}">{{ . }}</a></dd>
+      {{ end }}
     </dl>
     </div>
 


### PR DESCRIPTION
This reflects the changes made to the paper templates earlier, see
commit 0c9ba6a8cc1e85d6a3dd14e01823f238ce306994.  Fixes #587 (now for
real, hopefully)
