### PR TITLE
fix incomplete abstracts in EMNLP 2018 demos

### DIFF
--- a/data/xml/D18.xml
+++ b/data/xml/D18.xml
@@ -6426,7 +6426,7 @@
       <doi>10.18653/v1/D18-2003</doi>
     </paper>
     <paper id="4">
-      <title>Term Set Expansion based <fixed-case>NLP</fixed-case> Architect by Intel <fixed-case>AI</fixed-case> Lab</title>
+      <title>Term Set Expansion based <fixed-case>NLP</fixed-case> Architect by <fixed-case>I</fixed-case>ntel <fixed-case>AI</fixed-case> Lab</title>
       <author><first>Jonathan</first><last>Mamou</last></author>
       <author><first>Oren</first><last>Pereg</last></author>
       <author><first>Moshe</first><last>Wasserblat</last></author>
@@ -6437,7 +6437,7 @@
       <author><first>Daniel</first><last>Korat</last></author>
       <pages>19–24</pages>
       <url>D18-2004</url>
-      <abstract>We present SetExpander, a corpus-based system for expanding a seed set of terms into a more complete set of terms that belong to the same semantic class. SetExpander implements an iterative end-to-end workflow. It enables users to easily select a seed set of terms, expand it, view the expanded set, validate it, re-expand the validated set and store it, thus simplifying</abstract>
+      <abstract>We present SetExpander, a corpus-based system for expanding a seed set of terms into a more complete set of terms that belong to the same semantic class. SetExpander implements an iterative end-to-end workflow. It enables users to easily select a seed set of terms, expand it, view the expanded set, validate it, re-expand the validated set and store it, thus simplifying the extraction of domain-specific fine-grained semantic classes. SetExpander has been used successfully in real-life use cases including integration into an automated recruitment system and an issues and defects resolution system.</abstract>
       <doi>10.18653/v1/D18-2004</doi>
     </paper>
     <paper id="5">
@@ -6526,7 +6526,7 @@
       <author><first>John</first><last>Richardson</last></author>
       <pages>66–71</pages>
       <url>D18-2012</url>
-      <abstract>This paper describes SentencePiece, a language-independent subword</abstract>
+      <abstract>This paper describes SentencePiece, a language-independent subword tokenizer and detokenizer designed for Neural-based text processing, including Neural Machine Translation. It provides open-source C++ and Python implementations for subword units.  While existing subword segmentation tools assume that the input is pre-tokenized into word sequences, SentencePiece can train subword models directly from raw sentences, which allows us to make a purely end-to-end and language independent system. We perform a validation experiment of NMT on English-Japanese machine translation, and find that it is possible to achieve comparable accuracy to direct subword training from raw sentences. We also compare the performance of subword training and segmentation with various configurations.  SentencePiece is available under the Apache 2 license at <url>https://github.com/google/sentencepiece</url>.</abstract>
       <doi>10.18653/v1/D18-2012</doi>
     </paper>
     <paper id="13">
@@ -6610,7 +6610,7 @@
       <author><first>Sophia</first><last>Ananiadou</last></author>
       <pages>108–113</pages>
       <url>D18-2019</url>
-      <abstract>In this paper, we present APLenty, an annotation tool for creating high-quality sequence labeling datasets using active and proactive learning.</abstract>
+      <abstract>In this paper, we present APLenty, an annotation tool for creating high-quality sequence labeling datasets using active and proactive learning. A major innovation of our tool is the integration of automatic annotation with active learning and proactive learning. This makes the task of creating labeled datasets easier, less time-consuming and requiring less human effort. APLenty is highly flexible and can be adapted to various other tasks.</abstract>
       <doi>10.18653/v1/D18-2019</doi>
     </paper>
     <paper id="20">
@@ -6709,7 +6709,7 @@
       <author><first>Vasudeva</first><last>Varma</last></author>
       <pages>163–168</pages>
       <url>D18-2028</url>
-      <abstract>We present an online interactive tool that generates titles of blog titles and thus take the first step toward automating science journalism. Science journalism aims to transform jargon-laden scientific articles into a form that</abstract>
+      <abstract>We present an online interactive tool that generates titles of blog titles and thus take the first step toward automating science journalism. Science journalism aims to transform jargon-laden scientific articles into a form that the common reader can comprehend while ensuring that the underlying meaning of the article is retained. In this work, we present a tool, which, given the title and abstract of a research paper will generate a blog title by mimicking a human science journalist. The tool makes use of a model trained on a corpus of 87,328 pairs of research papers and their corresponding blogs, built from two science news aggregators. The architecture of the model is a two-stage mechanism which generates blog titles. Evaluation using standard metrics indicate the viability of the proposed system.</abstract>
       <doi>10.18653/v1/D18-2028</doi>
     </paper>
     <paper id="29">


### PR DESCRIPTION
Fixes #690. I am not sure how this happened, but the reason it was not fixed in #134 is that the demo abstracts were not missing.
