### PR TITLE
Do not inherit 'pdf' from volume (fixes #698)

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -54,6 +54,7 @@ class Paper:
                 "venues",
                 "meta_date",
                 "url",
+                "pdf",
             ):
                 continue
 


### PR DESCRIPTION
Fixes PDF links appearing (inherited from the volume) when the paper does not have an associated PDF.