### PR TITLE
Name fix spelling

### DIFF
--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -122,7 +122,7 @@
     <paper id="11">
       <title>Case Studies in the Automatic Characterization of Grammars from Small Wordlists</title>
       <author><first>Jordan</first> <last>Kodner</last></author>
-      <author><first>Spencer</first> <last>Kaplan</last></author>
+      <author><first>Spencer</first> <last>Caplan</last></author>
       <author><first>Hongzhi</first> <last>Xu</last></author>
       <author><first>Mitchell P.</first> <last>Marcus</last></author>
       <author><first>Charles</first> <last>Yang</last></author>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -21,206 +21,206 @@
     </frontmatter>
     <paper id="1">
       <title>A Morphological Parser for Odawa</title>
-      <author><first>Dustin</first> <last>Bowers</last></author>
-      <author><first>Antti</first> <last>Arppe</last></author>
-      <author><first>Jordan</first> <last>Lachler</last></author>
-      <author><first>Sjur</first> <last>Moshagen</last></author>
-      <author><first>Trond</first> <last>Trosterud</last></author>
+      <author><first>Dustin</first><last>Bowers</last></author>
+      <author><first>Antti</first><last>Arppe</last></author>
+      <author><first>Jordan</first><last>Lachler</last></author>
+      <author><first>Sjur</first><last>Moshagen</last></author>
+      <author><first>Trond</first><last>Trosterud</last></author>
       <pages>1–9</pages>
       <url>W17-0101</url>
       <doi>10.18653/v1/W17-0101</doi>
     </paper>
     <paper id="2">
       <title>Creating lexical resources for polysynthetic languages—the case of <fixed-case>A</fixed-case>rapaho</title>
-      <author><first>Ghazaleh</first> <last>Kazeminejad</last></author>
-      <author><first>Andrew</first> <last>Cowell</last></author>
-      <author><first>Mans</first> <last>Hulden</last></author>
+      <author><first>Ghazaleh</first><last>Kazeminejad</last></author>
+      <author><first>Andrew</first><last>Cowell</last></author>
+      <author><first>Mans</first><last>Hulden</last></author>
       <pages>10–18</pages>
       <url>W17-0102</url>
       <doi>10.18653/v1/W17-0102</doi>
     </paper>
     <paper id="3">
       <title>From Small to Big Data: paper manuscripts to <fixed-case>RDF</fixed-case> triples of <fixed-case>A</fixed-case>ustralian Indigenous Vocabularies</title>
-      <author><first>Nick</first> <last>Thieberger</last></author>
-      <author><first>Conal</first> <last>Tuohy</last></author>
+      <author><first>Nick</first><last>Thieberger</last></author>
+      <author><first>Conal</first><last>Tuohy</last></author>
       <pages>19–23</pages>
       <url>W17-0103</url>
       <doi>10.18653/v1/W17-0103</doi>
     </paper>
     <paper id="4">
       <title>Issues in digital text representation, on-line dissemination, sharing and re-use for <fixed-case>A</fixed-case>frican minority languages</title>
-      <author><first>Emmanuel Ngué</first> <last>Um</last></author>
+      <author><first>Emmanuel Ngué</first><last>Um</last></author>
       <pages>24–32</pages>
       <url>W17-0104</url>
       <doi>10.18653/v1/W17-0104</doi>
     </paper>
     <paper id="5">
       <title>Developing collection management tools to create more robust and reliable linguistic data</title>
-      <author><first>Gary</first> <last>Holton</last></author>
-      <author><first>Kavon</first> <last>Hooshiar</last></author>
-      <author><first>Nick</first> <last>Thieberger</last></author>
+      <author><first>Gary</first><last>Holton</last></author>
+      <author><first>Kavon</first><last>Hooshiar</last></author>
+      <author><first>Nick</first><last>Thieberger</last></author>
       <pages>33–38</pages>
       <url>W17-0105</url>
       <doi>10.18653/v1/W17-0105</doi>
     </paper>
     <paper id="6">
       <title><fixed-case>STREAMLI</fixed-case>n<fixed-case>ED</fixed-case> Challenges: Aligning Research Interests with Shared Tasks</title>
-      <author><first>Gina-Anne</first> <last>Levow</last></author>
-      <author><first>Emily M.</first> <last>Bender</last></author>
-      <author><first>Patrick</first> <last>Littell</last></author>
-      <author><first>Kristen</first> <last>Howell</last></author>
-      <author><first>Shobhana</first> <last>Chelliah</last></author>
-      <author><first>Joshua</first> <last>Crowgey</last></author>
-      <author><first>Dan</first> <last>Garrette</last></author>
-      <author><first>Jeff</first> <last>Good</last></author>
-      <author><first>Sharon</first> <last>Hargus</last></author>
-      <author><first>David</first> <last>Inman</last></author>
-      <author><first>Michael</first> <last>Maxwell</last></author>
-      <author><first>Michael</first> <last>Tjalve</last></author>
-      <author><first>Fei</first> <last>Xia</last></author>
+      <author><first>Gina-Anne</first><last>Levow</last></author>
+      <author><first>Emily M.</first><last>Bender</last></author>
+      <author><first>Patrick</first><last>Littell</last></author>
+      <author><first>Kristen</first><last>Howell</last></author>
+      <author><first>Shobhana</first><last>Chelliah</last></author>
+      <author><first>Joshua</first><last>Crowgey</last></author>
+      <author><first>Dan</first><last>Garrette</last></author>
+      <author><first>Jeff</first><last>Good</last></author>
+      <author><first>Sharon</first><last>Hargus</last></author>
+      <author><first>David</first><last>Inman</last></author>
+      <author><first>Michael</first><last>Maxwell</last></author>
+      <author><first>Michael</first><last>Tjalve</last></author>
+      <author><first>Fei</first><last>Xia</last></author>
       <pages>39–47</pages>
       <url>W17-0106</url>
       <doi>10.18653/v1/W17-0106</doi>
     </paper>
     <paper id="7">
       <title>Work With What You’ve Got</title>
-      <author><first>Lucy</first> <last>Bell</last></author>
-      <author><first>Lawrence</first> <last>Bell</last></author>
+      <author><first>Lucy</first><last>Bell</last></author>
+      <author><first>Lawrence</first><last>Bell</last></author>
       <pages>48–51</pages>
       <url>W17-0107</url>
       <doi>10.18653/v1/W17-0107</doi>
     </paper>
     <paper id="8">
       <title>Converting a comprehensive lexical database into a computational model: The case of East Cree verb inflection</title>
-      <author><first>Antti</first> <last>Arppe</last></author>
-      <author><first>Marie-Odile</first> <last>Junker</last></author>
-      <author><first>Delasie</first> <last>Torkornoo</last></author>
+      <author><first>Antti</first><last>Arppe</last></author>
+      <author><first>Marie-Odile</first><last>Junker</last></author>
+      <author><first>Delasie</first><last>Torkornoo</last></author>
       <pages>52–56</pages>
       <url>W17-0108</url>
       <doi>10.18653/v1/W17-0108</doi>
     </paper>
     <paper id="9">
       <title>Instant annotations in <fixed-case>ELAN</fixed-case> corpora of spoken and written <fixed-case>K</fixed-case>omi, an endangered language of the Barents Sea region</title>
-      <author><first>Ciprian</first> <last>Gerstenberger</last></author>
-      <author><first>Niko</first> <last>Partanen</last></author>
-      <author><first>Michael</first> <last>Rießler</last></author>
+      <author><first>Ciprian</first><last>Gerstenberger</last></author>
+      <author><first>Niko</first><last>Partanen</last></author>
+      <author><first>Michael</first><last>Rießler</last></author>
       <pages>57–66</pages>
       <url>W17-0109</url>
       <doi>10.18653/v1/W17-0109</doi>
     </paper>
     <paper id="10">
       <title>Inferring Case Systems from <fixed-case>IGT</fixed-case>: Enriching the Enrichment</title>
-      <author><first>Kristen</first> <last>Howell</last></author>
-      <author><first>Emily M.</first> <last>Bender</last></author>
-      <author><first>Michel</first> <last>Lockwood</last></author>
-      <author><first>Fei</first> <last>Xia</last></author>
-      <author><first>Olga</first> <last>Zamaraeva</last></author>
+      <author><first>Kristen</first><last>Howell</last></author>
+      <author><first>Emily M.</first><last>Bender</last></author>
+      <author><first>Michel</first><last>Lockwood</last></author>
+      <author><first>Fei</first><last>Xia</last></author>
+      <author><first>Olga</first><last>Zamaraeva</last></author>
       <pages>67–75</pages>
       <url>W17-0110</url>
       <doi>10.18653/v1/W17-0110</doi>
     </paper>
     <paper id="11">
       <title>Case Studies in the Automatic Characterization of Grammars from Small Wordlists</title>
-      <author><first>Jordan</first> <last>Kodner</last></author>
-      <author><first>Spencer</first> <last>Caplan</last></author>
-      <author><first>Hongzhi</first> <last>Xu</last></author>
-      <author><first>Mitchell P.</first> <last>Marcus</last></author>
-      <author><first>Charles</first> <last>Yang</last></author>
+      <author><first>Jordan</first><last>Kodner</last></author>
+      <author><first>Spencer</first><last>Caplan</last></author>
+      <author><first>Hongzhi</first><last>Xu</last></author>
+      <author><first>Mitchell P.</first><last>Marcus</last></author>
+      <author><first>Charles</first><last>Yang</last></author>
       <pages>76–84</pages>
       <url>W17-0111</url>
       <doi>10.18653/v1/W17-0111</doi>
     </paper>
     <paper id="12">
       <title>Endangered Data for Endangered Languages: Digitizing Print dictionaries</title>
-      <author><first>Michael</first> <last>Maxwell</last></author>
-      <author><first>Aric</first> <last>Bills</last></author>
+      <author><first>Michael</first><last>Maxwell</last></author>
+      <author><first>Aric</first><last>Bills</last></author>
       <pages>85–91</pages>
       <url>W17-0112</url>
       <doi>10.18653/v1/W17-0112</doi>
     </paper>
     <paper id="13">
       <title>A computationally-assisted procedure for discovering poetic organization within oral tradition</title>
-      <author><first>David</first> <last>Meyer</last></author>
+      <author><first>David</first><last>Meyer</last></author>
       <pages>92–100</pages>
       <url>W17-0113</url>
       <doi>10.18653/v1/W17-0113</doi>
     </paper>
     <paper id="14">
       <title>Improving Coverage of an <fixed-case>I</fixed-case>nuktitut Morphological Analyzer Using a Segmental Recurrent Neural Network</title>
-      <author><first>Jeffrey</first> <last>Micher</last></author>
+      <author><first>Jeffrey</first><last>Micher</last></author>
       <pages>101–106</pages>
       <url>W17-0114</url>
       <doi>10.18653/v1/W17-0114</doi>
     </paper>
     <paper id="15">
       <title>Click reduction in fluent speech: a semi-automated analysis of <fixed-case>M</fixed-case>angetti Dune !<fixed-case>X</fixed-case>ung</title>
-      <author><first>Amanda</first> <last>Miller</last></author>
-      <author><first>Micha</first> <last>Elsner</last></author>
+      <author><first>Amanda</first><last>Miller</last></author>
+      <author><first>Micha</first><last>Elsner</last></author>
       <pages>107–115</pages>
       <url>W17-0115</url>
       <doi>10.18653/v1/W17-0115</doi>
     </paper>
     <paper id="16">
       <title><fixed-case>DECCA</fixed-case> Repurposed: Detecting transcription inconsistencies without an orthographic standard</title>
-      <author><first>C. Anton</first> <last>Rytting</last></author>
-      <author><first>Julie</first> <last>Yelle</last></author>
+      <author><first>C. Anton</first><last>Rytting</last></author>
+      <author><first>Julie</first><last>Yelle</last></author>
       <pages>116–121</pages>
       <url>W17-0116</url>
       <doi>10.18653/v1/W17-0116</doi>
     </paper>
     <paper id="17">
       <title>Jejueo talking dictionary: A collaborative online database for language revitalization</title>
-      <author><first>Moira</first> <last>Saltzman</last></author>
+      <author><first>Moira</first><last>Saltzman</last></author>
       <pages>122–129</pages>
       <url>W17-0117</url>
       <doi>10.18653/v1/W17-0117</doi>
     </paper>
     <paper id="18">
       <title>Computational Support for Finding Word Classes: A Case Study of Abui</title>
-      <author><first>Olga</first> <last>Zamaraeva</last></author>
-      <author><first>František</first> <last>Kratochvíl</last></author>
-      <author><first>Emily M.</first> <last>Bender</last></author>
-      <author><first>Fei</first> <last>Xia</last></author>
-      <author><first>Kristen</first> <last>Howell</last></author>
+      <author><first>Olga</first><last>Zamaraeva</last></author>
+      <author><first>František</first><last>Kratochvíl</last></author>
+      <author><first>Emily M.</first><last>Bender</last></author>
+      <author><first>Fei</first><last>Xia</last></author>
+      <author><first>Kristen</first><last>Howell</last></author>
       <pages>130–140</pages>
       <url>W17-0118</url>
       <doi>10.18653/v1/W17-0118</doi>
     </paper>
     <paper id="19">
       <title>Waldayu and Waldayu Mobile: Modern digital dictionary interfaces for endangered languages</title>
-      <author><first>Patrick</first> <last>Littell</last></author>
-      <author><first>Aidan</first> <last>Pine</last></author>
-      <author><first>Henry</first> <last>Davis</last></author>
+      <author><first>Patrick</first><last>Littell</last></author>
+      <author><first>Aidan</first><last>Pine</last></author>
+      <author><first>Henry</first><last>Davis</last></author>
       <pages>141–150</pages>
       <url>W17-0119</url>
       <doi>10.18653/v1/W17-0119</doi>
     </paper>
     <paper id="20">
       <title>Connecting Documentation and Revitalization: A New Approach to Language Apps</title>
-      <author><first>Alexa N.</first> <last>Little</last></author>
+      <author><first>Alexa N.</first><last>Little</last></author>
       <pages>151–155</pages>
       <url>W17-0120</url>
       <doi>10.18653/v1/W17-0120</doi>
     </paper>
     <paper id="21">
       <title>Developing a Suite of Mobile Applications for Collaborative Language Documentation</title>
-      <author><first>Mat</first> <last>Bettinson</last></author>
-      <author><first>Steven</first> <last>Bird</last></author>
+      <author><first>Mat</first><last>Bettinson</last></author>
+      <author><first>Steven</first><last>Bird</last></author>
       <pages>156–164</pages>
       <url>W17-0121</url>
       <doi>10.18653/v1/W17-0121</doi>
     </paper>
     <paper id="22">
       <title>Cross-language forced alignment to assist community-based linguistics for low resource languages</title>
-      <author><first>Timothy</first> <last>Kempton</last></author>
+      <author><first>Timothy</first><last>Kempton</last></author>
       <pages>165–169</pages>
       <url>W17-0122</url>
       <doi>10.18653/v1/W17-0122</doi>
     </paper>
     <paper id="23">
       <title>A case study on using speech-to-translation alignments for language documentation</title>
-      <author><first>Antonios</first> <last>Anastasopoulos</last></author>
-      <author><first>David</first> <last>Chiang</last></author>
+      <author><first>Antonios</first><last>Anastasopoulos</last></author>
+      <author><first>David</first><last>Chiang</last></author>
       <pages>170–178</pages>
       <url>W17-0123</url>
       <doi>10.18653/v1/W17-0123</doi>
@@ -242,384 +242,384 @@
     </frontmatter>
     <paper id="1">
       <title>Joint <fixed-case>UD</fixed-case> Parsing of <fixed-case>N</fixed-case>orwegian <fixed-case>B</fixed-case>okmål and Nynorsk</title>
-      <author><first>Erik</first> <last>Velldal</last></author>
-      <author><first>Lilja</first> <last>Øvrelid</last></author>
-      <author><first>Petter</first> <last>Hohle</last></author>
+      <author><first>Erik</first><last>Velldal</last></author>
+      <author><first>Lilja</first><last>Øvrelid</last></author>
+      <author><first>Petter</first><last>Hohle</last></author>
       <pages>1–10</pages>
       <url>W17-0201</url>
     </paper>
     <paper id="2">
       <title>Replacing <fixed-case>OOV</fixed-case> Words For Dependency Parsing With Distributional Semantics</title>
-      <author><first>Prasanth</first> <last>Kolachina</last></author>
-      <author><first>Martin</first> <last>Riedl</last></author>
-      <author><first>Chris</first> <last>Biemann</last></author>
+      <author><first>Prasanth</first><last>Kolachina</last></author>
+      <author><first>Martin</first><last>Riedl</last></author>
+      <author><first>Chris</first><last>Biemann</last></author>
       <pages>11–19</pages>
       <url>W17-0202</url>
     </paper>
     <paper id="3">
       <title>Real-valued Syntactic Word Vectors (<fixed-case>RSV</fixed-case>) for Greedy Neural Dependency Parsing</title>
-      <author><first>Ali</first> <last>Basirat</last></author>
-      <author><first>Joakim</first> <last>Nivre</last></author>
+      <author><first>Ali</first><last>Basirat</last></author>
+      <author><first>Joakim</first><last>Nivre</last></author>
       <pages>20–28</pages>
       <url>W17-0203</url>
     </paper>
     <paper id="4">
       <title>Tagging Named Entities in 19th Century and Modern <fixed-case>F</fixed-case>innish Newspaper Material with a <fixed-case>F</fixed-case>innish Semantic Tagger</title>
-      <author><first>Kimmo</first> <last>Kettunen</last></author>
-      <author><first>Laura</first> <last>Löfberg</last></author>
+      <author><first>Kimmo</first><last>Kettunen</last></author>
+      <author><first>Laura</first><last>Löfberg</last></author>
       <pages>29–36</pages>
       <url>W17-0204</url>
     </paper>
     <paper id="5">
       <title>Machine Learning for Rhetorical Figure Detection: More Chiasmus with Less Annotation</title>
-      <author><first>Marie</first> <last>Dubremetz</last></author>
-      <author><first>Joakim</first> <last>Nivre</last></author>
+      <author><first>Marie</first><last>Dubremetz</last></author>
+      <author><first>Joakim</first><last>Nivre</last></author>
       <pages>37–45</pages>
       <url>W17-0205</url>
     </paper>
     <paper id="6">
       <title>Coreference Resolution for <fixed-case>S</fixed-case>wedish and <fixed-case>G</fixed-case>erman using Distant Supervision</title>
-      <author><first>Alexander</first> <last>Wallin</last></author>
-      <author><first>Pierre</first> <last>Nugues</last></author>
+      <author><first>Alexander</first><last>Wallin</last></author>
+      <author><first>Pierre</first><last>Nugues</last></author>
       <pages>46–55</pages>
       <url>W17-0206</url>
     </paper>
     <paper id="7">
       <title>Aligning phonemes using finte-state methods</title>
-      <author><first>Kimmo</first> <last>Koskenniemi</last></author>
+      <author><first>Kimmo</first><last>Koskenniemi</last></author>
       <pages>56–64</pages>
       <url>W17-0207</url>
     </paper>
     <paper id="8">
       <title>Acoustic Model Compression with <fixed-case>MAP</fixed-case> adaptation</title>
-      <author><first>Katri</first> <last>Leino</last></author>
-      <author><first>Mikko</first> <last>Kurimo</last></author>
+      <author><first>Katri</first><last>Leino</last></author>
+      <author><first>Mikko</first><last>Kurimo</last></author>
       <pages>65–69</pages>
       <url>W17-0208</url>
     </paper>
     <paper id="9">
       <title><fixed-case>OCR</fixed-case> and post-correction of historical <fixed-case>F</fixed-case>innish texts</title>
-      <author><first>Senka</first> <last>Drobac</last></author>
-      <author><first>Pekka</first> <last>Kauppinen</last></author>
-      <author><first>Krister</first> <last>Lindén</last></author>
+      <author><first>Senka</first><last>Drobac</last></author>
+      <author><first>Pekka</first><last>Kauppinen</last></author>
+      <author><first>Krister</first><last>Lindén</last></author>
       <pages>70–76</pages>
       <url>W17-0209</url>
     </paper>
     <paper id="10">
       <title>Twitter Topic Modeling by Tweet Aggregation</title>
-      <author><first>Asbjørn</first> <last>Steinskog</last></author>
-      <author><first>Jonas</first> <last>Therkelsen</last></author>
-      <author><first>Björn</first> <last>Gambäck</last></author>
+      <author><first>Asbjørn</first><last>Steinskog</last></author>
+      <author><first>Jonas</first><last>Therkelsen</last></author>
+      <author><first>Björn</first><last>Gambäck</last></author>
       <pages>77–86</pages>
       <url>W17-0210</url>
     </paper>
     <paper id="11">
       <title>A Multilingual Entity Linker Using <fixed-case>P</fixed-case>age<fixed-case>R</fixed-case>ank and Semantic Graphs</title>
-      <author><first>Anton</first> <last>Södergren</last></author>
-      <author><first>Pierre</first> <last>Nugues</last></author>
+      <author><first>Anton</first><last>Södergren</last></author>
+      <author><first>Pierre</first><last>Nugues</last></author>
       <pages>87–95</pages>
       <url>W17-0211</url>
     </paper>
     <paper id="12">
       <title>Linear Ensembles of Word Embedding Models</title>
-      <author><first>Avo</first> <last>Muromägi</last></author>
-      <author><first>Kairit</first> <last>Sirts</last></author>
-      <author><first>Sven</first> <last>Laur</last></author>
+      <author><first>Avo</first><last>Muromägi</last></author>
+      <author><first>Kairit</first><last>Sirts</last></author>
+      <author><first>Sven</first><last>Laur</last></author>
       <pages>96–104</pages>
       <url>W17-0212</url>
     </paper>
     <paper id="13">
       <title>Using Pseudowords for Algorithm Comparison: An Evaluation Framework for Graph-based Word Sense Induction</title>
-      <author><first>Flavio</first> <last>Massimiliano Cecchini</last></author>
-      <author><first>Chris</first> <last>Biemann</last></author>
-      <author><first>Martin</first> <last>Riedl</last></author>
+      <author><first>Flavio</first><last>Massimiliano Cecchini</last></author>
+      <author><first>Chris</first><last>Biemann</last></author>
+      <author><first>Martin</first><last>Riedl</last></author>
       <pages>105–114</pages>
       <url>W17-0213</url>
     </paper>
     <paper id="14">
       <title>North-Sámi to <fixed-case>F</fixed-case>innish rule-based machine translation system</title>
-      <author><first>Tommi</first> <last>Pirinen</last></author>
-      <author><first>Francis M.</first> <last>Tyers</last></author>
-      <author><first>Trond</first> <last>Trosterud</last></author>
-      <author><first>Ryan</first> <last>Johnson</last></author>
-      <author><first>Kevin</first> <last>Unhammer</last></author>
-      <author><first>Tiina</first> <last>Puolakainen</last></author>
+      <author><first>Tommi</first><last>Pirinen</last></author>
+      <author><first>Francis M.</first><last>Tyers</last></author>
+      <author><first>Trond</first><last>Trosterud</last></author>
+      <author><first>Ryan</first><last>Johnson</last></author>
+      <author><first>Kevin</first><last>Unhammer</last></author>
+      <author><first>Tiina</first><last>Puolakainen</last></author>
       <pages>115–122</pages>
       <url>W17-0214</url>
     </paper>
     <paper id="15">
       <title>Machine translation with North Saami as a pivot language</title>
-      <author><first>Lene</first> <last>Antonsen</last></author>
-      <author><first>Ciprian</first> <last>Gerstenberger</last></author>
-      <author><first>Maja</first> <last>Kappfjell</last></author>
-      <author><first>Sandra</first> <last>Nystø Rahka</last></author>
-      <author><first>Marja-Liisa</first> <last>Olthuis</last></author>
-      <author><first>Trond</first> <last>Trosterud</last></author>
-      <author><first>Francis M.</first> <last>Tyers</last></author>
+      <author><first>Lene</first><last>Antonsen</last></author>
+      <author><first>Ciprian</first><last>Gerstenberger</last></author>
+      <author><first>Maja</first><last>Kappfjell</last></author>
+      <author><first>Sandra</first><last>Nystø Rahka</last></author>
+      <author><first>Marja-Liisa</first><last>Olthuis</last></author>
+      <author><first>Trond</first><last>Trosterud</last></author>
+      <author><first>Francis M.</first><last>Tyers</last></author>
       <pages>123–131</pages>
       <url>W17-0215</url>
     </paper>
     <paper id="16">
       <title><fixed-case>SWEGRAM</fixed-case> – A Web-Based Tool for Automatic Annotation and Analysis of <fixed-case>S</fixed-case>wedish Texts</title>
-      <author><first>Jesper</first> <last>Näsman</last></author>
-      <author><first>Beáta</first> <last>Megyesi</last></author>
-      <author><first>Anne</first> <last>Palmér</last></author>
+      <author><first>Jesper</first><last>Näsman</last></author>
+      <author><first>Beáta</first><last>Megyesi</last></author>
+      <author><first>Anne</first><last>Palmér</last></author>
       <pages>132–141</pages>
       <url>W17-0216</url>
     </paper>
     <paper id="17">
       <title>Optimizing a <fixed-case>P</fixed-case>o<fixed-case>S</fixed-case> Tagset for <fixed-case>N</fixed-case>orwegian Dependency Parsing</title>
-      <author><first>Petter</first> <last>Hohle</last></author>
-      <author><first>Lilja</first> <last>Øvrelid</last></author>
-      <author><first>Erik</first> <last>Velldal</last></author>
+      <author><first>Petter</first><last>Hohle</last></author>
+      <author><first>Lilja</first><last>Øvrelid</last></author>
+      <author><first>Erik</first><last>Velldal</last></author>
       <pages>142–151</pages>
       <url>W17-0217</url>
     </paper>
     <paper id="18">
       <title>Creating register sub-corpora for the <fixed-case>F</fixed-case>innish <fixed-case>I</fixed-case>nternet Parsebank</title>
-      <author><first>Veronika</first> <last>Laippala</last></author>
-      <author><first>Juhani</first> <last>Luotolahti</last></author>
-      <author><first>Aki-Juhani</first> <last>Kyröläinen</last></author>
-      <author><first>Tapio</first> <last>Salakoski</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
+      <author><first>Veronika</first><last>Laippala</last></author>
+      <author><first>Juhani</first><last>Luotolahti</last></author>
+      <author><first>Aki-Juhani</first><last>Kyröläinen</last></author>
+      <author><first>Tapio</first><last>Salakoski</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
       <pages>152–161</pages>
       <url>W17-0218</url>
     </paper>
     <paper id="19">
       <title><fixed-case>KILLE</fixed-case>: a Framework for Situated Agents for Learning Language Through Interaction</title>
-      <author><first>Simon</first> <last>Dobnik</last></author>
-      <author><first>Erik</first> <last>de Graaf</last></author>
+      <author><first>Simon</first><last>Dobnik</last></author>
+      <author><first>Erik</first><last>de Graaf</last></author>
       <pages>162–171</pages>
       <url>W17-0219</url>
     </paper>
     <paper id="20">
       <title>Data Collection from Persons with Mild Forms of Cognitive Impairment and Healthy Controls - Infrastructure for Classification and Prediction of Dementia</title>
-      <author><first>Dimitrios</first> <last>Kokkinakis</last></author>
-      <author><first>Kristina</first> <last>Lundholm Fors</last></author>
-      <author><first>Eva</first> <last>Björkner</last></author>
-      <author><first>Arto</first> <last>Nordlund</last></author>
+      <author><first>Dimitrios</first><last>Kokkinakis</last></author>
+      <author><first>Kristina</first><last>Lundholm Fors</last></author>
+      <author><first>Eva</first><last>Björkner</last></author>
+      <author><first>Arto</first><last>Nordlund</last></author>
       <pages>172–182</pages>
       <url>W17-0220</url>
     </paper>
     <paper id="21">
       <title>Evaluation of language identification methods using 285 languages</title>
-      <author><first>Tommi</first> <last>Jauhiainen</last></author>
-      <author><first>Krister</first> <last>Lindén</last></author>
-      <author><first>Heidi</first> <last>Jauhiainen</last></author>
+      <author><first>Tommi</first><last>Jauhiainen</last></author>
+      <author><first>Krister</first><last>Lindén</last></author>
+      <author><first>Heidi</first><last>Jauhiainen</last></author>
       <pages>183–191</pages>
       <url>W17-0221</url>
     </paper>
     <paper id="22">
       <title>Can We Create a Tool for General Domain Event Analysis?</title>
-      <author><first>Siim</first> <last>Orasmaa</last></author>
-      <author><first>Heiki-Jaan</first> <last>Kaalep</last></author>
+      <author><first>Siim</first><last>Orasmaa</last></author>
+      <author><first>Heiki-Jaan</first><last>Kaalep</last></author>
       <pages>192–201</pages>
       <url>W17-0222</url>
     </paper>
     <paper id="23">
       <title>From Treebank to <fixed-case>P</fixed-case>ropbank: A Semantic-Role and <fixed-case>V</fixed-case>erb<fixed-case>N</fixed-case>et Corpus for <fixed-case>D</fixed-case>anish</title>
-      <author><first>Eckhard</first> <last>Bick</last></author>
+      <author><first>Eckhard</first><last>Bick</last></author>
       <pages>202–210</pages>
       <url>W17-0223</url>
     </paper>
     <paper id="24">
       <title>Cross-lingual Learning of Semantic Textual Similarity with Multilingual Word Representations</title>
-      <author><first>Johannes</first> <last>Bjerva</last></author>
-      <author><first>Robert</first> <last>Östling</last></author>
+      <author><first>Johannes</first><last>Bjerva</last></author>
+      <author><first>Robert</first><last>Östling</last></author>
       <pages>211–215</pages>
       <url>W17-0224</url>
     </paper>
     <paper id="25">
       <title>Will my auxiliary tagging task help? Estimating Auxiliary Tasks Effectivity in Multi-Task Learning</title>
-      <author><first>Johannes</first> <last>Bjerva</last></author>
+      <author><first>Johannes</first><last>Bjerva</last></author>
       <pages>216–220</pages>
       <url>W17-0225</url>
     </paper>
     <paper id="26">
       <title>Iconic Locations in <fixed-case>S</fixed-case>wedish Sign Language: Mapping Form to Meaning with Lexical Databases</title>
-      <author><first>Carl</first> <last>Börstell</last></author>
-      <author><first>Robert</first> <last>Östling</last></author>
+      <author><first>Carl</first><last>Börstell</last></author>
+      <author><first>Robert</first><last>Östling</last></author>
       <pages>221–225</pages>
       <url>W17-0226</url>
     </paper>
     <paper id="27">
       <title><fixed-case>D</fixed-case>ocforia: A Multilayer Document Model</title>
-      <author><first>Marcus</first> <last>Klang</last></author>
-      <author><first>Pierre</first> <last>Nugues</last></author>
+      <author><first>Marcus</first><last>Klang</last></author>
+      <author><first>Pierre</first><last>Nugues</last></author>
       <pages>226–230</pages>
       <url>W17-0227</url>
     </paper>
     <paper id="28">
       <title><fixed-case>F</fixed-case>innish resources for evaluating language model semantics</title>
-      <author><first>Viljami</first> <last>Venekoski</last></author>
-      <author><first>Jouko</first> <last>Vankka</last></author>
+      <author><first>Viljami</first><last>Venekoski</last></author>
+      <author><first>Jouko</first><last>Vankka</last></author>
       <pages>231–236</pages>
       <url>W17-0228</url>
     </paper>
     <paper id="29">
       <title><fixed-case>M</fixed-case>álrómur: A Manually Verified Corpus of Recorded <fixed-case>I</fixed-case>celandic Speech</title>
-      <author><first>Steinþór</first> <last>Steingrímsson</last></author>
-      <author><first>Jón</first> <last>Guðnason</last></author>
-      <author><first>Sigrún</first> <last>Helgadóttir</last></author>
-      <author><first>Eiríkur</first> <last>Rögnvaldsson</last></author>
+      <author><first>Steinþór</first><last>Steingrímsson</last></author>
+      <author><first>Jón</first><last>Guðnason</last></author>
+      <author><first>Sigrún</first><last>Helgadóttir</last></author>
+      <author><first>Eiríkur</first><last>Rögnvaldsson</last></author>
       <pages>237–240</pages>
       <url>W17-0229</url>
     </paper>
     <paper id="30">
       <title>The Effect of Translationese on Tuning for Statistical Machine Translation</title>
-      <author><first>Sara</first> <last>Stymne</last></author>
+      <author><first>Sara</first><last>Stymne</last></author>
       <pages>241–246</pages>
       <url>W17-0230</url>
     </paper>
     <paper id="31">
       <title>Multilingwis² – Explore Your Parallel Corpus</title>
-      <author><first>Johannes</first> <last>Graën</last></author>
-      <author><first>Dominique</first> <last>Sandoz</last></author>
-      <author><first>Martin</first> <last>Volk</last></author>
+      <author><first>Johannes</first><last>Graën</last></author>
+      <author><first>Dominique</first><last>Sandoz</last></author>
+      <author><first>Martin</first><last>Volk</last></author>
       <pages>247–250</pages>
       <url>W17-0231</url>
     </paper>
     <paper id="32">
       <title>A modernised version of the Glossa corpus search system</title>
-      <author><first>Anders</first> <last>Nøklestad</last></author>
-      <author><first>Kristin</first> <last>Hagen</last></author>
-      <author><first>Janne</first> <last>Bondi Johannessen</last></author>
-      <author><first>Michał</first> <last>Kosek</last></author>
-      <author><first>Joel</first> <last>Priestley</last></author>
+      <author><first>Anders</first><last>Nøklestad</last></author>
+      <author><first>Kristin</first><last>Hagen</last></author>
+      <author><first>Janne</first><last>Bondi Johannessen</last></author>
+      <author><first>Michał</first><last>Kosek</last></author>
+      <author><first>Joel</first><last>Priestley</last></author>
       <pages>251–254</pages>
       <url>W17-0232</url>
     </paper>
     <paper id="33">
       <title><fixed-case>D</fixed-case>ep_search: Efficient Search Tool for Large Dependency Parsebanks</title>
-      <author><first>Juhani</first> <last>Luotolahti</last></author>
-      <author><first>Jenna</first> <last>Kanerva</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
+      <author><first>Juhani</first><last>Luotolahti</last></author>
+      <author><first>Jenna</first><last>Kanerva</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
       <pages>255–258</pages>
       <url>W17-0233</url>
     </paper>
     <paper id="34">
       <title>Proto-<fixed-case>I</fixed-case>ndo-<fixed-case>E</fixed-case>uropean Lexicon: The Generative Etymological Dictionary of <fixed-case>I</fixed-case>ndo-<fixed-case>E</fixed-case>uropean Languages</title>
-      <author><first>Jouna</first> <last>Pyysalo</last></author>
+      <author><first>Jouna</first><last>Pyysalo</last></author>
       <pages>259–262</pages>
       <url>W17-0234</url>
     </paper>
     <paper id="35">
       <title>Tilde <fixed-case>MODEL</fixed-case> - Multilingual Open Data for <fixed-case>EU</fixed-case> Languages</title>
-      <author><first>Roberts</first> <last>Rozis</last></author>
-      <author><first>Raivis</first> <last>Skadiņš</last></author>
+      <author><first>Roberts</first><last>Rozis</last></author>
+      <author><first>Raivis</first><last>Skadiņš</last></author>
       <pages>263–265</pages>
       <url>W17-0235</url>
     </paper>
     <paper id="36">
       <title>Mainstreaming August Strindberg with Text Normalization</title>
-      <author><first>Adam</first> <last>Ek</last></author>
-      <author><first>Sofia</first> <last>Knuutinen</last></author>
+      <author><first>Adam</first><last>Ek</last></author>
+      <author><first>Sofia</first><last>Knuutinen</last></author>
       <pages>266–270</pages>
       <url>W17-0236</url>
     </paper>
     <paper id="37">
       <title>Word vectors, reuse, and replicability: Towards a community repository of large-text resources</title>
-      <author><first>Murhaf</first> <last>Fares</last></author>
-      <author><first>Andrey</first> <last>Kutuzov</last></author>
-      <author><first>Stephan</first> <last>Oepen</last></author>
-      <author><first>Erik</first> <last>Velldal</last></author>
+      <author><first>Murhaf</first><last>Fares</last></author>
+      <author><first>Andrey</first><last>Kutuzov</last></author>
+      <author><first>Stephan</first><last>Oepen</last></author>
+      <author><first>Erik</first><last>Velldal</last></author>
       <pages>271–276</pages>
       <url>W17-0237</url>
     </paper>
     <paper id="38">
       <title>Improving Optical Character Recognition of <fixed-case>F</fixed-case>innish Historical Newspapers with a Combination of Fraktur &amp; Antiqua Models and Image Preprocessing</title>
-      <author><first>Mika</first> <last>Koistinen</last></author>
-      <author><first>Kimmo</first> <last>Kettunen</last></author>
-      <author><first>Tuula</first> <last>Pääkkönen</last></author>
+      <author><first>Mika</first><last>Koistinen</last></author>
+      <author><first>Kimmo</first><last>Kettunen</last></author>
+      <author><first>Tuula</first><last>Pääkkönen</last></author>
       <pages>277–283</pages>
       <url>W17-0238</url>
     </paper>
     <paper id="39">
       <title>Redefining Context Windows for Word Embedding Models: An Experimental Study</title>
-      <author><first>Pierre</first> <last>Lison</last></author>
-      <author><first>Andrey</first> <last>Kutuzov</last></author>
+      <author><first>Pierre</first><last>Lison</last></author>
+      <author><first>Andrey</first><last>Kutuzov</last></author>
       <pages>284–288</pages>
       <url>W17-0239</url>
     </paper>
     <paper id="40">
       <title>The Effect of Excluding Out of Domain Training Data from Supervised Named-Entity Recognition</title>
-      <author><first>Adam</first> <last>Persson</last></author>
+      <author><first>Adam</first><last>Persson</last></author>
       <pages>289–292</pages>
       <url>W17-0240</url>
     </paper>
     <paper id="41">
       <title>Quote Extraction and Attribution from <fixed-case>N</fixed-case>orwegian Newspapers</title>
-      <author><first>Andrew</first> <last>Salway</last></author>
-      <author><first>Paul</first> <last>Meurer</last></author>
-      <author><first>Knut</first> <last>Hofland</last></author>
-      <author><first>Øystein</first> <last>Reigem</last></author>
+      <author><first>Andrew</first><last>Salway</last></author>
+      <author><first>Paul</first><last>Meurer</last></author>
+      <author><first>Knut</first><last>Hofland</last></author>
+      <author><first>Øystein</first><last>Reigem</last></author>
       <pages>293–297</pages>
       <url>W17-0241</url>
     </paper>
     <paper id="42">
       <title><fixed-case>W</fixed-case>ordnet extension via word embeddings: Experiments on the <fixed-case>N</fixed-case>orwegian <fixed-case>W</fixed-case>ordnet</title>
-      <author><first>Heidi</first> <last>Sand</last></author>
-      <author><first>Erik</first> <last>Velldal</last></author>
-      <author><first>Lilja</first> <last>Øvrelid</last></author>
+      <author><first>Heidi</first><last>Sand</last></author>
+      <author><first>Erik</first><last>Velldal</last></author>
+      <author><first>Lilja</first><last>Øvrelid</last></author>
       <pages>298–302</pages>
       <url>W17-0242</url>
     </paper>
     <paper id="43">
       <title>Universal Dependencies for <fixed-case>S</fixed-case>wedish Sign Language</title>
-      <author><first>Robert</first> <last>Östling</last></author>
-      <author><first>Carl</first> <last>Börstell</last></author>
-      <author><first>Moa</first> <last>Gärdenfors</last></author>
-      <author><first>Mats</first> <last>Wirén</last></author>
+      <author><first>Robert</first><last>Östling</last></author>
+      <author><first>Carl</first><last>Börstell</last></author>
+      <author><first>Moa</first><last>Gärdenfors</last></author>
+      <author><first>Mats</first><last>Wirén</last></author>
       <pages>303–308</pages>
       <url>W17-0243</url>
     </paper>
     <paper id="44">
       <title>Services for text simplification and analysis</title>
-      <author><first>Johan</first> <last>Falkenjack</last></author>
-      <author><first>Evelina</first> <last>Rennes</last></author>
-      <author><first>Daniel</first> <last>Fahlborg</last></author>
-      <author><first>Vida</first> <last>Johansson</last></author>
-      <author><first>Arne</first> <last>Jönsson</last></author>
+      <author><first>Johan</first><last>Falkenjack</last></author>
+      <author><first>Evelina</first><last>Rennes</last></author>
+      <author><first>Daniel</first><last>Fahlborg</last></author>
+      <author><first>Vida</first><last>Johansson</last></author>
+      <author><first>Arne</first><last>Jönsson</last></author>
       <pages>309–313</pages>
       <url>W17-0244</url>
     </paper>
     <paper id="45">
       <title>Exploring Properties of Intralingual and Interlingual Association Measures Visually</title>
-      <author><first>Johannes</first> <last>Graën</last></author>
-      <author><first>Christof</first> <last>Bless</last></author>
+      <author><first>Johannes</first><last>Graën</last></author>
+      <author><first>Christof</first><last>Bless</last></author>
       <pages>314–317</pages>
       <url>W17-0245</url>
     </paper>
     <paper id="46">
       <title><fixed-case>TALERUM</fixed-case> - Learning <fixed-case>D</fixed-case>anish by Doing <fixed-case>D</fixed-case>anish</title>
-      <author><first>Peter</first> <last>Juel Henrichsen</last></author>
+      <author><first>Peter</first><last>Juel Henrichsen</last></author>
       <pages>318–321</pages>
       <url>W17-0246</url>
     </paper>
     <paper id="47">
       <title>Cross-Lingual Syntax: Relating Grammatical Framework with Universal Dependencies</title>
-      <author><first>Aarne</first> <last>Ranta</last></author>
-      <author><first>Prasanth</first> <last>Kolachina</last></author>
-      <author><first>Thomas</first> <last>Hallgren</last></author>
+      <author><first>Aarne</first><last>Ranta</last></author>
+      <author><first>Prasanth</first><last>Kolachina</last></author>
+      <author><first>Thomas</first><last>Hallgren</last></author>
       <pages>322–325</pages>
       <url>W17-0247</url>
     </paper>
     <paper id="48">
       <title>Exploring Treebanks with <fixed-case>INESS</fixed-case> Search</title>
-      <author><first>Victoria</first> <last>Rosén</last></author>
-      <author><first>Helge</first> <last>Dyvik</last></author>
-      <author><first>Paul</first> <last>Meurer</last></author>
-      <author><first>Koenraad</first> <last>De Smedt</last></author>
+      <author><first>Victoria</first><last>Rosén</last></author>
+      <author><first>Helge</first><last>Dyvik</last></author>
+      <author><first>Paul</first><last>Meurer</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <pages>326–329</pages>
       <url>W17-0248</url>
     </paper>
     <paper id="49">
       <title>A System for Identifying and Exploring Text Repetition in Large Historical Document Corpora</title>
-      <author><first>Aleksi</first> <last>Vesanto</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
-      <author><first>Hannu</first> <last>Salmi</last></author>
-      <author><first>Asko</first> <last>Nivala</last></author>
-      <author><first>Tapio</first> <last>Salakoski</last></author>
+      <author><first>Aleksi</first><last>Vesanto</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
+      <author><first>Hannu</first><last>Salmi</last></author>
+      <author><first>Asko</first><last>Nivala</last></author>
+      <author><first>Tapio</first><last>Salakoski</last></author>
       <pages>330–333</pages>
       <url>W17-0249</url>
     </paper>
@@ -642,56 +642,56 @@
     </frontmatter>
     <paper id="1">
       <title>Learning with learner corpora: Using the <fixed-case>TLE</fixed-case> for native language identification</title>
-      <author><first>Allison</first> <last>Adams</last></author>
-      <author><first>Sara</first> <last>Stymne</last></author>
+      <author><first>Allison</first><last>Adams</last></author>
+      <author><first>Sara</first><last>Stymne</last></author>
       <pages>1-7</pages>
       <url>W17-0301</url>
     </paper>
     <paper id="2">
       <title>Challenging learners in their individual zone of proximal development using pedagogic developmental benchmarks of syntactic complexity</title>
-      <author><first>Xiaobin</first> <last>Chen</last></author>
-      <author><first>Detmar</first> <last>Meurers</last></author>
+      <author><first>Xiaobin</first><last>Chen</last></author>
+      <author><first>Detmar</first><last>Meurers</last></author>
       <pages>8-17</pages>
       <url>W17-0302</url>
     </paper>
     <paper id="3">
       <title>Crossing the border twice: Reimporting prepositions to alleviate <fixed-case>L</fixed-case>1-specific transfer errors</title>
-      <author><first>Johannes</first> <last>Graën</last></author>
-      <author><first>Gerold</first> <last>Schneider</last></author>
+      <author><first>Johannes</first><last>Graën</last></author>
+      <author><first>Gerold</first><last>Schneider</last></author>
       <pages>18-26</pages>
       <url>W17-0303</url>
     </paper>
     <paper id="4">
       <title><fixed-case>R</fixed-case>evita: a system for language learning and supporting endangered languages</title>
-      <author><first>Anisia</first> <last>Katinskaia</last></author>
-      <author><first>Javad</first> <last>Nouri</last></author>
-      <author><first>Roman</first> <last>Yangarber</last></author>
+      <author><first>Anisia</first><last>Katinskaia</last></author>
+      <author><first>Javad</first><last>Nouri</last></author>
+      <author><first>Roman</first><last>Yangarber</last></author>
       <pages>27-35</pages>
       <url>W17-0304</url>
     </paper>
     <paper id="5">
       <title>Developing a web-based workbook for <fixed-case>E</fixed-case>nglish supporting the interaction of students and teachers</title>
-      <author><first>Björn</first> <last>Rudzewitz</last></author>
-      <author><first>Ramon</first> <last>Ziai</last></author>
-      <author><first>Kordula</first> <last>De Kuthy</last></author>
-      <author><first>Detmar</first> <last>Meurers</last></author>
+      <author><first>Björn</first><last>Rudzewitz</last></author>
+      <author><first>Ramon</first><last>Ziai</last></author>
+      <author><first>Kordula</first><last>De Kuthy</last></author>
+      <author><first>Detmar</first><last>Meurers</last></author>
       <pages>36-46</pages>
       <url>W17-0305</url>
     </paper>
     <paper id="6">
       <title>Annotating errors in student texts: First experiences and experiments</title>
-      <author><first>Sara</first> <last>Stymne</last></author>
-      <author><first>Eva</first> <last>Pettersson</last></author>
-      <author><first>Beáta</first> <last>Megyesi</last></author>
-      <author><first>Anne</first> <last>Palmér</last></author>
+      <author><first>Sara</first><last>Stymne</last></author>
+      <author><first>Eva</first><last>Pettersson</last></author>
+      <author><first>Beáta</first><last>Megyesi</last></author>
+      <author><first>Anne</first><last>Palmér</last></author>
       <pages>47-60</pages>
       <url>W17-0306</url>
     </paper>
     <paper id="7">
       <title>Building and using language resources and infrastructure to develop e-learning programs for a minority language</title>
-      <author><first>Heli</first> <last>Uibo</last></author>
-      <author><first>Jack</first> <last>Rueter</last></author>
-      <author><first>Sulev</first> <last>Iva</last></author>
+      <author><first>Heli</first><last>Uibo</last></author>
+      <author><first>Jack</first><last>Rueter</last></author>
+      <author><first>Sulev</first><last>Iva</last></author>
       <pages>61-67</pages>
       <url>W17-0307</url>
     </paper>
@@ -713,138 +713,138 @@
     </frontmatter>
     <paper id="1">
       <title>Cross-Lingual Parser Selection for Low-Resource Languages</title>
-      <author><first>Željko</first> <last>Agić</last></author>
+      <author><first>Željko</first><last>Agić</last></author>
       <pages>1–10</pages>
       <url>W17-0401</url>
     </paper>
     <paper id="2">
       <title><fixed-case>S</fixed-case>wedish Prepositions are not Pure Function Words</title>
-      <author><first>Lars</first> <last>Ahrenberg</last></author>
+      <author><first>Lars</first><last>Ahrenberg</last></author>
       <pages>11–18</pages>
       <url>W17-0402</url>
     </paper>
     <paper id="3">
       <title>Increasing Return on Annotation Investment: The Automatic Construction of a Universal Dependency Treebank for <fixed-case>D</fixed-case>utch</title>
-      <author><first>Gosse</first> <last>Bouma</last></author>
-      <author><first>Gertjan</first> <last>van Noord</last></author>
+      <author><first>Gosse</first><last>Bouma</last></author>
+      <author><first>Gertjan</first><last>van Noord</last></author>
       <pages>19–26</pages>
       <url>W17-0403</url>
     </paper>
     <paper id="4">
       <title>Converting the <fixed-case>T</fixed-case>ü<fixed-case>B</fixed-case>a-D/Z Treebank of <fixed-case>G</fixed-case>erman to Universal Dependencies</title>
-      <author><first>Çağrı</first> <last>Çöltekin</last></author>
-      <author><first>Ben</first> <last>Campbell</last></author>
-      <author><first>Erhard</first> <last>Hinrichs</last></author>
-      <author><first>Heike</first> <last>Telljohann</last></author>
+      <author><first>Çağrı</first><last>Çöltekin</last></author>
+      <author><first>Ben</first><last>Campbell</last></author>
+      <author><first>Erhard</first><last>Hinrichs</last></author>
+      <author><first>Heike</first><last>Telljohann</last></author>
       <pages>27–37</pages>
       <url>W17-0404</url>
     </paper>
     <paper id="5">
       <title>Universal Dependencies for <fixed-case>A</fixed-case>frikaans</title>
-      <author><first>Peter</first> <last>Dirix</last></author>
-      <author><first>Liesbeth</first> <last>Augustinus</last></author>
-      <author><first>Daniel</first> <last>van Niekerk</last></author>
-      <author><first>Frank</first> <last>Van Eynde</last></author>
+      <author><first>Peter</first><last>Dirix</last></author>
+      <author><first>Liesbeth</first><last>Augustinus</last></author>
+      <author><first>Daniel</first><last>van Niekerk</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <pages>38–47</pages>
       <url>W17-0405</url>
     </paper>
     <paper id="6">
       <title>Elliptic Constructions: Spotting Patterns in <fixed-case>UD</fixed-case> Treebanks</title>
-      <author><first>Kira</first> <last>Droganova</last></author>
-      <author><first>Daniel</first> <last>Zeman</last></author>
+      <author><first>Kira</first><last>Droganova</last></author>
+      <author><first>Daniel</first><last>Zeman</last></author>
       <pages>48–57</pages>
       <url>W17-0406</url>
     </paper>
     <paper id="7">
       <title>Dependency Tree Transformation with Tree Transducers</title>
-      <author><first>Felix</first> <last>Hennig</last></author>
-      <author><first>Arne</first> <last>Köhn</last></author>
+      <author><first>Felix</first><last>Hennig</last></author>
+      <author><first>Arne</first><last>Köhn</last></author>
       <pages>58–66</pages>
       <url>W17-0407</url>
     </paper>
     <paper id="8">
       <title>Towards Universal Dependencies for Learner <fixed-case>C</fixed-case>hinese</title>
-      <author><first>John</first> <last>Lee</last></author>
-      <author><first>Herman</first> <last>Leung</last></author>
-      <author><first>Keying</first> <last>Li</last></author>
+      <author><first>John</first><last>Lee</last></author>
+      <author><first>Herman</first><last>Leung</last></author>
+      <author><first>Keying</first><last>Li</last></author>
       <pages>67–71</pages>
       <url>W17-0408</url>
     </paper>
     <paper id="9">
       <title>Does Syntactic Informativity Predict Word Length? A Cross-Linguistic Study Based on the Universal Dependencies Corpora</title>
-      <author><first>Natalia</first> <last>Levshina</last></author>
+      <author><first>Natalia</first><last>Levshina</last></author>
       <pages>72–78</pages>
       <url>W17-0409</url>
     </paper>
     <paper id="10">
       <title><fixed-case>E</fixed-case>stonian Copular and Existential Constructions as an <fixed-case>UD</fixed-case> Annotation Problem</title>
-      <author><first>Kadri</first> <last>Muischnek</last></author>
-      <author><first>Kaili</first> <last>Müürisep</last></author>
+      <author><first>Kadri</first><last>Muischnek</last></author>
+      <author><first>Kaili</first><last>Müürisep</last></author>
       <pages>79–85</pages>
       <url>W17-0410</url>
     </paper>
     <paper id="11">
       <title>Universal Dependency Evaluation</title>
-      <author><first>Joakim</first> <last>Nivre</last></author>
-      <author><first>Chiao-Ting</first> <last>Fang</last></author>
+      <author><first>Joakim</first><last>Nivre</last></author>
+      <author><first>Chiao-Ting</first><last>Fang</last></author>
       <pages>86–95</pages>
       <url>W17-0411</url>
     </paper>
     <paper id="12">
       <title><fixed-case>U</fixed-case>dapi: Universal <fixed-case>API</fixed-case> for Universal Dependencies</title>
-      <author><first>Martin</first> <last>Popel</last></author>
-      <author><first>Zdeněk</first> <last>Žabokrtský</last></author>
-      <author><first>Martin</first> <last>Vojtek</last></author>
+      <author><first>Martin</first><last>Popel</last></author>
+      <author><first>Zdeněk</first><last>Žabokrtský</last></author>
+      <author><first>Martin</first><last>Vojtek</last></author>
       <pages>96–101</pages>
       <url>W17-0412</url>
     </paper>
     <paper id="13">
       <title>Universal Dependencies for <fixed-case>G</fixed-case>reek</title>
-      <author><first>Prokopis</first> <last>Prokopidis</last></author>
-      <author><first>Haris</first> <last>Papageorgiou</last></author>
+      <author><first>Prokopis</first><last>Prokopidis</last></author>
+      <author><first>Haris</first><last>Papageorgiou</last></author>
       <pages>102–106</pages>
       <url>W17-0413</url>
     </paper>
     <paper id="14">
       <title>From Universal Dependencies to Abstract Syntax</title>
-      <author><first>Aarne</first> <last>Ranta</last></author>
-      <author><first>Prasanth</first> <last>Kolachina</last></author>
+      <author><first>Aarne</first><last>Ranta</last></author>
+      <author><first>Prasanth</first><last>Kolachina</last></author>
       <pages>107–116</pages>
       <url>W17-0414</url>
     </paper>
     <paper id="15">
       <title>Empirically Sampling Universal Dependencies</title>
-      <author><first>Natalie</first> <last>Schluter</last></author>
-      <author><first>Željko</first> <last>Agić</last></author>
+      <author><first>Natalie</first><last>Schluter</last></author>
+      <author><first>Željko</first><last>Agić</last></author>
       <pages>117–122</pages>
       <url>W17-0415</url>
     </paper>
     <paper id="16">
       <title>Gapping Constructions in Universal Dependencies v2</title>
-      <author><first>Sebastian</first> <last>Schuster</last></author>
-      <author><first>Matthew</first> <last>Lamm</last></author>
-      <author><first>Christopher D.</first> <last>Manning</last></author>
+      <author><first>Sebastian</first><last>Schuster</last></author>
+      <author><first>Matthew</first><last>Lamm</last></author>
+      <author><first>Christopher D.</first><last>Manning</last></author>
       <pages>123–132</pages>
       <url>W17-0416</url>
     </paper>
     <paper id="17">
       <title>Toward Universal Dependencies for <fixed-case>A</fixed-case>inu</title>
-      <author><first>Hajime</first> <last>Senuma</last></author>
-      <author><first>Akiko</first> <last>Aizawa</last></author>
+      <author><first>Hajime</first><last>Senuma</last></author>
+      <author><first>Akiko</first><last>Aizawa</last></author>
       <pages>133–139</pages>
       <url>W17-0417</url>
     </paper>
     <paper id="18">
       <title>Automatic Morpheme Segmentation and Labeling in Universal Dependencies Resources</title>
-      <author><first>Miikka</first> <last>Silfverberg</last></author>
-      <author><first>Mans</first> <last>Hulden</last></author>
+      <author><first>Miikka</first><last>Silfverberg</last></author>
+      <author><first>Mans</first><last>Hulden</last></author>
       <pages>140–145</pages>
       <url>W17-0418</url>
     </paper>
     <paper id="19">
       <title>A Systematic Comparison of Syntactic Representations of Dependency Parsing</title>
-      <author><first>Guillaume</first> <last>Wisniewski</last></author>
-      <author><first>Ophélie</first> <last>Lacroix</last></author>
+      <author><first>Guillaume</first><last>Wisniewski</last></author>
+      <author><first>Ophélie</first><last>Lacroix</last></author>
       <pages>146–152</pages>
       <url>W17-0419</url>
     </paper>
@@ -865,84 +865,84 @@
     </frontmatter>
     <paper id="1">
       <title>Variance in Historical Data: How bad is it and how can we profit from it for historical linguistics?</title>
-      <author><first>Stefanie</first> <last>Dipper</last></author>
+      <author><first>Stefanie</first><last>Dipper</last></author>
       <pages>1–1</pages>
       <url>W17-0501</url>
     </paper>
     <paper id="2">
       <title>Improving <fixed-case>POS</fixed-case> Tagging in Old <fixed-case>S</fixed-case>panish Using <fixed-case>TEITOK</fixed-case></title>
-      <author><first>Maarten</first> <last>Janssen</last></author>
-      <author><first>Josep</first> <last>Ausensi</last></author>
-      <author><first>Josep</first> <last>Fontana</last></author>
+      <author><first>Maarten</first><last>Janssen</last></author>
+      <author><first>Josep</first><last>Ausensi</last></author>
+      <author><first>Josep</first><last>Fontana</last></author>
       <pages>2–6</pages>
       <url>W17-0502</url>
     </paper>
     <paper id="3">
       <title>The Making of the Royal Society Corpus</title>
-      <author><first>Jörg</first> <last>Knappen</last></author>
-      <author><first>Stefan</first> <last>Fischer</last></author>
-      <author><first>Hannah</first> <last>Kermes</last></author>
-      <author><first>Elke</first> <last>Teich</last></author>
-      <author><first>Peter</first> <last>Fankhauser</last></author>
+      <author><first>Jörg</first><last>Knappen</last></author>
+      <author><first>Stefan</first><last>Fischer</last></author>
+      <author><first>Hannah</first><last>Kermes</last></author>
+      <author><first>Elke</first><last>Teich</last></author>
+      <author><first>Peter</first><last>Fankhauser</last></author>
       <pages>7–11</pages>
       <url>W17-0503</url>
     </paper>
     <paper id="4">
       <title>Normalizing Medieval <fixed-case>G</fixed-case>erman Texts: from rules to deep learning</title>
-      <author><first>Natalia</first> <last>Korchagina</last></author>
+      <author><first>Natalia</first><last>Korchagina</last></author>
       <pages>12–17</pages>
       <url>W17-0504</url>
     </paper>
     <paper id="5">
       <title>Ambiguity in Semantically Related Word Substitutions: an investigation in historical <fixed-case>B</fixed-case>ible translations</title>
-      <author><first>Maria</first> <last>Moritz</last></author>
-      <author><first>Marco</first> <last>Büchler</last></author>
+      <author><first>Maria</first><last>Moritz</last></author>
+      <author><first>Marco</first><last>Büchler</last></author>
       <pages>18–23</pages>
       <url>W17-0505</url>
     </paper>
     <paper id="6">
       <title>The Lemlat 3.0 Package for Morphological Analysis of <fixed-case>L</fixed-case>atin</title>
-      <author><first>Marco</first> <last>Passarotti</last></author>
-      <author><first>Marco</first> <last>Budassi</last></author>
-      <author><first>Eleonora</first> <last>Litta</last></author>
-      <author><first>Paolo</first> <last>Ruffolo</last></author>
+      <author><first>Marco</first><last>Passarotti</last></author>
+      <author><first>Marco</first><last>Budassi</last></author>
+      <author><first>Eleonora</first><last>Litta</last></author>
+      <author><first>Paolo</first><last>Ruffolo</last></author>
       <pages>24–31</pages>
       <url>W17-0506</url>
     </paper>
     <paper id="7">
       <title><fixed-case>H</fixed-case>isto<fixed-case>B</fixed-case>ank<fixed-case>V</fixed-case>is: Detecting Language Change via Data Visualization</title>
-      <author><first>Christin</first> <last>Schätzle</last></author>
-      <author><first>Michael</first> <last>Hund</last></author>
-      <author><first>Frederik</first> <last>Dennig</last></author>
-      <author><first>Miriam</first> <last>Butt</last></author>
-      <author><first>Daniel</first> <last>Keim</last></author>
+      <author><first>Christin</first><last>Schätzle</last></author>
+      <author><first>Michael</first><last>Hund</last></author>
+      <author><first>Frederik</first><last>Dennig</last></author>
+      <author><first>Miriam</first><last>Butt</last></author>
+      <author><first>Daniel</first><last>Keim</last></author>
       <pages>32–39</pages>
       <url>W17-0507</url>
     </paper>
     <paper id="8">
       <title>Comparing Rule-based and <fixed-case>SMT</fixed-case>-based Spelling Normalisation for <fixed-case>E</fixed-case>nglish Historical Texts</title>
-      <author><first>Gerold</first> <last>Schneider</last></author>
-      <author><first>Eva</first> <last>Pettersson</last></author>
-      <author><first>Michael</first> <last>Percillier</last></author>
+      <author><first>Gerold</first><last>Schneider</last></author>
+      <author><first>Eva</first><last>Pettersson</last></author>
+      <author><first>Michael</first><last>Percillier</last></author>
       <pages>40–46</pages>
       <url>W17-0508</url>
     </paper>
     <paper id="9">
       <title>Data-driven Morphology and Sociolinguistics for Early Modern <fixed-case>D</fixed-case>utch</title>
-      <author><first>Marijn</first> <last>Schraagen</last></author>
-      <author><first>Marjo</first> <last>van Koppen</last></author>
-      <author><first>Feike</first> <last>Dietz</last></author>
+      <author><first>Marijn</first><last>Schraagen</last></author>
+      <author><first>Marjo</first><last>van Koppen</last></author>
+      <author><first>Feike</first><last>Dietz</last></author>
       <pages>47–53</pages>
       <url>W17-0509</url>
     </paper>
     <paper id="10">
       <title>Applying <fixed-case>BLAST</fixed-case> to Text Reuse Detection in <fixed-case>F</fixed-case>innish Newspapers and Journals, 1771-1910</title>
-      <author><first>Aleksi</first> <last>Vesanto</last></author>
-      <author><first>Asko</first> <last>Nivala</last></author>
-      <author><first>Heli</first> <last>Rantala</last></author>
-      <author><first>Tapio</first> <last>Salakoski</last></author>
-      <author><first>Hannu</first> <last>Salmi</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
+      <author><first>Aleksi</first><last>Vesanto</last></author>
+      <author><first>Asko</first><last>Nivala</last></author>
+      <author><first>Heli</first><last>Rantala</last></author>
+      <author><first>Tapio</first><last>Salakoski</last></author>
+      <author><first>Hannu</first><last>Salmi</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
       <pages>54–58</pages>
       <url>W17-0510</url>
     </paper>
@@ -966,71 +966,71 @@
     </frontmatter>
     <paper id="1">
       <title>Synchronized Mediawiki based analyzer dictionary development</title>
-      <author><first>Jack</first> <last>Rueter</last></author>
-      <author><first>Mika</first> <last>Hämäläinen</last></author>
+      <author><first>Jack</first><last>Rueter</last></author>
+      <author><first>Mika</first><last>Hämäläinen</last></author>
       <pages>1–7</pages>
       <url>W17-0601</url>
       <doi>10.18653/v1/W17-0601</doi>
     </paper>
     <paper id="2">
       <title><fixed-case>DEMO</fixed-case>: Giellatekno Open-source click-in-text dictionaries for bringing closely related languages into contact.</title>
-      <author><first>Jack</first> <last>Rueter</last></author>
+      <author><first>Jack</first><last>Rueter</last></author>
       <pages>8–9</pages>
       <url>W17-0602</url>
       <doi>10.18653/v1/W17-0602</doi>
     </paper>
     <paper id="3">
       <title>Languages under the influence: Building a database of Uralic languages</title>
-      <author><first>Eszter</first> <last>Simon</last></author>
-      <author><first>Nikolett</first> <last>Mus</last></author>
+      <author><first>Eszter</first><last>Simon</last></author>
+      <author><first>Nikolett</first><last>Mus</last></author>
       <pages>10–24</pages>
       <url>W17-0603</url>
       <doi>10.18653/v1/W17-0603</doi>
     </paper>
     <paper id="4">
       <title>Instant Annotations – Applying <fixed-case>NLP</fixed-case> Methods to the Annotation of Spoken Language Documentation Corpora</title>
-      <author><first>Ciprian</first> <last>Gerstenberger</last></author>
-      <author><first>Niko</first> <last>Partanen</last></author>
-      <author><first>Michael</first> <last>Rießler</last></author>
-      <author><first>Joshua</first> <last>Wilbur</last></author>
+      <author><first>Ciprian</first><last>Gerstenberger</last></author>
+      <author><first>Niko</first><last>Partanen</last></author>
+      <author><first>Michael</first><last>Rießler</last></author>
+      <author><first>Joshua</first><last>Wilbur</last></author>
       <pages>25–36</pages>
       <url>W17-0604</url>
       <doi>10.18653/v1/W17-0604</doi>
     </paper>
     <paper id="5">
       <title>Preliminary Experiments concerning Verbal Predicative Structure Extraction from a Large <fixed-case>F</fixed-case>innish Corpus</title>
-      <author><first>Guersande</first> <last>Chaminade</last></author>
-      <author><first>Thierry</first> <last>Poibeau</last></author>
+      <author><first>Guersande</first><last>Chaminade</last></author>
+      <author><first>Thierry</first><last>Poibeau</last></author>
       <pages>37–55</pages>
       <url>W17-0605</url>
       <doi>10.18653/v1/W17-0605</doi>
     </paper>
     <paper id="6">
       <title>Language technology resources and tools for Mansi: an overview</title>
-      <author><first>Csilla</first> <last>Horváth</last></author>
-      <author><first>Norbert</first> <last>Szilágyi</last></author>
-      <author><first>Veronika</first> <last>Vincze</last></author>
-      <author><first>Ágoston</first> <last>Nagy</last></author>
+      <author><first>Csilla</first><last>Horváth</last></author>
+      <author><first>Norbert</first><last>Szilágyi</last></author>
+      <author><first>Veronika</first><last>Vincze</last></author>
+      <author><first>Ágoston</first><last>Nagy</last></author>
       <pages>56–65</pages>
       <url>W17-0606</url>
       <doi>10.18653/v1/W17-0606</doi>
     </paper>
     <paper id="7">
       <title>Annotation schemes in North Sámi dependency parsing</title>
-      <author><first>Francis M.</first> <last>Tyers</last></author>
-      <author><first>Mariya</first> <last>Sheyanova</last></author>
+      <author><first>Francis M.</first><last>Tyers</last></author>
+      <author><first>Mariya</first><last>Sheyanova</last></author>
       <pages>66–75</pages>
       <url>W17-0607</url>
       <doi>10.18653/v1/W17-0607</doi>
     </paper>
     <paper id="8">
       <title>A morphological analyser for Kven</title>
-      <author><first>Sindre</first> <last>Reino Trosterud</last></author>
-      <author><first>Trond</first> <last>Trosterud</last></author>
-      <author><first>Anna-Kaisa</first> <last>Räisänen</last></author>
-      <author><first>Leena</first> <last>Niiranen</last></author>
-      <author><first>Mervi</first> <last>Haavisto</last></author>
-      <author><first>Kaisa</first> <last>Maliniemi</last></author>
+      <author><first>Sindre</first><last>Reino Trosterud</last></author>
+      <author><first>Trond</first><last>Trosterud</last></author>
+      <author><first>Anna-Kaisa</first><last>Räisänen</last></author>
+      <author><first>Leena</first><last>Niiranen</last></author>
+      <author><first>Mervi</first><last>Haavisto</last></author>
+      <author><first>Kaisa</first><last>Maliniemi</last></author>
       <pages>76–88</pages>
       <url>W17-0608</url>
       <doi>10.18653/v1/W17-0608</doi>
@@ -1055,10 +1055,10 @@
     </frontmatter>
     <paper id="1">
       <title>Entropy Reduction correlates with temporal lobe activity</title>
-      <author><first>Matthew</first> <last>Nelson</last></author>
-      <author><first>Stanislas</first> <last>Dehaene</last></author>
-      <author><first>Christophe</first> <last>Pallier</last></author>
-      <author><first>John</first> <last>Hale</last></author>
+      <author><first>Matthew</first><last>Nelson</last></author>
+      <author><first>Stanislas</first><last>Dehaene</last></author>
+      <author><first>Christophe</first><last>Pallier</last></author>
+      <author><first>John</first><last>Hale</last></author>
       <pages>1–10</pages>
       <url>W17-0701</url>
       <doi>10.18653/v1/W17-0701</doi>
@@ -1066,9 +1066,9 @@
     </paper>
     <paper id="2">
       <title>Learning an Input Filter for Argument Structure Acquisition</title>
-      <author><first>Laurel</first> <last>Perkins</last></author>
-      <author><first>Naomi</first> <last>Feldman</last></author>
-      <author><first>Jeffrey</first> <last>Lidz</last></author>
+      <author><first>Laurel</first><last>Perkins</last></author>
+      <author><first>Naomi</first><last>Feldman</last></author>
+      <author><first>Jeffrey</first><last>Lidz</last></author>
       <pages>11–19</pages>
       <url>W17-0702</url>
       <doi>10.18653/v1/W17-0702</doi>
@@ -1076,8 +1076,8 @@
     </paper>
     <paper id="3">
       <title>Grounding sound change in ideal observer models of perception</title>
-      <author><first>Zachary</first> <last>Burchill</last></author>
-      <author><first>T. Florian</first> <last>Jaeger</last></author>
+      <author><first>Zachary</first><last>Burchill</last></author>
+      <author><first>T. Florian</first><last>Jaeger</last></author>
       <pages>20–28</pages>
       <url>W17-0703</url>
       <doi>10.18653/v1/W17-0703</doi>
@@ -1085,7 +1085,7 @@
     </paper>
     <paper id="4">
       <title>“Oh, <fixed-case>I</fixed-case>’ve Heard That Before”: Modelling Own-Dialect Bias After Perceptual Learning by Weighting Training Data</title>
-      <author><first>Rachael</first> <last>Tatman</last></author>
+      <author><first>Rachael</first><last>Tatman</last></author>
       <pages>29–34</pages>
       <url>W17-0704</url>
       <doi>10.18653/v1/W17-0704</doi>
@@ -1093,7 +1093,7 @@
     </paper>
     <paper id="5">
       <title>Inherent Biases of Recurrent Neural Networks for Phonological Assimilation and Dissimilation</title>
-      <author><first>Amanda</first> <last>Doucette</last></author>
+      <author><first>Amanda</first><last>Doucette</last></author>
       <pages>35–40</pages>
       <url>W17-0705</url>
       <doi>10.18653/v1/W17-0705</doi>
@@ -1101,7 +1101,7 @@
     </paper>
     <paper id="6">
       <title>Predicting <fixed-case>J</fixed-case>apanese scrambling in the wild</title>
-      <author><first>Naho</first> <last>Orita</last></author>
+      <author><first>Naho</first><last>Orita</last></author>
       <pages>41–45</pages>
       <url>W17-0706</url>
       <doi>10.18653/v1/W17-0706</doi>
@@ -1125,8 +1125,8 @@
     </frontmatter>
     <paper id="1">
       <title>Readers vs. Writers vs. Texts: Coping with Different Perspectives of Text Understanding in Emotion Annotation</title>
-      <author><first>Sven</first> <last>Buechel</last></author>
-      <author><first>Udo</first> <last>Hahn</last></author>
+      <author><first>Sven</first><last>Buechel</last></author>
+      <author><first>Udo</first><last>Hahn</last></author>
       <pages>1–12</pages>
       <url>W17-0801</url>
       <doi>10.18653/v1/W17-0801</doi>
@@ -1134,11 +1134,11 @@
     </paper>
     <paper id="2">
       <title>Finding Good Conversations Online: The Yahoo News Annotated Comments Corpus</title>
-      <author><first>Courtney</first> <last>Napoles</last></author>
-      <author><first>Joel</first> <last>Tetreault</last></author>
-      <author><first>Aasish</first> <last>Pappu</last></author>
-      <author><first>Enrica</first> <last>Rosato</last></author>
-      <author><first>Brian</first> <last>Provenzale</last></author>
+      <author><first>Courtney</first><last>Napoles</last></author>
+      <author><first>Joel</first><last>Tetreault</last></author>
+      <author><first>Aasish</first><last>Pappu</last></author>
+      <author><first>Enrica</first><last>Rosato</last></author>
+      <author><first>Brian</first><last>Provenzale</last></author>
       <pages>13–23</pages>
       <url>W17-0802</url>
       <doi>10.18653/v1/W17-0802</doi>
@@ -1146,8 +1146,8 @@
     </paper>
     <paper id="3">
       <title>Crowdsourcing discourse interpretations: On the influence of context and the reliability of a connective insertion task</title>
-      <author><first>Merel</first> <last>Scholman</last></author>
-      <author><first>Vera</first> <last>Demberg</last></author>
+      <author><first>Merel</first><last>Scholman</last></author>
+      <author><first>Vera</first><last>Demberg</last></author>
       <pages>24–33</pages>
       <url>W17-0803</url>
       <doi>10.18653/v1/W17-0803</doi>
@@ -1155,7 +1155,7 @@
     </paper>
     <paper id="4">
       <title>A Code-Switching Corpus of <fixed-case>T</fixed-case>urkish-<fixed-case>G</fixed-case>erman Conversations</title>
-      <author><first>Özlem</first> <last>Çetinoğlu</last></author>
+      <author><first>Özlem</first><last>Çetinoğlu</last></author>
       <pages>34–40</pages>
       <url>W17-0804</url>
       <doi>10.18653/v1/W17-0804</doi>
@@ -1163,9 +1163,9 @@
     </paper>
     <paper id="5">
       <title>Annotating omission in statement pairs</title>
-      <author><first>Héctor</first> <last>Martínez Alonso</last></author>
-      <author><first>Amaury</first> <last>Delamaire</last></author>
-      <author><first>Benoît</first> <last>Sagot</last></author>
+      <author><first>Héctor</first><last>Martínez Alonso</last></author>
+      <author><first>Amaury</first><last>Delamaire</last></author>
+      <author><first>Benoît</first><last>Sagot</last></author>
       <pages>41–45</pages>
       <url>W17-0805</url>
       <doi>10.18653/v1/W17-0805</doi>
@@ -1173,11 +1173,11 @@
     </paper>
     <paper id="6">
       <title>Annotating Speech, Attitude and Perception Reports</title>
-      <author><first>Corien</first> <last>Bary</last></author>
-      <author><first>Leopold</first> <last>Hess</last></author>
-      <author><first>Kees</first> <last>Thijs</last></author>
-      <author><first>Peter</first> <last>Berck</last></author>
-      <author><first>Iris</first> <last>Hendrickx</last></author>
+      <author><first>Corien</first><last>Bary</last></author>
+      <author><first>Leopold</first><last>Hess</last></author>
+      <author><first>Kees</first><last>Thijs</last></author>
+      <author><first>Peter</first><last>Berck</last></author>
+      <author><first>Iris</first><last>Hendrickx</last></author>
       <pages>46–56</pages>
       <url>W17-0806</url>
       <doi>10.18653/v1/W17-0806</doi>
@@ -1185,12 +1185,12 @@
     </paper>
     <paper id="7">
       <title>Consistent Classification of Translation Revisions: A Case Study of <fixed-case>E</fixed-case>nglish-<fixed-case>J</fixed-case>apanese Student Translations</title>
-      <author><first>Atsushi</first> <last>Fujita</last></author>
-      <author><first>Kikuko</first> <last>Tanabe</last></author>
-      <author><first>Chiho</first> <last>Toyoshima</last></author>
-      <author><first>Mayuka</first> <last>Yamamoto</last></author>
-      <author><first>Kyo</first> <last>Kageura</last></author>
-      <author><first>Anthony</first> <last>Hartley</last></author>
+      <author><first>Atsushi</first><last>Fujita</last></author>
+      <author><first>Kikuko</first><last>Tanabe</last></author>
+      <author><first>Chiho</first><last>Toyoshima</last></author>
+      <author><first>Mayuka</first><last>Yamamoto</last></author>
+      <author><first>Kyo</first><last>Kageura</last></author>
+      <author><first>Anthony</first><last>Hartley</last></author>
       <pages>57–66</pages>
       <url>W17-0807</url>
       <doi>10.18653/v1/W17-0807</doi>
@@ -1198,13 +1198,13 @@
     </paper>
     <paper id="8">
       <title>Representation and Interchange of Linguistic Annotation. An In-Depth, Side-by-Side Comparison of Three Designs</title>
-      <author><first>Richard</first> <last>Eckart de Castilho</last></author>
-      <author><first>Nancy</first> <last>Ide</last></author>
-      <author><first>Emanuele</first> <last>Lapponi</last></author>
-      <author><first>Stephan</first> <last>Oepen</last></author>
-      <author><first>Keith</first> <last>Suderman</last></author>
-      <author><first>Erik</first> <last>Velldal</last></author>
-      <author><first>Marc</first> <last>Verhagen</last></author>
+      <author><first>Richard</first><last>Eckart de Castilho</last></author>
+      <author><first>Nancy</first><last>Ide</last></author>
+      <author><first>Emanuele</first><last>Lapponi</last></author>
+      <author><first>Stephan</first><last>Oepen</last></author>
+      <author><first>Keith</first><last>Suderman</last></author>
+      <author><first>Erik</first><last>Velldal</last></author>
+      <author><first>Marc</first><last>Verhagen</last></author>
       <pages>67–75</pages>
       <url>W17-0808</url>
       <doi>10.18653/v1/W17-0808</doi>
@@ -1212,8 +1212,8 @@
     </paper>
     <paper id="9">
       <title><fixed-case>TDB</fixed-case> 1.1: Extensions on <fixed-case>T</fixed-case>urkish Discourse Bank</title>
-      <author><first>Deniz</first> <last>Zeyrek</last></author>
-      <author><first>Murathan</first> <last>Kurfalı</last></author>
+      <author><first>Deniz</first><last>Zeyrek</last></author>
+      <author><first>Murathan</first><last>Kurfalı</last></author>
       <pages>76–81</pages>
       <url>W17-0809</url>
       <doi>10.18653/v1/W17-0809</doi>
@@ -1221,12 +1221,12 @@
     </paper>
     <paper id="10">
       <title>Two Layers of Annotation for Representing Event Mentions in News Stories</title>
-      <author><first>Maria Pia</first> <last>di Buono</last></author>
-      <author><first>Martin</first> <last>Tutek</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
-      <author><first>Goran</first> <last>Glavaš</last></author>
-      <author><first>Bojana</first> <last>Dalbelo Bašić</last></author>
-      <author><first>Nataša</first> <last>Milić-Frayling</last></author>
+      <author><first>Maria Pia</first><last>di Buono</last></author>
+      <author><first>Martin</first><last>Tutek</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
+      <author><first>Goran</first><last>Glavaš</last></author>
+      <author><first>Bojana</first><last>Dalbelo Bašić</last></author>
+      <author><first>Nataša</first><last>Milić-Frayling</last></author>
       <pages>82–90</pages>
       <url>W17-0810</url>
       <doi>10.18653/v1/W17-0810</doi>
@@ -1234,11 +1234,11 @@
     </paper>
     <paper id="11">
       <title>Word Similarity Datasets for <fixed-case>I</fixed-case>ndian Languages: Annotation and Baseline Systems</title>
-      <author><first>Syed Sarfaraz</first> <last>Akhtar</last></author>
-      <author><first>Arihant</first> <last>Gupta</last></author>
-      <author><first>Avijit</first> <last>Vajpayee</last></author>
-      <author><first>Arjit</first> <last>Srivastava</last></author>
-      <author><first>Manish</first> <last>Shrivastava</last></author>
+      <author><first>Syed Sarfaraz</first><last>Akhtar</last></author>
+      <author><first>Arihant</first><last>Gupta</last></author>
+      <author><first>Avijit</first><last>Vajpayee</last></author>
+      <author><first>Arjit</first><last>Srivastava</last></author>
+      <author><first>Manish</first><last>Shrivastava</last></author>
       <pages>91–94</pages>
       <url>W17-0811</url>
       <doi>10.18653/v1/W17-0811</doi>
@@ -1246,9 +1246,9 @@
     </paper>
     <paper id="12">
       <title>The <fixed-case>BEC</fixed-case>au<fixed-case>SE</fixed-case> Corpus 2.0: Annotating Causality and Overlapping Relations</title>
-      <author><first>Jesse</first> <last>Dunietz</last></author>
-      <author><first>Lori</first> <last>Levin</last></author>
-      <author><first>Jaime</first> <last>Carbonell</last></author>
+      <author><first>Jesse</first><last>Dunietz</last></author>
+      <author><first>Lori</first><last>Levin</last></author>
+      <author><first>Jaime</first><last>Carbonell</last></author>
       <pages>95–104</pages>
       <url>W17-0812</url>
       <doi>10.18653/v1/W17-0812</doi>
@@ -1256,8 +1256,8 @@
     </paper>
     <paper id="13">
       <title>Catching the Common Cause: Extraction and Annotation of Causal Relations and their Participants</title>
-      <author><first>Ines</first> <last>Rehbein</last></author>
-      <author><first>Josef</first> <last>Ruppenhofer</last></author>
+      <author><first>Ines</first><last>Rehbein</last></author>
+      <author><first>Josef</first><last>Ruppenhofer</last></author>
       <pages>105–114</pages>
       <url>W17-0813</url>
       <doi>10.18653/v1/W17-0813</doi>
@@ -1265,11 +1265,11 @@
     </paper>
     <paper id="14">
       <title>Assessing <fixed-case>SRL</fixed-case> Frameworks with Automatic Training Data Expansion</title>
-      <author><first>Silvana</first> <last>Hartmann</last></author>
-      <author><first>Éva</first> <last>Mújdricza-Maydt</last></author>
-      <author><first>Ilia</first> <last>Kuznetsov</last></author>
-      <author><first>Iryna</first> <last>Gurevych</last></author>
-      <author><first>Anette</first> <last>Frank</last></author>
+      <author><first>Silvana</first><last>Hartmann</last></author>
+      <author><first>Éva</first><last>Mújdricza-Maydt</last></author>
+      <author><first>Ilia</first><last>Kuznetsov</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
+      <author><first>Anette</first><last>Frank</last></author>
       <pages>115–121</pages>
       <url>W17-0814</url>
       <doi>10.18653/v1/W17-0814</doi>
@@ -1295,10 +1295,10 @@
     </frontmatter>
     <paper id="1">
       <title>Inducing Script Structure from Crowdsourced Event Descriptions via Semi-Supervised Clustering</title>
-      <author><first>Lilian</first> <last>Wanzare</last></author>
-      <author><first>Alessandra</first> <last>Zarcone</last></author>
-      <author><first>Stefan</first> <last>Thater</last></author>
-      <author><first>Manfred</first> <last>Pinkal</last></author>
+      <author><first>Lilian</first><last>Wanzare</last></author>
+      <author><first>Alessandra</first><last>Zarcone</last></author>
+      <author><first>Stefan</first><last>Thater</last></author>
+      <author><first>Manfred</first><last>Pinkal</last></author>
       <pages>1–11</pages>
       <url>W17-0901</url>
       <doi>10.18653/v1/W17-0901</doi>
@@ -1306,16 +1306,16 @@
     </paper>
     <paper id="2">
       <title>A Consolidated Open Knowledge Representation for Multiple Texts</title>
-      <author><first>Rachel</first> <last>Wities</last></author>
-      <author><first>Vered</first> <last>Shwartz</last></author>
-      <author><first>Gabriel</first> <last>Stanovsky</last></author>
-      <author><first>Meni</first> <last>Adler</last></author>
-      <author><first>Ori</first> <last>Shapira</last></author>
-      <author><first>Shyam</first> <last>Upadhyay</last></author>
-      <author><first>Dan</first> <last>Roth</last></author>
-      <author><first>Eugenio</first> <last>Martinez Camara</last></author>
-      <author><first>Iryna</first> <last>Gurevych</last></author>
-      <author><first>Ido</first> <last>Dagan</last></author>
+      <author><first>Rachel</first><last>Wities</last></author>
+      <author><first>Vered</first><last>Shwartz</last></author>
+      <author><first>Gabriel</first><last>Stanovsky</last></author>
+      <author><first>Meni</first><last>Adler</last></author>
+      <author><first>Ori</first><last>Shapira</last></author>
+      <author><first>Shyam</first><last>Upadhyay</last></author>
+      <author><first>Dan</first><last>Roth</last></author>
+      <author><first>Eugenio</first><last>Martinez Camara</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
+      <author><first>Ido</first><last>Dagan</last></author>
       <pages>12–24</pages>
       <url>W17-0902</url>
       <doi>10.18653/v1/W17-0902</doi>
@@ -1323,8 +1323,8 @@
     </paper>
     <paper id="3">
       <title>Event-Related Features in Feedforward Neural Networks Contribute to Identifying Causal Relations in Discourse</title>
-      <author><first>Edoardo Maria</first> <last>Ponti</last></author>
-      <author><first>Anna</first> <last>Korhonen</last></author>
+      <author><first>Edoardo Maria</first><last>Ponti</last></author>
+      <author><first>Anna</first><last>Korhonen</last></author>
       <pages>25–30</pages>
       <url>W17-0903</url>
       <doi>10.18653/v1/W17-0903</doi>
@@ -1332,9 +1332,9 @@
     </paper>
     <paper id="4">
       <title>Stance Detection in <fixed-case>F</fixed-case>acebook Posts of a <fixed-case>G</fixed-case>erman Right-wing Party</title>
-      <author><first>Manfred</first> <last>Klenner</last></author>
-      <author><first>Don</first> <last>Tuggener</last></author>
-      <author><first>Simon</first> <last>Clematide</last></author>
+      <author><first>Manfred</first><last>Klenner</last></author>
+      <author><first>Don</first><last>Tuggener</last></author>
+      <author><first>Simon</first><last>Clematide</last></author>
       <pages>31–40</pages>
       <url>W17-0904</url>
       <doi>10.18653/v1/W17-0904</doi>
@@ -1342,7 +1342,7 @@
     </paper>
     <paper id="5">
       <title>Behind the Scenes of an Evolving Event Cloze Test</title>
-      <author><first>Nathanael</first> <last>Chambers</last></author>
+      <author><first>Nathanael</first><last>Chambers</last></author>
       <pages>41–45</pages>
       <url>W17-0905</url>
       <doi>10.18653/v1/W17-0905</doi>
@@ -1350,11 +1350,11 @@
     </paper>
     <paper id="6">
       <title><fixed-case>LSDS</fixed-case>em 2017 Shared Task: The Story Cloze Test</title>
-      <author><first>Nasrin</first> <last>Mostafazadeh</last></author>
-      <author><first>Michael</first> <last>Roth</last></author>
-      <author><first>Annie</first> <last>Louis</last></author>
-      <author><first>Nathanael</first> <last>Chambers</last></author>
-      <author><first>James</first> <last>Allen</last></author>
+      <author><first>Nasrin</first><last>Mostafazadeh</last></author>
+      <author><first>Michael</first><last>Roth</last></author>
+      <author><first>Annie</first><last>Louis</last></author>
+      <author><first>Nathanael</first><last>Chambers</last></author>
+      <author><first>James</first><last>Allen</last></author>
       <pages>46–51</pages>
       <url>W17-0906</url>
       <doi>10.18653/v1/W17-0906</doi>
@@ -1362,12 +1362,12 @@
     </paper>
     <paper id="7">
       <title>Story Cloze Task: <fixed-case>UW</fixed-case> <fixed-case>NLP</fixed-case> System</title>
-      <author><first>Roy</first> <last>Schwartz</last></author>
-      <author><first>Maarten</first> <last>Sap</last></author>
-      <author><first>Ioannis</first> <last>Konstas</last></author>
-      <author><first>Leila</first> <last>Zilles</last></author>
-      <author><first>Yejin</first> <last>Choi</last></author>
-      <author><first>Noah A.</first> <last>Smith</last></author>
+      <author><first>Roy</first><last>Schwartz</last></author>
+      <author><first>Maarten</first><last>Sap</last></author>
+      <author><first>Ioannis</first><last>Konstas</last></author>
+      <author><first>Leila</first><last>Zilles</last></author>
+      <author><first>Yejin</first><last>Choi</last></author>
+      <author><first>Noah A.</first><last>Smith</last></author>
       <pages>52–55</pages>
       <url>W17-0907</url>
       <doi>10.18653/v1/W17-0907</doi>
@@ -1375,15 +1375,15 @@
     </paper>
     <paper id="8">
       <title><fixed-case>LSDS</fixed-case>em 2017: Exploring Data Generation Methods for the Story Cloze Test</title>
-      <author><first>Michael</first> <last>Bugert</last></author>
-      <author><first>Yevgeniy</first> <last>Puzikov</last></author>
-      <author><first>Andreas</first> <last>Rücklé</last></author>
-      <author><first>Judith</first> <last>Eckle-Kohler</last></author>
-      <author><first>Teresa</first> <last>Martin</last></author>
-      <author><first>Eugenio</first> <last>Martínez-Cámara</last></author>
-      <author><first>Daniil</first> <last>Sorokin</last></author>
-      <author><first>Maxime</first> <last>Peyrard</last></author>
-      <author><first>Iryna</first> <last>Gurevych</last></author>
+      <author><first>Michael</first><last>Bugert</last></author>
+      <author><first>Yevgeniy</first><last>Puzikov</last></author>
+      <author><first>Andreas</first><last>Rücklé</last></author>
+      <author><first>Judith</first><last>Eckle-Kohler</last></author>
+      <author><first>Teresa</first><last>Martin</last></author>
+      <author><first>Eugenio</first><last>Martínez-Cámara</last></author>
+      <author><first>Daniil</first><last>Sorokin</last></author>
+      <author><first>Maxime</first><last>Peyrard</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
       <pages>56–61</pages>
       <url>W17-0908</url>
       <doi>10.18653/v1/W17-0908</doi>
@@ -1391,8 +1391,8 @@
     </paper>
     <paper id="9">
       <title>Sentiment Analysis and Lexical Cohesion for the Story Cloze Task</title>
-      <author><first>Michael</first> <last>Flor</last></author>
-      <author><first>Swapna</first> <last>Somasundaran</last></author>
+      <author><first>Michael</first><last>Flor</last></author>
+      <author><first>Swapna</first><last>Somasundaran</last></author>
       <pages>62–67</pages>
       <url>W17-0909</url>
       <doi>10.18653/v1/W17-0909</doi>
@@ -1400,8 +1400,8 @@
     </paper>
     <paper id="10">
       <title>Resource-Lean Modeling of Coherence in Commonsense Stories</title>
-      <author><first>Niko</first> <last>Schenk</last></author>
-      <author><first>Christian</first> <last>Chiarcos</last></author>
+      <author><first>Niko</first><last>Schenk</last></author>
+      <author><first>Christian</first><last>Chiarcos</last></author>
       <pages>68–73</pages>
       <url>W17-0910</url>
       <doi>10.18653/v1/W17-0910</doi>
@@ -1409,10 +1409,10 @@
     </paper>
     <paper id="11">
       <title>An <fixed-case>RNN</fixed-case>-based Binary Classifier for the Story Cloze Test</title>
-      <author><first>Melissa</first> <last>Roemmele</last></author>
-      <author><first>Sosuke</first> <last>Kobayashi</last></author>
-      <author><first>Naoya</first> <last>Inoue</last></author>
-      <author><first>Andrew</first> <last>Gordon</last></author>
+      <author><first>Melissa</first><last>Roemmele</last></author>
+      <author><first>Sosuke</first><last>Kobayashi</last></author>
+      <author><first>Naoya</first><last>Inoue</last></author>
+      <author><first>Andrew</first><last>Gordon</last></author>
       <pages>74–80</pages>
       <url>W17-0911</url>
       <doi>10.18653/v1/W17-0911</doi>
@@ -1420,8 +1420,8 @@
     </paper>
     <paper id="12">
       <title>IIT (BHU): System Description for LSDSem’17 Shared Task</title>
-      <author><first>Pranav</first> <last>Goel</last></author>
-      <author><first>Anil Kumar</first> <last>Singh</last></author>
+      <author><first>Pranav</first><last>Goel</last></author>
+      <author><first>Anil Kumar</first><last>Singh</last></author>
       <pages>81–86</pages>
       <url>W17-0912</url>
       <doi>10.18653/v1/W17-0912</doi>
@@ -1429,8 +1429,8 @@
     </paper>
     <paper id="13">
       <title>Story Cloze Ending Selection Baselines and Data Examination</title>
-      <author><first>Todor</first> <last>Mihaylov</last></author>
-      <author><first>Anette</first> <last>Frank</last></author>
+      <author><first>Todor</first><last>Mihaylov</last></author>
+      <author><first>Anette</first><last>Frank</last></author>
       <pages>87–92</pages>
       <url>W17-0913</url>
       <doi>10.18653/v1/W17-0913</doi>
@@ -1459,14 +1459,14 @@
     </frontmatter>
     <paper id="1">
       <title><fixed-case>M</fixed-case>ulti<fixed-case>L</fixed-case>ing 2017 Overview</title>
-      <author><first>George</first> <last>Giannakopoulos</last></author>
-      <author><first>John</first> <last>Conroy</last></author>
-      <author><first>Jeff</first> <last>Kubina</last></author>
-      <author><first>Peter A.</first> <last>Rankel</last></author>
-      <author><first>Elena</first> <last>Lloret</last></author>
-      <author><first>Josef</first> <last>Steinberger</last></author>
-      <author><first>Marina</first> <last>Litvak</last></author>
-      <author><first>Benoit</first> <last>Favre</last></author>
+      <author><first>George</first><last>Giannakopoulos</last></author>
+      <author><first>John</first><last>Conroy</last></author>
+      <author><first>Jeff</first><last>Kubina</last></author>
+      <author><first>Peter A.</first><last>Rankel</last></author>
+      <author><first>Elena</first><last>Lloret</last></author>
+      <author><first>Josef</first><last>Steinberger</last></author>
+      <author><first>Marina</first><last>Litvak</last></author>
+      <author><first>Benoit</first><last>Favre</last></author>
       <pages>1–6</pages>
       <url>W17-1001</url>
       <doi>10.18653/v1/W17-1001</doi>
@@ -1474,10 +1474,10 @@
     </paper>
     <paper id="2">
       <title>Decoupling Encoder and Decoder Networks for Abstractive Document Summarization</title>
-      <author><first>Ying</first> <last>Xu</last></author>
-      <author><first>Jey Han</first> <last>Lau</last></author>
-      <author><first>Timothy</first> <last>Baldwin</last></author>
-      <author><first>Trevor</first> <last>Cohn</last></author>
+      <author><first>Ying</first><last>Xu</last></author>
+      <author><first>Jey Han</first><last>Lau</last></author>
+      <author><first>Timothy</first><last>Baldwin</last></author>
+      <author><first>Trevor</first><last>Cohn</last></author>
       <pages>7–11</pages>
       <url>W17-1002</url>
       <doi>10.18653/v1/W17-1002</doi>
@@ -1485,9 +1485,9 @@
     </paper>
     <paper id="3">
       <title>Centroid-based Text Summarization through Compositionality of Word Embeddings</title>
-      <author><first>Gaetano</first> <last>Rossiello</last></author>
-      <author><first>Pierpaolo</first> <last>Basile</last></author>
-      <author><first>Giovanni</first> <last>Semeraro</last></author>
+      <author><first>Gaetano</first><last>Rossiello</last></author>
+      <author><first>Pierpaolo</first><last>Basile</last></author>
+      <author><first>Giovanni</first><last>Semeraro</last></author>
       <pages>12–21</pages>
       <url>W17-1003</url>
       <doi>10.18653/v1/W17-1003</doi>
@@ -1495,8 +1495,8 @@
     </paper>
     <paper id="4">
       <title>Query-based summarization using <fixed-case>MDL</fixed-case> principle</title>
-      <author><first>Marina</first> <last>Litvak</last></author>
-      <author><first>Natalia</first> <last>Vanetik</last></author>
+      <author><first>Marina</first><last>Litvak</last></author>
+      <author><first>Natalia</first><last>Vanetik</last></author>
       <pages>22–31</pages>
       <url>W17-1004</url>
       <doi>10.18653/v1/W17-1004</doi>
@@ -1504,9 +1504,9 @@
     </paper>
     <paper id="5">
       <title>Word Embedding and Topic Modeling Enhanced Multiple Features for Content Linking and Argument / Sentiment Labeling in Online Forums</title>
-      <author><first>Lei</first> <last>Li</last></author>
-      <author><first>Liyuan</first> <last>Mao</last></author>
-      <author><first>Moye</first> <last>Chen</last></author>
+      <author><first>Lei</first><last>Li</last></author>
+      <author><first>Liyuan</first><last>Mao</last></author>
+      <author><first>Moye</first><last>Chen</last></author>
       <pages>32–36</pages>
       <url>W17-1005</url>
       <doi>10.18653/v1/W17-1005</doi>
@@ -1514,10 +1514,10 @@
     </paper>
     <paper id="6">
       <title>Ultra-Concise Multi-genre Summarisation of Web2.0: towards Intelligent Content Generation</title>
-      <author><first>Elena</first> <last>Lloret</last></author>
-      <author><first>Ester</first> <last>Boldrini</last></author>
-      <author><first>Patricio</first> <last>Martínez-Barco</last></author>
-      <author><first>Manuel</first> <last>Palomar</last></author>
+      <author><first>Elena</first><last>Lloret</last></author>
+      <author><first>Ester</first><last>Boldrini</last></author>
+      <author><first>Patricio</first><last>Martínez-Barco</last></author>
+      <author><first>Manuel</first><last>Palomar</last></author>
       <pages>37–46</pages>
       <url>W17-1006</url>
       <doi>10.18653/v1/W17-1006</doi>
@@ -1525,9 +1525,9 @@
     </paper>
     <paper id="7">
       <title>Machine Learning Approach to Evaluate <fixed-case>M</fixed-case>ulti<fixed-case>L</fixed-case>ingual Summaries</title>
-      <author><first>Samira</first> <last>Ellouze</last></author>
-      <author><first>Maher</first> <last>Jaoua</last></author>
-      <author><first>Lamia</first> <last>Hadrich Belguith</last></author>
+      <author><first>Samira</first><last>Ellouze</last></author>
+      <author><first>Maher</first><last>Jaoua</last></author>
+      <author><first>Lamia</first><last>Hadrich Belguith</last></author>
       <pages>47–54</pages>
       <url>W17-1007</url>
       <doi>10.18653/v1/W17-1007</doi>
@@ -1551,8 +1551,8 @@
     </frontmatter>
     <paper id="1">
       <title>A Survey on Hate Speech Detection using Natural Language Processing</title>
-      <author><first>Anna</first> <last>Schmidt</last></author>
-      <author><first>Michael</first> <last>Wiegand</last></author>
+      <author><first>Anna</first><last>Schmidt</last></author>
+      <author><first>Michael</first><last>Wiegand</last></author>
       <pages>1–10</pages>
       <url>W17-1101</url>
       <doi>10.18653/v1/W17-1101</doi>
@@ -1560,11 +1560,11 @@
     </paper>
     <paper id="2">
       <title><fixed-case>F</fixed-case>acebook sentiment: Reactions and Emojis</title>
-      <author><first>Ye</first> <last>Tian</last></author>
-      <author><first>Thiago</first> <last>Galery</last></author>
-      <author><first>Giulio</first> <last>Dulcinati</last></author>
-      <author><first>Emilia</first> <last>Molimpakis</last></author>
-      <author><first>Chao</first> <last>Sun</last></author>
+      <author><first>Ye</first><last>Tian</last></author>
+      <author><first>Thiago</first><last>Galery</last></author>
+      <author><first>Giulio</first><last>Dulcinati</last></author>
+      <author><first>Emilia</first><last>Molimpakis</last></author>
+      <author><first>Chao</first><last>Sun</last></author>
       <pages>11–16</pages>
       <url>W17-1102</url>
       <doi>10.18653/v1/W17-1102</doi>
@@ -1572,10 +1572,10 @@
     </paper>
     <paper id="3">
       <title>Potential and Limitations of Cross-Domain Sentiment Classification</title>
-      <author><first>Jan Milan</first> <last>Deriu</last></author>
-      <author><first>Martin</first> <last>Weilenmann</last></author>
-      <author><first>Dirk</first> <last>Von Gruenigen</last></author>
-      <author><first>Mark</first> <last>Cieliebak</last></author>
+      <author><first>Jan Milan</first><last>Deriu</last></author>
+      <author><first>Martin</first><last>Weilenmann</last></author>
+      <author><first>Dirk</first><last>Von Gruenigen</last></author>
+      <author><first>Mark</first><last>Cieliebak</last></author>
       <pages>17–24</pages>
       <url>W17-1103</url>
       <doi>10.18653/v1/W17-1103</doi>
@@ -1583,10 +1583,10 @@
     </paper>
     <paper id="4">
       <title>Aligning Entity Names with Online Aliases on Twitter</title>
-      <author><first>Kevin</first> <last>McKelvey</last></author>
-      <author><first>Peter</first> <last>Goutzounis</last></author>
-      <author><first>Stephen</first> <last>da Cruz</last></author>
-      <author><first>Nathanael</first> <last>Chambers</last></author>
+      <author><first>Kevin</first><last>McKelvey</last></author>
+      <author><first>Peter</first><last>Goutzounis</last></author>
+      <author><first>Stephen</first><last>da Cruz</last></author>
+      <author><first>Nathanael</first><last>Chambers</last></author>
       <pages>25–35</pages>
       <url>W17-1104</url>
       <doi>10.18653/v1/W17-1104</doi>
@@ -1594,9 +1594,9 @@
     </paper>
     <paper id="5">
       <title>Character-based Neural Embeddings for Tweet Clustering</title>
-      <author><first>Svitlana</first> <last>Vakulenko</last></author>
-      <author><first>Lyndon</first> <last>Nixon</last></author>
-      <author><first>Mihai</first> <last>Lupu</last></author>
+      <author><first>Svitlana</first><last>Vakulenko</last></author>
+      <author><first>Lyndon</first><last>Nixon</last></author>
+      <author><first>Mihai</first><last>Lupu</last></author>
       <pages>36–44</pages>
       <url>W17-1105</url>
       <doi>10.18653/v1/W17-1105</doi>
@@ -1605,10 +1605,10 @@
     </paper>
     <paper id="6">
       <title>A Twitter Corpus and Benchmark Resources for <fixed-case>G</fixed-case>erman Sentiment Analysis</title>
-      <author><first>Mark</first> <last>Cieliebak</last></author>
-      <author><first>Jan Milan</first> <last>Deriu</last></author>
-      <author><first>Dominic</first> <last>Egger</last></author>
-      <author><first>Fatih</first> <last>Uzdilli</last></author>
+      <author><first>Mark</first><last>Cieliebak</last></author>
+      <author><first>Jan Milan</first><last>Deriu</last></author>
+      <author><first>Dominic</first><last>Egger</last></author>
+      <author><first>Fatih</first><last>Uzdilli</last></author>
       <pages>45–51</pages>
       <url>W17-1106</url>
       <doi>10.18653/v1/W17-1106</doi>
@@ -1636,14 +1636,14 @@
     </frontmatter>
     <paper id="1">
       <title>Findings of the <fixed-case>V</fixed-case>ar<fixed-case>D</fixed-case>ial Evaluation Campaign 2017</title>
-      <author><first>Marcos</first> <last>Zampieri</last></author>
-      <author><first>Shervin</first> <last>Malmasi</last></author>
-      <author><first>Nikola</first> <last>Ljubešić</last></author>
-      <author><first>Preslav</first> <last>Nakov</last></author>
-      <author><first>Ahmed</first> <last>Ali</last></author>
-      <author><first>Jörg</first> <last>Tiedemann</last></author>
-      <author><first>Yves</first> <last>Scherrer</last></author>
-      <author><first>Noëmi</first> <last>Aepli</last></author>
+      <author><first>Marcos</first><last>Zampieri</last></author>
+      <author><first>Shervin</first><last>Malmasi</last></author>
+      <author><first>Nikola</first><last>Ljubešić</last></author>
+      <author><first>Preslav</first><last>Nakov</last></author>
+      <author><first>Ahmed</first><last>Ali</last></author>
+      <author><first>Jörg</first><last>Tiedemann</last></author>
+      <author><first>Yves</first><last>Scherrer</last></author>
+      <author><first>Noëmi</first><last>Aepli</last></author>
       <pages>1–15</pages>
       <url>W17-1201</url>
       <doi>10.18653/v1/W17-1201</doi>
@@ -1651,8 +1651,8 @@
     </paper>
     <paper id="2">
       <title>Dialectometric analysis of language variation in Twitter</title>
-      <author><first>Gonzalo</first> <last>Donoso</last></author>
-      <author><first>David</first> <last>Sánchez</last></author>
+      <author><first>Gonzalo</first><last>Donoso</last></author>
+      <author><first>David</first><last>Sánchez</last></author>
       <pages>16–25</pages>
       <url>W17-1202</url>
       <doi>10.18653/v1/W17-1202</doi>
@@ -1660,9 +1660,9 @@
     </paper>
     <paper id="3">
       <title>Computational analysis of <fixed-case>G</fixed-case>ondi dialects</title>
-      <author><first>Taraka</first> <last>Rama</last></author>
-      <author><first>Çağrı</first> <last>Çöltekin</last></author>
-      <author><first>Pavel</first> <last>Sofroniev</last></author>
+      <author><first>Taraka</first><last>Rama</last></author>
+      <author><first>Çağrı</first><last>Çöltekin</last></author>
+      <author><first>Pavel</first><last>Sofroniev</last></author>
       <pages>26–35</pages>
       <url>W17-1203</url>
       <doi>10.18653/v1/W17-1203</doi>
@@ -1670,8 +1670,8 @@
     </paper>
     <paper id="4">
       <title>Investigating Diatopic Variation in a Historical Corpus</title>
-      <author><first>Stefanie</first> <last>Dipper</last></author>
-      <author><first>Sandra</first> <last>Waldenberger</last></author>
+      <author><first>Stefanie</first><last>Dipper</last></author>
+      <author><first>Sandra</first><last>Waldenberger</last></author>
       <pages>36–45</pages>
       <url>W17-1204</url>
       <doi>10.18653/v1/W17-1204</doi>
@@ -1679,7 +1679,7 @@
     </paper>
     <paper id="5">
       <title>Author Profiling at <fixed-case>PAN</fixed-case>: from Age and Gender Identification to Language Variety Identification (invited talk)</title>
-      <author><first>Paolo</first> <last>Rosso</last></author>
+      <author><first>Paolo</first><last>Rosso</last></author>
       <pages>46</pages>
       <url>W17-1205</url>
       <doi>10.18653/v1/W17-1205</doi>
@@ -1687,7 +1687,7 @@
     </paper>
     <paper id="6">
       <title>The similarity and Mutual Intelligibility between <fixed-case>A</fixed-case>mharic and <fixed-case>T</fixed-case>igrigna Varieties</title>
-      <author><first>Tekabe Legesse</first> <last>Feleke</last></author>
+      <author><first>Tekabe Legesse</first><last>Feleke</last></author>
       <pages>47–54</pages>
       <url>W17-1206</url>
       <doi>10.18653/v1/W17-1206</doi>
@@ -1695,7 +1695,7 @@
     </paper>
     <paper id="7">
       <title>Why <fixed-case>C</fixed-case>atalan-<fixed-case>S</fixed-case>panish Neural Machine Translation? Analysis, comparison and combination with standard Rule and Phrase-based technologies</title>
-      <author><first>Marta R.</first> <last>Costa-jussà</last></author>
+      <author><first>Marta R.</first><last>Costa-jussà</last></author>
       <pages>55–62</pages>
       <url>W17-1207</url>
       <doi>10.18653/v1/W17-1207</doi>
@@ -1703,7 +1703,7 @@
     </paper>
     <paper id="8">
       <title><fixed-case>K</fixed-case>urdish Interdialect Machine Translation</title>
-      <author><first>Hossein</first> <last>Hassani</last></author>
+      <author><first>Hossein</first><last>Hassani</last></author>
       <pages>63–72</pages>
       <url>W17-1208</url>
       <doi>10.18653/v1/W17-1208</doi>
@@ -1711,8 +1711,8 @@
     </paper>
     <paper id="9">
       <title>Twitter Language Identification Of Similar Languages And Dialects Without Ground Truth</title>
-      <author><first>Jennifer</first> <last>Williams</last></author>
-      <author><first>Charlie</first> <last>Dagli</last></author>
+      <author><first>Jennifer</first><last>Williams</last></author>
+      <author><first>Charlie</first><last>Dagli</last></author>
       <pages>73–83</pages>
       <url>W17-1209</url>
       <doi>10.18653/v1/W17-1209</doi>
@@ -1720,8 +1720,8 @@
     </paper>
     <paper id="10">
       <title>Multi-source morphosyntactic tagging for spoken <fixed-case>R</fixed-case>usyn</title>
-      <author><first>Yves</first> <last>Scherrer</last></author>
-      <author><first>Achim</first> <last>Rabus</last></author>
+      <author><first>Yves</first><last>Scherrer</last></author>
+      <author><first>Achim</first><last>Rabus</last></author>
       <pages>84–92</pages>
       <url>W17-1210</url>
       <doi>10.18653/v1/W17-1210</doi>
@@ -1729,9 +1729,9 @@
     </paper>
     <paper id="11">
       <title>Identifying dialects with textual and acoustic cues</title>
-      <author><first>Abualsoud</first> <last>Hanani</last></author>
-      <author><first>Aziz</first> <last>Qaroush</last></author>
-      <author><first>Stephen</first> <last>Taylor</last></author>
+      <author><first>Abualsoud</first><last>Hanani</last></author>
+      <author><first>Aziz</first><last>Qaroush</last></author>
+      <author><first>Stephen</first><last>Taylor</last></author>
       <pages>93–101</pages>
       <url>W17-1211</url>
       <doi>10.18653/v1/W17-1211</doi>
@@ -1739,9 +1739,9 @@
     </paper>
     <paper id="12">
       <title>Evaluating <fixed-case>H</fixed-case>e<fixed-case>LI</fixed-case> with Non-Linear Mappings</title>
-      <author><first>Tommi</first> <last>Jauhiainen</last></author>
-      <author><first>Krister</first> <last>Lindén</last></author>
-      <author><first>Heidi</first> <last>Jauhiainen</last></author>
+      <author><first>Tommi</first><last>Jauhiainen</last></author>
+      <author><first>Krister</first><last>Lindén</last></author>
+      <author><first>Heidi</first><last>Jauhiainen</last></author>
       <pages>102–108</pages>
       <url>W17-1212</url>
       <doi>10.18653/v1/W17-1212</doi>
@@ -1749,9 +1749,9 @@
     </paper>
     <paper id="13">
       <title>A Perplexity-Based Method for Similar Languages Discrimination</title>
-      <author><first>Pablo</first> <last>Gamallo</last></author>
-      <author><first>Jose Ramom</first> <last>Pichel</last></author>
-      <author><first>Iñaki</first> <last>Alegria</last></author>
+      <author><first>Pablo</first><last>Gamallo</last></author>
+      <author><first>Jose Ramom</first><last>Pichel</last></author>
+      <author><first>Iñaki</first><last>Alegria</last></author>
       <pages>109–114</pages>
       <url>W17-1213</url>
       <doi>10.18653/v1/W17-1213</doi>
@@ -1759,7 +1759,7 @@
     </paper>
     <paper id="14">
       <title>Improving the Character Ngram Model for the <fixed-case>DSL</fixed-case> Task with <fixed-case>BM</fixed-case>25 Weighting and Less Frequently Used Feature Sets</title>
-      <author><first>Yves</first> <last>Bestgen</last></author>
+      <author><first>Yves</first><last>Bestgen</last></author>
       <pages>115–123</pages>
       <url>W17-1214</url>
       <doi>10.18653/v1/W17-1214</doi>
@@ -1767,8 +1767,8 @@
     </paper>
     <paper id="15">
       <title>Discriminating between Similar Languages with Word-level Convolutional Neural Networks</title>
-      <author><first>Marcelo</first> <last>Criscuolo</last></author>
-      <author><first>Sandra Maria</first> <last>Aluísio</last></author>
+      <author><first>Marcelo</first><last>Criscuolo</last></author>
+      <author><first>Sandra Maria</first><last>Aluísio</last></author>
       <pages>124–130</pages>
       <url>W17-1215</url>
       <doi>10.18653/v1/W17-1215</doi>
@@ -1776,7 +1776,7 @@
     </paper>
     <paper id="16">
       <title>Cross-lingual dependency parsing for closely related languages - <fixed-case>H</fixed-case>elsinki’s submission to <fixed-case>V</fixed-case>ar<fixed-case>D</fixed-case>ial 2017</title>
-      <author><first>Jörg</first> <last>Tiedemann</last></author>
+      <author><first>Jörg</first><last>Tiedemann</last></author>
       <pages>131–136</pages>
       <url>W17-1216</url>
       <doi>10.18653/v1/W17-1216</doi>
@@ -1784,11 +1784,11 @@
     </paper>
     <paper id="17">
       <title>Discriminating between Similar Languages Using a Combination of Typed and Untyped Character N-grams and Words</title>
-      <author><first>Helena</first> <last>Gomez</last></author>
-      <author><first>Ilia</first> <last>Markov</last></author>
-      <author><first>Jorge</first> <last>Baptista</last></author>
-      <author><first>Grigori</first> <last>Sidorov</last></author>
-      <author><first>David</first> <last>Pinto</last></author>
+      <author><first>Helena</first><last>Gomez</last></author>
+      <author><first>Ilia</first><last>Markov</last></author>
+      <author><first>Jorge</first><last>Baptista</last></author>
+      <author><first>Grigori</first><last>Sidorov</last></author>
+      <author><first>David</first><last>Pinto</last></author>
       <pages>137–145</pages>
       <url>W17-1217</url>
       <doi>10.18653/v1/W17-1217</doi>
@@ -1796,8 +1796,8 @@
     </paper>
     <paper id="18">
       <title>Tübingen system in <fixed-case>V</fixed-case>ar<fixed-case>D</fixed-case>ial 2017 shared task: experiments with language identification and cross-lingual parsing</title>
-      <author><first>Çağrı</first> <last>Çöltekin</last></author>
-      <author><first>Taraka</first> <last>Rama</last></author>
+      <author><first>Çağrı</first><last>Çöltekin</last></author>
+      <author><first>Taraka</first><last>Rama</last></author>
       <pages>146–155</pages>
       <url>W17-1218</url>
       <doi>10.18653/v1/W17-1218</doi>
@@ -1805,9 +1805,9 @@
     </paper>
     <paper id="19">
       <title>When Sparse Traditional Models Outperform Dense Neural Networks: the Curious Case of Discriminating between Similar Languages</title>
-      <author><first>Maria</first> <last>Medvedeva</last></author>
-      <author><first>Martin</first> <last>Kroon</last></author>
-      <author><first>Barbara</first> <last>Plank</last></author>
+      <author><first>Maria</first><last>Medvedeva</last></author>
+      <author><first>Martin</first><last>Kroon</last></author>
+      <author><first>Barbara</first><last>Plank</last></author>
       <pages>156–163</pages>
       <url>W17-1219</url>
       <doi>10.18653/v1/W17-1219</doi>
@@ -1815,8 +1815,8 @@
     </paper>
     <paper id="20">
       <title><fixed-case>G</fixed-case>erman Dialect Identification in Interview Transcriptions</title>
-      <author><first>Shervin</first> <last>Malmasi</last></author>
-      <author><first>Marcos</first> <last>Zampieri</last></author>
+      <author><first>Shervin</first><last>Malmasi</last></author>
+      <author><first>Marcos</first><last>Zampieri</last></author>
       <pages>164–169</pages>
       <url>W17-1220</url>
       <doi>10.18653/v1/W17-1220</doi>
@@ -1824,8 +1824,8 @@
     </paper>
     <paper id="21">
       <title><fixed-case>CLUZH</fixed-case> at <fixed-case>V</fixed-case>ar<fixed-case>D</fixed-case>ial <fixed-case>GDI</fixed-case> 2017: Testing a Variety of Machine Learning Tools for the Classification of Swiss <fixed-case>G</fixed-case>erman Dialects</title>
-      <author><first>Simon</first> <last>Clematide</last></author>
-      <author><first>Peter</first> <last>Makarov</last></author>
+      <author><first>Simon</first><last>Clematide</last></author>
+      <author><first>Peter</first><last>Makarov</last></author>
       <pages>170–177</pages>
       <url>W17-1221</url>
       <doi>10.18653/v1/W17-1221</doi>
@@ -1833,8 +1833,8 @@
     </paper>
     <paper id="22">
       <title><fixed-case>A</fixed-case>rabic Dialect Identification Using i<fixed-case>V</fixed-case>ectors and <fixed-case>ASR</fixed-case> Transcripts</title>
-      <author><first>Shervin</first> <last>Malmasi</last></author>
-      <author><first>Marcos</first> <last>Zampieri</last></author>
+      <author><first>Shervin</first><last>Malmasi</last></author>
+      <author><first>Marcos</first><last>Zampieri</last></author>
       <pages>178–183</pages>
       <url>W17-1222</url>
       <doi>10.18653/v1/W17-1222</doi>
@@ -1842,7 +1842,7 @@
     </paper>
     <paper id="23">
       <title>Discriminating between Similar Languages using Weighted Subword Features</title>
-      <author><first>Adrien</first> <last>Barbaresi</last></author>
+      <author><first>Adrien</first><last>Barbaresi</last></author>
       <pages>184–189</pages>
       <url>W17-1223</url>
       <doi>10.18653/v1/W17-1223</doi>
@@ -1850,8 +1850,8 @@
     </paper>
     <paper id="24">
       <title>Exploring Lexical and Syntactic Features for Language Variety Identification</title>
-      <author><first>Chris</first> <last>van der Lee</last></author>
-      <author><first>Antal</first> <last>van den Bosch</last></author>
+      <author><first>Chris</first><last>van der Lee</last></author>
+      <author><first>Antal</first><last>van den Bosch</last></author>
       <pages>190–199</pages>
       <url>W17-1224</url>
       <doi>10.18653/v1/W17-1224</doi>
@@ -1859,8 +1859,8 @@
     </paper>
     <paper id="25">
       <title>Learning to Identify <fixed-case>A</fixed-case>rabic and <fixed-case>G</fixed-case>erman Dialects using Multiple Kernels</title>
-      <author><first>Radu Tudor</first> <last>Ionescu</last></author>
-      <author><first>Andrei</first> <last>Butnaru</last></author>
+      <author><first>Radu Tudor</first><last>Ionescu</last></author>
+      <author><first>Andrei</first><last>Butnaru</last></author>
       <pages>200–209</pages>
       <url>W17-1225</url>
       <doi>10.18653/v1/W17-1225</doi>
@@ -1868,10 +1868,10 @@
     </paper>
     <paper id="26">
       <title><fixed-case>S</fixed-case>lavic Forest, <fixed-case>N</fixed-case>orwegian Wood</title>
-      <author><first>Rudolf</first> <last>Rosa</last></author>
-      <author><first>Daniel</first> <last>Zeman</last></author>
-      <author><first>David</first> <last>Mareček</last></author>
-      <author><first>Zdeněk</first> <last>Žabokrtský</last></author>
+      <author><first>Rudolf</first><last>Rosa</last></author>
+      <author><first>Daniel</first><last>Zeman</last></author>
+      <author><first>David</first><last>Mareček</last></author>
+      <author><first>Zdeněk</first><last>Žabokrtský</last></author>
       <pages>210–219</pages>
       <url>W17-1226</url>
       <doi>10.18653/v1/W17-1226</doi>
@@ -1901,8 +1901,8 @@
     </frontmatter>
     <paper id="1">
       <title>Identification of Languages in <fixed-case>A</fixed-case>lgerian <fixed-case>A</fixed-case>rabic Multilingual Documents</title>
-      <author><first>Wafia</first> <last>Adouane</last></author>
-      <author><first>Simon</first> <last>Dobnik</last></author>
+      <author><first>Wafia</first><last>Adouane</last></author>
+      <author><first>Simon</first><last>Dobnik</last></author>
       <pages>1–8</pages>
       <url>W17-1301</url>
       <doi>10.18653/v1/W17-1301</doi>
@@ -1910,9 +1910,9 @@
     </paper>
     <paper id="2">
       <title><fixed-case>A</fixed-case>rabic Diacritization: Stats, Rules, and Hacks</title>
-      <author><first>Kareem</first> <last>Darwish</last></author>
-      <author><first>Hamdy</first> <last>Mubarak</last></author>
-      <author><first>Ahmed</first> <last>Abdelali</last></author>
+      <author><first>Kareem</first><last>Darwish</last></author>
+      <author><first>Hamdy</first><last>Mubarak</last></author>
+      <author><first>Ahmed</first><last>Abdelali</last></author>
       <pages>9–17</pages>
       <url>W17-1302</url>
       <doi>10.18653/v1/W17-1302</doi>
@@ -1920,8 +1920,8 @@
     </paper>
     <paper id="3">
       <title>Semantic Similarity of <fixed-case>A</fixed-case>rabic Sentences with Word Embeddings</title>
-      <author><first>El Moatez Billah</first> <last>Nagoudi</last></author>
-      <author><first>Didier</first> <last>Schwab</last></author>
+      <author><first>El Moatez Billah</first><last>Nagoudi</last></author>
+      <author><first>Didier</first><last>Schwab</last></author>
       <pages>18–24</pages>
       <url>W17-1303</url>
       <doi>10.18653/v1/W17-1303</doi>
@@ -1929,8 +1929,8 @@
     </paper>
     <paper id="4">
       <title>Morphological Analysis for the <fixed-case>M</fixed-case>altese Language: The challenges of a hybrid system</title>
-      <author><first>Claudia</first> <last>Borg</last></author>
-      <author><first>Albert</first> <last>Gatt</last></author>
+      <author><first>Claudia</first><last>Borg</last></author>
+      <author><first>Albert</first><last>Gatt</last></author>
       <pages>25–34</pages>
       <url>W17-1304</url>
       <doi>10.18653/v1/W17-1304</doi>
@@ -1938,9 +1938,9 @@
     </paper>
     <paper id="5">
       <title>A Morphological Analyzer for Gulf <fixed-case>A</fixed-case>rabic Verbs</title>
-      <author><first>Salam</first> <last>Khalifa</last></author>
-      <author><first>Sara</first> <last>Hassan</last></author>
-      <author><first>Nizar</first> <last>Habash</last></author>
+      <author><first>Salam</first><last>Khalifa</last></author>
+      <author><first>Sara</first><last>Hassan</last></author>
+      <author><first>Nizar</first><last>Habash</last></author>
       <pages>35–45</pages>
       <url>W17-1305</url>
       <doi>10.18653/v1/W17-1305</doi>
@@ -1948,13 +1948,13 @@
     </paper>
     <paper id="6">
       <title>A Neural Architecture for Dialectal <fixed-case>A</fixed-case>rabic Segmentation</title>
-      <author><first>Younes</first> <last>Samih</last></author>
-      <author><first>Mohammed</first> <last>Attia</last></author>
-      <author><first>Mohamed</first> <last>Eldesouki</last></author>
-      <author><first>Ahmed</first> <last>Abdelali</last></author>
-      <author><first>Hamdy</first> <last>Mubarak</last></author>
-      <author><first>Laura</first> <last>Kallmeyer</last></author>
-      <author><first>Kareem</first> <last>Darwish</last></author>
+      <author><first>Younes</first><last>Samih</last></author>
+      <author><first>Mohammed</first><last>Attia</last></author>
+      <author><first>Mohamed</first><last>Eldesouki</last></author>
+      <author><first>Ahmed</first><last>Abdelali</last></author>
+      <author><first>Hamdy</first><last>Mubarak</last></author>
+      <author><first>Laura</first><last>Kallmeyer</last></author>
+      <author><first>Kareem</first><last>Darwish</last></author>
       <pages>46–54</pages>
       <url>W17-1306</url>
       <doi>10.18653/v1/W17-1306</doi>
@@ -1962,10 +1962,10 @@
     </paper>
     <paper id="7">
       <title>Sentiment Analysis of <fixed-case>T</fixed-case>unisian Dialects: Linguistic Ressources and Experiments</title>
-      <author><first>Salima</first> <last>Medhaffar</last></author>
-      <author><first>Fethi</first> <last>Bougares</last></author>
-      <author><first>Yannick</first> <last>Estève</last></author>
-      <author><first>Lamia</first> <last>Hadrich-Belguith</last></author>
+      <author><first>Salima</first><last>Medhaffar</last></author>
+      <author><first>Fethi</first><last>Bougares</last></author>
+      <author><first>Yannick</first><last>Estève</last></author>
+      <author><first>Lamia</first><last>Hadrich-Belguith</last></author>
       <pages>55–61</pages>
       <url>W17-1307</url>
       <doi>10.18653/v1/W17-1307</doi>
@@ -1973,12 +1973,12 @@
     </paper>
     <paper id="8">
       <title><fixed-case>CAT</fixed-case>: Credibility Analysis of <fixed-case>A</fixed-case>rabic Content on Twitter</title>
-      <author><first>Rim</first> <last>El Ballouli</last></author>
-      <author><first>Wassim</first> <last>El-Hajj</last></author>
-      <author><first>Ahmad</first> <last>Ghandour</last></author>
-      <author><first>Shady</first> <last>Elbassuoni</last></author>
-      <author><first>Hazem</first> <last>Hajj</last></author>
-      <author><first>Khaled</first> <last>Shaban</last></author>
+      <author><first>Rim</first><last>El Ballouli</last></author>
+      <author><first>Wassim</first><last>El-Hajj</last></author>
+      <author><first>Ahmad</first><last>Ghandour</last></author>
+      <author><first>Shady</first><last>Elbassuoni</last></author>
+      <author><first>Hazem</first><last>Hajj</last></author>
+      <author><first>Khaled</first><last>Shaban</last></author>
       <pages>62–71</pages>
       <url>W17-1308</url>
       <doi>10.18653/v1/W17-1308</doi>
@@ -1986,8 +1986,8 @@
     </paper>
     <paper id="9">
       <title>A New Error Annotation for Dyslexic texts in <fixed-case>A</fixed-case>rabic</title>
-      <author><first>Maha</first> <last>Alamri</last></author>
-      <author><first>William J</first> <last>Teahan</last></author>
+      <author><first>Maha</first><last>Alamri</last></author>
+      <author><first>William J</first><last>Teahan</last></author>
       <pages>72–78</pages>
       <url>W17-1309</url>
       <doi>10.18653/v1/W17-1309</doi>
@@ -1995,12 +1995,12 @@
     </paper>
     <paper id="10">
       <title>An Unsupervised Speaker Clustering Technique based on <fixed-case>SOM</fixed-case> and <fixed-case>I</fixed-case>-vectors for Speech Recognition Systems</title>
-      <author><first>Hany</first> <last>Ahmed</last></author>
-      <author><first>Mohamed</first> <last>Elaraby</last></author>
-      <author><first>Abdullah</first> <last>M. Mousa</last></author>
-      <author><first>Mostafa</first> <last>Elhosiny</last></author>
-      <author><first>Sherif</first> <last>Abdou</last></author>
-      <author><first>Mohsen</first> <last>Rashwan</last></author>
+      <author><first>Hany</first><last>Ahmed</last></author>
+      <author><first>Mohamed</first><last>Elaraby</last></author>
+      <author><first>Abdullah</first><last>M. Mousa</last></author>
+      <author><first>Mostafa</first><last>Elhosiny</last></author>
+      <author><first>Sherif</first><last>Abdou</last></author>
+      <author><first>Mohsen</first><last>Rashwan</last></author>
       <pages>79–83</pages>
       <url>W17-1310</url>
       <doi>10.18653/v1/W17-1310</doi>
@@ -2008,8 +2008,8 @@
     </paper>
     <paper id="11">
       <title><fixed-case>SHAKKIL</fixed-case>: An Automatic Diacritization System for Modern Standard <fixed-case>A</fixed-case>rabic Texts</title>
-      <author><first>Amany</first> <last>Fashwan</last></author>
-      <author><first>Sameh</first> <last>Alansary</last></author>
+      <author><first>Amany</first><last>Fashwan</last></author>
+      <author><first>Sameh</first><last>Alansary</last></author>
       <pages>84–93</pages>
       <url>W17-1311</url>
       <doi>10.18653/v1/W17-1311</doi>
@@ -2017,9 +2017,9 @@
     </paper>
     <paper id="12">
       <title><fixed-case>A</fixed-case>rabic Tweets Treebanking and Parsing: A Bootstrapping Approach</title>
-      <author><first>Fahad</first> <last>Albogamy</last></author>
-      <author><first>Allan</first> <last>Ramsay</last></author>
-      <author><first>Hanady</first> <last>Ahmed</last></author>
+      <author><first>Fahad</first><last>Albogamy</last></author>
+      <author><first>Allan</first><last>Ramsay</last></author>
+      <author><first>Hanady</first><last>Ahmed</last></author>
       <pages>94–99</pages>
       <url>W17-1312</url>
       <doi>10.18653/v1/W17-1312</doi>
@@ -2027,10 +2027,10 @@
     </paper>
     <paper id="13">
       <title>Identifying Effective Translations for Cross-lingual <fixed-case>A</fixed-case>rabic-to-<fixed-case>E</fixed-case>nglish User-generated Speech Search</title>
-      <author><first>Ahmad</first> <last>Khwileh</last></author>
-      <author><first>Haithem</first> <last>Afli</last></author>
-      <author><first>Gareth</first> <last>Jones</last></author>
-      <author><first>Andy</first> <last>Way</last></author>
+      <author><first>Ahmad</first><last>Khwileh</last></author>
+      <author><first>Haithem</first><last>Afli</last></author>
+      <author><first>Gareth</first><last>Jones</last></author>
+      <author><first>Andy</first><last>Way</last></author>
       <pages>100–109</pages>
       <url>W17-1313</url>
       <doi>10.18653/v1/W17-1313</doi>
@@ -2038,15 +2038,15 @@
     </paper>
     <paper id="14">
       <title>A Characterization Study of <fixed-case>A</fixed-case>rabic Twitter Data with a Benchmarking for State-of-the-Art Opinion Mining Models</title>
-      <author><first>Ramy</first> <last>Baly</last></author>
-      <author><first>Gilbert</first> <last>Badaro</last></author>
-      <author><first>Georges</first> <last>El-Khoury</last></author>
-      <author><first>Rawan</first> <last>Moukalled</last></author>
-      <author><first>Rita</first> <last>Aoun</last></author>
-      <author><first>Hazem</first> <last>Hajj</last></author>
-      <author><first>Wassim</first> <last>El-Hajj</last></author>
-      <author><first>Nizar</first> <last>Habash</last></author>
-      <author><first>Khaled</first> <last>Shaban</last></author>
+      <author><first>Ramy</first><last>Baly</last></author>
+      <author><first>Gilbert</first><last>Badaro</last></author>
+      <author><first>Georges</first><last>El-Khoury</last></author>
+      <author><first>Rawan</first><last>Moukalled</last></author>
+      <author><first>Rita</first><last>Aoun</last></author>
+      <author><first>Hazem</first><last>Hajj</last></author>
+      <author><first>Wassim</first><last>El-Hajj</last></author>
+      <author><first>Nizar</first><last>Habash</last></author>
+      <author><first>Khaled</first><last>Shaban</last></author>
       <pages>110–118</pages>
       <url>W17-1314</url>
       <doi>10.18653/v1/W17-1314</doi>
@@ -2054,9 +2054,9 @@
     </paper>
     <paper id="15">
       <title>Robust Dictionary Lookup in Multiple Noisy Orthographies</title>
-      <author><first>Lingliang</first> <last>Zhang</last></author>
-      <author><first>Nizar</first> <last>Habash</last></author>
-      <author><first>Godfried</first> <last>Toussaint</last></author>
+      <author><first>Lingliang</first><last>Zhang</last></author>
+      <author><first>Nizar</first><last>Habash</last></author>
+      <author><first>Godfried</first><last>Toussaint</last></author>
       <pages>119–129</pages>
       <url>W17-1315</url>
       <doi>10.18653/v1/W17-1315</doi>
@@ -2064,10 +2064,10 @@
     </paper>
     <paper id="16">
       <title><fixed-case>A</fixed-case>rabic <fixed-case>POS</fixed-case> Tagging: Don’t Abandon Feature Engineering Just Yet</title>
-      <author><first>Kareem</first> <last>Darwish</last></author>
-      <author><first>Hamdy</first> <last>Mubarak</last></author>
-      <author><first>Ahmed</first> <last>Abdelali</last></author>
-      <author><first>Mohamed</first> <last>Eldesouki</last></author>
+      <author><first>Kareem</first><last>Darwish</last></author>
+      <author><first>Hamdy</first><last>Mubarak</last></author>
+      <author><first>Ahmed</first><last>Abdelali</last></author>
+      <author><first>Mohamed</first><last>Eldesouki</last></author>
       <pages>130–137</pages>
       <url>W17-1316</url>
       <doi>10.18653/v1/W17-1316</doi>
@@ -2075,10 +2075,10 @@
     </paper>
     <paper id="17">
       <title>Toward a Web-based Speech Corpus for <fixed-case>A</fixed-case>lgerian Dialectal <fixed-case>A</fixed-case>rabic Varieties</title>
-      <author><first>Soumia</first> <last>Bougrine</last></author>
-      <author><first>Aicha</first> <last>Chorana</last></author>
-      <author><first>Abdallah</first> <last>Lakhdari</last></author>
-      <author><first>Hadda</first> <last>Cherroun</last></author>
+      <author><first>Soumia</first><last>Bougrine</last></author>
+      <author><first>Aicha</first><last>Chorana</last></author>
+      <author><first>Abdallah</first><last>Lakhdari</last></author>
+      <author><first>Hadda</first><last>Cherroun</last></author>
       <pages>138–146</pages>
       <url>W17-1317</url>
       <doi>10.18653/v1/W17-1317</doi>
@@ -2086,7 +2086,7 @@
     </paper>
     <paper id="18">
       <title>Not All Segments are Created Equal: Syntactically Motivated Sentiment Analysis in Lexical Space</title>
-      <author><first>Muhammad</first> <last>Abdul-Mageed</last></author>
+      <author><first>Muhammad</first><last>Abdul-Mageed</last></author>
       <pages>147–156</pages>
       <url>W17-1318</url>
       <doi>10.18653/v1/W17-1318</doi>
@@ -2094,12 +2094,12 @@
     </paper>
     <paper id="19">
       <title>An enhanced automatic speech recognition system for <fixed-case>A</fixed-case>rabic</title>
-      <author><first>Mohamed Amine</first> <last>Menacer</last></author>
-      <author><first>Odile</first> <last>Mella</last></author>
-      <author><first>Dominique</first> <last>Fohr</last></author>
-      <author><first>Denis</first> <last>Jouvet</last></author>
-      <author><first>David</first> <last>Langlois</last></author>
-      <author><first>Kamel</first> <last>Smaili</last></author>
+      <author><first>Mohamed Amine</first><last>Menacer</last></author>
+      <author><first>Odile</first><last>Mella</last></author>
+      <author><first>Dominique</first><last>Fohr</last></author>
+      <author><first>Denis</first><last>Jouvet</last></author>
+      <author><first>David</first><last>Langlois</last></author>
+      <author><first>Kamel</first><last>Smaili</last></author>
       <pages>157–165</pages>
       <url>W17-1319</url>
       <doi>10.18653/v1/W17-1319</doi>
@@ -2107,9 +2107,9 @@
     </paper>
     <paper id="20">
       <title>Universal Dependencies for <fixed-case>A</fixed-case>rabic</title>
-      <author><first>Dima</first> <last>Taji</last></author>
-      <author><first>Nizar</first> <last>Habash</last></author>
-      <author><first>Daniel</first> <last>Zeman</last></author>
+      <author><first>Dima</first><last>Taji</last></author>
+      <author><first>Nizar</first><last>Habash</last></author>
+      <author><first>Daniel</first><last>Zeman</last></author>
       <pages>166–176</pages>
       <url>W17-1320</url>
       <doi>10.18653/v1/W17-1320</doi>
@@ -2117,9 +2117,9 @@
     </paper>
     <paper id="21">
       <title>A Layered Language Model based Hybrid Approach to Automatic Full Diacritization of <fixed-case>A</fixed-case>rabic</title>
-      <author><first>Mohamed</first> <last>Al-Badrashiny</last></author>
-      <author><first>Abdelati</first> <last>Hawwari</last></author>
-      <author><first>Mona</first> <last>Diab</last></author>
+      <author><first>Mohamed</first><last>Al-Badrashiny</last></author>
+      <author><first>Abdelati</first><last>Hawwari</last></author>
+      <author><first>Mona</first><last>Diab</last></author>
       <pages>177–184</pages>
       <url>W17-1321</url>
       <doi>10.18653/v1/W17-1321</doi>
@@ -2127,8 +2127,8 @@
     </paper>
     <paper id="22">
       <title><fixed-case>A</fixed-case>rabic Textual Entailment with Word Embeddings</title>
-      <author><first>Nada</first> <last>Almarwani</last></author>
-      <author><first>Mona</first> <last>Diab</last></author>
+      <author><first>Nada</first><last>Almarwani</last></author>
+      <author><first>Mona</first><last>Diab</last></author>
       <pages>185–190</pages>
       <url>W17-1322</url>
       <doi>10.18653/v1/W17-1322</doi>
@@ -2156,7 +2156,7 @@
     </frontmatter>
     <paper id="1">
       <title>Toward Pan-<fixed-case>S</fixed-case>lavic <fixed-case>NLP</fixed-case>: Some Experiments with Language Adaptation</title>
-      <author><first>Serge</first> <last>Sharoff</last></author>
+      <author><first>Serge</first><last>Sharoff</last></author>
       <pages>1–2</pages>
       <url>W17-1401</url>
       <doi>10.18653/v1/W17-1401</doi>
@@ -2164,9 +2164,9 @@
     </paper>
     <paper id="2">
       <title>Clustering of <fixed-case>R</fixed-case>ussian Adjective-Noun Constructions using Word Embeddings</title>
-      <author><first>Andrey</first> <last>Kutuzov</last></author>
-      <author><first>Elizaveta</first> <last>Kuzmenko</last></author>
-      <author><first>Lidia</first> <last>Pivovarova</last></author>
+      <author><first>Andrey</first><last>Kutuzov</last></author>
+      <author><first>Elizaveta</first><last>Kuzmenko</last></author>
+      <author><first>Lidia</first><last>Pivovarova</last></author>
       <pages>3–13</pages>
       <url>W17-1402</url>
       <doi>10.18653/v1/W17-1402</doi>
@@ -2174,8 +2174,8 @@
     </paper>
     <paper id="3">
       <title>A Preliminary Study of <fixed-case>C</fixed-case>roatian Lexical Substitution</title>
-      <author><first>Domagoj</first> <last>Alagić</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
+      <author><first>Domagoj</first><last>Alagić</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
       <pages>14–19</pages>
       <url>W17-1403</url>
       <doi>10.18653/v1/W17-1403</doi>
@@ -2183,8 +2183,8 @@
     </paper>
     <paper id="4">
       <title>Projecting Multiword Expression Resources on a Polish Treebank</title>
-      <author><first>Agata</first> <last>Savary</last></author>
-      <author><first>Jakub</first> <last>Waszczuk</last></author>
+      <author><first>Agata</first><last>Savary</last></author>
+      <author><first>Jakub</first><last>Waszczuk</last></author>
       <pages>20–26</pages>
       <url>W17-1404</url>
       <doi>10.18653/v1/W17-1404</doi>
@@ -2192,8 +2192,8 @@
     </paper>
     <paper id="5">
       <title>Lexicon Induction for Spoken <fixed-case>R</fixed-case>usyn – Challenges and Results</title>
-      <author><first>Achim</first> <last>Rabus</last></author>
-      <author><first>Yves</first> <last>Scherrer</last></author>
+      <author><first>Achim</first><last>Rabus</last></author>
+      <author><first>Yves</first><last>Scherrer</last></author>
       <pages>27–32</pages>
       <url>W17-1405</url>
       <doi>10.18653/v1/W17-1405</doi>
@@ -2201,9 +2201,9 @@
     </paper>
     <paper id="6">
       <title>The Universal Dependencies Treebank for <fixed-case>S</fixed-case>lovenian</title>
-      <author><first>Kaja</first> <last>Dobrovoljc</last></author>
-      <author><first>Tomaž</first> <last>Erjavec</last></author>
-      <author><first>Simon</first> <last>Krek</last></author>
+      <author><first>Kaja</first><last>Dobrovoljc</last></author>
+      <author><first>Tomaž</first><last>Erjavec</last></author>
+      <author><first>Simon</first><last>Krek</last></author>
       <pages>33–38</pages>
       <url>W17-1406</url>
       <doi>10.18653/v1/W17-1406</doi>
@@ -2211,10 +2211,10 @@
     </paper>
     <paper id="7">
       <title>Universal Dependencies for <fixed-case>S</fixed-case>erbian in Comparison with <fixed-case>C</fixed-case>roatian and Other <fixed-case>S</fixed-case>lavic Languages</title>
-      <author><first>Tanja</first> <last>Samardžić</last></author>
-      <author><first>Mirjana</first> <last>Starović</last></author>
-      <author><first>Željko</first> <last>Agić</last></author>
-      <author><first>Nikola</first> <last>Ljubešić</last></author>
+      <author><first>Tanja</first><last>Samardžić</last></author>
+      <author><first>Mirjana</first><last>Starović</last></author>
+      <author><first>Željko</first><last>Agić</last></author>
+      <author><first>Nikola</first><last>Ljubešić</last></author>
       <pages>39–44</pages>
       <url>W17-1407</url>
       <doi>10.18653/v1/W17-1407</doi>
@@ -2222,7 +2222,7 @@
     </paper>
     <paper id="8">
       <title>Spelling Correction for Morphologically Rich Language: a Case Study of <fixed-case>R</fixed-case>ussian</title>
-      <author><first>Alexey</first> <last>Sorokin</last></author>
+      <author><first>Alexey</first><last>Sorokin</last></author>
       <pages>45–53</pages>
       <url>W17-1408</url>
       <doi>10.18653/v1/W17-1408</doi>
@@ -2230,10 +2230,10 @@
     </paper>
     <paper id="9">
       <title>Debunking Sentiment Lexicons: A Case of Domain-Specific Sentiment Classification for <fixed-case>C</fixed-case>roatian</title>
-      <author><first>Paula</first> <last>Gombar</last></author>
-      <author><first>Zoran</first> <last>Medić</last></author>
-      <author><first>Domagoj</first> <last>Alagić</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
+      <author><first>Paula</first><last>Gombar</last></author>
+      <author><first>Zoran</first><last>Medić</last></author>
+      <author><first>Domagoj</first><last>Alagić</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
       <pages>54–59</pages>
       <url>W17-1409</url>
       <doi>10.18653/v1/W17-1409</doi>
@@ -2241,9 +2241,9 @@
     </paper>
     <paper id="10">
       <title>Adapting a State-of-the-Art Tagger for South <fixed-case>S</fixed-case>lavic Languages to Non-Standard Text</title>
-      <author><first>Nikola</first> <last>Ljubešić</last></author>
-      <author><first>Tomaž</first> <last>Erjavec</last></author>
-      <author><first>Darja</first> <last>Fišer</last></author>
+      <author><first>Nikola</first><last>Ljubešić</last></author>
+      <author><first>Tomaž</first><last>Erjavec</last></author>
+      <author><first>Darja</first><last>Fišer</last></author>
       <pages>60–68</pages>
       <url>W17-1410</url>
       <doi>10.18653/v1/W17-1410</doi>
@@ -2251,8 +2251,8 @@
     </paper>
     <paper id="11">
       <title>Comparison of Short-Text Sentiment Analysis Methods for <fixed-case>C</fixed-case>roatian</title>
-      <author><first>Leon</first> <last>Rotim</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
+      <author><first>Leon</first><last>Rotim</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
       <pages>69–75</pages>
       <url>W17-1411</url>
       <doi>10.18653/v1/W17-1411</doi>
@@ -2260,11 +2260,11 @@
     </paper>
     <paper id="12">
       <title>The First Cross-Lingual Challenge on Recognition, Normalization, and Matching of Named Entities in <fixed-case>S</fixed-case>lavic Languages</title>
-      <author><first>Jakub</first> <last>Piskorski</last></author>
-      <author><first>Lidia</first> <last>Pivovarova</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
-      <author><first>Josef</first> <last>Steinberger</last></author>
-      <author><first>Roman</first> <last>Yangarber</last></author>
+      <author><first>Jakub</first><last>Piskorski</last></author>
+      <author><first>Lidia</first><last>Pivovarova</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
+      <author><first>Josef</first><last>Steinberger</last></author>
+      <author><first>Roman</first><last>Yangarber</last></author>
       <pages>76–85</pages>
       <url>W17-1412</url>
       <doi>10.18653/v1/W17-1412</doi>
@@ -2272,9 +2272,9 @@
     </paper>
     <paper id="13">
       <title><fixed-case>L</fixed-case>iner2 — a Generic Framework for Named Entity Recognition</title>
-      <author><first>Michał</first> <last>Marcińczuk</last></author>
-      <author><first>Jan</first> <last>Kocoń</last></author>
-      <author><first>Marcin</first> <last>Oleksy</last></author>
+      <author><first>Michał</first><last>Marcińczuk</last></author>
+      <author><first>Jan</first><last>Kocoń</last></author>
+      <author><first>Marcin</first><last>Oleksy</last></author>
       <pages>86–91</pages>
       <url>W17-1413</url>
       <doi>10.18653/v1/W17-1413</doi>
@@ -2282,9 +2282,9 @@
     </paper>
     <paper id="14">
       <title>Language-Independent Named Entity Analysis Using Parallel Projection and Rule-Based Disambiguation</title>
-      <author><first>James</first> <last>Mayfield</last></author>
-      <author><first>Paul</first> <last>McNamee</last></author>
-      <author><first>Cash</first> <last>Costello</last></author>
+      <author><first>James</first><last>Mayfield</last></author>
+      <author><first>Paul</first><last>McNamee</last></author>
+      <author><first>Cash</first><last>Costello</last></author>
       <pages>92–96</pages>
       <url>W17-1414</url>
       <doi>10.18653/v1/W17-1414</doi>
@@ -2292,7 +2292,7 @@
     </paper>
     <paper id="15">
       <title>Comparison of String Similarity Measures for Obscenity Filtering</title>
-      <author><first>Ekaterina</first> <last>Chernyak</last></author>
+      <author><first>Ekaterina</first><last>Chernyak</last></author>
       <pages>97–101</pages>
       <url>W17-1415</url>
       <doi>10.18653/v1/W17-1415</doi>
@@ -2300,8 +2300,8 @@
     </paper>
     <paper id="16">
       <title>Stylometric Analysis of Parliamentary Speeches: Gender Dimension</title>
-      <author><first>Justina</first> <last>Mandravickaitė</last></author>
-      <author><first>Tomas</first> <last>Krilavičius</last></author>
+      <author><first>Justina</first><last>Mandravickaitė</last></author>
+      <author><first>Tomas</first><last>Krilavičius</last></author>
       <pages>102–107</pages>
       <url>W17-1416</url>
       <doi>10.18653/v1/W17-1416</doi>
@@ -2309,10 +2309,10 @@
     </paper>
     <paper id="17">
       <title>Towards Never Ending Language Learning for Morphologically Rich Languages</title>
-      <author><first>Kseniya</first> <last>Buraya</last></author>
-      <author><first>Lidia</first> <last>Pivovarova</last></author>
-      <author><first>Sergey</first> <last>Budkov</last></author>
-      <author><first>Andrey</first> <last>Filchenkov</last></author>
+      <author><first>Kseniya</first><last>Buraya</last></author>
+      <author><first>Lidia</first><last>Pivovarova</last></author>
+      <author><first>Sergey</first><last>Budkov</last></author>
+      <author><first>Andrey</first><last>Filchenkov</last></author>
       <pages>108–118</pages>
       <url>W17-1417</url>
       <doi>10.18653/v1/W17-1417</doi>
@@ -2320,9 +2320,9 @@
     </paper>
     <paper id="18">
       <title>Gender Profiling for <fixed-case>S</fixed-case>lovene Twitter communication: the Influence of Gender Marking, Content and Style</title>
-      <author><first>Ben</first> <last>Verhoeven</last></author>
-      <author><first>Iza</first> <last>Škrjanec</last></author>
-      <author><first>Senja</first> <last>Pollak</last></author>
+      <author><first>Ben</first><last>Verhoeven</last></author>
+      <author><first>Iza</first><last>Škrjanec</last></author>
+      <author><first>Senja</first><last>Pollak</last></author>
       <pages>119–125</pages>
       <url>W17-1418</url>
       <doi>10.18653/v1/W17-1418</doi>
@@ -2346,8 +2346,8 @@
     </frontmatter>
     <paper id="1">
       <title>Use Generalized Representations, But Do Not Forget Surface Features</title>
-      <author><first>Nafise Sadat</first> <last>Moosavi</last></author>
-      <author><first>Michael</first> <last>Strube</last></author>
+      <author><first>Nafise Sadat</first><last>Moosavi</last></author>
+      <author><first>Michael</first><last>Strube</last></author>
       <pages>1–7</pages>
       <url>W17-1501</url>
       <doi>10.18653/v1/W17-1501</doi>
@@ -2355,10 +2355,10 @@
     </paper>
     <paper id="2">
       <title>Enriching Basque Coreference Resolution System using Semantic Knowledge sources</title>
-      <author><first>Ander</first> <last>Soraluze</last></author>
-      <author><first>Olatz</first> <last>Arregi</last></author>
-      <author><first>Xabier</first> <last>Arregi</last></author>
-      <author><first>Arantza</first> <last>Díaz de Ilarraza</last></author>
+      <author><first>Ander</first><last>Soraluze</last></author>
+      <author><first>Olatz</first><last>Arregi</last></author>
+      <author><first>Xabier</first><last>Arregi</last></author>
+      <author><first>Arantza</first><last>Díaz de Ilarraza</last></author>
       <pages>8–16</pages>
       <url>W17-1502</url>
       <doi>10.18653/v1/W17-1502</doi>
@@ -2366,8 +2366,8 @@
     </paper>
     <paper id="3">
       <title>Improving Polish Mention Detection with Valency Dictionary</title>
-      <author><first>Maciej</first> <last>Ogrodniczuk</last></author>
-      <author><first>Bartłomiej</first> <last>Nitoń</last></author>
+      <author><first>Maciej</first><last>Ogrodniczuk</last></author>
+      <author><first>Bartłomiej</first><last>Nitoń</last></author>
       <pages>17–23</pages>
       <url>W17-1503</url>
       <doi>10.18653/v1/W17-1503</doi>
@@ -2375,8 +2375,8 @@
     </paper>
     <paper id="4">
       <title>A <fixed-case>G</fixed-case>oogle-Proof Collection of <fixed-case>F</fixed-case>rench <fixed-case>W</fixed-case>inograd Schemas</title>
-      <author><first>Pascal</first> <last>Amsili</last></author>
-      <author><first>Olga</first> <last>Seminck</last></author>
+      <author><first>Pascal</first><last>Amsili</last></author>
+      <author><first>Olga</first><last>Seminck</last></author>
       <pages>24–29</pages>
       <url>W17-1504</url>
       <doi>10.18653/v1/W17-1504</doi>
@@ -2384,8 +2384,8 @@
     </paper>
     <paper id="5">
       <title>Using Coreference Links to Improve <fixed-case>S</fixed-case>panish-to-<fixed-case>E</fixed-case>nglish Machine Translation</title>
-      <author><first>Lesly</first> <last>Miculicich Werlen</last></author>
-      <author><first>Andrei</first> <last>Popescu-Belis</last></author>
+      <author><first>Lesly</first><last>Miculicich Werlen</last></author>
+      <author><first>Andrei</first><last>Popescu-Belis</last></author>
       <pages>30–40</pages>
       <url>W17-1505</url>
       <doi>10.18653/v1/W17-1505</doi>
@@ -2393,8 +2393,8 @@
     </paper>
     <paper id="6">
       <title>Multi-source annotation projection of coreference chains: assessing strategies and testing opportunities</title>
-      <author><first>Yulia</first> <last>Grishina</last></author>
-      <author><first>Manfred</first> <last>Stede</last></author>
+      <author><first>Yulia</first><last>Grishina</last></author>
+      <author><first>Manfred</first><last>Stede</last></author>
       <pages>41–50</pages>
       <url>W17-1506</url>
       <doi>10.18653/v1/W17-1506</doi>
@@ -2402,7 +2402,7 @@
     </paper>
     <paper id="7">
       <title><fixed-case>CORBON</fixed-case> 2017 Shared Task: Projection-Based Coreference Resolution</title>
-      <author><first>Yulia</first> <last>Grishina</last></author>
+      <author><first>Yulia</first><last>Grishina</last></author>
       <pages>51–55</pages>
       <url>W17-1507</url>
       <doi>10.18653/v1/W17-1507</doi>
@@ -2410,9 +2410,9 @@
     </paper>
     <paper id="8">
       <title>Projection-based Coreference Resolution Using Deep Syntax</title>
-      <author><first>Michal</first> <last>Novák</last></author>
-      <author><first>Anna</first> <last>Nedoluzhko</last></author>
-      <author><first>Zdeněk</first> <last>Žabokrtský</last></author>
+      <author><first>Michal</first><last>Novák</last></author>
+      <author><first>Anna</first><last>Nedoluzhko</last></author>
+      <author><first>Zdeněk</first><last>Žabokrtský</last></author>
       <pages>56–64</pages>
       <url>W17-1508</url>
       <doi>10.18653/v1/W17-1508</doi>
@@ -2440,7 +2440,7 @@
     </frontmatter>
     <paper id="1">
       <title>Gender as a Variable in Natural-Language Processing: Ethical Considerations</title>
-      <author><first>Brian</first> <last>Larson</last></author>
+      <author><first>Brian</first><last>Larson</last></author>
       <pages>1–11</pages>
       <url>W17-1601</url>
       <doi>10.18653/v1/W17-1601</doi>
@@ -2448,8 +2448,8 @@
     </paper>
     <paper id="2">
       <title>These are not the Stereotypes You are Looking For: Bias and Fairness in Authorial Gender Attribution</title>
-      <author><first>Corina</first> <last>Koolen</last></author>
-      <author><first>Andreas</first> <last>van Cranenburgh</last></author>
+      <author><first>Corina</first><last>Koolen</last></author>
+      <author><first>Andreas</first><last>van Cranenburgh</last></author>
       <pages>12–22</pages>
       <url>W17-1602</url>
       <doi>10.18653/v1/W17-1602</doi>
@@ -2457,7 +2457,7 @@
     </paper>
     <paper id="3">
       <title>A Quantitative Study of Data in the <fixed-case>NLP</fixed-case> community</title>
-      <author><first>Margot</first> <last>Mieskes</last></author>
+      <author><first>Margot</first><last>Mieskes</last></author>
       <pages>23–29</pages>
       <url>W17-1603</url>
       <doi>10.18653/v1/W17-1603</doi>
@@ -2465,8 +2465,8 @@
     </paper>
     <paper id="4">
       <title>Ethical by Design: Ethics Best Practices for Natural Language Processing</title>
-      <author><first>Jochen L.</first> <last>Leidner</last></author>
-      <author><first>Vassilis</first> <last>Plachouras</last></author>
+      <author><first>Jochen L.</first><last>Leidner</last></author>
+      <author><first>Vassilis</first><last>Plachouras</last></author>
       <pages>30–40</pages>
       <url>W17-1604</url>
       <doi>10.18653/v1/W17-1604</doi>
@@ -2474,11 +2474,11 @@
     </paper>
     <paper id="5">
       <title>Building Better Open-Source Tools to Support Fairness in Automated Scoring</title>
-      <author><first>Nitin</first> <last>Madnani</last></author>
-      <author><first>Anastassia</first> <last>Loukina</last></author>
-      <author><first>Alina</first> <last>von Davier</last></author>
-      <author><first>Jill</first> <last>Burstein</last></author>
-      <author><first>Aoife</first> <last>Cahill</last></author>
+      <author><first>Nitin</first><last>Madnani</last></author>
+      <author><first>Anastassia</first><last>Loukina</last></author>
+      <author><first>Alina</first><last>von Davier</last></author>
+      <author><first>Jill</first><last>Burstein</last></author>
+      <author><first>Aoife</first><last>Cahill</last></author>
       <pages>41–52</pages>
       <url>W17-1605</url>
       <doi>10.18653/v1/W17-1605</doi>
@@ -2486,7 +2486,7 @@
     </paper>
     <paper id="6">
       <title>Gender and Dialect Bias in <fixed-case>Y</fixed-case>ou<fixed-case>T</fixed-case>ube’s Automatic Captions</title>
-      <author><first>Rachael</first> <last>Tatman</last></author>
+      <author><first>Rachael</first><last>Tatman</last></author>
       <pages>53–59</pages>
       <url>W17-1606</url>
       <doi>10.18653/v1/W17-1606</doi>
@@ -2494,9 +2494,9 @@
     </paper>
     <paper id="7">
       <title>Integrating the Management of Personal Data Protection and Open Science with Research Ethics</title>
-      <author><first>Dave</first> <last>Lewis</last></author>
-      <author><first>Joss</first> <last>Moorkens</last></author>
-      <author><first>Kaniz</first> <last>Fatema</last></author>
+      <author><first>Dave</first><last>Lewis</last></author>
+      <author><first>Joss</first><last>Moorkens</last></author>
+      <author><first>Kaniz</first><last>Fatema</last></author>
       <pages>60–65</pages>
       <url>W17-1607</url>
       <doi>10.18653/v1/W17-1607</doi>
@@ -2504,12 +2504,12 @@
     </paper>
     <paper id="8">
       <title>Ethical Considerations in <fixed-case>NLP</fixed-case> Shared Tasks</title>
-      <author><first>Carla</first> <last>Parra Escartín</last></author>
-      <author><first>Wessel</first> <last>Reijers</last></author>
-      <author><first>Teresa</first> <last>Lynn</last></author>
-      <author><first>Joss</first> <last>Moorkens</last></author>
-      <author><first>Andy</first> <last>Way</last></author>
-      <author><first>Chao-Hong</first> <last>Liu</last></author>
+      <author><first>Carla</first><last>Parra Escartín</last></author>
+      <author><first>Wessel</first><last>Reijers</last></author>
+      <author><first>Teresa</first><last>Lynn</last></author>
+      <author><first>Joss</first><last>Moorkens</last></author>
+      <author><first>Andy</first><last>Way</last></author>
+      <author><first>Chao-Hong</first><last>Liu</last></author>
       <pages>66–73</pages>
       <url>W17-1608</url>
       <doi>10.18653/v1/W17-1608</doi>
@@ -2517,9 +2517,9 @@
     </paper>
     <paper id="9">
       <title>Social Bias in Elicited Natural Language Inferences</title>
-      <author><first>Rachel</first> <last>Rudinger</last></author>
-      <author><first>Chandler</first> <last>May</last></author>
-      <author><first>Benjamin</first> <last>Van Durme</last></author>
+      <author><first>Rachel</first><last>Rudinger</last></author>
+      <author><first>Chandler</first><last>May</last></author>
+      <author><first>Benjamin</first><last>Van Durme</last></author>
       <pages>74–79</pages>
       <url>W17-1609</url>
       <doi>10.18653/v1/W17-1609</doi>
@@ -2527,9 +2527,9 @@
     </paper>
     <paper id="10">
       <title>A Short Review of Ethical Challenges in Clinical Natural Language Processing</title>
-      <author><first>Simon</first> <last>Šuster</last></author>
-      <author><first>Stéphan</first> <last>Tulkens</last></author>
-      <author><first>Walter</first> <last>Daelemans</last></author>
+      <author><first>Simon</first><last>Šuster</last></author>
+      <author><first>Stéphan</first><last>Tulkens</last></author>
+      <author><first>Walter</first><last>Daelemans</last></author>
       <pages>80–87</pages>
       <url>W17-1610</url>
       <doi>10.18653/v1/W17-1610</doi>
@@ -2537,7 +2537,7 @@
     </paper>
     <paper id="11">
       <title>Goal-Oriented Design for Ethical Machine Learning and <fixed-case>NLP</fixed-case></title>
-      <author><first>Tyler</first> <last>Schnoebelen</last></author>
+      <author><first>Tyler</first><last>Schnoebelen</last></author>
       <pages>88–93</pages>
       <url>W17-1611</url>
       <doi>10.18653/v1/W17-1611</doi>
@@ -2545,9 +2545,9 @@
     </paper>
     <paper id="12">
       <title>Ethical Research Protocols for Social Media Health Research</title>
-      <author><first>Adrian</first> <last>Benton</last></author>
-      <author><first>Glen</first> <last>Coppersmith</last></author>
-      <author><first>Mark</first> <last>Dredze</last></author>
+      <author><first>Adrian</first><last>Benton</last></author>
+      <author><first>Glen</first><last>Coppersmith</last></author>
+      <author><first>Mark</first><last>Dredze</last></author>
       <pages>94–102</pages>
       <url>W17-1612</url>
       <doi>10.18653/v1/W17-1612</doi>
@@ -2555,10 +2555,10 @@
     </paper>
     <paper id="13">
       <title>Say the Right Thing Right: Ethics Issues in Natural Language Generation Systems</title>
-      <author><first>Charese</first> <last>Smiley</last></author>
-      <author><first>Frank</first> <last>Schilder</last></author>
-      <author><first>Vassilis</first> <last>Plachouras</last></author>
-      <author><first>Jochen L.</first> <last>Leidner</last></author>
+      <author><first>Charese</first><last>Smiley</last></author>
+      <author><first>Frank</first><last>Schilder</last></author>
+      <author><first>Vassilis</first><last>Plachouras</last></author>
+      <author><first>Jochen L.</first><last>Leidner</last></author>
       <pages>103–108</pages>
       <url>W17-1613</url>
       <doi>10.18653/v1/W17-1613</doi>
@@ -2584,8 +2584,8 @@
     </frontmatter>
     <paper id="1">
       <title><fixed-case>P</fixed-case>ara<fixed-case>D</fixed-case>i: Dictionary of Paraphrases of <fixed-case>C</fixed-case>zech Complex Predicates with Light Verbs</title>
-      <author><first>Petra</first> <last>Barančíková</last></author>
-      <author><first>Václava</first> <last>Kettnerová</last></author>
+      <author><first>Petra</first><last>Barančíková</last></author>
+      <author><first>Václava</first><last>Kettnerová</last></author>
       <pages>1–10</pages>
       <url>W17-1701</url>
       <doi>10.18653/v1/W17-1701</doi>
@@ -2593,10 +2593,10 @@
     </paper>
     <paper id="2">
       <title>Multi-word Entity Classification in a Highly Multilingual Environment</title>
-      <author><first>Sophie</first> <last>Chesney</last></author>
-      <author><first>Guillaume</first> <last>Jacquet</last></author>
-      <author><first>Ralf</first> <last>Steinberger</last></author>
-      <author><first>Jakub</first> <last>Piskorski</last></author>
+      <author><first>Sophie</first><last>Chesney</last></author>
+      <author><first>Guillaume</first><last>Jacquet</last></author>
+      <author><first>Ralf</first><last>Steinberger</last></author>
+      <author><first>Jakub</first><last>Piskorski</last></author>
       <pages>11–20</pages>
       <url>W17-1702</url>
       <doi>10.18653/v1/W17-1702</doi>
@@ -2604,9 +2604,9 @@
     </paper>
     <paper id="3">
       <title>Using bilingual word-embeddings for multilingual collocation extraction</title>
-      <author><first>Marcos</first> <last>Garcia</last></author>
-      <author><first>Marcos</first> <last>García-Salido</last></author>
-      <author><first>Margarita</first> <last>Alonso-Ramos</last></author>
+      <author><first>Marcos</first><last>Garcia</last></author>
+      <author><first>Marcos</first><last>García-Salido</last></author>
+      <author><first>Margarita</first><last>Alonso-Ramos</last></author>
       <pages>21–30</pages>
       <url>W17-1703</url>
       <doi>10.18653/v1/W17-1703</doi>
@@ -2614,17 +2614,17 @@
     </paper>
     <paper id="4">
       <title>The <fixed-case>PARSEME</fixed-case> Shared Task on Automatic Identification of Verbal Multiword Expressions</title>
-      <author><first>Agata</first> <last>Savary</last></author>
-      <author><first>Carlos</first> <last>Ramisch</last></author>
-      <author><first>Silvio</first> <last>Cordeiro</last></author>
-      <author><first>Federico</first> <last>Sangati</last></author>
-      <author><first>Veronika</first> <last>Vincze</last></author>
-      <author><first>Behrang</first> <last>QasemiZadeh</last></author>
-      <author><first>Marie</first> <last>Candito</last></author>
-      <author><first>Fabienne</first> <last>Cap</last></author>
-      <author><first>Voula</first> <last>Giouli</last></author>
-      <author><first>Ivelina</first> <last>Stoyanova</last></author>
-      <author><first>Antoine</first> <last>Doucet</last></author>
+      <author><first>Agata</first><last>Savary</last></author>
+      <author><first>Carlos</first><last>Ramisch</last></author>
+      <author><first>Silvio</first><last>Cordeiro</last></author>
+      <author><first>Federico</first><last>Sangati</last></author>
+      <author><first>Veronika</first><last>Vincze</last></author>
+      <author><first>Behrang</first><last>QasemiZadeh</last></author>
+      <author><first>Marie</first><last>Candito</last></author>
+      <author><first>Fabienne</first><last>Cap</last></author>
+      <author><first>Voula</first><last>Giouli</last></author>
+      <author><first>Ivelina</first><last>Stoyanova</last></author>
+      <author><first>Antoine</first><last>Doucet</last></author>
       <pages>31–47</pages>
       <url>W17-1704</url>
       <doi>10.18653/v1/W17-1704</doi>
@@ -2632,9 +2632,9 @@
     </paper>
     <paper id="5">
       <title><fixed-case>US</fixed-case>zeged: Identifying Verbal Multiword Expressions with <fixed-case>POS</fixed-case> Tagging and Parsing Techniques</title>
-      <author><first>Katalin Ilona</first> <last>Simkó</last></author>
-      <author><first>Viktória</first> <last>Kovács</last></author>
-      <author><first>Veronika</first> <last>Vincze</last></author>
+      <author><first>Katalin Ilona</first><last>Simkó</last></author>
+      <author><first>Viktória</first><last>Kovács</last></author>
+      <author><first>Veronika</first><last>Vincze</last></author>
       <pages>48–53</pages>
       <url>W17-1705</url>
       <doi>10.18653/v1/W17-1705</doi>
@@ -2642,9 +2642,9 @@
     </paper>
     <paper id="6">
       <title>Parsing and <fixed-case>MWE</fixed-case> Detection: Fips at the <fixed-case>PARSEME</fixed-case> Shared Task</title>
-      <author><first>Luka</first> <last>Nerima</last></author>
-      <author><first>Vasiliki</first> <last>Foufi</last></author>
-      <author><first>Éric</first> <last>Wehrli</last></author>
+      <author><first>Luka</first><last>Nerima</last></author>
+      <author><first>Vasiliki</first><last>Foufi</last></author>
+      <author><first>Éric</first><last>Wehrli</last></author>
       <pages>54–59</pages>
       <url>W17-1706</url>
       <doi>10.18653/v1/W17-1706</doi>
@@ -2652,9 +2652,9 @@
     </paper>
     <paper id="7">
       <title>Neural Networks for Multi-Word Expression Detection</title>
-      <author><first>Natalia</first> <last>Klyueva</last></author>
-      <author><first>Antoine</first> <last>Doucet</last></author>
-      <author><first>Milan</first> <last>Straka</last></author>
+      <author><first>Natalia</first><last>Klyueva</last></author>
+      <author><first>Antoine</first><last>Doucet</last></author>
+      <author><first>Milan</first><last>Straka</last></author>
       <pages>60–65</pages>
       <url>W17-1707</url>
       <doi>10.18653/v1/W17-1707</doi>
@@ -2662,8 +2662,8 @@
     </paper>
     <paper id="8">
       <title>Factoring Ambiguity out of the Prediction of Compositionality for <fixed-case>G</fixed-case>erman Multi-Word Expressions</title>
-      <author><first>Stefan</first> <last>Bott</last></author>
-      <author><first>Sabine</first> <last>Schulte im Walde</last></author>
+      <author><first>Stefan</first><last>Bott</last></author>
+      <author><first>Sabine</first><last>Schulte im Walde</last></author>
       <pages>66–72</pages>
       <url>W17-1708</url>
       <doi>10.18653/v1/W17-1708</doi>
@@ -2671,7 +2671,7 @@
     </paper>
     <paper id="9">
       <title>Multiword expressions and lexicalism: the view from <fixed-case>LFG</fixed-case></title>
-      <author><first>Jamie Y.</first> <last>Findlay</last></author>
+      <author><first>Jamie Y.</first><last>Findlay</last></author>
       <pages>73–79</pages>
       <url>W17-1709</url>
       <doi>10.18653/v1/W17-1709</doi>
@@ -2679,9 +2679,9 @@
     </paper>
     <paper id="10">
       <title>Understanding Idiomatic Variation</title>
-      <author><first>Kristina</first> <last>Geeraert</last></author>
-      <author><first>R. Harald</first> <last>Baayen</last></author>
-      <author><first>John</first> <last>Newman</last></author>
+      <author><first>Kristina</first><last>Geeraert</last></author>
+      <author><first>R. Harald</first><last>Baayen</last></author>
+      <author><first>John</first><last>Newman</last></author>
       <pages>80–90</pages>
       <url>W17-1710</url>
       <doi>10.18653/v1/W17-1710</doi>
@@ -2689,9 +2689,9 @@
     </paper>
     <paper id="11">
       <title>Discovering Light Verb Constructions and their Translations from Parallel Corpora without Word Alignment</title>
-      <author><first>Natalie</first> <last>Vargas</last></author>
-      <author><first>Carlos</first> <last>Ramisch</last></author>
-      <author><first>Helena</first> <last>Caseli</last></author>
+      <author><first>Natalie</first><last>Vargas</last></author>
+      <author><first>Carlos</first><last>Ramisch</last></author>
+      <author><first>Helena</first><last>Caseli</last></author>
       <pages>91–96</pages>
       <url>W17-1711</url>
       <doi>10.18653/v1/W17-1711</doi>
@@ -2699,8 +2699,8 @@
     </paper>
     <paper id="12">
       <title>Identification of Multiword Expressions for <fixed-case>L</fixed-case>atvian and <fixed-case>L</fixed-case>ithuanian: Hybrid Approach</title>
-      <author><first>Justina</first> <last>Mandravickaitė</last></author>
-      <author><first>Tomas</first> <last>Krilavičius</last></author>
+      <author><first>Justina</first><last>Mandravickaitė</last></author>
+      <author><first>Tomas</first><last>Krilavičius</last></author>
       <pages>97–101</pages>
       <url>W17-1712</url>
       <doi>10.18653/v1/W17-1712</doi>
@@ -2708,7 +2708,7 @@
     </paper>
     <paper id="13">
       <title>Show Me Your Variance and <fixed-case>I</fixed-case> Tell You Who You Are - Deriving Compound Compositionality from Word Alignments</title>
-      <author><first>Fabienne</first> <last>Cap</last></author>
+      <author><first>Fabienne</first><last>Cap</last></author>
       <pages>102–107</pages>
       <url>W17-1713</url>
       <doi>10.18653/v1/W17-1713</doi>
@@ -2716,8 +2716,8 @@
     </paper>
     <paper id="14">
       <title>Semantic annotation to characterize contextual variation in terminological noun compounds: a pilot study</title>
-      <author><first>Melania</first> <last>Cabezas-García</last></author>
-      <author><first>Antonio</first> <last>San Martín</last></author>
+      <author><first>Melania</first><last>Cabezas-García</last></author>
+      <author><first>Antonio</first><last>San Martín</last></author>
       <pages>108–113</pages>
       <url>W17-1714</url>
       <doi>10.18653/v1/W17-1714</doi>
@@ -2725,13 +2725,13 @@
     </paper>
     <paper id="15">
       <title>Detection of Verbal Multi-Word Expressions via Conditional Random Fields with Syntactic Dependency Features and Semantic Re-Ranking</title>
-      <author><first>Alfredo</first> <last>Maldonado</last></author>
-      <author><first>Lifeng</first> <last>Han</last></author>
-      <author><first>Erwan</first> <last>Moreau</last></author>
-      <author><first>Ashjan</first> <last>Alsulaimani</last></author>
-      <author><first>Koel Dutta</first> <last>Chowdhury</last></author>
-      <author><first>Carl</first> <last>Vogel</last></author>
-      <author><first>Qun</first> <last>Liu</last></author>
+      <author><first>Alfredo</first><last>Maldonado</last></author>
+      <author><first>Lifeng</first><last>Han</last></author>
+      <author><first>Erwan</first><last>Moreau</last></author>
+      <author><first>Ashjan</first><last>Alsulaimani</last></author>
+      <author><first>Koel Dutta</first><last>Chowdhury</last></author>
+      <author><first>Carl</first><last>Vogel</last></author>
+      <author><first>Qun</first><last>Liu</last></author>
       <pages>114–120</pages>
       <url>W17-1715</url>
       <doi>10.18653/v1/W17-1715</doi>
@@ -2739,10 +2739,10 @@
     </paper>
     <paper id="16">
       <title>A data-driven approach to verbal multiword expression detection. <fixed-case>PARSEME</fixed-case> Shared Task system description paper</title>
-      <author><first>Tiberiu</first> <last>Boros</last></author>
-      <author><first>Sonia</first> <last>Pipa</last></author>
-      <author><first>Verginica</first> <last>Barbu Mititelu</last></author>
-      <author><first>Dan</first> <last>Tufis</last></author>
+      <author><first>Tiberiu</first><last>Boros</last></author>
+      <author><first>Sonia</first><last>Pipa</last></author>
+      <author><first>Verginica</first><last>Barbu Mititelu</last></author>
+      <author><first>Dan</first><last>Tufis</last></author>
       <pages>121–126</pages>
       <url>W17-1716</url>
       <doi>10.18653/v1/W17-1716</doi>
@@ -2750,9 +2750,9 @@
     </paper>
     <paper id="17">
       <title>The <fixed-case>ATILF</fixed-case>-<fixed-case>LLF</fixed-case> System for Parseme Shared Task: a Transition-based Verbal Multiword Expression Tagger</title>
-      <author><first>Hazem</first> <last>Al Saied</last></author>
-      <author><first>Matthieu</first> <last>Constant</last></author>
-      <author><first>Marie</first> <last>Candito</last></author>
+      <author><first>Hazem</first><last>Al Saied</last></author>
+      <author><first>Matthieu</first><last>Constant</last></author>
+      <author><first>Marie</first><last>Candito</last></author>
       <pages>127–132</pages>
       <url>W17-1717</url>
       <doi>10.18653/v1/W17-1717</doi>
@@ -2760,10 +2760,10 @@
     </paper>
     <paper id="18">
       <title>Investigating the Opacity of Verb-Noun Multiword Expression Usages in Context</title>
-      <author><first>Shiva</first> <last>Taslimipoor</last></author>
-      <author><first>Omid</first> <last>Rohanian</last></author>
-      <author><first>Ruslan</first> <last>Mitkov</last></author>
-      <author><first>Afsaneh</first> <last>Fazly</last></author>
+      <author><first>Shiva</first><last>Taslimipoor</last></author>
+      <author><first>Omid</first><last>Rohanian</last></author>
+      <author><first>Ruslan</first><last>Mitkov</last></author>
+      <author><first>Afsaneh</first><last>Fazly</last></author>
       <pages>133–138</pages>
       <url>W17-1718</url>
       <doi>10.18653/v1/W17-1718</doi>
@@ -2771,9 +2771,9 @@
     </paper>
     <paper id="19">
       <title>Compositionality in Verb-Particle Constructions</title>
-      <author><first>Archna</first> <last>Bhatia</last></author>
-      <author><first>Choh Man</first> <last>Teng</last></author>
-      <author><first>James</first> <last>Allen</last></author>
+      <author><first>Archna</first><last>Bhatia</last></author>
+      <author><first>Choh Man</first><last>Teng</last></author>
+      <author><first>James</first><last>Allen</last></author>
       <pages>139–148</pages>
       <url>W17-1719</url>
       <doi>10.18653/v1/W17-1719</doi>
@@ -2781,11 +2781,11 @@
     </paper>
     <paper id="20">
       <title>Rule-Based Translation of <fixed-case>S</fixed-case>panish Verb-Noun Combinations into Basque</title>
-      <author><first>Uxoa</first> <last>Iñurrieta</last></author>
-      <author><first>Itziar</first> <last>Aduriz</last></author>
-      <author><first>Arantza</first> <last>Díaz de Ilarraza</last></author>
-      <author><first>Gorka</first> <last>Labaka</last></author>
-      <author><first>Kepa</first> <last>Sarasola</last></author>
+      <author><first>Uxoa</first><last>Iñurrieta</last></author>
+      <author><first>Itziar</first><last>Aduriz</last></author>
+      <author><first>Arantza</first><last>Díaz de Ilarraza</last></author>
+      <author><first>Gorka</first><last>Labaka</last></author>
+      <author><first>Kepa</first><last>Sarasola</last></author>
       <pages>149–154</pages>
       <url>W17-1720</url>
       <doi>10.18653/v1/W17-1720</doi>
@@ -2793,7 +2793,7 @@
     </paper>
     <paper id="21">
       <title>Verb-Particle Constructions in Questions</title>
-      <author><first>Veronika</first> <last>Vincze</last></author>
+      <author><first>Veronika</first><last>Vincze</last></author>
       <pages>155–160</pages>
       <url>W17-1721</url>
       <doi>10.18653/v1/W17-1721</doi>
@@ -2801,7 +2801,7 @@
     </paper>
     <paper id="22">
       <title>Simple Compound Splitting for <fixed-case>G</fixed-case>erman</title>
-      <author><first>Marion</first> <last>Weller-Di Marco</last></author>
+      <author><first>Marion</first><last>Weller-Di Marco</last></author>
       <pages>161–166</pages>
       <url>W17-1722</url>
       <doi>10.18653/v1/W17-1722</doi>
@@ -2809,8 +2809,8 @@
     </paper>
     <paper id="23">
       <title>Identification of Ambiguous Multiword Expressions Using Sequence Models and Lexical Resources</title>
-      <author><first>Manon</first> <last>Scholivet</last></author>
-      <author><first>Carlos</first> <last>Ramisch</last></author>
+      <author><first>Manon</first><last>Scholivet</last></author>
+      <author><first>Carlos</first><last>Ramisch</last></author>
       <pages>167–175</pages>
       <url>W17-1723</url>
       <doi>10.18653/v1/W17-1723</doi>
@@ -2818,8 +2818,8 @@
     </paper>
     <paper id="24">
       <title>Comparing Recurring Lexico-Syntactic Trees (<fixed-case>RLT</fixed-case>s) and Ngram Techniques for Extended Phraseology Extraction</title>
-      <author><first>Agnès</first> <last>Tutin</last></author>
-      <author><first>Olivier</first> <last>Kraif</last></author>
+      <author><first>Agnès</first><last>Tutin</last></author>
+      <author><first>Olivier</first><last>Kraif</last></author>
       <pages>176–180</pages>
       <url>W17-1724</url>
       <doi>10.18653/v1/W17-1724</doi>
@@ -2827,8 +2827,8 @@
     </paper>
     <paper id="25">
       <title>Benchmarking Joint Lexical and Syntactic Analysis on Multiword-Rich Data</title>
-      <author><first>Matthieu</first> <last>Constant</last></author>
-      <author><first>Héctor</first> <last>Martinez Alonso</last></author>
+      <author><first>Matthieu</first><last>Constant</last></author>
+      <author><first>Héctor</first><last>Martinez Alonso</last></author>
       <pages>181–186</pages>
       <url>W17-1725</url>
       <doi>10.18653/v1/W17-1725</doi>
@@ -2836,9 +2836,9 @@
     </paper>
     <paper id="26">
       <title>Semi-Automated Resolution of Inconsistency for a Harmonized Multiword Expression and Dependency Parse Annotation</title>
-      <author><first>King</first> <last>Chan</last></author>
-      <author><first>Julian</first> <last>Brooke</last></author>
-      <author><first>Timothy</first> <last>Baldwin</last></author>
+      <author><first>King</first><last>Chan</last></author>
+      <author><first>Julian</first><last>Brooke</last></author>
+      <author><first>Timothy</first><last>Baldwin</last></author>
       <pages>187–193</pages>
       <url>W17-1726</url>
       <doi>10.18653/v1/W17-1726</doi>
@@ -2846,8 +2846,8 @@
     </paper>
     <paper id="27">
       <title>Combining Linguistic Features for the Detection of <fixed-case>C</fixed-case>roatian Multiword Expressions</title>
-      <author><first>Maja</first> <last>Buljan</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
+      <author><first>Maja</first><last>Buljan</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
       <pages>194–199</pages>
       <url>W17-1727</url>
       <doi>10.18653/v1/W17-1727</doi>
@@ -2855,8 +2855,8 @@
     </paper>
     <paper id="28">
       <title>Complex Verbs are Different: Exploring the Visual Modality in Multi-Modal Models to Predict Compositionality</title>
-      <author><first>Maximilian</first> <last>Köper</last></author>
-      <author><first>Sabine</first> <last>Schulte im Walde</last></author>
+      <author><first>Maximilian</first><last>Köper</last></author>
+      <author><first>Sabine</first><last>Schulte im Walde</last></author>
       <pages>200–206</pages>
       <url>W17-1728</url>
       <doi>10.18653/v1/W17-1728</doi>
@@ -2881,11 +2881,11 @@
     </frontmatter>
     <paper id="1">
       <title>Understanding the Semantics of Narratives of Interpersonal Violence through Reader Annotations and Physiological Reactions</title>
-      <author><first>Alexander</first> <last>Calderwood</last></author>
-      <author><first>Elizabeth A.</first> <last>Pruett</last></author>
-      <author><first>Raymond</first> <last>Ptucha</last></author>
-      <author><first>Christopher</first> <last>Homan</last></author>
-      <author><first>Cecilia</first> <last>Ovesdotter Alm</last></author>
+      <author><first>Alexander</first><last>Calderwood</last></author>
+      <author><first>Elizabeth A.</first><last>Pruett</last></author>
+      <author><first>Raymond</first><last>Ptucha</last></author>
+      <author><first>Christopher</first><last>Homan</last></author>
+      <author><first>Cecilia</first><last>Ovesdotter Alm</last></author>
       <pages>1–9</pages>
       <url>W17-1801</url>
       <doi>10.18653/v1/W17-1801</doi>
@@ -2893,8 +2893,8 @@
     </paper>
     <paper id="2">
       <title>Intension, Attitude, and Tense Annotation in a High-Fidelity Semantic Representation</title>
-      <author><first>Gene</first> <last>Kim</last></author>
-      <author><first>Lenhart</first> <last>Schubert</last></author>
+      <author><first>Gene</first><last>Kim</last></author>
+      <author><first>Lenhart</first><last>Schubert</last></author>
       <pages>10–15</pages>
       <url>W17-1802</url>
       <doi>10.18653/v1/W17-1802</doi>
@@ -2902,8 +2902,8 @@
     </paper>
     <paper id="3">
       <title>Towards a lexicon of event-selecting predicates for a <fixed-case>F</fixed-case>rench <fixed-case>F</fixed-case>act<fixed-case>B</fixed-case>ank</title>
-      <author><first>Ingrid</first> <last>Falk</last></author>
-      <author><first>Fabienne</first> <last>Martin</last></author>
+      <author><first>Ingrid</first><last>Falk</last></author>
+      <author><first>Fabienne</first><last>Martin</last></author>
       <pages>16–21</pages>
       <url>W17-1803</url>
       <doi>10.18653/v1/W17-1803</doi>
@@ -2911,10 +2911,10 @@
     </paper>
     <paper id="4">
       <title>Universal Dependencies to Logical Form with Negation Scope</title>
-      <author><first>Federico</first> <last>Fancellu</last></author>
-      <author><first>Siva</first> <last>Reddy</last></author>
-      <author><first>Adam</first> <last>Lopez</last></author>
-      <author><first>Bonnie</first> <last>Webber</last></author>
+      <author><first>Federico</first><last>Fancellu</last></author>
+      <author><first>Siva</first><last>Reddy</last></author>
+      <author><first>Adam</first><last>Lopez</last></author>
+      <author><first>Bonnie</first><last>Webber</last></author>
       <pages>22–32</pages>
       <url>W17-1804</url>
       <doi>10.18653/v1/W17-1804</doi>
@@ -2925,7 +2925,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Meaning Banking beyond Events and Roles</title>
-      <author><first>Johan</first> <last>Bos</last></author>
+      <author><first>Johan</first><last>Bos</last></author>
       <pages>33</pages>
       <url>W17-1805</url>
       <doi>10.18653/v1/W17-1805</doi>
@@ -2933,9 +2933,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>The Scope and Focus of Negation: A Complete Annotation Framework for <fixed-case>I</fixed-case>talian</title>
-      <author><first>Begoña</first> <last>Altuna</last></author>
-      <author><first>Anne-Lyse</first> <last>Minard</last></author>
-      <author><first>Manuela</first> <last>Speranza</last></author>
+      <author><first>Begoña</first><last>Altuna</last></author>
+      <author><first>Anne-Lyse</first><last>Minard</last></author>
+      <author><first>Manuela</first><last>Speranza</last></author>
       <pages>34–42</pages>
       <url>W17-1806</url>
       <doi>10.18653/v1/W17-1806</doi>
@@ -2943,9 +2943,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Annotation of negation in the <fixed-case>IULA</fixed-case> <fixed-case>S</fixed-case>panish Clinical Record Corpus</title>
-      <author><first>Montserrat</first> <last>Marimon</last></author>
-      <author><first>Jorge</first> <last>Vivaldi</last></author>
-      <author><first>Núria</first> <last>Bel</last></author>
+      <author><first>Montserrat</first><last>Marimon</last></author>
+      <author><first>Jorge</first><last>Vivaldi</last></author>
+      <author><first>Núria</first><last>Bel</last></author>
       <pages>43–52</pages>
       <url>W17-1807</url>
       <doi>10.18653/v1/W17-1807</doi>
@@ -2953,11 +2953,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Annotating Negation in <fixed-case>S</fixed-case>panish Clinical Texts</title>
-      <author><first>Noa</first> <last>Cruz</last></author>
-      <author><first>Roser</first> <last>Morante</last></author>
-      <author><first>Manuel J.</first> <last>Maña López</last></author>
-      <author><first>Jacinto</first> <last>Mata Vázquez</last></author>
-      <author><first>Carlos L.</first> <last>Parra Calderón</last></author>
+      <author><first>Noa</first><last>Cruz</last></author>
+      <author><first>Roser</first><last>Morante</last></author>
+      <author><first>Manuel J.</first><last>Maña López</last></author>
+      <author><first>Jacinto</first><last>Mata Vázquez</last></author>
+      <author><first>Carlos L.</first><last>Parra Calderón</last></author>
       <pages>53–58</pages>
       <url>W17-1808</url>
       <doi>10.18653/v1/W17-1808</doi>
@@ -2965,9 +2965,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Neural Networks for Negation Cue Detection in <fixed-case>C</fixed-case>hinese</title>
-      <author><first>Hangfeng</first> <last>He</last></author>
-      <author><first>Federico</first> <last>Fancellu</last></author>
-      <author><first>Bonnie</first> <last>Webber</last></author>
+      <author><first>Hangfeng</first><last>He</last></author>
+      <author><first>Federico</first><last>Fancellu</last></author>
+      <author><first>Bonnie</first><last>Webber</last></author>
       <pages>59–63</pages>
       <url>W17-1809</url>
       <doi>10.18653/v1/W17-1809</doi>
@@ -2975,9 +2975,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>An open-source tool for negation detection: a maximum-margin approach</title>
-      <author><first>Martine</first> <last>Enger</last></author>
-      <author><first>Erik</first> <last>Velldal</last></author>
-      <author><first>Lilja</first> <last>Øvrelid</last></author>
+      <author><first>Martine</first><last>Enger</last></author>
+      <author><first>Erik</first><last>Velldal</last></author>
+      <author><first>Lilja</first><last>Øvrelid</last></author>
       <pages>64–69</pages>
       <url>W17-1810</url>
       <doi>10.18653/v1/W17-1810</doi>
@@ -3001,8 +3001,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Compositional Semantics using Feature-Based Models from <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et</title>
-      <author><first>Pablo</first> <last>Gamallo</last></author>
-      <author><first>Martín</first> <last>Pereira-Fariña</last></author>
+      <author><first>Pablo</first><last>Gamallo</last></author>
+      <author><first>Martín</first><last>Pereira-Fariña</last></author>
       <pages>1–11</pages>
       <url>W17-1901</url>
       <doi>10.18653/v1/W17-1901</doi>
@@ -3010,10 +3010,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Automated <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Construction Using Word Embeddings</title>
-      <author><first>Mikhail</first> <last>Khodak</last></author>
-      <author><first>Andrej</first> <last>Risteski</last></author>
-      <author><first>Christiane</first> <last>Fellbaum</last></author>
-      <author><first>Sanjeev</first> <last>Arora</last></author>
+      <author><first>Mikhail</first><last>Khodak</last></author>
+      <author><first>Andrej</first><last>Risteski</last></author>
+      <author><first>Christiane</first><last>Fellbaum</last></author>
+      <author><first>Sanjeev</first><last>Arora</last></author>
       <pages>12–23</pages>
       <url>W17-1902</url>
       <doi>10.18653/v1/W17-1902</doi>
@@ -3021,8 +3021,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Improving Verb Metaphor Detection by Propagating Abstractness to Words, Phrases and Individual Senses</title>
-      <author><first>Maximilian</first> <last>Köper</last></author>
-      <author><first>Sabine</first> <last>Schulte im Walde</last></author>
+      <author><first>Maximilian</first><last>Köper</last></author>
+      <author><first>Sabine</first><last>Schulte im Walde</last></author>
       <pages>24–30</pages>
       <url>W17-1903</url>
       <doi>10.18653/v1/W17-1903</doi>
@@ -3030,9 +3030,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Improving Clinical Diagnosis Inference through Integration of Structured and Unstructured Knowledge</title>
-      <author><first>Yuan</first> <last>Ling</last></author>
-      <author><first>Yuan</first> <last>An</last></author>
-      <author><first>Sadid</first> <last>Hasan</last></author>
+      <author><first>Yuan</first><last>Ling</last></author>
+      <author><first>Yuan</first><last>An</last></author>
+      <author><first>Sadid</first><last>Hasan</last></author>
       <pages>31–36</pages>
       <url>W17-1904</url>
       <doi>10.18653/v1/W17-1904</doi>
@@ -3040,9 +3040,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Classifying Lexical-semantic Relationships by Exploiting Sense/Concept Representations</title>
-      <author><first>Kentaro</first> <last>Kanada</last></author>
-      <author><first>Tetsunori</first> <last>Kobayashi</last></author>
-      <author><first>Yoshihiko</first> <last>Hayashi</last></author>
+      <author><first>Kentaro</first><last>Kanada</last></author>
+      <author><first>Tetsunori</first><last>Kobayashi</last></author>
+      <author><first>Yoshihiko</first><last>Hayashi</last></author>
       <pages>37–46</pages>
       <url>W17-1905</url>
       <doi>10.18653/v1/W17-1905</doi>
@@ -3050,8 +3050,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Supervised and unsupervised approaches to measuring usage similarity</title>
-      <author><first>Milton</first> <last>King</last></author>
-      <author><first>Paul</first> <last>Cook</last></author>
+      <author><first>Milton</first><last>King</last></author>
+      <author><first>Paul</first><last>Cook</last></author>
       <pages>47–52</pages>
       <url>W17-1906</url>
       <doi>10.18653/v1/W17-1906</doi>
@@ -3059,9 +3059,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Lexical Disambiguation of <fixed-case>I</fixed-case>gbo using Diacritic Restoration</title>
-      <author><first>Ignatius</first> <last>Ezeani</last></author>
-      <author><first>Mark</first> <last>Hepple</last></author>
-      <author><first>Ikechukwu</first> <last>Onyenwe</last></author>
+      <author><first>Ignatius</first><last>Ezeani</last></author>
+      <author><first>Mark</first><last>Hepple</last></author>
+      <author><first>Ikechukwu</first><last>Onyenwe</last></author>
       <pages>53–60</pages>
       <url>W17-1907</url>
       <doi>10.18653/v1/W17-1907</doi>
@@ -3069,10 +3069,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Creating and Validating Multilingual Semantic Representations for Six Languages: Expert versus Non-Expert Crowds</title>
-      <author><first>Mahmoud</first> <last>El-Haj</last></author>
-      <author><first>Paul</first> <last>Rayson</last></author>
-      <author><first>Scott</first> <last>Piao</last></author>
-      <author><first>Stephen</first> <last>Wattam</last></author>
+      <author><first>Mahmoud</first><last>El-Haj</last></author>
+      <author><first>Paul</first><last>Rayson</last></author>
+      <author><first>Scott</first><last>Piao</last></author>
+      <author><first>Stephen</first><last>Wattam</last></author>
       <pages>61–71</pages>
       <url>W17-1908</url>
       <doi>10.18653/v1/W17-1908</doi>
@@ -3080,10 +3080,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Using Linked Disambiguated Distributional Networks for Word Sense Disambiguation</title>
-      <author><first>Alexander</first> <last>Panchenko</last></author>
-      <author><first>Stefano</first> <last>Faralli</last></author>
-      <author><first>Simone Paolo</first> <last>Ponzetto</last></author>
-      <author><first>Chris</first> <last>Biemann</last></author>
+      <author><first>Alexander</first><last>Panchenko</last></author>
+      <author><first>Stefano</first><last>Faralli</last></author>
+      <author><first>Simone Paolo</first><last>Ponzetto</last></author>
+      <author><first>Chris</first><last>Biemann</last></author>
       <pages>72–78</pages>
       <url>W17-1909</url>
       <doi>10.18653/v1/W17-1909</doi>
@@ -3091,11 +3091,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>One Representation per Word - Does it make Sense for Composition?</title>
-      <author><first>Thomas</first> <last>Kober</last></author>
-      <author><first>Julie</first> <last>Weeds</last></author>
-      <author><first>John</first> <last>Wilkie</last></author>
-      <author><first>Jeremy</first> <last>Reffin</last></author>
-      <author><first>David</first> <last>Weir</last></author>
+      <author><first>Thomas</first><last>Kober</last></author>
+      <author><first>Julie</first><last>Weeds</last></author>
+      <author><first>John</first><last>Wilkie</last></author>
+      <author><first>Jeremy</first><last>Reffin</last></author>
+      <author><first>David</first><last>Weir</last></author>
       <pages>79–90</pages>
       <url>W17-1910</url>
       <doi>10.18653/v1/W17-1910</doi>
@@ -3103,8 +3103,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Elucidating Conceptual Properties from Word Embeddings</title>
-      <author><first>Kyoung-Rok</first> <last>Jang</last></author>
-      <author><first>Sung-Hyon</first> <last>Myaeng</last></author>
+      <author><first>Kyoung-Rok</first><last>Jang</last></author>
+      <author><first>Sung-Hyon</first><last>Myaeng</last></author>
       <pages>91–95</pages>
       <url>W17-1911</url>
       <doi>10.18653/v1/W17-1911</doi>
@@ -3112,9 +3112,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>TTCS<tex-math>^{\mathcal{E}}</tex-math>: a Vectorial Resource for Computing Conceptual Similarity</title>
-      <author><first>Enrico</first> <last>Mensa</last></author>
-      <author><first>Daniele P.</first> <last>Radicioni</last></author>
-      <author><first>Antonio</first> <last>Lieto</last></author>
+      <author><first>Enrico</first><last>Mensa</last></author>
+      <author><first>Daniele P.</first><last>Radicioni</last></author>
+      <author><first>Antonio</first><last>Lieto</last></author>
       <pages>96–101</pages>
       <url>W17-1912</url>
       <doi>10.18653/v1/W17-1912</doi>
@@ -3122,8 +3122,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Measuring the <fixed-case>I</fixed-case>talian-<fixed-case>E</fixed-case>nglish lexical gap for action verbs and its impact on translation</title>
-      <author><first>Lorenzo</first> <last>Gregori</last></author>
-      <author><first>Alessandro</first> <last>Panunzi</last></author>
+      <author><first>Lorenzo</first><last>Gregori</last></author>
+      <author><first>Alessandro</first><last>Panunzi</last></author>
       <pages>102–109</pages>
       <url>W17-1913</url>
       <doi>10.18653/v1/W17-1913</doi>
@@ -3131,9 +3131,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Word Sense Filtering Improves Embedding-Based Lexical Substitution</title>
-      <author><first>Anne</first> <last>Cocos</last></author>
-      <author><first>Marianna</first> <last>Apidianaki</last></author>
-      <author><first>Chris</first> <last>Callison-Burch</last></author>
+      <author><first>Anne</first><last>Cocos</last></author>
+      <author><first>Marianna</first><last>Apidianaki</last></author>
+      <author><first>Chris</first><last>Callison-Burch</last></author>
       <pages>110–119</pages>
       <url>W17-1914</url>
       <doi>10.18653/v1/W17-1914</doi>
@@ -3141,8 +3141,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Supervised and Unsupervised Word Sense Disambiguation on Word Embedding Vectors of Unambigous Synonyms</title>
-      <author><first>Aleksander</first> <last>Wawer</last></author>
-      <author><first>Agnieszka</first> <last>Mykowiecka</last></author>
+      <author><first>Aleksander</first><last>Wawer</last></author>
+      <author><first>Agnieszka</first><last>Mykowiecka</last></author>
       <pages>120–125</pages>
       <url>W17-1915</url>
       <doi>10.18653/v1/W17-1915</doi>
@@ -3168,10 +3168,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>The <fixed-case>BURCHAK</fixed-case> corpus: a Challenge Data Set for Interactive Learning of Visually Grounded Word Meanings</title>
-      <author><first>Yanchao</first> <last>Yu</last></author>
-      <author><first>Arash</first> <last>Eshghi</last></author>
-      <author><first>Gregory</first> <last>Mills</last></author>
-      <author><first>Oliver</first> <last>Lemon</last></author>
+      <author><first>Yanchao</first><last>Yu</last></author>
+      <author><first>Arash</first><last>Eshghi</last></author>
+      <author><first>Gregory</first><last>Mills</last></author>
+      <author><first>Oliver</first><last>Lemon</last></author>
       <pages>1–10</pages>
       <url>W17-2001</url>
       <doi>10.18653/v1/W17-2001</doi>
@@ -3179,8 +3179,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>The Use of Object Labels and Spatial Prepositions as Keywords in a Web-Retrieval-Based Image Caption Generation System</title>
-      <author><first>Brandon</first> <last>Birmingham</last></author>
-      <author><first>Adrian</first> <last>Muscat</last></author>
+      <author><first>Brandon</first><last>Birmingham</last></author>
+      <author><first>Adrian</first><last>Muscat</last></author>
       <pages>11–20</pages>
       <url>W17-2002</url>
       <doi>10.18653/v1/W17-2002</doi>
@@ -3188,9 +3188,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Learning to Recognize Animals by Watching Documentaries: Using Subtitles as Weak Supervision</title>
-      <author><first>Aparna</first> <last>Nurani Venkitasubramanian</last></author>
-      <author><first>Tinne</first> <last>Tuytelaars</last></author>
-      <author><first>Marie-Francine</first> <last>Moens</last></author>
+      <author><first>Aparna</first><last>Nurani Venkitasubramanian</last></author>
+      <author><first>Tinne</first><last>Tuytelaars</last></author>
+      <author><first>Marie-Francine</first><last>Moens</last></author>
       <pages>21–30</pages>
       <url>W17-2003</url>
       <doi>10.18653/v1/W17-2003</doi>
@@ -3198,11 +3198,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Human Evaluation of Multi-modal Neural Machine Translation: A Case-Study on E-Commerce Listing Titles</title>
-      <author><first>Iacer</first> <last>Calixto</last></author>
-      <author><first>Daniel</first> <last>Stein</last></author>
-      <author><first>Evgeny</first> <last>Matusov</last></author>
-      <author><first>Sheila</first> <last>Castilho</last></author>
-      <author><first>Andy</first> <last>Way</last></author>
+      <author><first>Iacer</first><last>Calixto</last></author>
+      <author><first>Daniel</first><last>Stein</last></author>
+      <author><first>Evgeny</first><last>Matusov</last></author>
+      <author><first>Sheila</first><last>Castilho</last></author>
+      <author><first>Andy</first><last>Way</last></author>
       <pages>31–37</pages>
       <url>W17-2004</url>
       <doi>10.18653/v1/W17-2004</doi>
@@ -3210,10 +3210,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>The <fixed-case>B</fixed-case>reaking<fixed-case>N</fixed-case>ews Dataset</title>
-      <author><first>Arnau</first> <last>Ramisa</last></author>
-      <author><first>Fei</first> <last>Yan</last></author>
-      <author><first>Francesc</first> <last>Moreno-Noguer</last></author>
-      <author><first>Krystian</first> <last>Mikolajczyk</last></author>
+      <author><first>Arnau</first><last>Ramisa</last></author>
+      <author><first>Fei</first><last>Yan</last></author>
+      <author><first>Francesc</first><last>Moreno-Noguer</last></author>
+      <author><first>Krystian</first><last>Mikolajczyk</last></author>
       <pages>38–39</pages>
       <url>W17-2005</url>
       <doi>10.18653/v1/W17-2005</doi>
@@ -3221,9 +3221,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Automatic identification of head movements in video-recorded conversations: can words help?</title>
-      <author><first>Patrizia</first> <last>Paggio</last></author>
-      <author><first>Costanza</first> <last>Navarretta</last></author>
-      <author><first>Bart</first> <last>Jongejan</last></author>
+      <author><first>Patrizia</first><last>Paggio</last></author>
+      <author><first>Costanza</first><last>Navarretta</last></author>
+      <author><first>Bart</first><last>Jongejan</last></author>
       <pages>40–42</pages>
       <url>W17-2006</url>
       <doi>10.18653/v1/W17-2006</doi>
@@ -3231,10 +3231,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Multi-Modal Fashion Product Retrieval</title>
-      <author><first>Antonio</first> <last>Rubio Romano</last></author>
-      <author><first>LongLong</first> <last>Yu</last></author>
-      <author><first>Edgar</first> <last>Simo-Serra</last></author>
-      <author><first>Francesc</first> <last>Moreno-Noguer</last></author>
+      <author><first>Antonio</first><last>Rubio Romano</last></author>
+      <author><first>LongLong</first><last>Yu</last></author>
+      <author><first>Edgar</first><last>Simo-Serra</last></author>
+      <author><first>Francesc</first><last>Moreno-Noguer</last></author>
       <pages>43–45</pages>
       <url>W17-2007</url>
       <doi>10.18653/v1/W17-2007</doi>
@@ -3262,10 +3262,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Metaphor Detection in a Poetry Corpus</title>
-      <author><first>Vaibhav</first> <last>Kesarwani</last></author>
-      <author><first>Diana</first> <last>Inkpen</last></author>
-      <author><first>Stan</first> <last>Szpakowicz</last></author>
-      <author><first>Chris</first> <last>Tanasescu</last></author>
+      <author><first>Vaibhav</first><last>Kesarwani</last></author>
+      <author><first>Diana</first><last>Inkpen</last></author>
+      <author><first>Stan</first><last>Szpakowicz</last></author>
+      <author><first>Chris</first><last>Tanasescu</last></author>
       <pages>1–9</pages>
       <url>W17-2201</url>
       <doi>10.18653/v1/W17-2201</doi>
@@ -3273,10 +3273,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Machine Translation and Automated Analysis of the <fixed-case>S</fixed-case>umerian Language</title>
-      <author><first>Émilie</first> <last>Pagé-Perron</last></author>
-      <author><first>Maria</first> <last>Sukhareva</last></author>
-      <author><first>Ilya</first> <last>Khait</last></author>
-      <author><first>Christian</first> <last>Chiarcos</last></author>
+      <author><first>Émilie</first><last>Pagé-Perron</last></author>
+      <author><first>Maria</first><last>Sukhareva</last></author>
+      <author><first>Ilya</first><last>Khait</last></author>
+      <author><first>Christian</first><last>Chiarcos</last></author>
       <pages>10–16</pages>
       <url>W17-2202</url>
       <doi>10.18653/v1/W17-2202</doi>
@@ -3284,9 +3284,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Investigating the Relationship between Literary Genres and Emotional Plot Development</title>
-      <author><first>Evgeny</first> <last>Kim</last></author>
-      <author><first>Sebastian</first> <last>Padó</last></author>
-      <author><first>Roman</first> <last>Klinger</last></author>
+      <author><first>Evgeny</first><last>Kim</last></author>
+      <author><first>Sebastian</first><last>Padó</last></author>
+      <author><first>Roman</first><last>Klinger</last></author>
       <pages>17–26</pages>
       <url>W17-2203</url>
       <doi>10.18653/v1/W17-2203</doi>
@@ -3294,10 +3294,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Enjambment Detection in a Large Diachronic Corpus of <fixed-case>S</fixed-case>panish Sonnets</title>
-      <author><first>Pablo</first> <last>Ruiz</last></author>
-      <author><first>Clara</first> <last>Martínez Cantón</last></author>
-      <author><first>Thierry</first> <last>Poibeau</last></author>
-      <author><first>Elena</first> <last>González-Blanco</last></author>
+      <author><first>Pablo</first><last>Ruiz</last></author>
+      <author><first>Clara</first><last>Martínez Cantón</last></author>
+      <author><first>Thierry</first><last>Poibeau</last></author>
+      <author><first>Elena</first><last>González-Blanco</last></author>
       <pages>27–32</pages>
       <url>W17-2204</url>
       <doi>10.18653/v1/W17-2204</doi>
@@ -3305,8 +3305,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Plotting <fixed-case>M</fixed-case>arkson’s “Mistress”</title>
-      <author><first>Conor</first> <last>Kelleher</last></author>
-      <author><first>Mark</first> <last>Keane</last></author>
+      <author><first>Conor</first><last>Kelleher</last></author>
+      <author><first>Mark</first><last>Keane</last></author>
       <pages>33–39</pages>
       <url>W17-2205</url>
       <doi>10.18653/v1/W17-2205</doi>
@@ -3314,11 +3314,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Annotation Challenges for Reconstructing the Structural Elaboration of Middle Low <fixed-case>G</fixed-case>erman</title>
-      <author><first>Nina</first> <last>Seemann</last></author>
-      <author><first>Marie-Luis</first> <last>Merten</last></author>
-      <author><first>Michaela</first> <last>Geierhos</last></author>
-      <author><first>Doris</first> <last>Tophinke</last></author>
-      <author><first>Eyke</first> <last>Hüllermeier</last></author>
+      <author><first>Nina</first><last>Seemann</last></author>
+      <author><first>Marie-Luis</first><last>Merten</last></author>
+      <author><first>Michaela</first><last>Geierhos</last></author>
+      <author><first>Doris</first><last>Tophinke</last></author>
+      <author><first>Eyke</first><last>Hüllermeier</last></author>
       <pages>40–45</pages>
       <url>W17-2206</url>
       <doi>10.18653/v1/W17-2206</doi>
@@ -3326,7 +3326,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Phonological Soundscapes in Medieval Poetry</title>
-      <author><first>Christopher</first> <last>Hench</last></author>
+      <author><first>Christopher</first><last>Hench</last></author>
       <pages>46–56</pages>
       <url>W17-2207</url>
       <doi>10.18653/v1/W17-2207</doi>
@@ -3334,10 +3334,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>An End-to-end Environment for Research Question-Driven Entity Extraction and Network Analysis</title>
-      <author><first>Andre</first> <last>Blessing</last></author>
-      <author><first>Nora</first> <last>Echelmeyer</last></author>
-      <author><first>Markus</first> <last>John</last></author>
-      <author><first>Nils</first> <last>Reiter</last></author>
+      <author><first>Andre</first><last>Blessing</last></author>
+      <author><first>Nora</first><last>Echelmeyer</last></author>
+      <author><first>Markus</first><last>John</last></author>
+      <author><first>Nils</first><last>Reiter</last></author>
       <pages>57–67</pages>
       <url>W17-2208</url>
       <doi>10.18653/v1/W17-2208</doi>
@@ -3347,8 +3347,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Modeling intra-textual variation with entropy and surprisal: topical vs. stylistic patterns</title>
-      <author><first>Stefania</first> <last>Degaetano-Ortlieb</last></author>
-      <author><first>Elke</first> <last>Teich</last></author>
+      <author><first>Stefania</first><last>Degaetano-Ortlieb</last></author>
+      <author><first>Elke</first><last>Teich</last></author>
       <pages>68–77</pages>
       <url>W17-2209</url>
       <doi>10.18653/v1/W17-2209</doi>
@@ -3356,8 +3356,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Finding a Character’s Voice: Stylome Classification on Literary Characters</title>
-      <author><first>Liviu P.</first> <last>Dinu</last></author>
-      <author><first>Ana Sabina</first> <last>Uban</last></author>
+      <author><first>Liviu P.</first><last>Dinu</last></author>
+      <author><first>Ana Sabina</first><last>Uban</last></author>
       <pages>78–82</pages>
       <url>W17-2210</url>
       <doi>10.18653/v1/W17-2210</doi>
@@ -3365,7 +3365,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>An Ontology-Based Method for Extracting and Classifying Domain-Specific Compositional Nominal Compounds</title>
-      <author><first>Maria Pia</first> <last>di Buono</last></author>
+      <author><first>Maria Pia</first><last>di Buono</last></author>
       <pages>83–88</pages>
       <url>W17-2211</url>
       <doi>10.18653/v1/W17-2211</doi>
@@ -3373,8 +3373,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Speeding up corpus development for linguistic research: language documentation and acquisition in <fixed-case>R</fixed-case>omansh Tuatschin</title>
-      <author><first>Géraldine</first> <last>Walther</last></author>
-      <author><first>Benoît</first> <last>Sagot</last></author>
+      <author><first>Géraldine</first><last>Walther</last></author>
+      <author><first>Benoît</first><last>Sagot</last></author>
       <pages>89–94</pages>
       <url>W17-2212</url>
       <doi>10.18653/v1/W17-2212</doi>
@@ -3382,12 +3382,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Distantly Supervised <fixed-case>POS</fixed-case> Tagging of Low-Resource Languages under Extreme Data Sparsity: The Case of <fixed-case>H</fixed-case>ittite</title>
-      <author><first>Maria</first> <last>Sukhareva</last></author>
-      <author><first>Francesco</first> <last>Fuscagni</last></author>
-      <author><first>Johannes</first> <last>Daxenberger</last></author>
-      <author><first>Susanne</first> <last>Görke</last></author>
-      <author><first>Doris</first> <last>Prechel</last></author>
-      <author><first>Iryna</first> <last>Gurevych</last></author>
+      <author><first>Maria</first><last>Sukhareva</last></author>
+      <author><first>Francesco</first><last>Fuscagni</last></author>
+      <author><first>Johannes</first><last>Daxenberger</last></author>
+      <author><first>Susanne</first><last>Görke</last></author>
+      <author><first>Doris</first><last>Prechel</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
       <pages>95–104</pages>
       <url>W17-2213</url>
       <doi>10.18653/v1/W17-2213</doi>
@@ -3395,9 +3395,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>A Dataset for <fixed-case>S</fixed-case>anskrit Word Segmentation</title>
-      <author><first>Amrith</first> <last>Krishna</last></author>
-      <author><first>Pavan Kumar</first> <last>Satuluri</last></author>
-      <author><first>Pawan</first> <last>Goyal</last></author>
+      <author><first>Amrith</first><last>Krishna</last></author>
+      <author><first>Pavan Kumar</first><last>Satuluri</last></author>
+      <author><first>Pawan</first><last>Goyal</last></author>
       <pages>105–114</pages>
       <url>W17-2214</url>
       <doi>10.18653/v1/W17-2214</doi>
@@ -3405,8 +3405,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Lexical Correction of Polish Twitter Political Data</title>
-      <author><first>Maciej</first> <last>Ogrodniczuk</last></author>
-      <author><first>Mateusz</first> <last>Kopeć</last></author>
+      <author><first>Maciej</first><last>Ogrodniczuk</last></author>
+      <author><first>Mateusz</first><last>Kopeć</last></author>
       <pages>115–125</pages>
       <url>W17-2215</url>
       <doi>10.18653/v1/W17-2215</doi>
@@ -3432,11 +3432,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Target word prediction and paraphasia classification in spoken discourse</title>
-      <author><first>Joel</first> <last>Adams</last></author>
-      <author><first>Steven</first> <last>Bedrick</last></author>
-      <author><first>Gerasimos</first> <last>Fergadiotis</last></author>
-      <author><first>Kyle</first> <last>Gorman</last></author>
-      <author><first>Jan</first> <last>van Santen</last></author>
+      <author><first>Joel</first><last>Adams</last></author>
+      <author><first>Steven</first><last>Bedrick</last></author>
+      <author><first>Gerasimos</first><last>Fergadiotis</last></author>
+      <author><first>Kyle</first><last>Gorman</last></author>
+      <author><first>Jan</first><last>van Santen</last></author>
       <pages>1–8</pages>
       <url>W17-2301</url>
       <doi>10.18653/v1/W17-2301</doi>
@@ -3444,9 +3444,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Extracting Drug-Drug Interactions with Attention <fixed-case>CNN</fixed-case>s</title>
-      <author><first>Masaki</first> <last>Asada</last></author>
-      <author><first>Makoto</first> <last>Miwa</last></author>
-      <author><first>Yutaka</first> <last>Sasaki</last></author>
+      <author><first>Masaki</first><last>Asada</last></author>
+      <author><first>Makoto</first><last>Miwa</last></author>
+      <author><first>Yutaka</first><last>Sasaki</last></author>
       <pages>9–18</pages>
       <url>W17-2302</url>
       <doi>10.18653/v1/W17-2302</doi>
@@ -3454,9 +3454,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Insights into Analogy Completion from the Biomedical Domain</title>
-      <author><first>Denis</first> <last>Newman-Griffis</last></author>
-      <author><first>Albert</first> <last>Lai</last></author>
-      <author><first>Eric</first> <last>Fosler-Lussier</last></author>
+      <author><first>Denis</first><last>Newman-Griffis</last></author>
+      <author><first>Albert</first><last>Lai</last></author>
+      <author><first>Eric</first><last>Fosler-Lussier</last></author>
       <pages>19–28</pages>
       <url>W17-2303</url>
       <doi>10.18653/v1/W17-2303</doi>
@@ -3464,8 +3464,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Deep learning for extracting protein-protein interactions from biomedical literature</title>
-      <author><first>Yifan</first> <last>Peng</last></author>
-      <author><first>Zhiyong</first> <last>Lu</last></author>
+      <author><first>Yifan</first><last>Peng</last></author>
+      <author><first>Zhiyong</first><last>Lu</last></author>
       <pages>29–38</pages>
       <url>W17-2304</url>
       <doi>10.18653/v1/W17-2304</doi>
@@ -3473,9 +3473,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Stacking With Auxiliary Features for Entity Linking in the Medical Domain</title>
-      <author><first>Nazneen Fatema</first> <last>Rajani</last></author>
-      <author><first>Mihaela</first> <last>Bornea</last></author>
-      <author><first>Ken</first> <last>Barker</last></author>
+      <author><first>Nazneen Fatema</first><last>Rajani</last></author>
+      <author><first>Mihaela</first><last>Bornea</last></author>
+      <author><first>Ken</first><last>Barker</last></author>
       <pages>39–47</pages>
       <url>W17-2305</url>
       <doi>10.18653/v1/W17-2305</doi>
@@ -3483,11 +3483,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Results of the fifth edition of the <fixed-case>B</fixed-case>io<fixed-case>ASQ</fixed-case> Challenge</title>
-      <author><first>Anastasios</first> <last>Nentidis</last></author>
-      <author><first>Konstantinos</first> <last>Bougiatiotis</last></author>
-      <author><first>Anastasia</first> <last>Krithara</last></author>
-      <author><first>Georgios</first> <last>Paliouras</last></author>
-      <author><first>Ioannis</first> <last>Kakadiaris</last></author>
+      <author><first>Anastasios</first><last>Nentidis</last></author>
+      <author><first>Konstantinos</first><last>Bougiatiotis</last></author>
+      <author><first>Anastasia</first><last>Krithara</last></author>
+      <author><first>Georgios</first><last>Paliouras</last></author>
+      <author><first>Ioannis</first><last>Kakadiaris</last></author>
       <pages>48–57</pages>
       <url>W17-2306</url>
       <doi>10.18653/v1/W17-2306</doi>
@@ -3496,12 +3496,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Tackling Biomedical Text Summarization: <fixed-case>OAQA</fixed-case> at <fixed-case>B</fixed-case>io<fixed-case>ASQ</fixed-case> 5<fixed-case>B</fixed-case></title>
-      <author><first>Khyathi</first> <last>Chandu</last></author>
-      <author><first>Aakanksha</first> <last>Naik</last></author>
-      <author><first>Aditya</first> <last>Chandrasekar</last></author>
-      <author><first>Zi</first> <last>Yang</last></author>
-      <author><first>Niloy</first> <last>Gupta</last></author>
-      <author><first>Eric</first> <last>Nyberg</last></author>
+      <author><first>Khyathi</first><last>Chandu</last></author>
+      <author><first>Aakanksha</first><last>Naik</last></author>
+      <author><first>Aditya</first><last>Chandrasekar</last></author>
+      <author><first>Zi</first><last>Yang</last></author>
+      <author><first>Niloy</first><last>Gupta</last></author>
+      <author><first>Eric</first><last>Nyberg</last></author>
       <pages>58–66</pages>
       <url>W17-2307</url>
       <doi>10.18653/v1/W17-2307</doi>
@@ -3509,7 +3509,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title><fixed-case>M</fixed-case>acquarie University at <fixed-case>B</fixed-case>io<fixed-case>ASQ</fixed-case> 5b – Query-based Summarisation Techniques for Selecting the Ideal Answers</title>
-      <author><first>Diego</first> <last>Mollá</last></author>
+      <author><first>Diego</first><last>Mollá</last></author>
       <pages>67–75</pages>
       <url>W17-2308</url>
       <doi>10.18653/v1/W17-2308</doi>
@@ -3517,9 +3517,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Neural Question Answering at <fixed-case>B</fixed-case>io<fixed-case>ASQ</fixed-case> 5<fixed-case>B</fixed-case></title>
-      <author><first>Georg</first> <last>Wiese</last></author>
-      <author><first>Dirk</first> <last>Weissenborn</last></author>
-      <author><first>Mariana</first> <last>Neves</last></author>
+      <author><first>Georg</first><last>Wiese</last></author>
+      <author><first>Dirk</first><last>Weissenborn</last></author>
+      <author><first>Mariana</first><last>Neves</last></author>
       <pages>76–79</pages>
       <url>W17-2309</url>
       <doi>10.18653/v1/W17-2309</doi>
@@ -3528,12 +3528,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>End-to-End System for Bacteria Habitat Extraction</title>
-      <author><first>Farrokh</first> <last>Mehryary</last></author>
-      <author><first>Kai</first> <last>Hakala</last></author>
-      <author><first>Suwisa</first> <last>Kaewphan</last></author>
-      <author><first>Jari</first> <last>Björne</last></author>
-      <author><first>Tapio</first> <last>Salakoski</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
+      <author><first>Farrokh</first><last>Mehryary</last></author>
+      <author><first>Kai</first><last>Hakala</last></author>
+      <author><first>Suwisa</first><last>Kaewphan</last></author>
+      <author><first>Jari</first><last>Björne</last></author>
+      <author><first>Tapio</first><last>Salakoski</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
       <pages>80–90</pages>
       <url>W17-2310</url>
       <doi>10.18653/v1/W17-2310</doi>
@@ -3542,11 +3542,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Creation and evaluation of a dictionary-based tagger for virus species and proteins</title>
-      <author><first>Helen</first> <last>Cook</last></author>
-      <author><first>Rūdolfs</first> <last>Bērziņš</last></author>
-      <author><first>Cristina Leal</first> <last>Rodrıguez</last></author>
-      <author><first>Juan Miguel</first> <last>Cejuela</last></author>
-      <author><first>Lars Juhl</first> <last>Jensen</last></author>
+      <author><first>Helen</first><last>Cook</last></author>
+      <author><first>Rūdolfs</first><last>Bērziņš</last></author>
+      <author><first>Cristina Leal</first><last>Rodrıguez</last></author>
+      <author><first>Juan Miguel</first><last>Cejuela</last></author>
+      <author><first>Lars Juhl</first><last>Jensen</last></author>
       <pages>91–98</pages>
       <url>W17-2311</url>
       <doi>10.18653/v1/W17-2311</doi>
@@ -3554,9 +3554,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Representation of complex terms in a vector space structured by an ontology for a normalization task</title>
-      <author><first>Arnaud</first> <last>Ferré</last></author>
-      <author><first>Pierre</first> <last>Zweigenbaum</last></author>
-      <author><first>Claire</first> <last>Nédellec</last></author>
+      <author><first>Arnaud</first><last>Ferré</last></author>
+      <author><first>Pierre</first><last>Zweigenbaum</last></author>
+      <author><first>Claire</first><last>Nédellec</last></author>
       <pages>99–106</pages>
       <url>W17-2312</url>
       <doi>10.18653/v1/W17-2312</doi>
@@ -3564,8 +3564,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Improving Correlation with Human Judgments by Integrating Semantic Similarity with Second–Order Vectors</title>
-      <author><first>Bridget</first> <last>McInnes</last></author>
-      <author><first>Ted</first> <last>Pedersen</last></author>
+      <author><first>Bridget</first><last>McInnes</last></author>
+      <author><first>Ted</first><last>Pedersen</last></author>
       <pages>107–116</pages>
       <url>W17-2313</url>
       <doi>10.18653/v1/W17-2313</doi>
@@ -3573,9 +3573,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Proactive Learning for Named Entity Recognition</title>
-      <author><first>Maolin</first> <last>Li</last></author>
-      <author><first>Nhung</first> <last>Nguyen</last></author>
-      <author><first>Sophia</first> <last>Ananiadou</last></author>
+      <author><first>Maolin</first><last>Li</last></author>
+      <author><first>Nhung</first><last>Nguyen</last></author>
+      <author><first>Sophia</first><last>Ananiadou</last></author>
       <pages>117–125</pages>
       <url>W17-2314</url>
       <doi>10.18653/v1/W17-2314</doi>
@@ -3583,10 +3583,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Biomedical Event Extraction using Abstract Meaning Representation</title>
-      <author><first>Sudha</first> <last>Rao</last></author>
-      <author><first>Daniel</first> <last>Marcu</last></author>
-      <author><first>Kevin</first> <last>Knight</last></author>
-      <author><first>Hal</first> <last>Daumé III</last></author>
+      <author><first>Sudha</first><last>Rao</last></author>
+      <author><first>Daniel</first><last>Marcu</last></author>
+      <author><first>Kevin</first><last>Knight</last></author>
+      <author><first>Hal</first><last>Daumé III</last></author>
       <pages>126–135</pages>
       <url>W17-2315</url>
       <doi>10.18653/v1/W17-2315</doi>
@@ -3594,11 +3594,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="16">
       <title>Detecting Personal Medication Intake in Twitter: An Annotated Corpus and Baseline Classification System</title>
-      <author><first>Ari</first> <last>Klein</last></author>
-      <author><first>Abeed</first> <last>Sarker</last></author>
-      <author><first>Masoud</first> <last>Rouhizadeh</last></author>
-      <author><first>Karen</first> <last>O’Connor</last></author>
-      <author><first>Graciela</first> <last>Gonzalez</last></author>
+      <author><first>Ari</first><last>Klein</last></author>
+      <author><first>Abeed</first><last>Sarker</last></author>
+      <author><first>Masoud</first><last>Rouhizadeh</last></author>
+      <author><first>Karen</first><last>O’Connor</last></author>
+      <author><first>Graciela</first><last>Gonzalez</last></author>
       <pages>136–142</pages>
       <url>W17-2316</url>
       <doi>10.18653/v1/W17-2316</doi>
@@ -3606,9 +3606,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="17">
       <title>Unsupervised Context-Sensitive Spelling Correction of Clinical Free-Text with Word and Character N-Gram Embeddings</title>
-      <author><first>Pieter</first> <last>Fivez</last></author>
-      <author><first>Simon</first> <last>Šuster</last></author>
-      <author><first>Walter</first> <last>Daelemans</last></author>
+      <author><first>Pieter</first><last>Fivez</last></author>
+      <author><first>Simon</first><last>Šuster</last></author>
+      <author><first>Walter</first><last>Daelemans</last></author>
       <pages>143–148</pages>
       <url>W17-2317</url>
       <doi>10.18653/v1/W17-2317</doi>
@@ -3616,11 +3616,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="18">
       <title>Characterization of Divergence in Impaired Speech of <fixed-case>ALS</fixed-case> Patients</title>
-      <author><first>Archna</first> <last>Bhatia</last></author>
-      <author><first>Bonnie</first> <last>Dorr</last></author>
-      <author><first>Kristy</first> <last>Hollingshead</last></author>
-      <author><first>Samuel L.</first> <last>Phillips</last></author>
-      <author><first>Barbara</first> <last>McKenzie</last></author>
+      <author><first>Archna</first><last>Bhatia</last></author>
+      <author><first>Bonnie</first><last>Dorr</last></author>
+      <author><first>Kristy</first><last>Hollingshead</last></author>
+      <author><first>Samuel L.</first><last>Phillips</last></author>
+      <author><first>Barbara</first><last>McKenzie</last></author>
       <pages>149–158</pages>
       <url>W17-2318</url>
       <doi>10.18653/v1/W17-2318</doi>
@@ -3628,11 +3628,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="19">
       <title>Deep Learning for Punctuation Restoration in Medical Reports</title>
-      <author><first>Wael</first> <last>Salloum</last></author>
-      <author><first>Greg</first> <last>Finley</last></author>
-      <author><first>Erik</first> <last>Edwards</last></author>
-      <author><first>Mark</first> <last>Miller</last></author>
-      <author><first>David</first> <last>Suendermann-Oeft</last></author>
+      <author><first>Wael</first><last>Salloum</last></author>
+      <author><first>Greg</first><last>Finley</last></author>
+      <author><first>Erik</first><last>Edwards</last></author>
+      <author><first>Mark</first><last>Miller</last></author>
+      <author><first>David</first><last>Suendermann-Oeft</last></author>
       <pages>159–164</pages>
       <url>W17-2319</url>
       <doi>10.18653/v1/W17-2319</doi>
@@ -3640,10 +3640,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="20">
       <title>Unsupervised Domain Adaptation for Clinical Negation Detection</title>
-      <author><first>Timothy</first> <last>Miller</last></author>
-      <author><first>Steven</first> <last>Bethard</last></author>
-      <author><first>Hadi</first> <last>Amiri</last></author>
-      <author><first>Guergana</first> <last>Savova</last></author>
+      <author><first>Timothy</first><last>Miller</last></author>
+      <author><first>Steven</first><last>Bethard</last></author>
+      <author><first>Hadi</first><last>Amiri</last></author>
+      <author><first>Guergana</first><last>Savova</last></author>
       <pages>165–170</pages>
       <url>W17-2320</url>
       <doi>10.18653/v1/W17-2320</doi>
@@ -3651,13 +3651,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="21">
       <title><fixed-case>B</fixed-case>io<fixed-case>C</fixed-case>reative <fixed-case>VI</fixed-case> Precision Medicine Track: creating a training corpus for mining protein-protein interactions affected by mutations</title>
-      <author><first>Rezarta</first> <last>Islamaj Doğan</last></author>
-      <author><first>Andrew</first> <last>Chatr-aryamontri</last></author>
-      <author><first>Sun</first> <last>Kim</last></author>
-      <author><first>Chih-Hsuan</first> <last>Wei</last></author>
-      <author><first>Yifan</first> <last>Peng</last></author>
-      <author><first>Donald</first> <last>Comeau</last></author>
-      <author><first>Zhiyong</first> <last>Lu</last></author>
+      <author><first>Rezarta</first><last>Islamaj Doğan</last></author>
+      <author><first>Andrew</first><last>Chatr-aryamontri</last></author>
+      <author><first>Sun</first><last>Kim</last></author>
+      <author><first>Chih-Hsuan</first><last>Wei</last></author>
+      <author><first>Yifan</first><last>Peng</last></author>
+      <author><first>Donald</first><last>Comeau</last></author>
+      <author><first>Zhiyong</first><last>Lu</last></author>
       <pages>171–175</pages>
       <url>W17-2321</url>
       <doi>10.18653/v1/W17-2321</doi>
@@ -3665,8 +3665,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="22">
       <title>Painless Relation Extraction with Kindred</title>
-      <author><first>Jake</first> <last>Lever</last></author>
-      <author><first>Steven</first> <last>Jones</last></author>
+      <author><first>Jake</first><last>Lever</last></author>
+      <author><first>Steven</first><last>Jones</last></author>
       <pages>176–183</pages>
       <url>W17-2322</url>
       <doi>10.18653/v1/W17-2322</doi>
@@ -3674,9 +3674,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="23">
       <title>Noise Reduction Methods for Distantly Supervised Biomedical Relation Extraction</title>
-      <author><first>Gang</first> <last>Li</last></author>
-      <author><first>Cathy</first> <last>Wu</last></author>
-      <author><first>K.</first> <last>Vijay-Shanker</last></author>
+      <author><first>Gang</first><last>Li</last></author>
+      <author><first>Cathy</first><last>Wu</last></author>
+      <author><first>K.</first><last>Vijay-Shanker</last></author>
       <pages>184–193</pages>
       <url>W17-2323</url>
       <doi>10.18653/v1/W17-2323</doi>
@@ -3684,11 +3684,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="24">
       <title>Role-Preserving Redaction of Medical Records to Enable Ontology-Driven Processing</title>
-      <author><first>Seth</first> <last>Polsley</last></author>
-      <author><first>Atif</first> <last>Tahir</last></author>
-      <author><first>Muppala</first> <last>Raju</last></author>
-      <author><first>Akintayo</first> <last>Akinleye</last></author>
-      <author><first>Duane</first> <last>Steward</last></author>
+      <author><first>Seth</first><last>Polsley</last></author>
+      <author><first>Atif</first><last>Tahir</last></author>
+      <author><first>Muppala</first><last>Raju</last></author>
+      <author><first>Akintayo</first><last>Akinleye</last></author>
+      <author><first>Duane</first><last>Steward</last></author>
       <pages>194–199</pages>
       <url>W17-2324</url>
       <doi>10.18653/v1/W17-2324</doi>
@@ -3696,10 +3696,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="25">
       <title>Annotation of pain and anesthesia events for surgery-related processes and outcomes extraction</title>
-      <author><first>Wen-wai</first> <last>Yim</last></author>
-      <author><first>Dario</first> <last>Tedesco</last></author>
-      <author><first>Catherine</first> <last>Curtin</last></author>
-      <author><first>Tina</first> <last>Hernandez-Boussard</last></author>
+      <author><first>Wen-wai</first><last>Yim</last></author>
+      <author><first>Dario</first><last>Tedesco</last></author>
+      <author><first>Catherine</first><last>Curtin</last></author>
+      <author><first>Tina</first><last>Hernandez-Boussard</last></author>
       <pages>200–205</pages>
       <url>W17-2325</url>
       <doi>10.18653/v1/W17-2325</doi>
@@ -3707,11 +3707,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="26">
       <title>Identifying Comparative Structures in Biomedical Text</title>
-      <author><first>Samir</first> <last>Gupta</last></author>
-      <author><first>A.S.M. Ashique</first> <last>Mahmood</last></author>
-      <author><first>Karen</first> <last>Ross</last></author>
-      <author><first>Cathy</first> <last>Wu</last></author>
-      <author><first>K.</first> <last>Vijay-Shanker</last></author>
+      <author><first>Samir</first><last>Gupta</last></author>
+      <author><first>A.S.M. Ashique</first><last>Mahmood</last></author>
+      <author><first>Karen</first><last>Ross</last></author>
+      <author><first>Cathy</first><last>Wu</last></author>
+      <author><first>K.</first><last>Vijay-Shanker</last></author>
       <pages>206–215</pages>
       <url>W17-2326</url>
       <doi>10.18653/v1/W17-2326</doi>
@@ -3719,13 +3719,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="27">
       <title>Tagging Funding Agencies and Grants in Scientific Articles using Sequential Learning Models</title>
-      <author><first>Subhradeep</first> <last>Kayal</last></author>
-      <author><first>Zubair</first> <last>Afzal</last></author>
-      <author><first>George</first> <last>Tsatsaronis</last></author>
-      <author><first>Sophia</first> <last>Katrenko</last></author>
-      <author><first>Pascal</first> <last>Coupet</last></author>
-      <author><first>Marius</first> <last>Doornenbal</last></author>
-      <author><first>Michelle</first> <last>Gregory</last></author>
+      <author><first>Subhradeep</first><last>Kayal</last></author>
+      <author><first>Zubair</first><last>Afzal</last></author>
+      <author><first>George</first><last>Tsatsaronis</last></author>
+      <author><first>Sophia</first><last>Katrenko</last></author>
+      <author><first>Pascal</first><last>Coupet</last></author>
+      <author><first>Marius</first><last>Doornenbal</last></author>
+      <author><first>Michelle</first><last>Gregory</last></author>
       <pages>216–221</pages>
       <url>W17-2327</url>
       <doi>10.18653/v1/W17-2327</doi>
@@ -3733,10 +3733,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="28">
       <title>Deep Learning for Biomedical Information Retrieval: Learning Textual Relevance from Click Logs</title>
-      <author><first>Sunil</first> <last>Mohan</last></author>
-      <author><first>Nicolas</first> <last>Fiorini</last></author>
-      <author><first>Sun</first> <last>Kim</last></author>
-      <author><first>Zhiyong</first> <last>Lu</last></author>
+      <author><first>Sunil</first><last>Mohan</last></author>
+      <author><first>Nicolas</first><last>Fiorini</last></author>
+      <author><first>Sun</first><last>Kim</last></author>
+      <author><first>Zhiyong</first><last>Lu</last></author>
       <pages>222–231</pages>
       <url>W17-2328</url>
       <doi>10.18653/v1/W17-2328</doi>
@@ -3744,10 +3744,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="29">
       <title>Detecting Dementia through Retrospective Analysis of Routine Blog Posts by Bloggers with Dementia</title>
-      <author><first>Vaden</first> <last>Masrani</last></author>
-      <author><first>Gabriel</first> <last>Murray</last></author>
-      <author><first>Thalia</first> <last>Field</last></author>
-      <author><first>Giuseppe</first> <last>Carenini</last></author>
+      <author><first>Vaden</first><last>Masrani</last></author>
+      <author><first>Gabriel</first><last>Murray</last></author>
+      <author><first>Thalia</first><last>Field</last></author>
+      <author><first>Giuseppe</first><last>Carenini</last></author>
       <pages>232–237</pages>
       <url>W17-2329</url>
       <doi>10.18653/v1/W17-2329</doi>
@@ -3755,9 +3755,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="30">
       <title>Protein Word Detection using Text Segmentation Techniques</title>
-      <author><first>Devi</first> <last>Ganesan</last></author>
-      <author><first>Ashish V.</first> <last>Tendulkar</last></author>
-      <author><first>Sutanu</first> <last>Chakraborti</last></author>
+      <author><first>Devi</first><last>Ganesan</last></author>
+      <author><first>Ashish V.</first><last>Tendulkar</last></author>
+      <author><first>Sutanu</first><last>Chakraborti</last></author>
       <pages>238–246</pages>
       <url>W17-2330</url>
       <doi>10.18653/v1/W17-2330</doi>
@@ -3765,8 +3765,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="31">
       <title>External Evaluation of Event Extraction Classifiers for Automatic Pathway Curation: An extended study of the m<fixed-case>TOR</fixed-case> pathway</title>
-      <author><first>Wojciech</first> <last>Kusa</last></author>
-      <author><first>Michael</first> <last>Spranger</last></author>
+      <author><first>Wojciech</first><last>Kusa</last></author>
+      <author><first>Michael</first><last>Spranger</last></author>
       <pages>247–256</pages>
       <url>W17-2331</url>
       <doi>10.18653/v1/W17-2331</doi>
@@ -3774,8 +3774,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="32">
       <title>Toward Automated Early Sepsis Alerting: Identifying Infection Patients from Nursing Notes</title>
-      <author><first>Emilia</first> <last>Apostolova</last></author>
-      <author><first>Tom</first> <last>Velez</last></author>
+      <author><first>Emilia</first><last>Apostolova</last></author>
+      <author><first>Tom</first><last>Velez</last></author>
       <pages>257–262</pages>
       <url>W17-2332</url>
       <doi>10.18653/v1/W17-2332</doi>
@@ -3783,10 +3783,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="33">
       <title>Enhancing Automatic <fixed-case>ICD</fixed-case>-9-<fixed-case>CM</fixed-case> Code Assignment for Medical Texts with <fixed-case>P</fixed-case>ub<fixed-case>M</fixed-case>ed</title>
-      <author><first>Danchen</first> <last>Zhang</last></author>
-      <author><first>Daqing</first> <last>He</last></author>
-      <author><first>Sanqiang</first> <last>Zhao</last></author>
-      <author><first>Lei</first> <last>Li</last></author>
+      <author><first>Danchen</first><last>Zhang</last></author>
+      <author><first>Daqing</first><last>He</last></author>
+      <author><first>Sanqiang</first><last>Zhao</last></author>
+      <author><first>Lei</first><last>Li</last></author>
       <pages>263–271</pages>
       <url>W17-2333</url>
       <doi>10.18653/v1/W17-2333</doi>
@@ -3794,9 +3794,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="34">
       <title>Evaluating Feature Extraction Methods for Knowledge-based Biomedical Word Sense Disambiguation</title>
-      <author><first>Sam</first> <last>Henry</last></author>
-      <author><first>Clint</first> <last>Cuffy</last></author>
-      <author><first>Bridget</first> <last>McInnes</last></author>
+      <author><first>Sam</first><last>Henry</last></author>
+      <author><first>Clint</first><last>Cuffy</last></author>
+      <author><first>Bridget</first><last>McInnes</last></author>
       <pages>272–281</pages>
       <url>W17-2334</url>
       <doi>10.18653/v1/W17-2334</doi>
@@ -3804,11 +3804,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="35">
       <title>Investigating the Documentation of Electronic Cigarette Use in the Veteran Affairs Electronic Health Record: A Pilot Study</title>
-      <author><first>Danielle</first> <last>Mowery</last></author>
-      <author><first>Brett</first> <last>South</last></author>
-      <author><first>Olga</first> <last>Patterson</last></author>
-      <author><first>Shu-Hong</first> <last>Zhu</last></author>
-      <author><first>Mike</first> <last>Conway</last></author>
+      <author><first>Danielle</first><last>Mowery</last></author>
+      <author><first>Brett</first><last>South</last></author>
+      <author><first>Olga</first><last>Patterson</last></author>
+      <author><first>Shu-Hong</first><last>Zhu</last></author>
+      <author><first>Mike</first><last>Conway</last></author>
       <pages>282–286</pages>
       <url>W17-2335</url>
       <doi>10.18653/v1/W17-2335</doi>
@@ -3816,11 +3816,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="36">
       <title>Automated Preamble Detection in Dictated Medical Reports</title>
-      <author><first>Wael</first> <last>Salloum</last></author>
-      <author><first>Greg</first> <last>Finley</last></author>
-      <author><first>Erik</first> <last>Edwards</last></author>
-      <author><first>Mark</first> <last>Miller</last></author>
-      <author><first>David</first> <last>Suendermann-Oeft</last></author>
+      <author><first>Wael</first><last>Salloum</last></author>
+      <author><first>Greg</first><last>Finley</last></author>
+      <author><first>Erik</first><last>Edwards</last></author>
+      <author><first>Mark</first><last>Miller</last></author>
+      <author><first>David</first><last>Suendermann-Oeft</last></author>
       <pages>287–295</pages>
       <url>W17-2336</url>
       <doi>10.18653/v1/W17-2336</doi>
@@ -3828,8 +3828,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="37">
       <title>A Biomedical Question Answering System in <fixed-case>B</fixed-case>io<fixed-case>ASQ</fixed-case> 2017</title>
-      <author><first>Mourad</first> <last>Sarrouti</last></author>
-      <author><first>Said</first> <last>Ouatik El Alaoui</last></author>
+      <author><first>Mourad</first><last>Sarrouti</last></author>
+      <author><first>Said</first><last>Ouatik El Alaoui</last></author>
       <pages>296–301</pages>
       <url>W17-2337</url>
       <doi>10.18653/v1/W17-2337</doi>
@@ -3837,11 +3837,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="38">
       <title>Adapting Pre-trained Word Embeddings For Use In Medical Coding</title>
-      <author><first>Kevin</first> <last>Patel</last></author>
-      <author><first>Divya</first> <last>Patel</last></author>
-      <author><first>Mansi</first> <last>Golakiya</last></author>
-      <author><first>Pushpak</first> <last>Bhattacharyya</last></author>
-      <author><first>Nilesh</first> <last>Birari</last></author>
+      <author><first>Kevin</first><last>Patel</last></author>
+      <author><first>Divya</first><last>Patel</last></author>
+      <author><first>Mansi</first><last>Golakiya</last></author>
+      <author><first>Pushpak</first><last>Bhattacharyya</last></author>
+      <author><first>Nilesh</first><last>Birari</last></author>
       <pages>302–306</pages>
       <url>W17-2338</url>
       <doi>10.18653/v1/W17-2338</doi>
@@ -3849,8 +3849,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="39">
       <title>Initializing neural networks for hierarchical multi-label text classification</title>
-      <author><first>Simon</first> <last>Baker</last></author>
-      <author><first>Anna</first> <last>Korhonen</last></author>
+      <author><first>Simon</first><last>Baker</last></author>
+      <author><first>Anna</first><last>Korhonen</last></author>
       <pages>307–315</pages>
       <url>W17-2339</url>
       <doi>10.18653/v1/W17-2339</doi>
@@ -3858,9 +3858,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="40">
       <title>Biomedical Event Trigger Identification Using Bidirectional Recurrent Neural Network Based Models</title>
-      <author><first>Rahul</first> <last>V S S Patchigolla</last></author>
-      <author><first>Sunil</first> <last>Sahu</last></author>
-      <author><first>Ashish</first> <last>Anand</last></author>
+      <author><first>Rahul</first><last>V S S Patchigolla</last></author>
+      <author><first>Sunil</first><last>Sahu</last></author>
+      <author><first>Ashish</first><last>Anand</last></author>
       <pages>316–321</pages>
       <url>W17-2340</url>
       <doi>10.18653/v1/W17-2340</doi>
@@ -3868,11 +3868,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="41">
       <title>Representations of Time Expressions for Temporal Relation Extraction with Convolutional Neural Networks</title>
-      <author><first>Chen</first> <last>Lin</last></author>
-      <author><first>Timothy</first> <last>Miller</last></author>
-      <author><first>Dmitriy</first> <last>Dligach</last></author>
-      <author><first>Steven</first> <last>Bethard</last></author>
-      <author><first>Guergana</first> <last>Savova</last></author>
+      <author><first>Chen</first><last>Lin</last></author>
+      <author><first>Timothy</first><last>Miller</last></author>
+      <author><first>Dmitriy</first><last>Dligach</last></author>
+      <author><first>Steven</first><last>Bethard</last></author>
+      <author><first>Guergana</first><last>Savova</last></author>
       <pages>322–327</pages>
       <url>W17-2341</url>
       <doi>10.18653/v1/W17-2341</doi>
@@ -3880,10 +3880,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="42">
       <title>Automatic Diagnosis Coding of Radiology Reports: A Comparison of Deep Learning and Conventional Classification Methods</title>
-      <author><first>Sarvnaz</first> <last>Karimi</last></author>
-      <author><first>Xiang</first> <last>Dai</last></author>
-      <author><first>Hamed</first> <last>Hassanzadeh</last></author>
-      <author><first>Anthony</first> <last>Nguyen</last></author>
+      <author><first>Sarvnaz</first><last>Karimi</last></author>
+      <author><first>Xiang</first><last>Dai</last></author>
+      <author><first>Hamed</first><last>Hassanzadeh</last></author>
+      <author><first>Anthony</first><last>Nguyen</last></author>
       <pages>328–332</pages>
       <url>W17-2342</url>
       <doi>10.18653/v1/W17-2342</doi>
@@ -3891,9 +3891,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="43">
       <title>Automatic classification of doctor-patient questions for a virtual patient record query task</title>
-      <author><first>Leonardo</first> <last>Campillos Llanos</last></author>
-      <author><first>Sophie</first> <last>Rosset</last></author>
-      <author><first>Pierre</first> <last>Zweigenbaum</last></author>
+      <author><first>Leonardo</first><last>Campillos Llanos</last></author>
+      <author><first>Sophie</first><last>Rosset</last></author>
+      <author><first>Pierre</first><last>Zweigenbaum</last></author>
       <pages>333–341</pages>
       <url>W17-2343</url>
       <doi>10.18653/v1/W17-2343</doi>
@@ -3901,10 +3901,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="44">
       <title>Assessing the performance of <fixed-case>O</fixed-case>lelo, a real-time biomedical question answering application</title>
-      <author><first>Mariana</first> <last>Neves</last></author>
-      <author><first>Fabian</first> <last>Eckert</last></author>
-      <author><first>Hendrik</first> <last>Folkerts</last></author>
-      <author><first>Matthias</first> <last>Uflacker</last></author>
+      <author><first>Mariana</first><last>Neves</last></author>
+      <author><first>Fabian</first><last>Eckert</last></author>
+      <author><first>Hendrik</first><last>Folkerts</last></author>
+      <author><first>Matthias</first><last>Uflacker</last></author>
       <pages>342–350</pages>
       <url>W17-2344</url>
       <doi>10.18653/v1/W17-2344</doi>
@@ -3913,8 +3913,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="45">
       <title>Clinical Event Detection with Hybrid Neural Architecture</title>
-      <author><first>Adyasha</first> <last>Maharana</last></author>
-      <author><first>Meliha</first> <last>Yetisgen</last></author>
+      <author><first>Adyasha</first><last>Maharana</last></author>
+      <author><first>Meliha</first><last>Yetisgen</last></author>
       <pages>351–355</pages>
       <url>W17-2345</url>
       <doi>10.18653/v1/W17-2345</doi>
@@ -3922,9 +3922,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="46">
       <title>Extracting Personal Medical Events for User Timeline Construction using Minimal Supervision</title>
-      <author><first>Aakanksha</first> <last>Naik</last></author>
-      <author><first>Chris</first> <last>Bogart</last></author>
-      <author><first>Carolyn</first> <last>Rose</last></author>
+      <author><first>Aakanksha</first><last>Naik</last></author>
+      <author><first>Chris</first><last>Bogart</last></author>
+      <author><first>Carolyn</first><last>Rose</last></author>
       <pages>356–364</pages>
       <url>W17-2346</url>
       <doi>10.18653/v1/W17-2346</doi>
@@ -3932,13 +3932,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="47">
       <title>Detecting mentions of pain and acute confusion in <fixed-case>F</fixed-case>innish clinical text</title>
-      <author><first>Hans</first> <last>Moen</last></author>
-      <author><first>Kai</first> <last>Hakala</last></author>
-      <author><first>Farrokh</first> <last>Mehryary</last></author>
-      <author><first>Laura-Maria</first> <last>Peltonen</last></author>
-      <author><first>Tapio</first> <last>Salakoski</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
-      <author><first>Sanna</first> <last>Salanterä</last></author>
+      <author><first>Hans</first><last>Moen</last></author>
+      <author><first>Kai</first><last>Hakala</last></author>
+      <author><first>Farrokh</first><last>Mehryary</last></author>
+      <author><first>Laura-Maria</first><last>Peltonen</last></author>
+      <author><first>Tapio</first><last>Salakoski</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
+      <author><first>Sanna</first><last>Salanterä</last></author>
       <pages>365–372</pages>
       <url>W17-2347</url>
       <doi>10.18653/v1/W17-2347</doi>
@@ -3946,11 +3946,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="48">
       <title>A Multi-strategy Query Processing Approach for Biomedical Question Answering: <fixed-case>USTB</fixed-case>_<fixed-case>PRIR</fixed-case> at <fixed-case>B</fixed-case>io<fixed-case>ASQ</fixed-case> 2017 Task 5<fixed-case>B</fixed-case></title>
-      <author><first>Zan-Xia</first> <last>Jin</last></author>
-      <author><first>Bo-Wen</first> <last>Zhang</last></author>
-      <author><first>Fan</first> <last>Fang</last></author>
-      <author><first>Le-Le</first> <last>Zhang</last></author>
-      <author><first>Xu-Cheng</first> <last>Yin</last></author>
+      <author><first>Zan-Xia</first><last>Jin</last></author>
+      <author><first>Bo-Wen</first><last>Zhang</last></author>
+      <author><first>Fan</first><last>Fang</last></author>
+      <author><first>Le-Le</first><last>Zhang</last></author>
+      <author><first>Xu-Cheng</first><last>Yin</last></author>
       <pages>373–380</pages>
       <url>W17-2348</url>
       <doi>10.18653/v1/W17-2348</doi>
@@ -3976,11 +3976,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>On the “Calligraphy” of Books</title>
-      <author><first>Vanessa Queiroz</first> <last>Marinho</last></author>
-      <author><first>Henrique Ferraz</first> <last>de Arruda</last></author>
-      <author><first>Thales</first> <last>Sinelli</last></author>
-      <author><first>Luciano da Fontoura</first> <last>Costa</last></author>
-      <author><first>Diego Raphael</first> <last>Amancio</last></author>
+      <author><first>Vanessa Queiroz</first><last>Marinho</last></author>
+      <author><first>Henrique Ferraz</first><last>de Arruda</last></author>
+      <author><first>Thales</first><last>Sinelli</last></author>
+      <author><first>Luciano da Fontoura</first><last>Costa</last></author>
+      <author><first>Diego Raphael</first><last>Amancio</last></author>
       <pages>1–10</pages>
       <url>W17-2401</url>
       <doi>10.18653/v1/W17-2401</doi>
@@ -3988,11 +3988,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Adapting predominant and novel sense discovery algorithms for identifying corpus-specific sense differences</title>
-      <author><first>Binny</first> <last>Mathew</last></author>
-      <author><first>Suman Kalyan</first> <last>Maity</last></author>
-      <author><first>Pratip</first> <last>Sarkar</last></author>
-      <author><first>Animesh</first> <last>Mukherjee</last></author>
-      <author><first>Pawan</first> <last>Goyal</last></author>
+      <author><first>Binny</first><last>Mathew</last></author>
+      <author><first>Suman Kalyan</first><last>Maity</last></author>
+      <author><first>Pratip</first><last>Sarkar</last></author>
+      <author><first>Animesh</first><last>Mukherjee</last></author>
+      <author><first>Pawan</first><last>Goyal</last></author>
       <pages>11–20</pages>
       <url>W17-2402</url>
       <doi>10.18653/v1/W17-2402</doi>
@@ -4000,9 +4000,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Merging knowledge bases in different languages</title>
-      <author><first>Jerónimo</first> <last>Hernández-González</last></author>
-      <author><first>Estevam R.</first> <last>Hruschka Jr.</last></author>
-      <author><first>Tom M.</first> <last>Mitchell</last></author>
+      <author><first>Jerónimo</first><last>Hernández-González</last></author>
+      <author><first>Estevam R.</first><last>Hruschka Jr.</last></author>
+      <author><first>Tom M.</first><last>Mitchell</last></author>
       <pages>21–29</pages>
       <url>W17-2403</url>
       <doi>10.18653/v1/W17-2403</doi>
@@ -4010,8 +4010,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Parameter Free Hierarchical Graph-Based Clustering for Analyzing Continuous Word Embeddings</title>
-      <author><first>Thomas Alexander</first> <last>Trost</last></author>
-      <author><first>Dietrich</first> <last>Klakow</last></author>
+      <author><first>Thomas Alexander</first><last>Trost</last></author>
+      <author><first>Dietrich</first><last>Klakow</last></author>
       <pages>30–38</pages>
       <url>W17-2404</url>
       <doi>10.18653/v1/W17-2404</doi>
@@ -4019,9 +4019,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Spectral Graph-Based Method of Multimodal Word Embedding</title>
-      <author><first>Kazuki</first> <last>Fukui</last></author>
-      <author><first>Takamasa</first> <last>Oshikiri</last></author>
-      <author><first>Hidetoshi</first> <last>Shimodaira</last></author>
+      <author><first>Kazuki</first><last>Fukui</last></author>
+      <author><first>Takamasa</first><last>Oshikiri</last></author>
+      <author><first>Hidetoshi</first><last>Shimodaira</last></author>
       <pages>39–44</pages>
       <url>W17-2405</url>
       <doi>10.18653/v1/W17-2405</doi>
@@ -4029,8 +4029,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Graph Methods for Multilingual <fixed-case>F</fixed-case>rame<fixed-case>N</fixed-case>ets</title>
-      <author><first>Collin</first> <last>Baker</last></author>
-      <author><first>Michael</first> <last>Ellsworth</last></author>
+      <author><first>Collin</first><last>Baker</last></author>
+      <author><first>Michael</first><last>Ellsworth</last></author>
       <pages>45–50</pages>
       <url>W17-2406</url>
       <doi>10.18653/v1/W17-2406</doi>
@@ -4039,8 +4039,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Extract with Order for Coherent Multi-Document Summarization</title>
-      <author><first>Mir Tafseer</first> <last>Nayeem</last></author>
-      <author><first>Yllias</first> <last>Chali</last></author>
+      <author><first>Mir Tafseer</first><last>Nayeem</last></author>
+      <author><first>Yllias</first><last>Chali</last></author>
       <pages>51–56</pages>
       <url>W17-2407</url>
       <doi>10.18653/v1/W17-2407</doi>
@@ -4048,8 +4048,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Work Hard, Play Hard: Email Classification on the Avocado and <fixed-case>E</fixed-case>nron Corpora</title>
-      <author><first>Sakhar</first> <last>Alkhereyf</last></author>
-      <author><first>Owen</first> <last>Rambow</last></author>
+      <author><first>Sakhar</first><last>Alkhereyf</last></author>
+      <author><first>Owen</first><last>Rambow</last></author>
       <pages>57–65</pages>
       <url>W17-2408</url>
       <doi>10.18653/v1/W17-2408</doi>
@@ -4057,13 +4057,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>A Graph Based Semi-Supervised Approach for Analysis of Derivational Nouns in <fixed-case>S</fixed-case>anskrit</title>
-      <author><first>Amrith</first> <last>Krishna</last></author>
-      <author><first>Pavankumar</first> <last>Satuluri</last></author>
-      <author><first>Harshavardhan</first> <last>Ponnada</last></author>
-      <author><first>Muneeb</first> <last>Ahmed</last></author>
-      <author><first>Gulab</first> <last>Arora</last></author>
-      <author><first>Kaustubh</first> <last>Hiware</last></author>
-      <author><first>Pawan</first> <last>Goyal</last></author>
+      <author><first>Amrith</first><last>Krishna</last></author>
+      <author><first>Pavankumar</first><last>Satuluri</last></author>
+      <author><first>Harshavardhan</first><last>Ponnada</last></author>
+      <author><first>Muneeb</first><last>Ahmed</last></author>
+      <author><first>Gulab</first><last>Arora</last></author>
+      <author><first>Kaustubh</first><last>Hiware</last></author>
+      <author><first>Pawan</first><last>Goyal</last></author>
       <pages>66–75</pages>
       <url>W17-2409</url>
       <doi>10.18653/v1/W17-2409</doi>
@@ -4071,8 +4071,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Evaluating text coherence based on semantic similarity graph</title>
-      <author><first>Jan Wira Gotama</first> <last>Putra</last></author>
-      <author><first>Takenobu</first> <last>Tokunaga</last></author>
+      <author><first>Jan Wira Gotama</first><last>Putra</last></author>
+      <author><first>Takenobu</first><last>Tokunaga</last></author>
       <pages>76–85</pages>
       <url>W17-2410</url>
       <doi>10.18653/v1/W17-2410</doi>
@@ -4084,9 +4084,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     <meta>
       <booktitle>Proceedings of the 10th Workshop on Building and Using Comparable Corpora</booktitle>
       <url>W17-25</url>
-      <editor><first>Serge</first> <last>Sharoff</last></editor>
-      <editor><first>Pierre</first> <last>Zweigenbaum</last></editor>
-      <editor><first>Reinhard</first> <last>Rapp</last></editor>
+      <editor><first>Serge</first><last>Sharoff</last></editor>
+      <editor><first>Pierre</first><last>Zweigenbaum</last></editor>
+      <editor><first>Reinhard</first><last>Rapp</last></editor>
       <doi>10.18653/v1/W17-25</doi>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Vancouver, Canada</address>
@@ -4098,7 +4098,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Users and Data: The Two Neglected Children of Bilingual Natural Language Processing Research</title>
-      <author><first>Phillippe</first> <last>Langlais</last></author>
+      <author><first>Phillippe</first><last>Langlais</last></author>
       <pages>1–5</pages>
       <url>W17-2501</url>
       <doi>10.18653/v1/W17-2501</doi>
@@ -4106,10 +4106,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Deep Investigation of Cross-Language Plagiarism Detection Methods</title>
-      <author><first>Jérémy</first> <last>Ferrero</last></author>
-      <author><first>Laurent</first> <last>Besacier</last></author>
-      <author><first>Didier</first> <last>Schwab</last></author>
-      <author><first>Frédéric</first> <last>Agnès</last></author>
+      <author><first>Jérémy</first><last>Ferrero</last></author>
+      <author><first>Laurent</first><last>Besacier</last></author>
+      <author><first>Didier</first><last>Schwab</last></author>
+      <author><first>Frédéric</first><last>Agnès</last></author>
       <pages>6–15</pages>
       <url>W17-2502</url>
       <doi>10.18653/v1/W17-2502</doi>
@@ -4118,8 +4118,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Sentence Alignment using Unfolding Recursive Autoencoders</title>
-      <author><first>Jeenu</first> <last>Grover</last></author>
-      <author><first>Pabitra</first> <last>Mitra</last></author>
+      <author><first>Jeenu</first><last>Grover</last></author>
+      <author><first>Pabitra</first><last>Mitra</last></author>
       <pages>16–20</pages>
       <url>W17-2503</url>
       <doi>10.18653/v1/W17-2503</doi>
@@ -4127,8 +4127,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Acquisition of Translation Lexicons for Historically Unwritten Languages via Bridging Loanwords</title>
-      <author><first>Michael</first> <last>Bloodgood</last></author>
-      <author><first>Benjamin</first> <last>Strauss</last></author>
+      <author><first>Michael</first><last>Bloodgood</last></author>
+      <author><first>Benjamin</first><last>Strauss</last></author>
       <pages>21–25</pages>
       <url>W17-2504</url>
       <doi>10.18653/v1/W17-2504</doi>
@@ -4137,7 +4137,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Toward a Comparable Corpus of <fixed-case>L</fixed-case>atvian, <fixed-case>R</fixed-case>ussian and <fixed-case>E</fixed-case>nglish Tweets</title>
-      <author><first>Dmitrijs</first> <last>Milajevs</last></author>
+      <author><first>Dmitrijs</first><last>Milajevs</last></author>
       <pages>26–30</pages>
       <url>W17-2505</url>
       <doi>10.18653/v1/W17-2505</doi>
@@ -4145,9 +4145,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Automatic Extraction of Parallel Speech Corpora from Dubbed Movies</title>
-      <author><first>Alp</first> <last>Öktem</last></author>
-      <author><first>Mireia</first> <last>Farrús</last></author>
-      <author><first>Leo</first> <last>Wanner</last></author>
+      <author><first>Alp</first><last>Öktem</last></author>
+      <author><first>Mireia</first><last>Farrús</last></author>
+      <author><first>Leo</first><last>Wanner</last></author>
       <pages>31–35</pages>
       <url>W17-2506</url>
       <doi>10.18653/v1/W17-2506</doi>
@@ -4156,7 +4156,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>A parallel collection of clinical trials in <fixed-case>P</fixed-case>ortuguese and <fixed-case>E</fixed-case>nglish</title>
-      <author><first>Mariana</first> <last>Neves</last></author>
+      <author><first>Mariana</first><last>Neves</last></author>
       <pages>36–40</pages>
       <url>W17-2507</url>
       <doi>10.18653/v1/W17-2507</doi>
@@ -4165,9 +4165,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Weighted Set-Theoretic Alignment of Comparable Sentences</title>
-      <author><first>Andoni</first> <last>Azpeitia</last></author>
-      <author><first>Thierry</first> <last>Etchegoyhen</last></author>
-      <author><first>Eva</first> <last>Martínez Garcia</last></author>
+      <author><first>Andoni</first><last>Azpeitia</last></author>
+      <author><first>Thierry</first><last>Etchegoyhen</last></author>
+      <author><first>Eva</first><last>Martínez Garcia</last></author>
       <pages>41–45</pages>
       <url>W17-2508</url>
       <doi>10.18653/v1/W17-2508</doi>
@@ -4175,8 +4175,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title><fixed-case>BUCC</fixed-case> 2017 Shared Task: a First Attempt Toward a Deep Learning Framework for Identifying Parallel Sentences in Comparable Corpora</title>
-      <author><first>Francis</first> <last>Grégoire</last></author>
-      <author><first>Philippe</first> <last>Langlais</last></author>
+      <author><first>Francis</first><last>Grégoire</last></author>
+      <author><first>Philippe</first><last>Langlais</last></author>
       <pages>46–50</pages>
       <url>W17-2509</url>
       <doi>10.18653/v1/W17-2509</doi>
@@ -4184,8 +4184,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>z<fixed-case>NLP</fixed-case>: Identifying Parallel Sentences in <fixed-case>C</fixed-case>hinese-<fixed-case>E</fixed-case>nglish Comparable Corpora</title>
-      <author><first>Zheng</first> <last>Zhang</last></author>
-      <author><first>Pierre</first> <last>Zweigenbaum</last></author>
+      <author><first>Zheng</first><last>Zhang</last></author>
+      <author><first>Pierre</first><last>Zweigenbaum</last></author>
       <pages>51–55</pages>
       <url>W17-2510</url>
       <doi>10.18653/v1/W17-2510</doi>
@@ -4193,9 +4193,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title><fixed-case>BUCC</fixed-case>2017: A Hybrid Approach for Identifying Parallel Sentences in Comparable Corpora</title>
-      <author><first>Sainik</first> <last>Mahata</last></author>
-      <author><first>Dipankar</first> <last>Das</last></author>
-      <author><first>Sivaji</first> <last>Bandyopadhyay</last></author>
+      <author><first>Sainik</first><last>Mahata</last></author>
+      <author><first>Dipankar</first><last>Das</last></author>
+      <author><first>Sivaji</first><last>Bandyopadhyay</last></author>
       <pages>56–59</pages>
       <url>W17-2511</url>
       <doi>10.18653/v1/W17-2511</doi>
@@ -4203,9 +4203,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Overview of the Second <fixed-case>BUCC</fixed-case> Shared Task: Spotting Parallel Sentences in Comparable Corpora</title>
-      <author><first>Pierre</first> <last>Zweigenbaum</last></author>
-      <author><first>Serge</first> <last>Sharoff</last></author>
-      <author><first>Reinhard</first> <last>Rapp</last></author>
+      <author><first>Pierre</first><last>Zweigenbaum</last></author>
+      <author><first>Serge</first><last>Sharoff</last></author>
+      <author><first>Reinhard</first><last>Rapp</last></author>
       <pages>60–67</pages>
       <url>W17-2512</url>
       <doi>10.18653/v1/W17-2512</doi>
@@ -4237,7 +4237,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Sense Contextualization in a Dependency-Based Compositional Distributional Model</title>
-      <author><first>Pablo</first> <last>Gamallo</last></author>
+      <author><first>Pablo</first><last>Gamallo</last></author>
       <pages>1–9</pages>
       <url>W17-2601</url>
       <doi>10.18653/v1/W17-2601</doi>
@@ -4245,7 +4245,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Context encoders as a simple but powerful extension of word2vec</title>
-      <author><first>Franziska</first> <last>Horn</last></author>
+      <author><first>Franziska</first><last>Horn</last></author>
       <pages>10–14</pages>
       <url>W17-2602</url>
       <doi>10.18653/v1/W17-2602</doi>
@@ -4253,14 +4253,14 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Machine Comprehension by Text-to-Text Neural Question Generation</title>
-      <author><first>Xingdi</first> <last>Yuan</last></author>
-      <author><first>Tong</first> <last>Wang</last></author>
-      <author><first>Caglar</first> <last>Gulcehre</last></author>
-      <author><first>Alessandro</first> <last>Sordoni</last></author>
-      <author><first>Philip</first> <last>Bachman</last></author>
-      <author><first>Saizheng</first> <last>Zhang</last></author>
-      <author><first>Sandeep</first> <last>Subramanian</last></author>
-      <author><first>Adam</first> <last>Trischler</last></author>
+      <author><first>Xingdi</first><last>Yuan</last></author>
+      <author><first>Tong</first><last>Wang</last></author>
+      <author><first>Caglar</first><last>Gulcehre</last></author>
+      <author><first>Alessandro</first><last>Sordoni</last></author>
+      <author><first>Philip</first><last>Bachman</last></author>
+      <author><first>Saizheng</first><last>Zhang</last></author>
+      <author><first>Sandeep</first><last>Subramanian</last></author>
+      <author><first>Adam</first><last>Trischler</last></author>
       <pages>15–25</pages>
       <url>W17-2603</url>
       <doi>10.18653/v1/W17-2603</doi>
@@ -4268,10 +4268,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Emergent Predication Structure in Hidden State Vectors of Neural Readers</title>
-      <author><first>Hai</first> <last>Wang</last></author>
-      <author><first>Takeshi</first> <last>Onishi</last></author>
-      <author><first>Kevin</first> <last>Gimpel</last></author>
-      <author><first>David</first> <last>McAllester</last></author>
+      <author><first>Hai</first><last>Wang</last></author>
+      <author><first>Takeshi</first><last>Onishi</last></author>
+      <author><first>Kevin</first><last>Gimpel</last></author>
+      <author><first>David</first><last>McAllester</last></author>
       <pages>26–36</pages>
       <url>W17-2604</url>
       <doi>10.18653/v1/W17-2604</doi>
@@ -4279,8 +4279,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Towards Harnessing Memory Networks for Coreference Resolution</title>
-      <author><first>Joe</first> <last>Cheri</last></author>
-      <author><first>Pushpak</first> <last>Bhattacharyya</last></author>
+      <author><first>Joe</first><last>Cheri</last></author>
+      <author><first>Pushpak</first><last>Bhattacharyya</last></author>
       <pages>37–42</pages>
       <url>W17-2605</url>
       <doi>10.18653/v1/W17-2605</doi>
@@ -4288,9 +4288,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Combining Word-Level and Character-Level Representations for Relation Classification of Informal Text</title>
-      <author><first>Dongyun</first> <last>Liang</last></author>
-      <author><first>Weiran</first> <last>Xu</last></author>
-      <author><first>Yinge</first> <last>Zhao</last></author>
+      <author><first>Dongyun</first><last>Liang</last></author>
+      <author><first>Weiran</first><last>Xu</last></author>
+      <author><first>Yinge</first><last>Zhao</last></author>
       <pages>43–47</pages>
       <url>W17-2606</url>
       <doi>10.18653/v1/W17-2606</doi>
@@ -4298,10 +4298,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Transfer Learning for Neural Semantic Parsing</title>
-      <author><first>Xing</first> <last>Fan</last></author>
-      <author><first>Emilio</first> <last>Monti</last></author>
-      <author><first>Lambert</first> <last>Mathias</last></author>
-      <author><first>Markus</first> <last>Dreyer</last></author>
+      <author><first>Xing</first><last>Fan</last></author>
+      <author><first>Emilio</first><last>Monti</last></author>
+      <author><first>Lambert</first><last>Mathias</last></author>
+      <author><first>Markus</first><last>Dreyer</last></author>
       <pages>48–56</pages>
       <url>W17-2607</url>
       <doi>10.18653/v1/W17-2607</doi>
@@ -4309,10 +4309,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Modeling Large-Scale Structured Relationships with Shared Memory for Knowledge Base Completion</title>
-      <author><first>Yelong</first> <last>Shen</last></author>
-      <author><first>Po-Sen</first> <last>Huang</last></author>
-      <author><first>Ming-Wei</first> <last>Chang</last></author>
-      <author><first>Jianfeng</first> <last>Gao</last></author>
+      <author><first>Yelong</first><last>Shen</last></author>
+      <author><first>Po-Sen</first><last>Huang</last></author>
+      <author><first>Ming-Wei</first><last>Chang</last></author>
+      <author><first>Jianfeng</first><last>Gao</last></author>
       <pages>57–68</pages>
       <url>W17-2608</url>
       <doi>10.18653/v1/W17-2608</doi>
@@ -4320,9 +4320,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Knowledge Base Completion: Baselines Strike Back</title>
-      <author><first>Rudolf</first> <last>Kadlec</last></author>
-      <author><first>Ondrej</first> <last>Bajgar</last></author>
-      <author><first>Jan</first> <last>Kleindienst</last></author>
+      <author><first>Rudolf</first><last>Kadlec</last></author>
+      <author><first>Ondrej</first><last>Bajgar</last></author>
+      <author><first>Jan</first><last>Kleindienst</last></author>
       <pages>69–74</pages>
       <url>W17-2609</url>
       <doi>10.18653/v1/W17-2609</doi>
@@ -4330,9 +4330,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Sequential Attention: A Context-Aware Alignment Function for Machine Reading</title>
-      <author><first>Sebastian</first> <last>Brarda</last></author>
-      <author><first>Philip</first> <last>Yeres</last></author>
-      <author><first>Samuel</first> <last>Bowman</last></author>
+      <author><first>Sebastian</first><last>Brarda</last></author>
+      <author><first>Philip</first><last>Yeres</last></author>
+      <author><first>Samuel</first><last>Bowman</last></author>
       <pages>75–80</pages>
       <url>W17-2610</url>
       <doi>10.18653/v1/W17-2610</doi>
@@ -4340,12 +4340,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Semantic Vector Encoding and Similarity Search Using Fulltext Search Engines</title>
-      <author><first>Jan</first> <last>Rygl</last></author>
-      <author><first>Jan</first> <last>Pomikálek</last></author>
-      <author><first>Radim</first> <last>Řehůřek</last></author>
-      <author><first>Michal</first> <last>Růžička</last></author>
-      <author><first>Vít</first> <last>Novotný</last></author>
-      <author><first>Petr</first> <last>Sojka</last></author>
+      <author><first>Jan</first><last>Rygl</last></author>
+      <author><first>Jan</first><last>Pomikálek</last></author>
+      <author><first>Radim</first><last>Řehůřek</last></author>
+      <author><first>Michal</first><last>Růžička</last></author>
+      <author><first>Vít</first><last>Novotný</last></author>
+      <author><first>Petr</first><last>Sojka</last></author>
       <pages>81–90</pages>
       <url>W17-2611</url>
       <doi>10.18653/v1/W17-2611</doi>
@@ -4353,8 +4353,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Multi-task Domain Adaptation for Sequence Tagging</title>
-      <author><first>Nanyun</first> <last>Peng</last></author>
-      <author><first>Mark</first> <last>Dredze</last></author>
+      <author><first>Nanyun</first><last>Peng</last></author>
+      <author><first>Mark</first><last>Dredze</last></author>
       <pages>91–100</pages>
       <url>W17-2612</url>
       <doi>10.18653/v1/W17-2612</doi>
@@ -4362,11 +4362,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Beyond Bilingual: Multi-sense Word Embeddings using Multilingual Context</title>
-      <author><first>Shyam</first> <last>Upadhyay</last></author>
-      <author><first>Kai-Wei</first> <last>Chang</last></author>
-      <author><first>Matt</first> <last>Taddy</last></author>
-      <author><first>Adam</first> <last>Kalai</last></author>
-      <author><first>James</first> <last>Zou</last></author>
+      <author><first>Shyam</first><last>Upadhyay</last></author>
+      <author><first>Kai-Wei</first><last>Chang</last></author>
+      <author><first>Matt</first><last>Taddy</last></author>
+      <author><first>Adam</first><last>Kalai</last></author>
+      <author><first>James</first><last>Zou</last></author>
       <pages>101–110</pages>
       <url>W17-2613</url>
       <doi>10.18653/v1/W17-2613</doi>
@@ -4374,10 +4374,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title><fixed-case>D</fixed-case>oc<fixed-case>T</fixed-case>ag2<fixed-case>V</fixed-case>ec: An Embedding Based Multi-label Learning Approach for Document Tagging</title>
-      <author><first>Sheng</first> <last>Chen</last></author>
-      <author><first>Akshay</first> <last>Soni</last></author>
-      <author><first>Aasish</first> <last>Pappu</last></author>
-      <author><first>Yashar</first> <last>Mehdad</last></author>
+      <author><first>Sheng</first><last>Chen</last></author>
+      <author><first>Akshay</first><last>Soni</last></author>
+      <author><first>Aasish</first><last>Pappu</last></author>
+      <author><first>Yashar</first><last>Mehdad</last></author>
       <pages>111–120</pages>
       <url>W17-2614</url>
       <doi>10.18653/v1/W17-2614</doi>
@@ -4385,8 +4385,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Binary Paragraph Vectors</title>
-      <author><first>Karol</first> <last>Grzegorczyk</last></author>
-      <author><first>Marcin</first> <last>Kurdziel</last></author>
+      <author><first>Karol</first><last>Grzegorczyk</last></author>
+      <author><first>Marcin</first><last>Kurdziel</last></author>
       <pages>121–130</pages>
       <url>W17-2615</url>
       <doi>10.18653/v1/W17-2615</doi>
@@ -4394,9 +4394,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="16">
       <title>Representing Compositionality based on Multiple Timescales Gated Recurrent Neural Networks with Adaptive Temporal Hierarchy for Character-Level Language Models</title>
-      <author><first>Dennis Singh</first> <last>Moirangthem</last></author>
-      <author><first>Jegyung</first> <last>Son</last></author>
-      <author><first>Minho</first> <last>Lee</last></author>
+      <author><first>Dennis Singh</first><last>Moirangthem</last></author>
+      <author><first>Jegyung</first><last>Son</last></author>
+      <author><first>Minho</first><last>Lee</last></author>
       <pages>131–138</pages>
       <url>W17-2616</url>
       <doi>10.18653/v1/W17-2616</doi>
@@ -4404,8 +4404,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="17">
       <title>Learning Bilingual Projections of Embeddings for Vocabulary Expansion in Machine Translation</title>
-      <author><first>Pranava Swaroop</first> <last>Madhyastha</last></author>
-      <author><first>Cristina</first> <last>España-Bonet</last></author>
+      <author><first>Pranava Swaroop</first><last>Madhyastha</last></author>
+      <author><first>Cristina</first><last>España-Bonet</last></author>
       <pages>139–145</pages>
       <url>W17-2617</url>
       <doi>10.18653/v1/W17-2617</doi>
@@ -4413,9 +4413,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="18">
       <title>Prediction of Frame-to-Frame Relations in the <fixed-case>F</fixed-case>rame<fixed-case>N</fixed-case>et Hierarchy with Frame Embeddings</title>
-      <author><first>Teresa</first> <last>Botschen</last></author>
-      <author><first>Hatem</first> <last>Mousselly-Sergieh</last></author>
-      <author><first>Iryna</first> <last>Gurevych</last></author>
+      <author><first>Teresa</first><last>Botschen</last></author>
+      <author><first>Hatem</first><last>Mousselly-Sergieh</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
       <pages>146–156</pages>
       <url>W17-2618</url>
       <doi>10.18653/v1/W17-2618</doi>
@@ -4423,8 +4423,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="19">
       <title>Learning Joint Multilingual Sentence Representations with Neural Machine Translation</title>
-      <author><first>Holger</first> <last>Schwenk</last></author>
-      <author><first>Matthijs</first> <last>Douze</last></author>
+      <author><first>Holger</first><last>Schwenk</last></author>
+      <author><first>Matthijs</first><last>Douze</last></author>
       <pages>157–167</pages>
       <url>W17-2619</url>
       <doi>10.18653/v1/W17-2619</doi>
@@ -4432,12 +4432,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="20">
       <title>Transfer Learning for Speech Recognition on a Budget</title>
-      <author><first>Julius</first> <last>Kunze</last></author>
-      <author><first>Louis</first> <last>Kirsch</last></author>
-      <author><first>Ilia</first> <last>Kurenkov</last></author>
-      <author><first>Andreas</first> <last>Krug</last></author>
-      <author><first>Jens</first> <last>Johannsmeier</last></author>
-      <author><first>Sebastian</first> <last>Stober</last></author>
+      <author><first>Julius</first><last>Kunze</last></author>
+      <author><first>Louis</first><last>Kirsch</last></author>
+      <author><first>Ilia</first><last>Kurenkov</last></author>
+      <author><first>Andreas</first><last>Krug</last></author>
+      <author><first>Jens</first><last>Johannsmeier</last></author>
+      <author><first>Sebastian</first><last>Stober</last></author>
       <pages>168–177</pages>
       <url>W17-2620</url>
       <doi>10.18653/v1/W17-2620</doi>
@@ -4445,8 +4445,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="21">
       <title>Gradual Learning of Matrix-Space Models of Language for Sentiment Analysis</title>
-      <author><first>Shima</first> <last>Asaadi</last></author>
-      <author><first>Sebastian</first> <last>Rudolph</last></author>
+      <author><first>Shima</first><last>Asaadi</last></author>
+      <author><first>Sebastian</first><last>Rudolph</last></author>
       <pages>178–185</pages>
       <url>W17-2621</url>
       <doi>10.18653/v1/W17-2621</doi>
@@ -4454,9 +4454,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="22">
       <title>Improving Language Modeling using Densely Connected Recurrent Neural Networks</title>
-      <author><first>Fréderic</first> <last>Godin</last></author>
-      <author><first>Joni</first> <last>Dambre</last></author>
-      <author><first>Wesley</first> <last>De Neve</last></author>
+      <author><first>Fréderic</first><last>Godin</last></author>
+      <author><first>Joni</first><last>Dambre</last></author>
+      <author><first>Wesley</first><last>De Neve</last></author>
       <pages>186–190</pages>
       <url>W17-2622</url>
       <doi>10.18653/v1/W17-2622</doi>
@@ -4464,13 +4464,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="23">
       <title><fixed-case>N</fixed-case>ews<fixed-case>QA</fixed-case>: A Machine Comprehension Dataset</title>
-      <author><first>Adam</first> <last>Trischler</last></author>
-      <author><first>Tong</first> <last>Wang</last></author>
-      <author><first>Xingdi</first> <last>Yuan</last></author>
-      <author><first>Justin</first> <last>Harris</last></author>
-      <author><first>Alessandro</first> <last>Sordoni</last></author>
-      <author><first>Philip</first> <last>Bachman</last></author>
-      <author><first>Kaheer</first> <last>Suleman</last></author>
+      <author><first>Adam</first><last>Trischler</last></author>
+      <author><first>Tong</first><last>Wang</last></author>
+      <author><first>Xingdi</first><last>Yuan</last></author>
+      <author><first>Justin</first><last>Harris</last></author>
+      <author><first>Alessandro</first><last>Sordoni</last></author>
+      <author><first>Philip</first><last>Bachman</last></author>
+      <author><first>Kaheer</first><last>Suleman</last></author>
       <pages>191–200</pages>
       <url>W17-2623</url>
       <doi>10.18653/v1/W17-2623</doi>
@@ -4478,11 +4478,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="24">
       <title>Intrinsic and Extrinsic Evaluation of Spatiotemporal Text Representations in Twitter Streams</title>
-      <author><first>Lawrence</first> <last>Phillips</last></author>
-      <author><first>Kyle</first> <last>Shaffer</last></author>
-      <author><first>Dustin</first> <last>Arendt</last></author>
-      <author><first>Nathan</first> <last>Hodas</last></author>
-      <author><first>Svitlana</first> <last>Volkova</last></author>
+      <author><first>Lawrence</first><last>Phillips</last></author>
+      <author><first>Kyle</first><last>Shaffer</last></author>
+      <author><first>Dustin</first><last>Arendt</last></author>
+      <author><first>Nathan</first><last>Hodas</last></author>
+      <author><first>Svitlana</first><last>Volkova</last></author>
       <pages>201–210</pages>
       <url>W17-2624</url>
       <doi>10.18653/v1/W17-2624</doi>
@@ -4490,11 +4490,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="25">
       <title>Rethinking Skip-thought: A Neighborhood based Approach</title>
-      <author><first>Shuai</first> <last>Tang</last></author>
-      <author><first>Hailin</first> <last>Jin</last></author>
-      <author><first>Chen</first> <last>Fang</last></author>
-      <author><first>Zhaowen</first> <last>Wang</last></author>
-      <author><first>Virginia</first> <last>de Sa</last></author>
+      <author><first>Shuai</first><last>Tang</last></author>
+      <author><first>Hailin</first><last>Jin</last></author>
+      <author><first>Chen</first><last>Fang</last></author>
+      <author><first>Zhaowen</first><last>Wang</last></author>
+      <author><first>Virginia</first><last>de Sa</last></author>
       <pages>211–218</pages>
       <url>W17-2625</url>
       <doi>10.18653/v1/W17-2625</doi>
@@ -4503,10 +4503,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="26">
       <title>A Frame Tracking Model for Memory-Enhanced Dialogue Systems</title>
-      <author><first>Hannes</first> <last>Schulz</last></author>
-      <author><first>Jeremie</first> <last>Zumer</last></author>
-      <author><first>Layla</first> <last>El Asri</last></author>
-      <author><first>Shikhar</first> <last>Sharma</last></author>
+      <author><first>Hannes</first><last>Schulz</last></author>
+      <author><first>Jeremie</first><last>Zumer</last></author>
+      <author><first>Layla</first><last>El Asri</last></author>
+      <author><first>Shikhar</first><last>Sharma</last></author>
       <pages>219–227</pages>
       <url>W17-2626</url>
       <doi>10.18653/v1/W17-2626</doi>
@@ -4514,10 +4514,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="27">
       <title>Plan, Attend, Generate: Character-Level Neural Machine Translation with Planning</title>
-      <author><first>Caglar</first> <last>Gulcehre</last></author>
-      <author><first>Francis</first> <last>Dutil</last></author>
-      <author><first>Adam</first> <last>Trischler</last></author>
-      <author><first>Yoshua</first> <last>Bengio</last></author>
+      <author><first>Caglar</first><last>Gulcehre</last></author>
+      <author><first>Francis</first><last>Dutil</last></author>
+      <author><first>Adam</first><last>Trischler</last></author>
+      <author><first>Yoshua</first><last>Bengio</last></author>
       <pages>228–234</pages>
       <url>W17-2627</url>
       <doi>10.18653/v1/W17-2627</doi>
@@ -4525,9 +4525,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="28">
       <title>Does the Geometry of Word Embeddings Help Document Classification? A Case Study on Persistent Homology-Based Representations</title>
-      <author><first>Paul</first> <last>Michel</last></author>
-      <author><first>Abhilasha</first> <last>Ravichander</last></author>
-      <author><first>Shruti</first> <last>Rijhwani</last></author>
+      <author><first>Paul</first><last>Michel</last></author>
+      <author><first>Abhilasha</first><last>Ravichander</last></author>
+      <author><first>Shruti</first><last>Rijhwani</last></author>
       <pages>235–240</pages>
       <url>W17-2628</url>
       <doi>10.18653/v1/W17-2628</doi>
@@ -4535,11 +4535,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="29">
       <title>Adversarial Generation of Natural Language</title>
-      <author><first>Sandeep</first> <last>Subramanian</last></author>
-      <author><first>Sai</first> <last>Rajeswar</last></author>
-      <author><first>Francis</first> <last>Dutil</last></author>
-      <author><first>Chris</first> <last>Pal</last></author>
-      <author><first>Aaron</first> <last>Courville</last></author>
+      <author><first>Sandeep</first><last>Subramanian</last></author>
+      <author><first>Sai</first><last>Rajeswar</last></author>
+      <author><first>Francis</first><last>Dutil</last></author>
+      <author><first>Chris</first><last>Pal</last></author>
+      <author><first>Aaron</first><last>Courville</last></author>
       <pages>241–251</pages>
       <url>W17-2629</url>
       <doi>10.18653/v1/W17-2629</doi>
@@ -4547,11 +4547,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="30">
       <title>Deep Active Learning for Named Entity Recognition</title>
-      <author><first>Yanyao</first> <last>Shen</last></author>
-      <author><first>Hyokun</first> <last>Yun</last></author>
-      <author><first>Zachary</first> <last>Lipton</last></author>
-      <author><first>Yakov</first> <last>Kronrod</last></author>
-      <author><first>Animashree</first> <last>Anandkumar</last></author>
+      <author><first>Yanyao</first><last>Shen</last></author>
+      <author><first>Hyokun</first><last>Yun</last></author>
+      <author><first>Zachary</first><last>Lipton</last></author>
+      <author><first>Yakov</first><last>Kronrod</last></author>
+      <author><first>Animashree</first><last>Anandkumar</last></author>
       <pages>252–256</pages>
       <url>W17-2630</url>
       <doi>10.18653/v1/W17-2630</doi>
@@ -4559,8 +4559,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="31">
       <title>Learning when to skim and when to read</title>
-      <author><first>Alexander</first> <last>Johansen</last></author>
-      <author><first>Richard</first> <last>Socher</last></author>
+      <author><first>Alexander</first><last>Johansen</last></author>
+      <author><first>Richard</first><last>Socher</last></author>
       <pages>257–264</pages>
       <url>W17-2631</url>
       <doi>10.18653/v1/W17-2631</doi>
@@ -4568,9 +4568,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="32">
       <title>Learning to Embed Words in Context for Syntactic Tasks</title>
-      <author><first>Lifu</first> <last>Tu</last></author>
-      <author><first>Kevin</first> <last>Gimpel</last></author>
-      <author><first>Karen</first> <last>Livescu</last></author>
+      <author><first>Lifu</first><last>Tu</last></author>
+      <author><first>Kevin</first><last>Gimpel</last></author>
+      <author><first>Karen</first><last>Livescu</last></author>
       <pages>265–275</pages>
       <url>W17-2632</url>
       <doi>10.18653/v1/W17-2632</doi>
@@ -4600,8 +4600,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>news<fixed-case>L</fixed-case>ens: building and visualizing long-ranging news stories</title>
-      <author><first>Philippe</first> <last>Laban</last></author>
-      <author><first>Marti</first> <last>Hearst</last></author>
+      <author><first>Philippe</first><last>Laban</last></author>
+      <author><first>Marti</first><last>Hearst</last></author>
       <pages>1–9</pages>
       <url>W17-2701</url>
       <doi>10.18653/v1/W17-2701</doi>
@@ -4609,8 +4609,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Detecting Changes in Twitter Streams using Temporal Clusters of Hashtags</title>
-      <author><first>Yunli</first> <last>Wang</last></author>
-      <author><first>Cyril</first> <last>Goutte</last></author>
+      <author><first>Yunli</first><last>Wang</last></author>
+      <author><first>Cyril</first><last>Goutte</last></author>
       <pages>10–14</pages>
       <url>W17-2702</url>
       <doi>10.18653/v1/W17-2702</doi>
@@ -4618,9 +4618,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Event Detection Using Frame-Semantic Parser</title>
-      <author><first>Evangelia</first> <last>Spiliopoulou</last></author>
-      <author><first>Eduard</first> <last>Hovy</last></author>
-      <author><first>Teruko</first> <last>Mitamura</last></author>
+      <author><first>Evangelia</first><last>Spiliopoulou</last></author>
+      <author><first>Eduard</first><last>Hovy</last></author>
+      <author><first>Teruko</first><last>Mitamura</last></author>
       <pages>15–20</pages>
       <url>W17-2703</url>
       <doi>10.18653/v1/W17-2703</doi>
@@ -4628,8 +4628,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Improving Shared Argument Identification in <fixed-case>J</fixed-case>apanese Event Knowledge Acquisition</title>
-      <author><first>Yin Jou</first> <last>Huang</last></author>
-      <author><first>Sadao</first> <last>Kurohashi</last></author>
+      <author><first>Yin Jou</first><last>Huang</last></author>
+      <author><first>Sadao</first><last>Kurohashi</last></author>
       <pages>21–30</pages>
       <url>W17-2704</url>
       <doi>10.18653/v1/W17-2704</doi>
@@ -4637,9 +4637,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Tracing armed conflicts with diachronic word embedding models</title>
-      <author><first>Andrey</first> <last>Kutuzov</last></author>
-      <author><first>Erik</first> <last>Velldal</last></author>
-      <author><first>Lilja</first> <last>Øvrelid</last></author>
+      <author><first>Andrey</first><last>Kutuzov</last></author>
+      <author><first>Erik</first><last>Velldal</last></author>
+      <author><first>Lilja</first><last>Øvrelid</last></author>
       <pages>31–36</pages>
       <url>W17-2705</url>
       <doi>10.18653/v1/W17-2705</doi>
@@ -4648,9 +4648,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>The Circumstantial Event Ontology (<fixed-case>CEO</fixed-case>)</title>
-      <author><first>Roxane</first> <last>Segers</last></author>
-      <author><first>Tommaso</first> <last>Caselli</last></author>
-      <author><first>Piek</first> <last>Vossen</last></author>
+      <author><first>Roxane</first><last>Segers</last></author>
+      <author><first>Tommaso</first><last>Caselli</last></author>
+      <author><first>Piek</first><last>Vossen</last></author>
       <pages>37–41</pages>
       <url>W17-2706</url>
       <doi>10.18653/v1/W17-2706</doi>
@@ -4658,15 +4658,15 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Event Detection and Semantic Storytelling: Generating a Travelogue from a large Collection of Personal Letters</title>
-      <author><first>Georg</first> <last>Rehm</last></author>
-      <author><first>Julian</first> <last>Moreno Schneider</last></author>
-      <author><first>Peter</first> <last>Bourgonje</last></author>
-      <author><first>Ankit</first> <last>Srivastava</last></author>
-      <author><first>Jan</first> <last>Nehring</last></author>
-      <author><first>Armin</first> <last>Berger</last></author>
-      <author><first>Luca</first> <last>König</last></author>
-      <author><first>Sören</first> <last>Räuchle</last></author>
-      <author><first>Jens</first> <last>Gerth</last></author>
+      <author><first>Georg</first><last>Rehm</last></author>
+      <author><first>Julian</first><last>Moreno Schneider</last></author>
+      <author><first>Peter</first><last>Bourgonje</last></author>
+      <author><first>Ankit</first><last>Srivastava</last></author>
+      <author><first>Jan</first><last>Nehring</last></author>
+      <author><first>Armin</first><last>Berger</last></author>
+      <author><first>Luca</first><last>König</last></author>
+      <author><first>Sören</first><last>Räuchle</last></author>
+      <author><first>Jens</first><last>Gerth</last></author>
       <pages>42–51</pages>
       <url>W17-2707</url>
       <doi>10.18653/v1/W17-2707</doi>
@@ -4674,9 +4674,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Inference of Fine-Grained Event Causality from Blogs and Films</title>
-      <author><first>Zhichao</first> <last>Hu</last></author>
-      <author><first>Elahe</first> <last>Rahimtoroghi</last></author>
-      <author><first>Marilyn</first> <last>Walker</last></author>
+      <author><first>Zhichao</first><last>Hu</last></author>
+      <author><first>Elahe</first><last>Rahimtoroghi</last></author>
+      <author><first>Marilyn</first><last>Walker</last></author>
       <pages>52–58</pages>
       <url>W17-2708</url>
       <doi>10.18653/v1/W17-2708</doi>
@@ -4684,10 +4684,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>On the Creation of a Security-Related Event Corpus</title>
-      <author><first>Martin</first> <last>Atkinson</last></author>
-      <author><first>Jakub</first> <last>Piskorski</last></author>
-      <author><first>Hristo</first> <last>Tanev</last></author>
-      <author><first>Vanni</first> <last>Zavarella</last></author>
+      <author><first>Martin</first><last>Atkinson</last></author>
+      <author><first>Jakub</first><last>Piskorski</last></author>
+      <author><first>Hristo</first><last>Tanev</last></author>
+      <author><first>Vanni</first><last>Zavarella</last></author>
       <pages>59–65</pages>
       <url>W17-2709</url>
       <doi>10.18653/v1/W17-2709</doi>
@@ -4695,7 +4695,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Inducing Event Types and Roles in Reverse: Using Function to Discover Theme</title>
-      <author><first>Natalie</first> <last>Ahn</last></author>
+      <author><first>Natalie</first><last>Ahn</last></author>
       <pages>66–76</pages>
       <url>W17-2710</url>
       <doi>10.18653/v1/W17-2710</doi>
@@ -4703,8 +4703,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>The Event <fixed-case>S</fixed-case>tory<fixed-case>L</fixed-case>ine Corpus: A New Benchmark for Causal and Temporal Relation Extraction</title>
-      <author><first>Tommaso</first> <last>Caselli</last></author>
-      <author><first>Piek</first> <last>Vossen</last></author>
+      <author><first>Tommaso</first><last>Caselli</last></author>
+      <author><first>Piek</first><last>Vossen</last></author>
       <pages>77–86</pages>
       <url>W17-2711</url>
       <doi>10.18653/v1/W17-2711</doi>
@@ -4712,10 +4712,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>The Rich Event Ontology</title>
-      <author><first>Susan</first> <last>Brown</last></author>
-      <author><first>Claire</first> <last>Bonial</last></author>
-      <author><first>Leo</first> <last>Obrst</last></author>
-      <author><first>Martha</first> <last>Palmer</last></author>
+      <author><first>Susan</first><last>Brown</last></author>
+      <author><first>Claire</first><last>Bonial</last></author>
+      <author><first>Leo</first><last>Obrst</last></author>
+      <author><first>Martha</first><last>Palmer</last></author>
       <pages>87–97</pages>
       <url>W17-2712</url>
       <doi>10.18653/v1/W17-2712</doi>
@@ -4723,9 +4723,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Integrating Decompositional Event Structures into Storylines</title>
-      <author><first>William</first> <last>Croft</last></author>
-      <author><first>Pavlína</first> <last>Pešková</last></author>
-      <author><first>Michael</first> <last>Regan</last></author>
+      <author><first>William</first><last>Croft</last></author>
+      <author><first>Pavlína</first><last>Pešková</last></author>
+      <author><first>Michael</first><last>Regan</last></author>
       <pages>98–109</pages>
       <url>W17-2713</url>
       <doi>10.18653/v1/W17-2713</doi>
@@ -4752,10 +4752,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Grounding Language for Interactive Task Learning</title>
-      <author><first>Peter</first> <last>Lindes</last></author>
-      <author><first>Aaron</first> <last>Mininger</last></author>
-      <author><first>James R.</first> <last>Kirk</last></author>
-      <author><first>John E.</first> <last>Laird</last></author>
+      <author><first>Peter</first><last>Lindes</last></author>
+      <author><first>Aaron</first><last>Mininger</last></author>
+      <author><first>James R.</first><last>Kirk</last></author>
+      <author><first>John E.</first><last>Laird</last></author>
       <pages>1–9</pages>
       <url>W17-2801</url>
       <doi>10.18653/v1/W17-2801</doi>
@@ -4765,9 +4765,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Learning how to Learn: An Adaptive Dialogue Agent for Incrementally Learning Visually Grounded Word Meanings</title>
-      <author><first>Yanchao</first> <last>Yu</last></author>
-      <author><first>Arash</first> <last>Eshghi</last></author>
-      <author><first>Oliver</first> <last>Lemon</last></author>
+      <author><first>Yanchao</first><last>Yu</last></author>
+      <author><first>Arash</first><last>Eshghi</last></author>
+      <author><first>Oliver</first><last>Lemon</last></author>
       <pages>10–19</pages>
       <url>W17-2802</url>
       <doi>10.18653/v1/W17-2802</doi>
@@ -4775,9 +4775,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Guiding Interaction Behaviors for Multi-modal Grounded Language Learning</title>
-      <author><first>Jesse</first> <last>Thomason</last></author>
-      <author><first>Jivko</first> <last>Sinapov</last></author>
-      <author><first>Raymond</first> <last>Mooney</last></author>
+      <author><first>Jesse</first><last>Thomason</last></author>
+      <author><first>Jivko</first><last>Sinapov</last></author>
+      <author><first>Raymond</first><last>Mooney</last></author>
       <pages>20–24</pages>
       <url>W17-2803</url>
       <doi>10.18653/v1/W17-2803</doi>
@@ -4785,10 +4785,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Structured Learning for Context-aware Spoken Language Understanding of Robotic Commands</title>
-      <author><first>Andrea</first> <last>Vanzo</last></author>
-      <author><first>Danilo</first> <last>Croce</last></author>
-      <author><first>Roberto</first> <last>Basili</last></author>
-      <author><first>Daniele</first> <last>Nardi</last></author>
+      <author><first>Andrea</first><last>Vanzo</last></author>
+      <author><first>Danilo</first><last>Croce</last></author>
+      <author><first>Roberto</first><last>Basili</last></author>
+      <author><first>Daniele</first><last>Nardi</last></author>
       <pages>25–34</pages>
       <url>W17-2804</url>
       <doi>10.18653/v1/W17-2804</doi>
@@ -4796,11 +4796,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Natural Language Grounding and Grammar Induction for Robotic Manipulation Commands</title>
-      <author><first>Muhannad</first> <last>Alomari</last></author>
-      <author><first>Paul</first> <last>Duckworth</last></author>
-      <author><first>Majd</first> <last>Hawasly</last></author>
-      <author><first>David C.</first> <last>Hogg</last></author>
-      <author><first>Anthony G.</first> <last>Cohn</last></author>
+      <author><first>Muhannad</first><last>Alomari</last></author>
+      <author><first>Paul</first><last>Duckworth</last></author>
+      <author><first>Majd</first><last>Hawasly</last></author>
+      <author><first>David C.</first><last>Hogg</last></author>
+      <author><first>Anthony G.</first><last>Cohn</last></author>
       <pages>35–43</pages>
       <url>W17-2805</url>
       <doi>10.18653/v1/W17-2805</doi>
@@ -4808,8 +4808,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Communication with Robots using Multilayer Recurrent Networks</title>
-      <author><first>Bedřich</first> <last>Pišl</last></author>
-      <author><first>David</first> <last>Mareček</last></author>
+      <author><first>Bedřich</first><last>Pišl</last></author>
+      <author><first>David</first><last>Mareček</last></author>
       <pages>44–48</pages>
       <url>W17-2806</url>
       <doi>10.18653/v1/W17-2806</doi>
@@ -4817,10 +4817,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Grounding Symbols in Multi-Modal Instructions</title>
-      <author><first>Yordan</first> <last>Hristov</last></author>
-      <author><first>Svetlin</first> <last>Penkov</last></author>
-      <author><first>Alex</first> <last>Lascarides</last></author>
-      <author><first>Subramanian</first> <last>Ramamoorthy</last></author>
+      <author><first>Yordan</first><last>Hristov</last></author>
+      <author><first>Svetlin</first><last>Penkov</last></author>
+      <author><first>Alex</first><last>Lascarides</last></author>
+      <author><first>Subramanian</first><last>Ramamoorthy</last></author>
       <pages>49–57</pages>
       <url>W17-2807</url>
       <doi>10.18653/v1/W17-2807</doi>
@@ -4828,15 +4828,15 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Exploring Variation of Natural Human Commands to a Robot in a Collaborative Navigation Task</title>
-      <author><first>Matthew</first> <last>Marge</last></author>
-      <author><first>Claire</first> <last>Bonial</last></author>
-      <author><first>Ashley</first> <last>Foots</last></author>
-      <author><first>Cory</first> <last>Hayes</last></author>
-      <author><first>Cassidy</first> <last>Henry</last></author>
-      <author><first>Kimberly</first> <last>Pollard</last></author>
-      <author><first>Ron</first> <last>Artstein</last></author>
-      <author><first>Clare</first> <last>Voss</last></author>
-      <author><first>David</first> <last>Traum</last></author>
+      <author><first>Matthew</first><last>Marge</last></author>
+      <author><first>Claire</first><last>Bonial</last></author>
+      <author><first>Ashley</first><last>Foots</last></author>
+      <author><first>Cory</first><last>Hayes</last></author>
+      <author><first>Cassidy</first><last>Henry</last></author>
+      <author><first>Kimberly</first><last>Pollard</last></author>
+      <author><first>Ron</first><last>Artstein</last></author>
+      <author><first>Clare</first><last>Voss</last></author>
+      <author><first>David</first><last>Traum</last></author>
       <pages>58–66</pages>
       <url>W17-2808</url>
       <doi>10.18653/v1/W17-2808</doi>
@@ -4845,13 +4845,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>A Tale of Two <fixed-case>DRAGGN</fixed-case>s: A Hybrid Approach for Interpreting Action-Oriented and Goal-Oriented Instructions</title>
-      <author><first>Siddharth</first> <last>Karamcheti</last></author>
-      <author><first>Edward Clem</first> <last>Williams</last></author>
-      <author><first>Dilip</first> <last>Arumugam</last></author>
-      <author><first>Mina</first> <last>Rhee</last></author>
-      <author><first>Nakul</first> <last>Gopalan</last></author>
-      <author><first>Lawson L.S.</first> <last>Wong</last></author>
-      <author><first>Stefanie</first> <last>Tellex</last></author>
+      <author><first>Siddharth</first><last>Karamcheti</last></author>
+      <author><first>Edward Clem</first><last>Williams</last></author>
+      <author><first>Dilip</first><last>Arumugam</last></author>
+      <author><first>Mina</first><last>Rhee</last></author>
+      <author><first>Nakul</first><last>Gopalan</last></author>
+      <author><first>Lawson L.S.</first><last>Wong</last></author>
+      <author><first>Stefanie</first><last>Tellex</last></author>
       <pages>67–75</pages>
       <url>W17-2809</url>
       <doi>10.18653/v1/W17-2809</doi>
@@ -4859,8 +4859,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Are Distributional Representations Ready for the Real World? Evaluating Word Vectors for Grounded Perceptual Meaning</title>
-      <author><first>Li</first> <last>Lucy</last></author>
-      <author><first>Jon</first> <last>Gauthier</last></author>
+      <author><first>Li</first><last>Lucy</last></author>
+      <author><first>Jon</first><last>Gauthier</last></author>
       <pages>76–85</pages>
       <url>W17-2810</url>
       <doi>10.18653/v1/W17-2810</doi>
@@ -4868,10 +4868,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Sympathy Begins with a Smile, Intelligence Begins with a Word: Use of Multimodal Features in Spoken Human-Robot Interaction</title>
-      <author><first>Jekaterina</first> <last>Novikova</last></author>
-      <author><first>Christian</first> <last>Dondrup</last></author>
-      <author><first>Ioannis</first> <last>Papaioannou</last></author>
-      <author><first>Oliver</first> <last>Lemon</last></author>
+      <author><first>Jekaterina</first><last>Novikova</last></author>
+      <author><first>Christian</first><last>Dondrup</last></author>
+      <author><first>Ioannis</first><last>Papaioannou</last></author>
+      <author><first>Oliver</first><last>Lemon</last></author>
       <pages>86–94</pages>
       <url>W17-2811</url>
       <doi>10.18653/v1/W17-2811</doi>
@@ -4879,16 +4879,16 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Towards Problem Solving Agents that Communicate and Learn</title>
-      <author><first>Anjali</first> <last>Narayan-Chen</last></author>
-      <author><first>Colin</first> <last>Graber</last></author>
-      <author><first>Mayukh</first> <last>Das</last></author>
-      <author><first>Md Rakibul</first> <last>Islam</last></author>
-      <author><first>Soham</first> <last>Dan</last></author>
-      <author><first>Sriraam</first> <last>Natarajan</last></author>
-      <author><first>Janardhan Rao</first> <last>Doppa</last></author>
-      <author><first>Julia</first> <last>Hockenmaier</last></author>
-      <author><first>Martha</first> <last>Palmer</last></author>
-      <author><first>Dan</first> <last>Roth</last></author>
+      <author><first>Anjali</first><last>Narayan-Chen</last></author>
+      <author><first>Colin</first><last>Graber</last></author>
+      <author><first>Mayukh</first><last>Das</last></author>
+      <author><first>Md Rakibul</first><last>Islam</last></author>
+      <author><first>Soham</first><last>Dan</last></author>
+      <author><first>Sriraam</first><last>Natarajan</last></author>
+      <author><first>Janardhan Rao</first><last>Doppa</last></author>
+      <author><first>Julia</first><last>Hockenmaier</last></author>
+      <author><first>Martha</first><last>Palmer</last></author>
+      <author><first>Dan</first><last>Roth</last></author>
       <pages>95–103</pages>
       <url>W17-2812</url>
       <doi>10.18653/v1/W17-2812</doi>
@@ -4917,9 +4917,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Language-independent Gender Prediction on Twitter</title>
-      <author><first>Nikola</first> <last>Ljubešić</last></author>
-      <author><first>Darja</first> <last>Fišer</last></author>
-      <author><first>Tomaž</first> <last>Erjavec</last></author>
+      <author><first>Nikola</first><last>Ljubešić</last></author>
+      <author><first>Darja</first><last>Fišer</last></author>
+      <author><first>Tomaž</first><last>Erjavec</last></author>
       <pages>1–6</pages>
       <url>W17-2901</url>
       <doi>10.18653/v1/W17-2901</doi>
@@ -4927,8 +4927,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>When does a compliment become sexist? Analysis and classification of ambivalent sexism using twitter data</title>
-      <author><first>Akshita</first> <last>Jha</last></author>
-      <author><first>Radhika</first> <last>Mamidi</last></author>
+      <author><first>Akshita</first><last>Jha</last></author>
+      <author><first>Radhika</first><last>Mamidi</last></author>
       <pages>7–16</pages>
       <url>W17-2902</url>
       <doi>10.18653/v1/W17-2902</doi>
@@ -4936,9 +4936,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Personality Driven Differences in Paraphrase Preference</title>
-      <author><first>Daniel</first> <last>Preoţiuc-Pietro</last></author>
-      <author><first>Jordan</first> <last>Carpenter</last></author>
-      <author><first>Lyle</first> <last>Ungar</last></author>
+      <author><first>Daniel</first><last>Preoţiuc-Pietro</last></author>
+      <author><first>Jordan</first><last>Carpenter</last></author>
+      <author><first>Lyle</first><last>Ungar</last></author>
       <pages>17–26</pages>
       <url>W17-2903</url>
       <doi>10.18653/v1/W17-2903</doi>
@@ -4947,7 +4947,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>community2vec: Vector representations of online communities encode semantic relationships</title>
-      <author><first>Trevor</first> <last>Martin</last></author>
+      <author><first>Trevor</first><last>Martin</last></author>
       <pages>27–31</pages>
       <url>W17-2904</url>
       <doi>10.18653/v1/W17-2904</doi>
@@ -4955,10 +4955,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Telling Apart Tweets Associated with Controversial versus Non-Controversial Topics</title>
-      <author><first>Aseel</first> <last>Addawood</last></author>
-      <author><first>Rezvaneh</first> <last>Rezapour</last></author>
-      <author><first>Omid</first> <last>Abdar</last></author>
-      <author><first>Jana</first> <last>Diesner</last></author>
+      <author><first>Aseel</first><last>Addawood</last></author>
+      <author><first>Rezvaneh</first><last>Rezapour</last></author>
+      <author><first>Omid</first><last>Abdar</last></author>
+      <author><first>Jana</first><last>Diesner</last></author>
       <pages>32–41</pages>
       <url>W17-2905</url>
       <doi>10.18653/v1/W17-2905</doi>
@@ -4966,9 +4966,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Cross-Lingual Classification of Topics in Political Texts</title>
-      <author><first>Goran</first> <last>Glavaš</last></author>
-      <author><first>Federico</first> <last>Nanni</last></author>
-      <author><first>Simone Paolo</first> <last>Ponzetto</last></author>
+      <author><first>Goran</first><last>Glavaš</last></author>
+      <author><first>Federico</first><last>Nanni</last></author>
+      <author><first>Simone Paolo</first><last>Ponzetto</last></author>
       <pages>42–46</pages>
       <url>W17-2906</url>
       <doi>10.18653/v1/W17-2906</doi>
@@ -4976,8 +4976,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Mining Social Science Publications for Survey Variables</title>
-      <author><first>Andrea</first> <last>Zielinski</last></author>
-      <author><first>Peter</first> <last>Mutschke</last></author>
+      <author><first>Andrea</first><last>Zielinski</last></author>
+      <author><first>Peter</first><last>Mutschke</last></author>
       <pages>47–52</pages>
       <url>W17-2907</url>
       <doi>10.18653/v1/W17-2907</doi>
@@ -4985,12 +4985,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Linguistic Markers of Influence in Informal Interactions</title>
-      <author><first>Shrimai</first> <last>Prabhumoye</last></author>
-      <author><first>Samridhi</first> <last>Choudhary</last></author>
-      <author><first>Evangelia</first> <last>Spiliopoulou</last></author>
-      <author><first>Christopher</first> <last>Bogart</last></author>
-      <author><first>Carolyn</first> <last>Rose</last></author>
-      <author><first>Alan W</first> <last>Black</last></author>
+      <author><first>Shrimai</first><last>Prabhumoye</last></author>
+      <author><first>Samridhi</first><last>Choudhary</last></author>
+      <author><first>Evangelia</first><last>Spiliopoulou</last></author>
+      <author><first>Christopher</first><last>Bogart</last></author>
+      <author><first>Carolyn</first><last>Rose</last></author>
+      <author><first>Alan W</first><last>Black</last></author>
       <pages>53–62</pages>
       <url>W17-2908</url>
       <doi>10.18653/v1/W17-2908</doi>
@@ -4998,10 +4998,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Non-lexical Features Encode Political Affiliation on Twitter</title>
-      <author><first>Rachael</first> <last>Tatman</last></author>
-      <author><first>Leo</first> <last>Stewart</last></author>
-      <author><first>Amandalynne</first> <last>Paullada</last></author>
-      <author><first>Emma</first> <last>Spiro</last></author>
+      <author><first>Rachael</first><last>Tatman</last></author>
+      <author><first>Leo</first><last>Stewart</last></author>
+      <author><first>Amandalynne</first><last>Paullada</last></author>
+      <author><first>Emma</first><last>Spiro</last></author>
       <pages>63–67</pages>
       <url>W17-2909</url>
       <doi>10.18653/v1/W17-2909</doi>
@@ -5009,7 +5009,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Modelling Participation in Small Group Social Sequences with <fixed-case>M</fixed-case>arkov Rewards Analysis</title>
-      <author><first>Gabriel</first> <last>Murray</last></author>
+      <author><first>Gabriel</first><last>Murray</last></author>
       <pages>68–72</pages>
       <url>W17-2910</url>
       <doi>10.18653/v1/W17-2910</doi>
@@ -5017,10 +5017,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Code-Switching as a Social Act: The Case of <fixed-case>A</fixed-case>rabic <fixed-case>W</fixed-case>ikipedia Talk Pages</title>
-      <author><first>Michael</first> <last>Yoder</last></author>
-      <author><first>Shruti</first> <last>Rijhwani</last></author>
-      <author><first>Carolyn</first> <last>Rosé</last></author>
-      <author><first>Lori</first> <last>Levin</last></author>
+      <author><first>Michael</first><last>Yoder</last></author>
+      <author><first>Shruti</first><last>Rijhwani</last></author>
+      <author><first>Carolyn</first><last>Rosé</last></author>
+      <author><first>Lori</first><last>Levin</last></author>
       <pages>73–82</pages>
       <url>W17-2911</url>
       <doi>10.18653/v1/W17-2911</doi>
@@ -5028,10 +5028,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>How Does Twitter User Behavior Vary Across Demographic Groups?</title>
-      <author><first>Zach</first> <last>Wood-Doughty</last></author>
-      <author><first>Michael</first> <last>Smith</last></author>
-      <author><first>David</first> <last>Broniatowski</last></author>
-      <author><first>Mark</first> <last>Dredze</last></author>
+      <author><first>Zach</first><last>Wood-Doughty</last></author>
+      <author><first>Michael</first><last>Smith</last></author>
+      <author><first>David</first><last>Broniatowski</last></author>
+      <author><first>Mark</first><last>Dredze</last></author>
       <pages>83–89</pages>
       <url>W17-2912</url>
       <doi>10.18653/v1/W17-2912</doi>
@@ -5039,9 +5039,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Ideological Phrase Indicators for Classification of Political Discourse Framing on Twitter</title>
-      <author><first>Kristen</first> <last>Johnson</last></author>
-      <author><first>I-Ta</first> <last>Lee</last></author>
-      <author><first>Dan</first> <last>Goldwasser</last></author>
+      <author><first>Kristen</first><last>Johnson</last></author>
+      <author><first>I-Ta</first><last>Lee</last></author>
+      <author><first>Dan</first><last>Goldwasser</last></author>
       <pages>90–99</pages>
       <url>W17-2913</url>
       <doi>10.18653/v1/W17-2913</doi>
@@ -5067,8 +5067,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Dimensions of Abusive Language on Twitter</title>
-      <author><first>Isobelle</first> <last>Clarke</last></author>
-      <author><first>Jack</first> <last>Grieve</last></author>
+      <author><first>Isobelle</first><last>Clarke</last></author>
+      <author><first>Jack</first><last>Grieve</last></author>
       <pages>1–10</pages>
       <url>W17-3001</url>
       <doi>10.18653/v1/W17-3001</doi>
@@ -5076,8 +5076,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Constructive Language in News Comments</title>
-      <author><first>Varada</first> <last>Kolhatkar</last></author>
-      <author><first>Maite</first> <last>Taboada</last></author>
+      <author><first>Varada</first><last>Kolhatkar</last></author>
+      <author><first>Maite</first><last>Taboada</last></author>
       <pages>11–17</pages>
       <url>W17-3002</url>
       <doi>10.18653/v1/W17-3002</doi>
@@ -5085,10 +5085,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Rephrasing Profanity in <fixed-case>C</fixed-case>hinese Text</title>
-      <author><first>Hui-Po</first> <last>Su</last></author>
-      <author><first>Zhen-Jie</first> <last>Huang</last></author>
-      <author><first>Hao-Tsung</first> <last>Chang</last></author>
-      <author><first>Chuan-Jie</first> <last>Lin</last></author>
+      <author><first>Hui-Po</first><last>Su</last></author>
+      <author><first>Zhen-Jie</first><last>Huang</last></author>
+      <author><first>Hao-Tsung</first><last>Chang</last></author>
+      <author><first>Chuan-Jie</first><last>Lin</last></author>
       <pages>18–24</pages>
       <url>W17-3003</url>
       <doi>10.18653/v1/W17-3003</doi>
@@ -5096,9 +5096,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Deep Learning for User Comment Moderation</title>
-      <author><first>John</first> <last>Pavlopoulos</last></author>
-      <author><first>Prodromos</first> <last>Malakasiotis</last></author>
-      <author><first>Ion</first> <last>Androutsopoulos</last></author>
+      <author><first>John</first><last>Pavlopoulos</last></author>
+      <author><first>Prodromos</first><last>Malakasiotis</last></author>
+      <author><first>Ion</first><last>Androutsopoulos</last></author>
       <pages>25–35</pages>
       <url>W17-3004</url>
       <doi>10.18653/v1/W17-3004</doi>
@@ -5106,12 +5106,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Class-based Prediction Errors to Detect Hate Speech with Out-of-vocabulary Words</title>
-      <author><first>Joan</first> <last>Serrà</last></author>
-      <author><first>Ilias</first> <last>Leontiadis</last></author>
-      <author><first>Dimitris</first> <last>Spathis</last></author>
-      <author><first>Gianluca</first> <last>Stringhini</last></author>
-      <author><first>Jeremy</first> <last>Blackburn</last></author>
-      <author><first>Athena</first> <last>Vakali</last></author>
+      <author><first>Joan</first><last>Serrà</last></author>
+      <author><first>Ilias</first><last>Leontiadis</last></author>
+      <author><first>Dimitris</first><last>Spathis</last></author>
+      <author><first>Gianluca</first><last>Stringhini</last></author>
+      <author><first>Jeremy</first><last>Blackburn</last></author>
+      <author><first>Athena</first><last>Vakali</last></author>
       <pages>36–40</pages>
       <url>W17-3005</url>
       <doi>10.18653/v1/W17-3005</doi>
@@ -5119,8 +5119,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>One-step and Two-step Classification for Abusive Language Detection on Twitter</title>
-      <author><first>Ji Ho</first> <last>Park</last></author>
-      <author><first>Pascale</first> <last>Fung</last></author>
+      <author><first>Ji Ho</first><last>Park</last></author>
+      <author><first>Pascale</first><last>Fung</last></author>
       <pages>41–45</pages>
       <url>W17-3006</url>
       <doi>10.18653/v1/W17-3006</doi>
@@ -5128,9 +5128,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Legal Framework, Dataset and Annotation Schema for Socially Unacceptable Online Discourse Practices in <fixed-case>S</fixed-case>lovene</title>
-      <author><first>Darja</first> <last>Fišer</last></author>
-      <author><first>Tomaž</first> <last>Erjavec</last></author>
-      <author><first>Nikola</first> <last>Ljubešić</last></author>
+      <author><first>Darja</first><last>Fišer</last></author>
+      <author><first>Tomaž</first><last>Erjavec</last></author>
+      <author><first>Nikola</first><last>Ljubešić</last></author>
       <pages>46–51</pages>
       <url>W17-3007</url>
       <doi>10.18653/v1/W17-3007</doi>
@@ -5138,9 +5138,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Abusive Language Detection on <fixed-case>A</fixed-case>rabic Social Media</title>
-      <author><first>Hamdy</first> <last>Mubarak</last></author>
-      <author><first>Kareem</first> <last>Darwish</last></author>
-      <author><first>Walid</first> <last>Magdy</last></author>
+      <author><first>Hamdy</first><last>Mubarak</last></author>
+      <author><first>Kareem</first><last>Darwish</last></author>
+      <author><first>Walid</first><last>Magdy</last></author>
       <pages>52–56</pages>
       <url>W17-3008</url>
       <doi>10.18653/v1/W17-3008</doi>
@@ -5148,11 +5148,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Vectors for Counterspeech on Twitter</title>
-      <author><first>Lucas</first> <last>Wright</last></author>
-      <author><first>Derek</first> <last>Ruths</last></author>
-      <author><first>Kelly P</first> <last>Dillon</last></author>
-      <author><first>Haji Mohammad</first> <last>Saleem</last></author>
-      <author><first>Susan</first> <last>Benesch</last></author>
+      <author><first>Lucas</first><last>Wright</last></author>
+      <author><first>Derek</first><last>Ruths</last></author>
+      <author><first>Kelly P</first><last>Dillon</last></author>
+      <author><first>Haji Mohammad</first><last>Saleem</last></author>
+      <author><first>Susan</first><last>Benesch</last></author>
       <pages>57–62</pages>
       <url>W17-3009</url>
       <doi>10.18653/v1/W17-3009</doi>
@@ -5160,11 +5160,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Detecting Nastiness in Social Media</title>
-      <author><first>Niloofar</first> <last>Safi Samghabadi</last></author>
-      <author><first>Suraj</first> <last>Maharjan</last></author>
-      <author><first>Alan</first> <last>Sprague</last></author>
-      <author><first>Raquel</first> <last>Diaz-Sprague</last></author>
-      <author><first>Thamar</first> <last>Solorio</last></author>
+      <author><first>Niloofar</first><last>Safi Samghabadi</last></author>
+      <author><first>Suraj</first><last>Maharjan</last></author>
+      <author><first>Alan</first><last>Sprague</last></author>
+      <author><first>Raquel</first><last>Diaz-Sprague</last></author>
+      <author><first>Thamar</first><last>Solorio</last></author>
       <pages>63–72</pages>
       <url>W17-3010</url>
       <doi>10.18653/v1/W17-3010</doi>
@@ -5172,13 +5172,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Technology Solutions to Combat Online Harassment</title>
-      <author><first>George</first> <last>Kennedy</last></author>
-      <author><first>Andrew</first> <last>McCollough</last></author>
-      <author><first>Edward</first> <last>Dixon</last></author>
-      <author><first>Alexei</first> <last>Bastidas</last></author>
-      <author><first>John</first> <last>Ryan</last></author>
-      <author><first>Chris</first> <last>Loo</last></author>
-      <author><first>Saurav</first> <last>Sahay</last></author>
+      <author><first>George</first><last>Kennedy</last></author>
+      <author><first>Andrew</first><last>McCollough</last></author>
+      <author><first>Edward</first><last>Dixon</last></author>
+      <author><first>Alexei</first><last>Bastidas</last></author>
+      <author><first>John</first><last>Ryan</last></author>
+      <author><first>Chris</first><last>Loo</last></author>
+      <author><first>Saurav</first><last>Sahay</last></author>
       <pages>73–77</pages>
       <url>W17-3011</url>
       <doi>10.18653/v1/W17-3011</doi>
@@ -5186,10 +5186,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Understanding Abuse: A Typology of Abusive Language Detection Subtasks</title>
-      <author><first>Zeerak</first> <last>Waseem</last></author>
-      <author><first>Thomas</first> <last>Davidson</last></author>
-      <author><first>Dana</first> <last>Warmsley</last></author>
-      <author><first>Ingmar</first> <last>Weber</last></author>
+      <author><first>Zeerak</first><last>Waseem</last></author>
+      <author><first>Thomas</first><last>Davidson</last></author>
+      <author><first>Dana</first><last>Warmsley</last></author>
+      <author><first>Ingmar</first><last>Weber</last></author>
       <pages>78–84</pages>
       <url>W17-3012</url>
       <doi>10.18653/v1/W17-3012</doi>
@@ -5197,8 +5197,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Using Convolutional Neural Networks to Classify Hate-Speech</title>
-      <author><first>Björn</first> <last>Gambäck</last></author>
-      <author><first>Utpal Kumar</first> <last>Sikdar</last></author>
+      <author><first>Björn</first><last>Gambäck</last></author>
+      <author><first>Utpal Kumar</first><last>Sikdar</last></author>
       <pages>85–90</pages>
       <url>W17-3013</url>
       <doi>10.18653/v1/W17-3013</doi>
@@ -5206,9 +5206,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Illegal is not a Noun: Linguistic Form for Detection of Pejorative Nominalizations</title>
-      <author><first>Alexis</first> <last>Palmer</last></author>
-      <author><first>Melissa</first> <last>Robinson</last></author>
-      <author><first>Kristy K.</first> <last>Phillips</last></author>
+      <author><first>Alexis</first><last>Palmer</last></author>
+      <author><first>Melissa</first><last>Robinson</last></author>
+      <author><first>Kristy K.</first><last>Phillips</last></author>
       <pages>91–100</pages>
       <url>W17-3014</url>
       <doi>10.18653/v1/W17-3014</doi>
@@ -5233,9 +5233,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>A Cross-modal Review of Indicators for Depression Detection Systems</title>
-      <author><first>Michelle</first> <last>Morales</last></author>
-      <author><first>Stefan</first> <last>Scherer</last></author>
-      <author><first>Rivka</first> <last>Levitan</last></author>
+      <author><first>Michelle</first><last>Morales</last></author>
+      <author><first>Stefan</first><last>Scherer</last></author>
+      <author><first>Rivka</first><last>Levitan</last></author>
       <pages>1–12</pages>
       <url>W17-3101</url>
       <doi>10.18653/v1/W17-3101</doi>
@@ -5243,11 +5243,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>In your wildest dreams: the language and psychological features of dreams</title>
-      <author><first>Kate</first> <last>Niederhoffer</last></author>
-      <author><first>Jonathan</first> <last>Schler</last></author>
-      <author><first>Patrick</first> <last>Crutchley</last></author>
-      <author><first>Kate</first> <last>Loveys</last></author>
-      <author><first>Glen</first> <last>Coppersmith</last></author>
+      <author><first>Kate</first><last>Niederhoffer</last></author>
+      <author><first>Jonathan</first><last>Schler</last></author>
+      <author><first>Patrick</first><last>Crutchley</last></author>
+      <author><first>Kate</first><last>Loveys</last></author>
+      <author><first>Glen</first><last>Coppersmith</last></author>
       <pages>13–25</pages>
       <url>W17-3102</url>
       <doi>10.18653/v1/W17-3102</doi>
@@ -5255,11 +5255,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>A Corpus Analysis of Social Connections and Social Isolation in Adolescents Suffering from Depressive Disorders</title>
-      <author><first>Jia-Wen</first> <last>Guo</last></author>
-      <author><first>Danielle L</first> <last>Mowery</last></author>
-      <author><first>Djin</first> <last>Lai</last></author>
-      <author><first>Katherine</first> <last>Sward</last></author>
-      <author><first>Mike</first> <last>Conway</last></author>
+      <author><first>Jia-Wen</first><last>Guo</last></author>
+      <author><first>Danielle L</first><last>Mowery</last></author>
+      <author><first>Djin</first><last>Lai</last></author>
+      <author><first>Katherine</first><last>Sward</last></author>
+      <author><first>Mike</first><last>Conway</last></author>
       <pages>26–31</pages>
       <url>W17-3103</url>
       <doi>10.18653/v1/W17-3103</doi>
@@ -5267,10 +5267,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Monitoring Tweets for Depression to Detect At-risk Users</title>
-      <author><first>Zunaira</first> <last>Jamil</last></author>
-      <author><first>Diana</first> <last>Inkpen</last></author>
-      <author><first>Prasadith</first> <last>Buddhitha</last></author>
-      <author><first>Kenton</first> <last>White</last></author>
+      <author><first>Zunaira</first><last>Jamil</last></author>
+      <author><first>Diana</first><last>Inkpen</last></author>
+      <author><first>Prasadith</first><last>Buddhitha</last></author>
+      <author><first>Kenton</first><last>White</last></author>
       <pages>32–40</pages>
       <url>W17-3104</url>
       <doi>10.18653/v1/W17-3104</doi>
@@ -5278,9 +5278,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Investigating Patient Attitudes Towards the use of Social Media Data to Augment Depression Diagnosis and Treatment: a Qualitative Study</title>
-      <author><first>Jude</first> <last>Mikal</last></author>
-      <author><first>Samantha</first> <last>Hurst</last></author>
-      <author><first>Mike</first> <last>Conway</last></author>
+      <author><first>Jude</first><last>Mikal</last></author>
+      <author><first>Samantha</first><last>Hurst</last></author>
+      <author><first>Mike</first><last>Conway</last></author>
       <pages>41–47</pages>
       <url>W17-3105</url>
       <doi>10.18653/v1/W17-3105</doi>
@@ -5288,9 +5288,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Natural-language Interactive Narratives in Imaginal Exposure Therapy for Obsessive-Compulsive Disorder</title>
-      <author><first>Melissa</first> <last>Roemmele</last></author>
-      <author><first>Paola</first> <last>Mardo</last></author>
-      <author><first>Andrew</first> <last>Gordon</last></author>
+      <author><first>Melissa</first><last>Roemmele</last></author>
+      <author><first>Paola</first><last>Mardo</last></author>
+      <author><first>Andrew</first><last>Gordon</last></author>
       <pages>48–57</pages>
       <url>W17-3106</url>
       <doi>10.18653/v1/W17-3106</doi>
@@ -5298,8 +5298,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Detecting Anxiety through <fixed-case>R</fixed-case>eddit</title>
-      <author><first>Judy Hanwen</first> <last>Shen</last></author>
-      <author><first>Frank</first> <last>Rudzicz</last></author>
+      <author><first>Judy Hanwen</first><last>Shen</last></author>
+      <author><first>Frank</first><last>Rudzicz</last></author>
       <pages>58–65</pages>
       <url>W17-3107</url>
       <doi>10.18653/v1/W17-3107</doi>
@@ -5307,9 +5307,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Detecting and Explaining Crisis</title>
-      <author><first>Rohan</first> <last>Kshirsagar</last></author>
-      <author><first>Robert</first> <last>Morris</last></author>
-      <author><first>Samuel</first> <last>Bowman</last></author>
+      <author><first>Rohan</first><last>Kshirsagar</last></author>
+      <author><first>Robert</first><last>Morris</last></author>
+      <author><first>Samuel</first><last>Bowman</last></author>
       <pages>66–73</pages>
       <url>W17-3108</url>
       <doi>10.18653/v1/W17-3108</doi>
@@ -5317,8 +5317,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>A Dictionary-Based Comparison of Autobiographies by People and Murderous Monsters</title>
-      <author><first>Micah</first> <last>Iserman</last></author>
-      <author><first>Molly</first> <last>Ireland</last></author>
+      <author><first>Micah</first><last>Iserman</last></author>
+      <author><first>Molly</first><last>Ireland</last></author>
       <pages>74–84</pages>
       <url>W17-3109</url>
       <doi>10.18653/v1/W17-3109</doi>
@@ -5326,10 +5326,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Small but Mighty: Affective Micropatterns for Quantifying Mental Health from Social Media Language</title>
-      <author><first>Kate</first> <last>Loveys</last></author>
-      <author><first>Patrick</first> <last>Crutchley</last></author>
-      <author><first>Emily</first> <last>Wyatt</last></author>
-      <author><first>Glen</first> <last>Coppersmith</last></author>
+      <author><first>Kate</first><last>Loveys</last></author>
+      <author><first>Patrick</first><last>Crutchley</last></author>
+      <author><first>Emily</first><last>Wyatt</last></author>
+      <author><first>Glen</first><last>Coppersmith</last></author>
       <pages>85–95</pages>
       <url>W17-3110</url>
       <doi>10.18653/v1/W17-3110</doi>
@@ -5355,8 +5355,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>An Empirical Study of Adequate Vision Span for Attention-Based Neural Machine Translation</title>
-      <author><first>Raphael</first> <last>Shu</last></author>
-      <author><first>Hideki</first> <last>Nakayama</last></author>
+      <author><first>Raphael</first><last>Shu</last></author>
+      <author><first>Hideki</first><last>Nakayama</last></author>
       <pages>1–10</pages>
       <url>W17-3201</url>
       <doi>10.18653/v1/W17-3201</doi>
@@ -5364,10 +5364,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Analyzing Neural <fixed-case>MT</fixed-case> Search and Model Performance</title>
-      <author><first>Jan</first> <last>Niehues</last></author>
-      <author><first>Eunah</first> <last>Cho</last></author>
-      <author><first>Thanh-Le</first> <last>Ha</last></author>
-      <author><first>Alex</first> <last>Waibel</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Eunah</first><last>Cho</last></author>
+      <author><first>Thanh-Le</first><last>Ha</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
       <pages>11–17</pages>
       <url>W17-3202</url>
       <doi>10.18653/v1/W17-3202</doi>
@@ -5375,8 +5375,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Stronger Baselines for Trustable Results in Neural Machine Translation</title>
-      <author><first>Michael</first> <last>Denkowski</last></author>
-      <author><first>Graham</first> <last>Neubig</last></author>
+      <author><first>Michael</first><last>Denkowski</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
       <pages>18–27</pages>
       <url>W17-3203</url>
       <doi>10.18653/v1/W17-3203</doi>
@@ -5384,8 +5384,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Six Challenges for Neural Machine Translation</title>
-      <author><first>Philipp</first> <last>Koehn</last></author>
-      <author><first>Rebecca</first> <last>Knowles</last></author>
+      <author><first>Philipp</first><last>Koehn</last></author>
+      <author><first>Rebecca</first><last>Knowles</last></author>
       <pages>28–39</pages>
       <url>W17-3204</url>
       <doi>10.18653/v1/W17-3204</doi>
@@ -5393,10 +5393,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Cost Weighting for Neural Machine Translation Domain Adaptation</title>
-      <author><first>Boxing</first> <last>Chen</last></author>
-      <author><first>Colin</first> <last>Cherry</last></author>
-      <author><first>George</first> <last>Foster</last></author>
-      <author><first>Samuel</first> <last>Larkin</last></author>
+      <author><first>Boxing</first><last>Chen</last></author>
+      <author><first>Colin</first><last>Cherry</last></author>
+      <author><first>George</first><last>Foster</last></author>
+      <author><first>Samuel</first><last>Larkin</last></author>
       <pages>40–46</pages>
       <url>W17-3205</url>
       <doi>10.18653/v1/W17-3205</doi>
@@ -5404,8 +5404,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Detecting Untranslated Content for Neural Machine Translation</title>
-      <author><first>Isao</first> <last>Goto</last></author>
-      <author><first>Hideki</first> <last>Tanaka</last></author>
+      <author><first>Isao</first><last>Goto</last></author>
+      <author><first>Hideki</first><last>Tanaka</last></author>
       <pages>47–55</pages>
       <url>W17-3206</url>
       <doi>10.18653/v1/W17-3206</doi>
@@ -5413,8 +5413,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Beam Search Strategies for Neural Machine Translation</title>
-      <author><first>Markus</first> <last>Freitag</last></author>
-      <author><first>Yaser</first> <last>Al-Onaizan</last></author>
+      <author><first>Markus</first><last>Freitag</last></author>
+      <author><first>Yaser</first><last>Al-Onaizan</last></author>
       <pages>56–60</pages>
       <url>W17-3207</url>
       <doi>10.18653/v1/W17-3207</doi>
@@ -5422,12 +5422,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>An Empirical Study of Mini-Batch Creation Strategies for Neural Machine Translation</title>
-      <author><first>Makoto</first> <last>Morishita</last></author>
-      <author><first>Yusuke</first> <last>Oda</last></author>
-      <author><first>Graham</first> <last>Neubig</last></author>
-      <author><first>Koichiro</first> <last>Yoshino</last></author>
-      <author><first>Katsuhito</first> <last>Sudoh</last></author>
-      <author><first>Satoshi</first> <last>Nakamura</last></author>
+      <author><first>Makoto</first><last>Morishita</last></author>
+      <author><first>Yusuke</first><last>Oda</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <author><first>Koichiro</first><last>Yoshino</last></author>
+      <author><first>Katsuhito</first><last>Sudoh</last></author>
+      <author><first>Satoshi</first><last>Nakamura</last></author>
       <pages>61–68</pages>
       <url>W17-3208</url>
       <doi>10.18653/v1/W17-3208</doi>
@@ -5435,9 +5435,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Detecting Cross-Lingual Semantic Divergence for Neural Machine Translation</title>
-      <author><first>Marine</first> <last>Carpuat</last></author>
-      <author><first>Yogarshi</first> <last>Vyas</last></author>
-      <author><first>Xing</first> <last>Niu</last></author>
+      <author><first>Marine</first><last>Carpuat</last></author>
+      <author><first>Yogarshi</first><last>Vyas</last></author>
+      <author><first>Xing</first><last>Niu</last></author>
       <pages>69–79</pages>
       <url>W17-3209</url>
       <doi>10.18653/v1/W17-3209</doi>
@@ -5448,9 +5448,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     <meta>
       <booktitle>Proceedings of the 15th Meeting on the Mathematics of Language</booktitle>
       <url>W17-34</url>
-      <editor><first>Makoto</first> <last>Kanazawa</last></editor>
-      <editor><first>Philippe</first> <last>de Groote</last></editor>
-      <editor><first>Mehrnoosh</first> <last>Sadrzadeh</last></editor>
+      <editor><first>Makoto</first><last>Kanazawa</last></editor>
+      <editor><first>Philippe</first><last>de Groote</last></editor>
+      <editor><first>Mehrnoosh</first><last>Sadrzadeh</last></editor>
       <doi>10.18653/v1/W17-34</doi>
       <publisher>Association for Computational Linguistics</publisher>
       <address>London, UK</address>
@@ -5462,109 +5462,109 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title><fixed-case>BE</fixed-case> Is Not the Unique Homomorphism That Makes the Partee Triangle Commute</title>
-      <author><first>Junri</first> <last>Shimada</last></author>
+      <author><first>Junri</first><last>Shimada</last></author>
       <pages>1–10</pages>
       <url>W17-3401</url>
       <doi>10.18653/v1/W17-3401</doi>
     </paper>
     <paper id="2">
       <title>How Many Stemmata with Root Degree k?</title>
-      <author><first>Armin</first> <last>Hoenen</last></author>
-      <author><first>Steffen</first> <last>Eger</last></author>
-      <author><first>Ralf</first> <last>Gehrke</last></author>
+      <author><first>Armin</first><last>Hoenen</last></author>
+      <author><first>Steffen</first><last>Eger</last></author>
+      <author><first>Ralf</first><last>Gehrke</last></author>
       <pages>11–21</pages>
       <url>W17-3402</url>
       <doi>10.18653/v1/W17-3402</doi>
     </paper>
     <paper id="3">
       <title>On the Logical Complexity of Autosegmental Representations</title>
-      <author><first>Adam</first> <last>Jardine</last></author>
+      <author><first>Adam</first><last>Jardine</last></author>
       <pages>22–35</pages>
       <url>W17-3403</url>
       <doi>10.18653/v1/W17-3403</doi>
     </paper>
     <paper id="4">
       <title>Extracting Forbidden Factors from Regular Stringsets</title>
-      <author><first>James</first> <last>Rogers</last></author>
-      <author><first>Dakotah</first> <last>Lambert</last></author>
+      <author><first>James</first><last>Rogers</last></author>
+      <author><first>Dakotah</first><last>Lambert</last></author>
       <pages>36–46</pages>
       <url>W17-3404</url>
       <doi>10.18653/v1/W17-3404</doi>
     </paper>
     <paper id="5">
       <title>Latent-Variable <fixed-case>PCFG</fixed-case>s: Background and Applications</title>
-      <author><first>Shay</first> <last>Cohen</last></author>
+      <author><first>Shay</first><last>Cohen</last></author>
       <pages>47–58</pages>
       <url>W17-3405</url>
       <doi>10.18653/v1/W17-3405</doi>
     </paper>
     <paper id="6">
       <title>A Proof-Theoretic Semantics for Transitive Verbs with an Implicit Object</title>
-      <author><first>Nissim</first> <last>Francez</last></author>
+      <author><first>Nissim</first><last>Francez</last></author>
       <pages>59–67</pages>
       <url>W17-3406</url>
       <doi>10.18653/v1/W17-3406</doi>
     </paper>
     <paper id="7">
       <title>Why We Speak</title>
-      <author><first>Rohit</first> <last>Parikh</last></author>
+      <author><first>Rohit</first><last>Parikh</last></author>
       <pages>68–74</pages>
       <url>W17-3407</url>
       <doi>10.18653/v1/W17-3407</doi>
     </paper>
     <paper id="8">
       <title>A Monotonicity Calculus and Its Completeness</title>
-      <author><first>Thomas</first> <last>Icard</last></author>
-      <author><first>Lawrence</first> <last>Moss</last></author>
-      <author><first>William</first> <last>Tune</last></author>
+      <author><first>Thomas</first><last>Icard</last></author>
+      <author><first>Lawrence</first><last>Moss</last></author>
+      <author><first>William</first><last>Tune</last></author>
       <pages>75–87</pages>
       <url>W17-3408</url>
       <doi>10.18653/v1/W17-3408</doi>
     </paper>
     <paper id="9">
       <title><fixed-case>DAG</fixed-case> Automata for Meaning Representation</title>
-      <author><first>Frank</first> <last>Drewes</last></author>
+      <author><first>Frank</first><last>Drewes</last></author>
       <pages>88–99</pages>
       <url>W17-3409</url>
       <doi>10.18653/v1/W17-3409</doi>
     </paper>
     <paper id="10">
       <title>(Re)introducing Regular Graph Languages</title>
-      <author><first>Sorcha</first> <last>Gilroy</last></author>
-      <author><first>Adam</first> <last>Lopez</last></author>
-      <author><first>Sebastian</first> <last>Maneth</last></author>
-      <author><first>Pijus</first> <last>Simonaitis</last></author>
+      <author><first>Sorcha</first><last>Gilroy</last></author>
+      <author><first>Adam</first><last>Lopez</last></author>
+      <author><first>Sebastian</first><last>Maneth</last></author>
+      <author><first>Pijus</first><last>Simonaitis</last></author>
       <pages>100–113</pages>
       <url>W17-3410</url>
       <doi>10.18653/v1/W17-3410</doi>
     </paper>
     <paper id="11">
       <title>Graph Transductions and Typological Gaps in Morphological Paradigms</title>
-      <author><first>Thomas</first> <last>Graf</last></author>
+      <author><first>Thomas</first><last>Graf</last></author>
       <pages>114–126</pages>
       <url>W17-3411</url>
       <doi>10.18653/v1/W17-3411</doi>
     </paper>
     <paper id="12">
       <title>Introducing Structure into Neural Network-Based Semantic Models</title>
-      <author><first>Stephen</first> <last>Clark</last></author>
+      <author><first>Stephen</first><last>Clark</last></author>
       <pages>127</pages>
       <url>W17-3412</url>
       <doi>10.18653/v1/W17-3412</doi>
     </paper>
     <paper id="13">
       <title>Count-Invariance Including Exponentials</title>
-      <author><first>Stepan</first> <last>Kuznetsov</last></author>
-      <author><first>Glyn</first> <last>Morrill</last></author>
-      <author><first>Oriol</first> <last>Valentín</last></author>
+      <author><first>Stepan</first><last>Kuznetsov</last></author>
+      <author><first>Glyn</first><last>Morrill</last></author>
+      <author><first>Oriol</first><last>Valentín</last></author>
       <pages>128–139</pages>
       <url>W17-3413</url>
       <doi>10.18653/v1/W17-3413</doi>
     </paper>
     <paper id="14">
       <title>Conjunctive Categorial Grammars</title>
-      <author><first>Stepan</first> <last>Kuznetsov</last></author>
-      <author><first>Alexander</first> <last>Okhotin</last></author>
+      <author><first>Stepan</first><last>Kuznetsov</last></author>
+      <author><first>Alexander</first><last>Okhotin</last></author>
       <pages>140–151</pages>
       <url>W17-3414</url>
       <doi>10.18653/v1/W17-3414</doi>
@@ -5588,10 +5588,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Linguistic realisation as machine translation: Comparing different <fixed-case>MT</fixed-case> models for <fixed-case>AMR</fixed-case>-to-text generation</title>
-      <author><first>Thiago</first> <last>Castro Ferreira</last></author>
-      <author><first>Iacer</first> <last>Calixto</last></author>
-      <author><first>Sander</first> <last>Wubben</last></author>
-      <author><first>Emiel</first> <last>Krahmer</last></author>
+      <author><first>Thiago</first><last>Castro Ferreira</last></author>
+      <author><first>Iacer</first><last>Calixto</last></author>
+      <author><first>Sander</first><last>Wubben</last></author>
+      <author><first>Emiel</first><last>Krahmer</last></author>
       <pages>1–10</pages>
       <url>W17-3501</url>
       <doi>10.18653/v1/W17-3501</doi>
@@ -5599,7 +5599,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>A Survey on Intelligent Poetry Generation: Languages, Features, Techniques, Reutilisation and Evaluation</title>
-      <author><first>Hugo</first> <last>Gonçalo Oliveira</last></author>
+      <author><first>Hugo</first><last>Gonçalo Oliveira</last></author>
       <pages>11–20</pages>
       <url>W17-3502</url>
       <doi>10.18653/v1/W17-3502</doi>
@@ -5607,9 +5607,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Cross-linguistic differences and similarities in image descriptions</title>
-      <author><first>Emiel</first> <last>van Miltenburg</last></author>
-      <author><first>Desmond</first> <last>Elliott</last></author>
-      <author><first>Piek</first> <last>Vossen</last></author>
+      <author><first>Emiel</first><last>van Miltenburg</last></author>
+      <author><first>Desmond</first><last>Elliott</last></author>
+      <author><first>Piek</first><last>Vossen</last></author>
       <pages>21–30</pages>
       <url>W17-3503</url>
       <doi>10.18653/v1/W17-3503</doi>
@@ -5617,10 +5617,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Content Selection for Real-time Sports News Construction from Commentary Texts</title>
-      <author><first>Jin-ge</first> <last>Yao</last></author>
-      <author><first>Jianmin</first> <last>Zhang</last></author>
-      <author><first>Xiaojun</first> <last>Wan</last></author>
-      <author><first>Jianguo</first> <last>Xiao</last></author>
+      <author><first>Jin-ge</first><last>Yao</last></author>
+      <author><first>Jianmin</first><last>Zhang</last></author>
+      <author><first>Xiaojun</first><last>Wan</last></author>
+      <author><first>Jianguo</first><last>Xiao</last></author>
       <pages>31–40</pages>
       <url>W17-3504</url>
       <doi>10.18653/v1/W17-3504</doi>
@@ -5628,9 +5628,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Improving the Naturalness and Expressivity of Language Generation for <fixed-case>S</fixed-case>panish</title>
-      <author><first>Cristina</first> <last>Barros</last></author>
-      <author><first>Dimitra</first> <last>Gkatzia</last></author>
-      <author><first>Elena</first> <last>Lloret</last></author>
+      <author><first>Cristina</first><last>Barros</last></author>
+      <author><first>Dimitra</first><last>Gkatzia</last></author>
+      <author><first>Elena</first><last>Lloret</last></author>
       <pages>41–50</pages>
       <url>W17-3505</url>
       <doi>10.18653/v1/W17-3505</doi>
@@ -5638,9 +5638,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>What is the Role of Recurrent Neural Networks (<fixed-case>RNN</fixed-case>s) in an Image Caption Generator?</title>
-      <author><first>Marc</first> <last>Tanti</last></author>
-      <author><first>Albert</first> <last>Gatt</last></author>
-      <author><first>Kenneth</first> <last>Camilleri</last></author>
+      <author><first>Marc</first><last>Tanti</last></author>
+      <author><first>Albert</first><last>Gatt</last></author>
+      <author><first>Kenneth</first><last>Camilleri</last></author>
       <pages>51–60</pages>
       <url>W17-3506</url>
       <doi>10.18653/v1/W17-3506</doi>
@@ -5648,11 +5648,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Exploring the Behavior of Classic <fixed-case>REG</fixed-case> Algorithms in the Description of Characters in 3<fixed-case>D</fixed-case> Images</title>
-      <author><first>Gonzalo</first> <last>Méndez</last></author>
-      <author><first>Raquel</first> <last>Hervás</last></author>
-      <author><first>Susana</first> <last>Bautista</last></author>
-      <author><first>Adrián</first> <last>Rabadán</last></author>
-      <author><first>Teresa</first> <last>Rodríguez</last></author>
+      <author><first>Gonzalo</first><last>Méndez</last></author>
+      <author><first>Raquel</first><last>Hervás</last></author>
+      <author><first>Susana</first><last>Bautista</last></author>
+      <author><first>Adrián</first><last>Rabadán</last></author>
+      <author><first>Teresa</first><last>Rodríguez</last></author>
       <pages>61–69</pages>
       <url>W17-3507</url>
       <doi>10.18653/v1/W17-3507</doi>
@@ -5660,9 +5660,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Co-<fixed-case>P</fixed-case>oe<fixed-case>T</fixed-case>ry<fixed-case>M</fixed-case>e: a Co-Creative Interface for the Composition of Poetry</title>
-      <author><first>Hugo</first> <last>Gonçalo Oliveira</last></author>
-      <author><first>Tiago</first> <last>Mendes</last></author>
-      <author><first>Ana</first> <last>Boavida</last></author>
+      <author><first>Hugo</first><last>Gonçalo Oliveira</last></author>
+      <author><first>Tiago</first><last>Mendes</last></author>
+      <author><first>Ana</first><last>Boavida</last></author>
       <pages>70–71</pages>
       <url>W17-3508</url>
       <doi>10.18653/v1/W17-3508</doi>
@@ -5670,9 +5670,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Refer-i<fixed-case>TTS</fixed-case>: A System for Referring in Spoken Installments to Objects in Real-World Images</title>
-      <author><first>Sina</first> <last>Zarrieß</last></author>
-      <author><first>M. Soledad</first> <last>López Gambino</last></author>
-      <author><first>David</first> <last>Schlangen</last></author>
+      <author><first>Sina</first><last>Zarrieß</last></author>
+      <author><first>M. Soledad</first><last>López Gambino</last></author>
+      <author><first>David</first><last>Schlangen</last></author>
       <pages>72–73</pages>
       <url>W17-3509</url>
       <doi>10.18653/v1/W17-3509</doi>
@@ -5680,7 +5680,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Finding the “right” answers for customers</title>
-      <author><first>Frank</first> <last>Schilder</last></author>
+      <author><first>Frank</first><last>Schilder</last></author>
       <pages>74</pages>
       <url>W17-3510</url>
       <doi>10.18653/v1/W17-3510</doi>
@@ -5688,8 +5688,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Referring Expression Generation under Uncertainty: Algorithm and Evaluation Framework</title>
-      <author><first>Tom</first> <last>Williams</last></author>
-      <author><first>Matthias</first> <last>Scheutz</last></author>
+      <author><first>Tom</first><last>Williams</last></author>
+      <author><first>Matthias</first><last>Scheutz</last></author>
       <pages>75–84</pages>
       <url>W17-3511</url>
       <doi>10.18653/v1/W17-3511</doi>
@@ -5697,8 +5697,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Natural Language Descriptions for Human Activities in Video Streams</title>
-      <author><first>Nouf</first> <last>Alharbi</last></author>
-      <author><first>Yoshihiko</first> <last>Gotoh</last></author>
+      <author><first>Nouf</first><last>Alharbi</last></author>
+      <author><first>Yoshihiko</first><last>Gotoh</last></author>
       <pages>85–94</pages>
       <url>W17-3512</url>
       <doi>10.18653/v1/W17-3512</doi>
@@ -5706,9 +5706,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title><fixed-case>PASS</fixed-case>: A <fixed-case>D</fixed-case>utch data-to-text system for soccer, targeted towards specific audiences</title>
-      <author><first>Chris</first> <last>van der Lee</last></author>
-      <author><first>Emiel</first> <last>Krahmer</last></author>
-      <author><first>Sander</first> <last>Wubben</last></author>
+      <author><first>Chris</first><last>van der Lee</last></author>
+      <author><first>Emiel</first><last>Krahmer</last></author>
+      <author><first>Sander</first><last>Wubben</last></author>
       <pages>95–104</pages>
       <url>W17-3513</url>
       <doi>10.18653/v1/W17-3513</doi>
@@ -5716,9 +5716,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Evaluation of a <fixed-case>R</fixed-case>unyankore grammar engine for healthcare messages</title>
-      <author><first>Joan</first> <last>Byamugisha</last></author>
-      <author><first>C. Maria</first> <last>Keet</last></author>
-      <author><first>Brian</first> <last>DeRenzi</last></author>
+      <author><first>Joan</first><last>Byamugisha</last></author>
+      <author><first>C. Maria</first><last>Keet</last></author>
+      <author><first>Brian</first><last>DeRenzi</last></author>
       <pages>105–113</pages>
       <url>W17-3514</url>
       <doi>10.18653/v1/W17-3514</doi>
@@ -5726,7 +5726,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Talking about the world with a distributed model</title>
-      <author><first>Gemma</first> <last>Boleda</last></author>
+      <author><first>Gemma</first><last>Boleda</last></author>
       <pages>114</pages>
       <url>W17-3515</url>
       <doi>10.18653/v1/W17-3515</doi>
@@ -5734,9 +5734,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="16">
       <title>The <fixed-case>C</fixed-case>ode2<fixed-case>T</fixed-case>ext Challenge: Text Generation in Source Libraries</title>
-      <author><first>Kyle</first> <last>Richardson</last></author>
-      <author><first>Sina</first> <last>Zarrieß</last></author>
-      <author><first>Jonas</first> <last>Kuhn</last></author>
+      <author><first>Kyle</first><last>Richardson</last></author>
+      <author><first>Sina</first><last>Zarrieß</last></author>
+      <author><first>Jonas</first><last>Kuhn</last></author>
       <pages>115–119</pages>
       <url>W17-3516</url>
       <doi>10.18653/v1/W17-3516</doi>
@@ -5744,10 +5744,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="17">
       <title>Shared Task Proposal: Multilingual Surface Realization Using Universal Dependency Trees</title>
-      <author><first>Simon</first> <last>Mille</last></author>
-      <author><first>Bernd</first> <last>Bohnet</last></author>
-      <author><first>Leo</first> <last>Wanner</last></author>
-      <author><first>Anja</first> <last>Belz</last></author>
+      <author><first>Simon</first><last>Mille</last></author>
+      <author><first>Bernd</first><last>Bohnet</last></author>
+      <author><first>Leo</first><last>Wanner</last></author>
+      <author><first>Anja</first><last>Belz</last></author>
       <pages>120–123</pages>
       <url>W17-3517</url>
       <doi>10.18653/v1/W17-3517</doi>
@@ -5755,10 +5755,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="18">
       <title>The <fixed-case>W</fixed-case>eb<fixed-case>NLG</fixed-case> Challenge: Generating Text from <fixed-case>RDF</fixed-case> Data</title>
-      <author><first>Claire</first> <last>Gardent</last></author>
-      <author><first>Anastasia</first> <last>Shimorina</last></author>
-      <author><first>Shashi</first> <last>Narayan</last></author>
-      <author><first>Laura</first> <last>Perez-Beltrachini</last></author>
+      <author><first>Claire</first><last>Gardent</last></author>
+      <author><first>Anastasia</first><last>Shimorina</last></author>
+      <author><first>Shashi</first><last>Narayan</last></author>
+      <author><first>Laura</first><last>Perez-Beltrachini</last></author>
       <pages>124–133</pages>
       <url>W17-3518</url>
       <doi>10.18653/v1/W17-3518</doi>
@@ -5766,7 +5766,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="19">
       <title>A Commercial Perspective on Reference</title>
-      <author><first>Ehud</first> <last>Reiter</last></author>
+      <author><first>Ehud</first><last>Reiter</last></author>
       <pages>134–138</pages>
       <url>W17-3519</url>
       <doi>10.18653/v1/W17-3519</doi>
@@ -5774,8 +5774,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="20">
       <title>Integrated sentence generation using charts</title>
-      <author><first>Alexander</first> <last>Koller</last></author>
-      <author><first>Nikos</first> <last>Engonopoulos</last></author>
+      <author><first>Alexander</first><last>Koller</last></author>
+      <author><first>Nikos</first><last>Engonopoulos</last></author>
       <pages>139–143</pages>
       <url>W17-3520</url>
       <doi>10.18653/v1/W17-3520</doi>
@@ -5783,9 +5783,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="21">
       <title>Adapting <fixed-case>S</fixed-case>imple<fixed-case>NLG</fixed-case> to <fixed-case>S</fixed-case>panish</title>
-      <author><first>Alejandro</first> <last>Ramos-Soto</last></author>
-      <author><first>Julio</first> <last>Janeiro-Gallardo</last></author>
-      <author><first>Alberto</first> <last>Bugarín Diz</last></author>
+      <author><first>Alejandro</first><last>Ramos-Soto</last></author>
+      <author><first>Julio</first><last>Janeiro-Gallardo</last></author>
+      <author><first>Alberto</first><last>Bugarín Diz</last></author>
       <pages>144–148</pages>
       <url>W17-3521</url>
       <doi>10.18653/v1/W17-3521</doi>
@@ -5793,9 +5793,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="22">
       <title>G-<fixed-case>TUNA</fixed-case>: a corpus of referring expressions in <fixed-case>G</fixed-case>erman, including duration information</title>
-      <author><first>David</first> <last>Howcroft</last></author>
-      <author><first>Jorrig</first> <last>Vogels</last></author>
-      <author><first>Vera</first> <last>Demberg</last></author>
+      <author><first>David</first><last>Howcroft</last></author>
+      <author><first>Jorrig</first><last>Vogels</last></author>
+      <author><first>Vera</first><last>Demberg</last></author>
       <pages>149–153</pages>
       <url>W17-3522</url>
       <doi>10.18653/v1/W17-3522</doi>
@@ -5803,9 +5803,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="23">
       <title>Toward an <fixed-case>NLG</fixed-case> System for <fixed-case>B</fixed-case>antu languages: first steps with <fixed-case>R</fixed-case>unyankore (demo)</title>
-      <author><first>Joan</first> <last>Byamugisha</last></author>
-      <author><first>C. Maria</first> <last>Keet</last></author>
-      <author><first>Brian</first> <last>DeRenzi</last></author>
+      <author><first>Joan</first><last>Byamugisha</last></author>
+      <author><first>C. Maria</first><last>Keet</last></author>
+      <author><first>Brian</first><last>DeRenzi</last></author>
       <pages>154–155</pages>
       <url>W17-3523</url>
       <doi>10.18653/v1/W17-3523</doi>
@@ -5813,8 +5813,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="24">
       <title>A working, non-trivial, topically indifferent <fixed-case>NLG</fixed-case> System for 17 languages</title>
-      <author><first>Robert</first> <last>Weißgraeber</last></author>
-      <author><first>Andreas</first> <last>Madsack</last></author>
+      <author><first>Robert</first><last>Weißgraeber</last></author>
+      <author><first>Andreas</first><last>Madsack</last></author>
       <pages>156–157</pages>
       <url>W17-3524</url>
       <doi>10.18653/v1/W17-3524</doi>
@@ -5822,9 +5822,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="25">
       <title>Generating titles for millions of browse pages on an e-Commerce site</title>
-      <author><first>Prashant</first> <last>Mathur</last></author>
-      <author><first>Nicola</first> <last>Ueffing</last></author>
-      <author><first>Gregor</first> <last>Leusch</last></author>
+      <author><first>Prashant</first><last>Mathur</last></author>
+      <author><first>Nicola</first><last>Ueffing</last></author>
+      <author><first>Gregor</first><last>Leusch</last></author>
       <pages>158–167</pages>
       <url>W17-3525</url>
       <doi>10.18653/v1/W17-3525</doi>
@@ -5832,8 +5832,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="26">
       <title>Towards Automatic Generation of Product Reviews from Aspect-Sentiment Scores</title>
-      <author><first>Hongyu</first> <last>Zang</last></author>
-      <author><first>Xiaojun</first> <last>Wan</last></author>
+      <author><first>Hongyu</first><last>Zang</last></author>
+      <author><first>Xiaojun</first><last>Wan</last></author>
       <pages>168–177</pages>
       <url>W17-3526</url>
       <doi>10.18653/v1/W17-3526</doi>
@@ -5841,8 +5841,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="27">
       <title>A model of suspense for narrative generation</title>
-      <author><first>Richard</first> <last>Doust</last></author>
-      <author><first>Paul</first> <last>Piwek</last></author>
+      <author><first>Richard</first><last>Doust</last></author>
+      <author><first>Paul</first><last>Piwek</last></author>
       <pages>178–187</pages>
       <url>W17-3527</url>
       <doi>10.18653/v1/W17-3527</doi>
@@ -5850,10 +5850,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="28">
       <title>Data-Driven News Generation for Automated Journalism</title>
-      <author><first>Leo</first> <last>Leppänen</last></author>
-      <author><first>Myriam</first> <last>Munezero</last></author>
-      <author><first>Mark</first> <last>Granroth-Wilding</last></author>
-      <author><first>Hannu</first> <last>Toivonen</last></author>
+      <author><first>Leo</first><last>Leppänen</last></author>
+      <author><first>Myriam</first><last>Munezero</last></author>
+      <author><first>Mark</first><last>Granroth-Wilding</last></author>
+      <author><first>Hannu</first><last>Toivonen</last></author>
       <pages>188–197</pages>
       <url>W17-3528</url>
       <doi>10.18653/v1/W17-3528</doi>
@@ -5861,9 +5861,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="29">
       <title>Data Augmentation for Visual Question Answering</title>
-      <author><first>Kushal</first> <last>Kafle</last></author>
-      <author><first>Mohammed</first> <last>Yousefhussien</last></author>
-      <author><first>Christopher</first> <last>Kanan</last></author>
+      <author><first>Kushal</first><last>Kafle</last></author>
+      <author><first>Mohammed</first><last>Yousefhussien</last></author>
+      <author><first>Christopher</first><last>Kanan</last></author>
       <pages>198–202</pages>
       <url>W17-3529</url>
       <doi>10.18653/v1/W17-3529</doi>
@@ -5871,7 +5871,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="30">
       <title>Personalized Questions, Answers and Grammars: Aiding the Search for Relevant Web Information</title>
-      <author><first>Marta</first> <last>Gatius</last></author>
+      <author><first>Marta</first><last>Gatius</last></author>
       <pages>203–207</pages>
       <url>W17-3530</url>
       <doi>10.18653/v1/W17-3530</doi>
@@ -5879,11 +5879,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="31">
       <title>A Comparison of Neural Models for Word Ordering</title>
-      <author><first>Eva</first> <last>Hasler</last></author>
-      <author><first>Felix</first> <last>Stahlberg</last></author>
-      <author><first>Marcus</first> <last>Tomalin</last></author>
-      <author><first>Adrià</first> <last>de Gispert</last></author>
-      <author><first>Bill</first> <last>Byrne</last></author>
+      <author><first>Eva</first><last>Hasler</last></author>
+      <author><first>Felix</first><last>Stahlberg</last></author>
+      <author><first>Marcus</first><last>Tomalin</last></author>
+      <author><first>Adrià</first><last>de Gispert</last></author>
+      <author><first>Bill</first><last>Byrne</last></author>
       <pages>208–212</pages>
       <url>W17-3531</url>
       <doi>10.18653/v1/W17-3531</doi>
@@ -5891,12 +5891,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="32">
       <title>Investigating the content and form of referring expressions in <fixed-case>M</fixed-case>andarin: introducing the Mtuna corpus</title>
-      <author><first>Kees</first> <last>van Deemter</last></author>
-      <author><first>Le</first> <last>Sun</last></author>
-      <author><first>Rint</first> <last>Sybesma</last></author>
-      <author><first>Xiao</first> <last>Li</last></author>
-      <author><first>Bo</first> <last>Chen</last></author>
-      <author><first>Muyun</first> <last>Yang</last></author>
+      <author><first>Kees</first><last>van Deemter</last></author>
+      <author><first>Le</first><last>Sun</last></author>
+      <author><first>Rint</first><last>Sybesma</last></author>
+      <author><first>Xiao</first><last>Li</last></author>
+      <author><first>Bo</first><last>Chen</last></author>
+      <author><first>Muyun</first><last>Yang</last></author>
       <pages>213–217</pages>
       <url>W17-3532</url>
       <doi>10.18653/v1/W17-3532</doi>
@@ -5904,8 +5904,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="33">
       <title>Realization of long sentences using chunking</title>
-      <author><first>Ewa</first> <last>Muszyńska</last></author>
-      <author><first>Ann</first> <last>Copestake</last></author>
+      <author><first>Ewa</first><last>Muszyńska</last></author>
+      <author><first>Ann</first><last>Copestake</last></author>
       <pages>218–222</pages>
       <url>W17-3533</url>
       <doi>10.18653/v1/W17-3533</doi>
@@ -5913,10 +5913,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="34">
       <title><fixed-case>S</fixed-case>a<fixed-case>T</fixed-case>o<fixed-case>S</fixed-case>: Assessing and Summarising Terms of Services from <fixed-case>G</fixed-case>erman Webshops</title>
-      <author><first>Daniel</first> <last>Braun</last></author>
-      <author><first>Elena</first> <last>Scepankova</last></author>
-      <author><first>Patrick</first> <last>Holl</last></author>
-      <author><first>Florian</first> <last>Matthes</last></author>
+      <author><first>Daniel</first><last>Braun</last></author>
+      <author><first>Elena</first><last>Scepankova</last></author>
+      <author><first>Patrick</first><last>Holl</last></author>
+      <author><first>Florian</first><last>Matthes</last></author>
       <pages>223–227</pages>
       <url>W17-3534</url>
       <doi>10.18653/v1/W17-3534</doi>
@@ -5924,9 +5924,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="35">
       <title>Textually Summarising Incomplete Data</title>
-      <author><first>Stephanie</first> <last>Inglis</last></author>
-      <author><first>Ehud</first> <last>Reiter</last></author>
-      <author><first>Somayajulu</first> <last>Sripada</last></author>
+      <author><first>Stephanie</first><last>Inglis</last></author>
+      <author><first>Ehud</first><last>Reiter</last></author>
+      <author><first>Somayajulu</first><last>Sripada</last></author>
       <pages>228–232</pages>
       <url>W17-3535</url>
       <doi>10.18653/v1/W17-3535</doi>
@@ -5934,8 +5934,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="36">
       <title>Improving the generation of personalised descriptions</title>
-      <author><first>Thiago</first> <last>Castro Ferreira</last></author>
-      <author><first>Ivandré</first> <last>Paraboni</last></author>
+      <author><first>Thiago</first><last>Castro Ferreira</last></author>
+      <author><first>Ivandré</first><last>Paraboni</last></author>
       <pages>233–237</pages>
       <url>W17-3536</url>
       <doi>10.18653/v1/W17-3536</doi>
@@ -5943,8 +5943,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="37">
       <title>Analysing Data-To-Text Generation Benchmarks</title>
-      <author><first>Laura</first> <last>Perez-Beltrachini</last></author>
-      <author><first>Claire</first> <last>Gardent</last></author>
+      <author><first>Laura</first><last>Perez-Beltrachini</last></author>
+      <author><first>Claire</first><last>Gardent</last></author>
       <pages>238–242</pages>
       <url>W17-3537</url>
       <doi>10.18653/v1/W17-3537</doi>
@@ -5952,9 +5952,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="38">
       <title>Linguistic Description of Complex Phenomena with the r<fixed-case>LDCP</fixed-case> R Package</title>
-      <author><first>Jose</first> <last>Alonso</last></author>
-      <author><first>Patricia</first> <last>Conde-Clemente</last></author>
-      <author><first>Gracian</first> <last>Trivino</last></author>
+      <author><first>Jose</first><last>Alonso</last></author>
+      <author><first>Patricia</first><last>Conde-Clemente</last></author>
+      <author><first>Gracian</first><last>Trivino</last></author>
       <pages>243–244</pages>
       <url>W17-3538</url>
       <doi>10.18653/v1/W17-3538</doi>
@@ -5962,8 +5962,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="39">
       <title>A demo of <fixed-case>FORG</fixed-case>e: the <fixed-case>P</fixed-case>ompeu <fixed-case>F</fixed-case>abra Open Rule-based Generator</title>
-      <author><first>Simon</first> <last>Mille</last></author>
-      <author><first>Leo</first> <last>Wanner</last></author>
+      <author><first>Simon</first><last>Mille</last></author>
+      <author><first>Leo</first><last>Wanner</last></author>
       <pages>245–246</pages>
       <url>W17-3539</url>
       <doi>10.18653/v1/W17-3539</doi>
@@ -5971,9 +5971,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="40">
       <title>Referential Success of Set Referring Expressions with Fuzzy Properties</title>
-      <author><first>Nicolás</first> <last>Marín</last></author>
-      <author><first>Gustavo</first> <last>Rivas-Gervilla</last></author>
-      <author><first>Daniel</first> <last>Sánchez</last></author>
+      <author><first>Nicolás</first><last>Marín</last></author>
+      <author><first>Gustavo</first><last>Rivas-Gervilla</last></author>
+      <author><first>Daniel</first><last>Sánchez</last></author>
       <pages>247–251</pages>
       <url>W17-3540</url>
       <doi>10.18653/v1/W17-3540</doi>
@@ -5981,10 +5981,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="41">
       <title>Neural Response Generation for Customer Service based on Personality Traits</title>
-      <author><first>Jonathan</first> <last>Herzig</last></author>
-      <author><first>Michal</first> <last>Shmueli-Scheuer</last></author>
-      <author><first>Tommy</first> <last>Sandbank</last></author>
-      <author><first>David</first> <last>Konopnicki</last></author>
+      <author><first>Jonathan</first><last>Herzig</last></author>
+      <author><first>Michal</first><last>Shmueli-Scheuer</last></author>
+      <author><first>Tommy</first><last>Sandbank</last></author>
+      <author><first>David</first><last>Konopnicki</last></author>
       <pages>252–256</pages>
       <url>W17-3541</url>
       <doi>10.18653/v1/W17-3541</doi>
@@ -5992,8 +5992,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="42">
       <title>Neural Paraphrase Generation using Transfer Learning</title>
-      <author><first>Florin</first> <last>Brad</last></author>
-      <author><first>Traian</first> <last>Rebedea</last></author>
+      <author><first>Florin</first><last>Brad</last></author>
+      <author><first>Traian</first><last>Rebedea</last></author>
       <pages>257–261</pages>
       <url>W17-3542</url>
       <doi>10.18653/v1/W17-3542</doi>
@@ -6022,91 +6022,91 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Deliberation as Genre: Mapping Argumentation through Relational Discourse Structure</title>
-      <author><first>Oier</first> <last>Imaz</last></author>
-      <author><first>Mikel</first> <last>Iruskieta</last></author>
+      <author><first>Oier</first><last>Imaz</last></author>
+      <author><first>Mikel</first><last>Iruskieta</last></author>
       <pages>1–10</pages>
       <url>W17-3601</url>
       <doi>10.18653/v1/W17-3601</doi>
     </paper>
     <paper id="2">
       <title>The Good, the Bad, and the Disagreement: Complex ground truth in rhetorical structure analysis</title>
-      <author><first>Debopam</first> <last>Das</last></author>
-      <author><first>Manfred</first> <last>Stede</last></author>
-      <author><first>Maite</first> <last>Taboada</last></author>
+      <author><first>Debopam</first><last>Das</last></author>
+      <author><first>Manfred</first><last>Stede</last></author>
+      <author><first>Maite</first><last>Taboada</last></author>
       <pages>11–19</pages>
       <url>W17-3602</url>
       <doi>10.18653/v1/W17-3602</doi>
     </paper>
     <paper id="3">
       <title>A Distributional View of Discourse Encapsulation: Multifactorial Prediction of Coreference Density in <fixed-case>RST</fixed-case></title>
-      <author><first>Amir</first> <last>Zeldes</last></author>
+      <author><first>Amir</first><last>Zeldes</last></author>
       <pages>20–28</pages>
       <url>W17-3603</url>
       <doi>10.18653/v1/W17-3603</doi>
     </paper>
     <paper id="4">
       <title>Rhetorical relations markers in <fixed-case>R</fixed-case>ussian <fixed-case>RST</fixed-case> Treebank</title>
-      <author><first>Svetlana</first> <last>Toldova</last></author>
-      <author><first>Dina</first> <last>Pisarevskaya</last></author>
-      <author><first>Margarita</first> <last>Ananyeva</last></author>
-      <author><first>Maria</first> <last>Kobozeva</last></author>
-      <author><first>Alexander</first> <last>Nasedkin</last></author>
-      <author><first>Sofia</first> <last>Nikiforova</last></author>
-      <author><first>Irina</first> <last>Pavlova</last></author>
-      <author><first>Alexey</first> <last>Shelepov</last></author>
+      <author><first>Svetlana</first><last>Toldova</last></author>
+      <author><first>Dina</first><last>Pisarevskaya</last></author>
+      <author><first>Margarita</first><last>Ananyeva</last></author>
+      <author><first>Maria</first><last>Kobozeva</last></author>
+      <author><first>Alexander</first><last>Nasedkin</last></author>
+      <author><first>Sofia</first><last>Nikiforova</last></author>
+      <author><first>Irina</first><last>Pavlova</last></author>
+      <author><first>Alexey</first><last>Shelepov</last></author>
       <pages>29–33</pages>
       <url>W17-3604</url>
       <doi>10.18653/v1/W17-3604</doi>
     </paper>
     <paper id="5">
       <title>Applying the Rhetorical Structure Theory in <fixed-case>A</fixed-case>lzheimer patients’ speech</title>
-      <author><first>Anayeli</first> <last>Paulino</last></author>
-      <author><first>Gerardo</first> <last>Sierra</last></author>
+      <author><first>Anayeli</first><last>Paulino</last></author>
+      <author><first>Gerardo</first><last>Sierra</last></author>
       <pages>34–38</pages>
       <url>W17-3605</url>
       <doi>10.18653/v1/W17-3605</doi>
     </paper>
     <paper id="6">
       <title>Using lexical level information in discourse structures for Basque sentiment analysis</title>
-      <author><first>Jon</first> <last>Alkorta</last></author>
-      <author><first>Koldo</first> <last>Gojenola</last></author>
-      <author><first>Mikel</first> <last>Iruskieta</last></author>
-      <author><first>Maite</first> <last>Taboada</last></author>
+      <author><first>Jon</first><last>Alkorta</last></author>
+      <author><first>Koldo</first><last>Gojenola</last></author>
+      <author><first>Mikel</first><last>Iruskieta</last></author>
+      <author><first>Maite</first><last>Taboada</last></author>
       <pages>39–47</pages>
       <url>W17-3606</url>
       <doi>10.18653/v1/W17-3606</doi>
     </paper>
     <paper id="7">
       <title>Framework for the Analysis of Simplified Texts Taking Discourse into Account: the Basque Causal Relations as Case Study</title>
-      <author><first>Itziar</first> <last>Gonzalez-Dios</last></author>
-      <author><first>Arantza</first> <last>Diaz de Ilarraza</last></author>
-      <author><first>Mikel</first> <last>Iruskieta</last></author>
+      <author><first>Itziar</first><last>Gonzalez-Dios</last></author>
+      <author><first>Arantza</first><last>Diaz de Ilarraza</last></author>
+      <author><first>Mikel</first><last>Iruskieta</last></author>
       <pages>48–57</pages>
       <url>W17-3607</url>
       <doi>10.18653/v1/W17-3607</doi>
     </paper>
     <paper id="8">
       <title>Using Rhetorical Structure Theory for Detection of Fake Online Reviews</title>
-      <author><first>Olu</first> <last>Popoola</last></author>
+      <author><first>Olu</first><last>Popoola</last></author>
       <pages>58–63</pages>
       <url>W17-3608</url>
       <doi>10.18653/v1/W17-3608</doi>
     </paper>
     <paper id="9">
       <title>“Haters gonna hate”: challenges for sentiment analysis of <fixed-case>F</fixed-case>acebook comments in <fixed-case>B</fixed-case>razilian <fixed-case>P</fixed-case>ortuguese</title>
-      <author><first>Juliano D.</first> <last>Antonio</last></author>
-      <author><first>Ana Carolina L.</first> <last>Santin</last></author>
+      <author><first>Juliano D.</first><last>Antonio</last></author>
+      <author><first>Ana Carolina L.</first><last>Santin</last></author>
       <pages>64–72</pages>
       <url>W17-3609</url>
       <doi>10.18653/v1/W17-3609</doi>
     </paper>
     <paper id="10">
       <title>Discourse Segmentation for Building a <fixed-case>RST</fixed-case> <fixed-case>C</fixed-case>hinese Treebank</title>
-      <author><first>Shuyuan</first> <last>Cao</last></author>
-      <author><first>Nianwen</first> <last>Xue</last></author>
-      <author><first>Iria</first> <last>da Cunha</last></author>
-      <author><first>Mikel</first> <last>Iruskieta</last></author>
-      <author><first>Chuan</first> <last>Wang</last></author>
+      <author><first>Shuyuan</first><last>Cao</last></author>
+      <author><first>Nianwen</first><last>Xue</last></author>
+      <author><first>Iria</first><last>da Cunha</last></author>
+      <author><first>Mikel</first><last>Iruskieta</last></author>
+      <author><first>Chuan</first><last>Wang</last></author>
       <pages>73–81</pages>
       <url>W17-3610</url>
       <doi>10.18653/v1/W17-3610</doi>
@@ -6129,30 +6129,30 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Two Challenges for <fixed-case>CI</fixed-case> Trustworthiness and How to Address Them</title>
-      <author><first>Kevin</first> <last>Baum</last></author>
-      <author><first>Maximilian A.</first> <last>Köhl</last></author>
-      <author><first>Eva</first> <last>Schmidt</last></author>
+      <author><first>Kevin</first><last>Baum</last></author>
+      <author><first>Maximilian A.</first><last>Köhl</last></author>
+      <author><first>Eva</first><last>Schmidt</last></author>
       <url>W17-3701</url>
       <doi>10.18653/v1/W17-3701</doi>
     </paper>
     <paper id="2">
       <title>A Simple Method for Clarifying Sentences with Coordination Ambiguities</title>
-      <author><first>Michael</first> <last>White</last></author>
-      <author><first>Manjuan</first> <last>Duan</last></author>
-      <author><first>David L.</first> <last>King</last></author>
+      <author><first>Michael</first><last>White</last></author>
+      <author><first>Manjuan</first><last>Duan</last></author>
+      <author><first>David L.</first><last>King</last></author>
       <url>W17-3702</url>
       <doi>10.18653/v1/W17-3702</doi>
     </paper>
     <paper id="3">
       <title>Requirements for Conceptual Representations of Explanations and How Reasoning Systems Can Serve Them</title>
-      <author><first>Helmut</first> <last>Horacek</last></author>
+      <author><first>Helmut</first><last>Horacek</last></author>
       <url>W17-3703</url>
       <doi>10.18653/v1/W17-3703</doi>
     </paper>
     <paper id="4">
       <title>An Essay on Self-explanatory Computational Intelligence: A Linguistic Model of Data Processing Systems</title>
-      <author><first>Jose M.</first> <last>Alonso</last></author>
-      <author><first>Gracian</first> <last>Trivino</last></author>
+      <author><first>Jose M.</first><last>Alonso</last></author>
+      <author><first>Gracian</first><last>Trivino</last></author>
       <url>W17-3704</url>
       <doi>10.18653/v1/W17-3704</doi>
     </paper>
@@ -6175,66 +6175,66 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>From <fixed-case>FOAF</fixed-case> to <fixed-case>E</fixed-case>nglish: Linguistic Contribution to Web Semantics</title>
-      <author><first>Max</first> <last>Silberztein</last></author>
+      <author><first>Max</first><last>Silberztein</last></author>
       <pages>1–9</pages>
       <url>W17-3801</url>
       <doi>10.18653/v1/W17-3801</doi>
     </paper>
     <paper id="2">
       <title>Lexicon for Natural Language Generation in <fixed-case>S</fixed-case>panish Adapted to Alternative and Augmentative Communication</title>
-      <author><first>Silvia</first> <last>García-Méndez</last></author>
-      <author><first>Milagros</first> <last>Fernández-Gavilanes</last></author>
-      <author><first>Enrique</first> <last>Costa-Montenegro</last></author>
-      <author><first>Jonathan</first> <last>Juncal-Martínez</last></author>
-      <author><first>Francisco J.</first> <last>González-Castaño</last></author>
+      <author><first>Silvia</first><last>García-Méndez</last></author>
+      <author><first>Milagros</first><last>Fernández-Gavilanes</last></author>
+      <author><first>Enrique</first><last>Costa-Montenegro</last></author>
+      <author><first>Jonathan</first><last>Juncal-Martínez</last></author>
+      <author><first>Francisco J.</first><last>González-Castaño</last></author>
       <pages>11-15</pages>
       <url>W17-3802</url>
       <doi>10.18653/v1/W17-3802</doi>
     </paper>
     <paper id="3">
       <title>Generating Answering Patterns from Factoid <fixed-case>A</fixed-case>rabic Questions</title>
-      <author><first>Essia</first> <last>Bessaies</last></author>
-      <author><first>Slim</first> <last>Mesfar</last></author>
-      <author><first>Henda</first> <last>Ben Ghezala</last></author>
+      <author><first>Essia</first><last>Bessaies</last></author>
+      <author><first>Slim</first><last>Mesfar</last></author>
+      <author><first>Henda</first><last>Ben Ghezala</last></author>
       <pages>17–24</pages>
       <url>W17-3803</url>
       <doi>10.18653/v1/W17-3803</doi>
     </paper>
     <paper id="4">
       <title>Language Generation from <fixed-case>DB</fixed-case> Query</title>
-      <author><first>Kristina</first> <last>Kocijan</last></author>
-      <author><first>Božo</first> <last>Bekavac</last></author>
-      <author><first>Krešimir</first> <last>Šojat</last></author>
+      <author><first>Kristina</first><last>Kocijan</last></author>
+      <author><first>Božo</first><last>Bekavac</last></author>
+      <author><first>Krešimir</first><last>Šojat</last></author>
       <pages>25–32</pages>
       <url>W17-3804</url>
       <doi>10.18653/v1/W17-3804</doi>
     </paper>
     <paper id="5">
       <title>Using Electronic Dictionaries and <fixed-case>N</fixed-case>oo<fixed-case>J</fixed-case> to Generate Sentences Containing <fixed-case>E</fixed-case>nglish Phrasal Verbs</title>
-      <author><first>Peter A.</first> <last>Machonis</last></author>
+      <author><first>Peter A.</first><last>Machonis</last></author>
       <pages>33–37</pages>
       <url>W17-3805</url>
       <doi>10.18653/v1/W17-3805</doi>
     </paper>
     <paper id="6">
       <title>Generating Text with Correct Verb Conjugation: Proposal for a New Automatic Conjugator with <fixed-case>N</fixed-case>oo<fixed-case>J</fixed-case></title>
-      <author><first>Héla</first> <last>Fehri</last></author>
-      <author><first>Sondes</first> <last>Dardour</last></author>
+      <author><first>Héla</first><last>Fehri</last></author>
+      <author><first>Sondes</first><last>Dardour</last></author>
       <pages>39–42</pages>
       <url>W17-3806</url>
       <doi>10.18653/v1/W17-3806</doi>
     </paper>
     <paper id="7">
       <title>Formalization of Speech Verbs with <fixed-case>N</fixed-case>oo<fixed-case>J</fixed-case> for Machine Translation: the <fixed-case>F</fixed-case>rench Verb accuser</title>
-      <author><first>Jouda</first> <last>Ghorbel</last></author>
+      <author><first>Jouda</first><last>Ghorbel</last></author>
       <pages>43–47</pages>
       <url>W17-3807</url>
       <doi>10.18653/v1/W17-3807</doi>
     </paper>
     <paper id="8">
       <title>Using Serious Games to Correct <fixed-case>F</fixed-case>rench Dictations: Proposal for a New <fixed-case>U</fixed-case>nity3<fixed-case>D</fixed-case>/<fixed-case>N</fixed-case>oo<fixed-case>J</fixed-case> Connector</title>
-      <author><first>Ikram</first> <last>Bououd</last></author>
-      <author><first>Rania</first> <last>Fafi</last></author>
+      <author><first>Ikram</first><last>Bououd</last></author>
+      <author><first>Rania</first><last>Fafi</last></author>
       <pages>49–52</pages>
       <url>W17-3808</url>
       <doi>10.18653/v1/W17-3808</doi>
@@ -6244,10 +6244,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     <meta>
       <booktitle>Proceedings of the Workshop on Computational Creativity in Natural Language Generation (<fixed-case>CC</fixed-case>-<fixed-case>NLG</fixed-case> 2017)</booktitle>
       <url>W17-39</url>
-      <editor><first>Hugo</first> <last>Gonçalo Oliveira</last></editor>
-      <editor><first>Ben</first> <last>Burtenshaw</last></editor>
-      <editor><first>Mike</first> <last>Kestemont</last></editor>
-      <editor><first>Tom</first> <last>De Smedt</last></editor>
+      <editor><first>Hugo</first><last>Gonçalo Oliveira</last></editor>
+      <editor><first>Ben</first><last>Burtenshaw</last></editor>
+      <editor><first>Mike</first><last>Kestemont</last></editor>
+      <editor><first>Tom</first><last>De Smedt</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Santiago de Compostela, Spain</address>
       <month>September</month>
@@ -6259,43 +6259,43 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Poet’s Little Helper: A methodology for computer-based poetry generation. A case study for the Basque language</title>
-      <author><first>Aitzol</first> <last>Astigarraga</last></author>
-      <author><first>José</first> <last>María Martínez-Otzeta</last></author>
-      <author><first>Igor</first> <last>Rodriguez</last></author>
-      <author><first>Basilio</first> <last>Sierra</last></author>
-      <author><first>Elena</first> <last>Lazkano</last></author>
+      <author><first>Aitzol</first><last>Astigarraga</last></author>
+      <author><first>José</first><last>María Martínez-Otzeta</last></author>
+      <author><first>Igor</first><last>Rodriguez</last></author>
+      <author><first>Basilio</first><last>Sierra</last></author>
+      <author><first>Elena</first><last>Lazkano</last></author>
       <pages>2–10</pages>
       <url>W17-3901</url>
       <doi>10.18653/v1/W17-3901</doi>
     </paper>
     <paper id="2">
       <title>O Poeta Artificial 2.0: Increasing Meaningfulness in a Poetry Generation Twitter bot</title>
-      <author><first>Hugo</first> <last>Gonçalo Oliveira</last></author>
+      <author><first>Hugo</first><last>Gonçalo Oliveira</last></author>
       <pages>11–20</pages>
       <url>W17-3902</url>
       <doi>10.18653/v1/W17-3902</doi>
     </paper>
     <paper id="3">
       <title>Template-Free Construction of Rhyming Poems with Thematic Cohesion</title>
-      <author><first>Pablo</first> <last>Gervás</last></author>
+      <author><first>Pablo</first><last>Gervás</last></author>
       <pages>21–28</pages>
       <url>W17-3903</url>
       <doi>10.18653/v1/W17-3903</doi>
     </paper>
     <paper id="4">
       <title>Synthetic Literature: Writing Science Fiction in a Co-Creative Process</title>
-      <author><first>Enrique</first> <last>Manjavacas</last></author>
-      <author><first>Folgert</first> <last>Karsdorp</last></author>
-      <author><first>Ben</first> <last>Burtenshaw</last></author>
-      <author><first>Mike</first> <last>Kestemont</last></author>
+      <author><first>Enrique</first><last>Manjavacas</last></author>
+      <author><first>Folgert</first><last>Karsdorp</last></author>
+      <author><first>Ben</first><last>Burtenshaw</last></author>
+      <author><first>Mike</first><last>Kestemont</last></author>
       <pages>29–37</pages>
       <url>W17-3904</url>
       <doi>10.18653/v1/W17-3904</doi>
     </paper>
     <paper id="5">
       <title>Constructing narrative using a generative model and continuous action policies</title>
-      <author><first>Emmanouil</first> <last>Theofanis Chourdakis</last></author>
-      <author><first>Joshua</first> <last>Reiss</last></author>
+      <author><first>Emmanouil</first><last>Theofanis Chourdakis</last></author>
+      <author><first>Joshua</first><last>Reiss</last></author>
       <pages>38–43</pages>
       <url>W17-3905</url>
       <doi>10.18653/v1/W17-3905</doi>
@@ -6418,8 +6418,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Character and Subword-Based Word Representation for Neural Language Modeling Prediction</title>
-      <author><first>Matthieu</first> <last>Labeau</last></author>
-      <author><first>Alexandre</first> <last>Allauzen</last></author>
+      <author><first>Matthieu</first><last>Labeau</last></author>
+      <author><first>Alexandre</first><last>Allauzen</last></author>
       <pages>1–13</pages>
       <url>W17-4101</url>
       <doi>10.18653/v1/W17-4101</doi>
@@ -6427,8 +6427,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Learning variable length units for <fixed-case>SMT</fixed-case> between related languages via Byte Pair Encoding</title>
-      <author><first>Anoop</first> <last>Kunchukuttan</last></author>
-      <author><first>Pushpak</first> <last>Bhattacharyya</last></author>
+      <author><first>Anoop</first><last>Kunchukuttan</last></author>
+      <author><first>Pushpak</first><last>Bhattacharyya</last></author>
       <pages>14–24</pages>
       <url>W17-4102</url>
       <doi>10.18653/v1/W17-4102</doi>
@@ -6436,8 +6436,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Character Based Pattern Mining for Neology Detection</title>
-      <author><first>Gaël</first> <last>Lejeune</last></author>
-      <author><first>Emmanuel</first> <last>Cartier</last></author>
+      <author><first>Gaël</first><last>Lejeune</last></author>
+      <author><first>Emmanuel</first><last>Cartier</last></author>
       <pages>25–30</pages>
       <url>W17-4103</url>
       <doi>10.18653/v1/W17-4103</doi>
@@ -6445,10 +6445,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Automated Word Stress Detection in <fixed-case>R</fixed-case>ussian</title>
-      <author><first>Maria</first> <last>Ponomareva</last></author>
-      <author><first>Kirill</first> <last>Milintsevich</last></author>
-      <author><first>Ekaterina</first> <last>Chernyak</last></author>
-      <author><first>Anatoly</first> <last>Starostin</last></author>
+      <author><first>Maria</first><last>Ponomareva</last></author>
+      <author><first>Kirill</first><last>Milintsevich</last></author>
+      <author><first>Ekaterina</first><last>Chernyak</last></author>
+      <author><first>Anatoly</first><last>Starostin</last></author>
       <pages>31–35</pages>
       <url>W17-4104</url>
       <doi>10.18653/v1/W17-4104</doi>
@@ -6456,10 +6456,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>A Syllable-based Technique for Word Embeddings of <fixed-case>K</fixed-case>orean Words</title>
-      <author><first>Sanghyuk</first> <last>Choi</last></author>
-      <author><first>Taeuk</first> <last>Kim</last></author>
-      <author><first>Jinseok</first> <last>Seol</last></author>
-      <author><first>Sang-goo</first> <last>Lee</last></author>
+      <author><first>Sanghyuk</first><last>Choi</last></author>
+      <author><first>Taeuk</first><last>Kim</last></author>
+      <author><first>Jinseok</first><last>Seol</last></author>
+      <author><first>Sang-goo</first><last>Lee</last></author>
       <pages>36–40</pages>
       <url>W17-4105</url>
       <doi>10.18653/v1/W17-4105</doi>
@@ -6467,8 +6467,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Supersense Tagging with a Combination of Character, Subword, and Word-level Representations</title>
-      <author><first>Youhyun</first> <last>Shin</last></author>
-      <author><first>Sang-goo</first> <last>Lee</last></author>
+      <author><first>Youhyun</first><last>Shin</last></author>
+      <author><first>Sang-goo</first><last>Lee</last></author>
       <pages>41–45</pages>
       <url>W17-4106</url>
       <doi>10.18653/v1/W17-4106</doi>
@@ -6476,8 +6476,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Weakly supervised learning of allomorphy</title>
-      <author><first>Miikka</first> <last>Silfverberg</last></author>
-      <author><first>Mans</first> <last>Hulden</last></author>
+      <author><first>Miikka</first><last>Silfverberg</last></author>
+      <author><first>Mans</first><last>Hulden</last></author>
       <pages>46–56</pages>
       <url>W17-4107</url>
       <doi>10.18653/v1/W17-4107</doi>
@@ -6485,8 +6485,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Character-based recurrent neural networks for morphological relational reasoning</title>
-      <author><first>Olof</first> <last>Mogren</last></author>
-      <author><first>Richard</first> <last>Johansson</last></author>
+      <author><first>Olof</first><last>Mogren</last></author>
+      <author><first>Richard</first><last>Johansson</last></author>
       <pages>57–63</pages>
       <url>W17-4108</url>
       <doi>10.18653/v1/W17-4108</doi>
@@ -6508,8 +6508,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Glyph-aware Embedding of <fixed-case>C</fixed-case>hinese Characters</title>
-      <author><first>Falcon</first> <last>Dai</last></author>
-      <author><first>Zheng</first> <last>Cai</last></author>
+      <author><first>Falcon</first><last>Dai</last></author>
+      <author><first>Zheng</first><last>Cai</last></author>
       <pages>64–69</pages>
       <url>W17-4109</url>
       <doi>10.18653/v1/W17-4109</doi>
@@ -6517,8 +6517,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Exploring Cross-Lingual Transfer of Morphological Knowledge In Sequence-to-Sequence Models</title>
-      <author><first>Huiming</first> <last>Jin</last></author>
-      <author><first>Katharina</first> <last>Kann</last></author>
+      <author><first>Huiming</first><last>Jin</last></author>
+      <author><first>Katharina</first><last>Kann</last></author>
       <pages>70–75</pages>
       <url>W17-4110</url>
       <doi>10.18653/v1/W17-4110</doi>
@@ -6526,8 +6526,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Unlabeled Data for Morphological Generation With Character-Based Sequence-to-Sequence Models</title>
-      <author><first>Katharina</first> <last>Kann</last></author>
-      <author><first>Hinrich</first> <last>Schütze</last></author>
+      <author><first>Katharina</first><last>Kann</last></author>
+      <author><first>Hinrich</first><last>Schütze</last></author>
       <pages>76–81</pages>
       <url>W17-4111</url>
       <doi>10.18653/v1/W17-4111</doi>
@@ -6535,8 +6535,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Vowel and Consonant Classification through Spectral Decomposition</title>
-      <author><first>Patricia</first> <last>Thaine</last></author>
-      <author><first>Gerald</first> <last>Penn</last></author>
+      <author><first>Patricia</first><last>Thaine</last></author>
+      <author><first>Gerald</first><last>Penn</last></author>
       <pages>82–91</pages>
       <url>W17-4112</url>
       <doi>10.18653/v1/W17-4112</doi>
@@ -6545,10 +6545,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Syllable-level Neural Language Model for Agglutinative Language</title>
-      <author><first>Seunghak</first> <last>Yu</last></author>
-      <author><first>Nilesh</first> <last>Kulkarni</last></author>
-      <author><first>Haejun</first> <last>Lee</last></author>
-      <author><first>Jihie</first> <last>Kim</last></author>
+      <author><first>Seunghak</first><last>Yu</last></author>
+      <author><first>Nilesh</first><last>Kulkarni</last></author>
+      <author><first>Haejun</first><last>Lee</last></author>
+      <author><first>Jihie</first><last>Kim</last></author>
       <pages>92–96</pages>
       <url>W17-4113</url>
       <doi>10.18653/v1/W17-4113</doi>
@@ -6557,10 +6557,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Character-based Bidirectional <fixed-case>LSTM</fixed-case>-<fixed-case>CRF</fixed-case> with words and characters for <fixed-case>J</fixed-case>apanese Named Entity Recognition</title>
-      <author><first>Shotaro</first> <last>Misawa</last></author>
-      <author><first>Motoki</first> <last>Taniguchi</last></author>
-      <author><first>Yasuhide</first> <last>Miura</last></author>
-      <author><first>Tomoko</first> <last>Ohkuma</last></author>
+      <author><first>Shotaro</first><last>Misawa</last></author>
+      <author><first>Motoki</first><last>Taniguchi</last></author>
+      <author><first>Yasuhide</first><last>Miura</last></author>
+      <author><first>Tomoko</first><last>Ohkuma</last></author>
       <pages>97–102</pages>
       <url>W17-4114</url>
       <doi>10.18653/v1/W17-4114</doi>
@@ -6568,10 +6568,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Word Representation Models for Morphologically Rich Languages in Neural Machine Translation</title>
-      <author><first>Ekaterina</first> <last>Vylomova</last></author>
-      <author><first>Trevor</first> <last>Cohn</last></author>
-      <author><first>Xuanli</first> <last>He</last></author>
-      <author><first>Gholamreza</first> <last>Haffari</last></author>
+      <author><first>Ekaterina</first><last>Vylomova</last></author>
+      <author><first>Trevor</first><last>Cohn</last></author>
+      <author><first>Xuanli</first><last>He</last></author>
+      <author><first>Gholamreza</first><last>Haffari</last></author>
       <pages>103–108</pages>
       <url>W17-4115</url>
       <doi>10.18653/v1/W17-4115</doi>
@@ -6579,8 +6579,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="16">
       <title>Spell-Checking based on Syllabification and Character-level Graphs for a <fixed-case>P</fixed-case>eruvian Agglutinative Language</title>
-      <author><first>Carlo</first> <last>Alva</last></author>
-      <author><first>Arturo</first> <last>Oncevay</last></author>
+      <author><first>Carlo</first><last>Alva</last></author>
+      <author><first>Arturo</first><last>Oncevay</last></author>
       <pages>109–116</pages>
       <url>W17-4116</url>
       <doi>10.18653/v1/W17-4116</doi>
@@ -6588,9 +6588,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="17">
       <title>What do we need to know about an unknown word when parsing <fixed-case>G</fixed-case>erman</title>
-      <author><first>Bich-Ngoc</first> <last>Do</last></author>
-      <author><first>Ines</first> <last>Rehbein</last></author>
-      <author><first>Anette</first> <last>Frank</last></author>
+      <author><first>Bich-Ngoc</first><last>Do</last></author>
+      <author><first>Ines</first><last>Rehbein</last></author>
+      <author><first>Anette</first><last>Frank</last></author>
       <pages>117–123</pages>
       <url>W17-4117</url>
       <doi>10.18653/v1/W17-4117</doi>
@@ -6598,9 +6598,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="18">
       <title>A General-Purpose Tagger with Convolutional Neural Networks</title>
-      <author><first>Xiang</first> <last>Yu</last></author>
-      <author><first>Agnieszka</first> <last>Falenska</last></author>
-      <author><first>Ngoc Thang</first> <last>Vu</last></author>
+      <author><first>Xiang</first><last>Yu</last></author>
+      <author><first>Agnieszka</first><last>Falenska</last></author>
+      <author><first>Ngoc Thang</first><last>Vu</last></author>
       <pages>124–129</pages>
       <url>W17-4118</url>
       <doi>10.18653/v1/W17-4118</doi>
@@ -6608,7 +6608,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="19">
       <title>Reconstruction of Word Embeddings from Sub-Word Parameters</title>
-      <author><first>Karl</first> <last>Stratos</last></author>
+      <author><first>Karl</first><last>Stratos</last></author>
       <pages>130–135</pages>
       <url>W17-4119</url>
       <doi>10.18653/v1/W17-4119</doi>
@@ -6616,9 +6616,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="20">
       <title>Inflection Generation for <fixed-case>S</fixed-case>panish Verbs using Supervised Learning</title>
-      <author><first>Cristina</first> <last>Barros</last></author>
-      <author><first>Dimitra</first> <last>Gkatzia</last></author>
-      <author><first>Elena</first> <last>Lloret</last></author>
+      <author><first>Cristina</first><last>Barros</last></author>
+      <author><first>Dimitra</first><last>Gkatzia</last></author>
+      <author><first>Elena</first><last>Lloret</last></author>
       <pages>136–141</pages>
       <url>W17-4120</url>
       <doi>10.18653/v1/W17-4120</doi>
@@ -6626,11 +6626,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="21">
       <title>Neural Paraphrase Identification of Questions with Noisy Pretraining</title>
-      <author><first>Gaurav Singh</first> <last>Tomar</last></author>
-      <author><first>Thyago</first> <last>Duque</last></author>
-      <author><first>Oscar</first> <last>Täckström</last></author>
-      <author><first>Jakob</first> <last>Uszkoreit</last></author>
-      <author><first>Dipanjan</first> <last>Das</last></author>
+      <author><first>Gaurav Singh</first><last>Tomar</last></author>
+      <author><first>Thyago</first><last>Duque</last></author>
+      <author><first>Oscar</first><last>Täckström</last></author>
+      <author><first>Jakob</first><last>Uszkoreit</last></author>
+      <author><first>Dipanjan</first><last>Das</last></author>
       <pages>142–147</pages>
       <url>W17-4121</url>
       <doi>10.18653/v1/W17-4121</doi>
@@ -6638,9 +6638,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="22">
       <title>Sub-character Neural Language Modelling in <fixed-case>J</fixed-case>apanese</title>
-      <author><first>Viet</first> <last>Nguyen</last></author>
-      <author><first>Julian</first> <last>Brooke</last></author>
-      <author><first>Timothy</first> <last>Baldwin</last></author>
+      <author><first>Viet</first><last>Nguyen</last></author>
+      <author><first>Julian</first><last>Brooke</last></author>
+      <author><first>Timothy</first><last>Baldwin</last></author>
       <pages>148–153</pages>
       <url>W17-4122</url>
       <doi>10.18653/v1/W17-4122</doi>
@@ -6648,9 +6648,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="23">
       <title>Byte-based Neural Machine Translation</title>
-      <author><first>Marta R.</first> <last>Costa-jussà</last></author>
-      <author><first>Carlos</first> <last>Escolano</last></author>
-      <author><first>José A. R.</first> <last>Fonollosa</last></author>
+      <author><first>Marta R.</first><last>Costa-jussà</last></author>
+      <author><first>Carlos</first><last>Escolano</last></author>
+      <author><first>José A. R.</first><last>Fonollosa</last></author>
       <pages>154–158</pages>
       <url>W17-4123</url>
       <doi>10.18653/v1/W17-4123</doi>
@@ -6658,8 +6658,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="24">
       <title>Improving Opinion-Target Extraction with Character-Level Word Embeddings</title>
-      <author><first>Soufian</first> <last>Jebbara</last></author>
-      <author><first>Philipp</first> <last>Cimiano</last></author>
+      <author><first>Soufian</first><last>Jebbara</last></author>
+      <author><first>Philipp</first><last>Cimiano</last></author>
       <pages>159–167</pages>
       <url>W17-4124</url>
       <doi>10.18653/v1/W17-4124</doi>
@@ -6670,8 +6670,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     <meta>
       <booktitle>Proceedings of the 2017 <fixed-case>EMNLP</fixed-case> Workshop: Natural Language Processing meets Journalism</booktitle>
       <url>W17-42</url>
-      <editor><first>Octavian</first> <last>Popescu</last></editor>
-      <editor><first>Carlo</first> <last>Strapparava</last></editor>
+      <editor><first>Octavian</first><last>Popescu</last></editor>
+      <editor><first>Carlo</first><last>Strapparava</last></editor>
       <doi>10.18653/v1/W17-42</doi>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Copenhagen, Denmark</address>
@@ -6683,12 +6683,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Predicting News Values from Headline Text and Emotions</title>
-      <author><first>Maria Pia</first> <last>di Buono</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
-      <author><first>Bojana</first> <last>Dalbelo Bašić</last></author>
-      <author><first>Goran</first> <last>Glavaš</last></author>
-      <author><first>Martin</first> <last>Tutek</last></author>
-      <author><first>Natasa</first> <last>Milic-Frayling</last></author>
+      <author><first>Maria Pia</first><last>di Buono</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
+      <author><first>Bojana</first><last>Dalbelo Bašić</last></author>
+      <author><first>Goran</first><last>Glavaš</last></author>
+      <author><first>Martin</first><last>Tutek</last></author>
+      <author><first>Natasa</first><last>Milic-Frayling</last></author>
       <pages>1–6</pages>
       <url>W17-4201</url>
       <doi>10.18653/v1/W17-4201</doi>
@@ -6696,8 +6696,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Predicting User Views in Online News</title>
-      <author><first>Daniel</first> <last>Hardt</last></author>
-      <author><first>Owen</first> <last>Rambow</last></author>
+      <author><first>Daniel</first><last>Hardt</last></author>
+      <author><first>Owen</first><last>Rambow</last></author>
       <pages>7–12</pages>
       <url>W17-4202</url>
       <doi>10.18653/v1/W17-4202</doi>
@@ -6705,11 +6705,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Tracking Bias in News Sources Using Social Media: the Russia-<fixed-case>U</fixed-case>kraine Maidan Crisis of 2013–2014</title>
-      <author><first>Peter</first> <last>Potash</last></author>
-      <author><first>Alexey</first> <last>Romanov</last></author>
-      <author><first>Mikhail</first> <last>Gronas</last></author>
-      <author><first>Anna</first> <last>Rumshisky</last></author>
-      <author><first>Mikhail</first> <last>Gronas</last></author>
+      <author><first>Peter</first><last>Potash</last></author>
+      <author><first>Alexey</first><last>Romanov</last></author>
+      <author><first>Mikhail</first><last>Gronas</last></author>
+      <author><first>Anna</first><last>Rumshisky</last></author>
+      <author><first>Mikhail</first><last>Gronas</last></author>
       <pages>13–18</pages>
       <url>W17-4203</url>
       <doi>10.18653/v1/W17-4203</doi>
@@ -6717,10 +6717,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>What to Write? A topic recommender for journalists</title>
-      <author><first>Alessandro</first> <last>Cucchiarelli</last></author>
-      <author><first>Christian</first> <last>Morbidoni</last></author>
-      <author><first>Giovanni</first> <last>Stilo</last></author>
-      <author><first>Paola</first> <last>Velardi</last></author>
+      <author><first>Alessandro</first><last>Cucchiarelli</last></author>
+      <author><first>Christian</first><last>Morbidoni</last></author>
+      <author><first>Giovanni</first><last>Stilo</last></author>
+      <author><first>Paola</first><last>Velardi</last></author>
       <pages>19–24</pages>
       <url>W17-4204</url>
       <doi>10.18653/v1/W17-4204</doi>
@@ -6728,11 +6728,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Comparing Attitudes to Climate Change in the Media using sentiment analysis based on Latent <fixed-case>D</fixed-case>irichlet Allocation</title>
-      <author><first>Ye</first> <last>Jiang</last></author>
-      <author><first>Xingyi</first> <last>Song</last></author>
-      <author><first>Jackie</first> <last>Harrison</last></author>
-      <author><first>Shaun</first> <last>Quegan</last></author>
-      <author><first>Diana</first> <last>Maynard</last></author>
+      <author><first>Ye</first><last>Jiang</last></author>
+      <author><first>Xingyi</first><last>Song</last></author>
+      <author><first>Jackie</first><last>Harrison</last></author>
+      <author><first>Shaun</first><last>Quegan</last></author>
+      <author><first>Diana</first><last>Maynard</last></author>
       <pages>25–30</pages>
       <url>W17-4205</url>
       <doi>10.18653/v1/W17-4205</doi>
@@ -6740,12 +6740,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Language-based Construction of Explorable News Graphs for Journalists</title>
-      <author><first>Rémi</first> <last>Bois</last></author>
-      <author><first>Guillaume</first> <last>Gravier</last></author>
-      <author><first>Eric</first> <last>Jamet</last></author>
-      <author><first>Emmanuel</first> <last>Morin</last></author>
-      <author><first>Pascale</first> <last>Sébillot</last></author>
-      <author><first>Maxime</first> <last>Robert</last></author>
+      <author><first>Rémi</first><last>Bois</last></author>
+      <author><first>Guillaume</first><last>Gravier</last></author>
+      <author><first>Eric</first><last>Jamet</last></author>
+      <author><first>Emmanuel</first><last>Morin</last></author>
+      <author><first>Pascale</first><last>Sébillot</last></author>
+      <author><first>Maxime</first><last>Robert</last></author>
       <pages>31–36</pages>
       <url>W17-4206</url>
       <doi>10.18653/v1/W17-4206</doi>
@@ -6753,13 +6753,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title><fixed-case>S</fixed-case>toryteller: Visual Analytics of Perspectives on Rich Text Interpretations</title>
-      <author><first>Maarten</first> <last>van Meersbergen</last></author>
-      <author><first>Piek</first> <last>Vossen</last></author>
-      <author><first>Janneke</first> <last>van der Zwaan</last></author>
-      <author><first>Antske</first> <last>Fokkens</last></author>
-      <author><first>Willem</first> <last>van Hage</last></author>
-      <author><first>Inger</first> <last>Leemans</last></author>
-      <author><first>Isa</first> <last>Maks</last></author>
+      <author><first>Maarten</first><last>van Meersbergen</last></author>
+      <author><first>Piek</first><last>Vossen</last></author>
+      <author><first>Janneke</first><last>van der Zwaan</last></author>
+      <author><first>Antske</first><last>Fokkens</last></author>
+      <author><first>Willem</first><last>van Hage</last></author>
+      <author><first>Inger</first><last>Leemans</last></author>
+      <author><first>Isa</first><last>Maks</last></author>
       <pages>37–45</pages>
       <url>W17-4207</url>
       <doi>10.18653/v1/W17-4207</doi>
@@ -6767,10 +6767,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Analyzing the Revision Logs of a <fixed-case>J</fixed-case>apanese Newspaper for Article Quality Assessment</title>
-      <author><first>Hideaki</first> <last>Tamori</last></author>
-      <author><first>Yuta</first> <last>Hitomi</last></author>
-      <author><first>Naoaki</first> <last>Okazaki</last></author>
-      <author><first>Kentaro</first> <last>Inui</last></author>
+      <author><first>Hideaki</first><last>Tamori</last></author>
+      <author><first>Yuta</first><last>Hitomi</last></author>
+      <author><first>Naoaki</first><last>Okazaki</last></author>
+      <author><first>Kentaro</first><last>Inui</last></author>
       <pages>46–50</pages>
       <url>W17-4208</url>
       <doi>10.18653/v1/W17-4208</doi>
@@ -6778,10 +6778,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Improved Abusive Comment Moderation with User Embeddings</title>
-      <author><first>John</first> <last>Pavlopoulos</last></author>
-      <author><first>Prodromos</first> <last>Malakasiotis</last></author>
-      <author><first>Juli</first> <last>Bakagianni</last></author>
-      <author><first>Ion</first> <last>Androutsopoulos</last></author>
+      <author><first>John</first><last>Pavlopoulos</last></author>
+      <author><first>Prodromos</first><last>Malakasiotis</last></author>
+      <author><first>Juli</first><last>Bakagianni</last></author>
+      <author><first>Ion</first><last>Androutsopoulos</last></author>
       <pages>51–55</pages>
       <url>W17-4209</url>
       <doi>10.18653/v1/W17-4209</doi>
@@ -6789,10 +6789,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Incongruent Headlines: Yet Another Way to Mislead Your Readers</title>
-      <author><first>Sophie</first> <last>Chesney</last></author>
-      <author><first>Maria</first> <last>Liakata</last></author>
-      <author><first>Massimo</first> <last>Poesio</last></author>
-      <author><first>Matthew</first> <last>Purver</last></author>
+      <author><first>Sophie</first><last>Chesney</last></author>
+      <author><first>Maria</first><last>Liakata</last></author>
+      <author><first>Massimo</first><last>Poesio</last></author>
+      <author><first>Matthew</first><last>Purver</last></author>
       <pages>56–61</pages>
       <url>W17-4210</url>
       <doi>10.18653/v1/W17-4210</doi>
@@ -6800,9 +6800,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Unsupervised Event Clustering and Aggregation from Newswire and Web Articles</title>
-      <author><first>Swen</first> <last>Ribeiro</last></author>
-      <author><first>Olivier</first> <last>Ferret</last></author>
-      <author><first>Xavier</first> <last>Tannier</last></author>
+      <author><first>Swen</first><last>Ribeiro</last></author>
+      <author><first>Olivier</first><last>Ferret</last></author>
+      <author><first>Xavier</first><last>Tannier</last></author>
       <pages>62–67</pages>
       <url>W17-4211</url>
       <doi>10.18653/v1/W17-4211</doi>
@@ -6810,11 +6810,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Semantic Storytelling, Cross-lingual Event Detection and other Semantic Services for a Newsroom Content Curation Dashboard</title>
-      <author><first>Julian</first> <last>Moreno-Schneider</last></author>
-      <author><first>Ankit</first> <last>Srivastava</last></author>
-      <author><first>Peter</first> <last>Bourgonje</last></author>
-      <author><first>David</first> <last>Wabnitz</last></author>
-      <author><first>Georg</first> <last>Rehm</last></author>
+      <author><first>Julian</first><last>Moreno-Schneider</last></author>
+      <author><first>Ankit</first><last>Srivastava</last></author>
+      <author><first>Peter</first><last>Bourgonje</last></author>
+      <author><first>David</first><last>Wabnitz</last></author>
+      <author><first>Georg</first><last>Rehm</last></author>
       <pages>68–73</pages>
       <url>W17-4212</url>
       <doi>10.18653/v1/W17-4212</doi>
@@ -6822,7 +6822,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Deception Detection in News Reports in the <fixed-case>R</fixed-case>ussian Language: Lexics and Discourse</title>
-      <author><first>Dina</first> <last>Pisarevskaya</last></author>
+      <author><first>Dina</first><last>Pisarevskaya</last></author>
       <pages>74–79</pages>
       <url>W17-4213</url>
       <doi>10.18653/v1/W17-4213</doi>
@@ -6830,12 +6830,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Fake news stance detection using stacked ensemble of classifiers</title>
-      <author><first>James</first> <last>Thorne</last></author>
-      <author><first>Mingjie</first> <last>Chen</last></author>
-      <author><first>Giorgos</first> <last>Myrianthous</last></author>
-      <author><first>Jiashu</first> <last>Pu</last></author>
-      <author><first>Xiaoxuan</first> <last>Wang</last></author>
-      <author><first>Andreas</first> <last>Vlachos</last></author>
+      <author><first>James</first><last>Thorne</last></author>
+      <author><first>Mingjie</first><last>Chen</last></author>
+      <author><first>Giorgos</first><last>Myrianthous</last></author>
+      <author><first>Jiashu</first><last>Pu</last></author>
+      <author><first>Xiaoxuan</first><last>Wang</last></author>
+      <author><first>Andreas</first><last>Vlachos</last></author>
       <pages>80–83</pages>
       <url>W17-4214</url>
       <doi>10.18653/v1/W17-4214</doi>
@@ -6843,9 +6843,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>From Clickbait to Fake News Detection: An Approach based on Detecting the Stance of Headlines to Articles</title>
-      <author><first>Peter</first> <last>Bourgonje</last></author>
-      <author><first>Julian</first> <last>Moreno Schneider</last></author>
-      <author><first>Georg</first> <last>Rehm</last></author>
+      <author><first>Peter</first><last>Bourgonje</last></author>
+      <author><first>Julian</first><last>Moreno Schneider</last></author>
+      <author><first>Georg</first><last>Rehm</last></author>
       <pages>84–89</pages>
       <url>W17-4215</url>
       <doi>10.18653/v1/W17-4215</doi>
@@ -6853,8 +6853,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="16">
       <title>‘Fighting’ or ‘Conflict’? An Approach to Revealing Concepts of Terms in Political Discourse</title>
-      <author><first>Linyuan</first> <last>Tang</last></author>
-      <author><first>Kyo</first> <last>Kageura</last></author>
+      <author><first>Linyuan</first><last>Tang</last></author>
+      <author><first>Kyo</first><last>Kageura</last></author>
       <pages>90–94</pages>
       <url>W17-4216</url>
       <doi>10.18653/v1/W17-4216</doi>
@@ -6862,9 +6862,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="17">
       <title>A News Chain Evaluation Methodology along with a Lattice-based Approach for News Chain Construction</title>
-      <author><first>Mustafa</first> <last>Toprak</last></author>
-      <author><first>Özer</first> <last>Özkahraman</last></author>
-      <author><first>Selma</first> <last>Tekir</last></author>
+      <author><first>Mustafa</first><last>Toprak</last></author>
+      <author><first>Özer</first><last>Özkahraman</last></author>
+      <author><first>Selma</first><last>Tekir</last></author>
       <pages>95–99</pages>
       <url>W17-4217</url>
       <doi>10.18653/v1/W17-4217</doi>
@@ -6872,8 +6872,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="18">
       <title>Using New York Times Picks to Identify Constructive Comments</title>
-      <author><first>Varada</first> <last>Kolhatkar</last></author>
-      <author><first>Maite</first> <last>Taboada</last></author>
+      <author><first>Varada</first><last>Kolhatkar</last></author>
+      <author><first>Maite</first><last>Taboada</last></author>
       <pages>100–105</pages>
       <url>W17-4218</url>
       <doi>10.18653/v1/W17-4218</doi>
@@ -6881,9 +6881,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="19">
       <title>An <fixed-case>NLP</fixed-case> Analysis of Exaggerated Claims in Science News</title>
-      <author><first>Yingya</first> <last>Li</last></author>
-      <author><first>Jieke</first> <last>Zhang</last></author>
-      <author><first>Bei</first> <last>Yu</last></author>
+      <author><first>Yingya</first><last>Li</last></author>
+      <author><first>Jieke</first><last>Zhang</last></author>
+      <author><first>Bei</first><last>Yu</last></author>
       <pages>106–111</pages>
       <url>W17-4219</url>
       <doi>10.18653/v1/W17-4219</doi>
@@ -6909,8 +6909,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Dependency Parsing with Dilated Iterated Graph <fixed-case>CNN</fixed-case>s</title>
-      <author><first>Emma</first> <last>Strubell</last></author>
-      <author><first>Andrew</first> <last>McCallum</last></author>
+      <author><first>Emma</first><last>Strubell</last></author>
+      <author><first>Andrew</first><last>McCallum</last></author>
       <pages>1–6</pages>
       <url>W17-4301</url>
       <doi>10.18653/v1/W17-4301</doi>
@@ -6918,7 +6918,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Entity Identification as Multitasking</title>
-      <author><first>Karl</first> <last>Stratos</last></author>
+      <author><first>Karl</first><last>Stratos</last></author>
       <pages>7–11</pages>
       <url>W17-4302</url>
       <doi>10.18653/v1/W17-4302</doi>
@@ -6926,8 +6926,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Towards Neural Machine Translation with Latent Tree Attention</title>
-      <author><first>James</first> <last>Bradbury</last></author>
-      <author><first>Richard</first> <last>Socher</last></author>
+      <author><first>James</first><last>Bradbury</last></author>
+      <author><first>Richard</first><last>Socher</last></author>
       <pages>12–16</pages>
       <url>W17-4303</url>
       <doi>10.18653/v1/W17-4303</doi>
@@ -6936,8 +6936,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Structured Prediction via Learning to Search under Bandit Feedback</title>
-      <author><first>Amr</first> <last>Sharaf</last></author>
-      <author><first>Hal</first> <last>Daumé III</last></author>
+      <author><first>Amr</first><last>Sharaf</last></author>
+      <author><first>Hal</first><last>Daumé III</last></author>
       <pages>17–26</pages>
       <url>W17-4304</url>
       <doi>10.18653/v1/W17-4304</doi>
@@ -6945,11 +6945,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Syntax Aware <fixed-case>LSTM</fixed-case> model for Semantic Role Labeling</title>
-      <author><first>Feng</first> <last>Qian</last></author>
-      <author><first>Lei</first> <last>Sha</last></author>
-      <author><first>Baobao</first> <last>Chang</last></author>
-      <author><first>Lu-chen</first> <last>Liu</last></author>
-      <author><first>Ming</first> <last>Zhang</last></author>
+      <author><first>Feng</first><last>Qian</last></author>
+      <author><first>Lei</first><last>Sha</last></author>
+      <author><first>Baobao</first><last>Chang</last></author>
+      <author><first>Lu-chen</first><last>Liu</last></author>
+      <author><first>Ming</first><last>Zhang</last></author>
       <pages>27–32</pages>
       <url>W17-4305</url>
       <doi>10.18653/v1/W17-4305</doi>
@@ -6957,9 +6957,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Spatial Language Understanding with Multimodal Graphs using Declarative Learning based Programming</title>
-      <author><first>Parisa</first> <last>Kordjamshidi</last></author>
-      <author><first>Taher</first> <last>Rahgooy</last></author>
-      <author><first>Umar</first> <last>Manzoor</last></author>
+      <author><first>Parisa</first><last>Kordjamshidi</last></author>
+      <author><first>Taher</first><last>Rahgooy</last></author>
+      <author><first>Umar</first><last>Manzoor</last></author>
       <pages>33–43</pages>
       <url>W17-4306</url>
       <doi>10.18653/v1/W17-4306</doi>
@@ -6967,8 +6967,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Boosting Information Extraction Systems with Character-level Neural Networks and Free Noisy Supervision</title>
-      <author><first>Philipp</first> <last>Meerkamp</last></author>
-      <author><first>Zhengyi</first> <last>Zhou</last></author>
+      <author><first>Philipp</first><last>Meerkamp</last></author>
+      <author><first>Zhengyi</first><last>Zhou</last></author>
       <pages>44–51</pages>
       <url>W17-4307</url>
       <doi>10.18653/v1/W17-4307</doi>
@@ -6976,10 +6976,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Piecewise Latent Variables for Neural Variational Text Processing</title>
-      <author><first>Iulian Vlad</first> <last>Serban</last></author>
-      <author><first>Alexander</first> <last>Ororbia II</last></author>
-      <author><first>Joelle</first> <last>Pineau</last></author>
-      <author><first>Aaron</first> <last>Courville</last></author>
+      <author><first>Iulian Vlad</first><last>Serban</last></author>
+      <author><first>Alexander</first><last>Ororbia II</last></author>
+      <author><first>Joelle</first><last>Pineau</last></author>
+      <author><first>Aaron</first><last>Courville</last></author>
       <pages>52–62</pages>
       <url>W17-4308</url>
       <doi>10.18653/v1/W17-4308</doi>
@@ -7005,7 +7005,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Boundary-based <fixed-case>MWE</fixed-case> segmentation with text partitioning</title>
-      <author><first>Jake</first> <last>Williams</last></author>
+      <author><first>Jake</first><last>Williams</last></author>
       <pages>1–10</pages>
       <url>W17-4401</url>
       <doi>10.18653/v1/W17-4401</doi>
@@ -7013,11 +7013,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Towards the Understanding of Gaming Audiences by Modeling Twitch Emotes</title>
-      <author><first>Francesco</first> <last>Barbieri</last></author>
-      <author><first>Luis</first> <last>Espinosa-Anke</last></author>
-      <author><first>Miguel</first> <last>Ballesteros</last></author>
-      <author><first>Juan</first> <last>Soler-Company</last></author>
-      <author><first>Horacio</first> <last>Saggion</last></author>
+      <author><first>Francesco</first><last>Barbieri</last></author>
+      <author><first>Luis</first><last>Espinosa-Anke</last></author>
+      <author><first>Miguel</first><last>Ballesteros</last></author>
+      <author><first>Juan</first><last>Soler-Company</last></author>
+      <author><first>Horacio</first><last>Saggion</last></author>
       <pages>11–20</pages>
       <url>W17-4402</url>
       <doi>10.18653/v1/W17-4402</doi>
@@ -7025,9 +7025,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Churn Identification in Microblogs using Convolutional Neural Networks with Structured Logical Knowledge</title>
-      <author><first>Mourad</first> <last>Gridach</last></author>
-      <author><first>Hatem</first> <last>Haddad</last></author>
-      <author><first>Hala</first> <last>Mulki</last></author>
+      <author><first>Mourad</first><last>Gridach</last></author>
+      <author><first>Hatem</first><last>Haddad</last></author>
+      <author><first>Hala</first><last>Mulki</last></author>
       <pages>21–30</pages>
       <url>W17-4403</url>
       <doi>10.18653/v1/W17-4403</doi>
@@ -7036,9 +7036,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>To normalize, or not to normalize: The impact of normalization on Part-of-Speech tagging</title>
-      <author><first>Rob</first> <last>van der Goot</last></author>
-      <author><first>Barbara</first> <last>Plank</last></author>
-      <author><first>Malvina</first> <last>Nissim</last></author>
+      <author><first>Rob</first><last>van der Goot</last></author>
+      <author><first>Barbara</first><last>Plank</last></author>
+      <author><first>Malvina</first><last>Nissim</last></author>
       <pages>31–39</pages>
       <url>W17-4404</url>
       <doi>10.18653/v1/W17-4404</doi>
@@ -7046,10 +7046,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Constructing an Alias List for Named Entities during an Event</title>
-      <author><first>Anietie</first> <last>Andy</last></author>
-      <author><first>Mark</first> <last>Dredze</last></author>
-      <author><first>Mugizi</first> <last>Rwebangira</last></author>
-      <author><first>Chris</first> <last>Callison-Burch</last></author>
+      <author><first>Anietie</first><last>Andy</last></author>
+      <author><first>Mark</first><last>Dredze</last></author>
+      <author><first>Mugizi</first><last>Rwebangira</last></author>
+      <author><first>Chris</first><last>Callison-Burch</last></author>
       <pages>40–44</pages>
       <url>W17-4405</url>
       <doi>10.18653/v1/W17-4405</doi>
@@ -7057,8 +7057,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Incorporating Metadata into Content-Based User Embeddings</title>
-      <author><first>Linzi</first> <last>Xing</last></author>
-      <author><first>Michael J.</first> <last>Paul</last></author>
+      <author><first>Linzi</first><last>Xing</last></author>
+      <author><first>Michael J.</first><last>Paul</last></author>
       <pages>45–49</pages>
       <url>W17-4406</url>
       <doi>10.18653/v1/W17-4406</doi>
@@ -7066,9 +7066,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Simple Queries as Distant Labels for Predicting Gender on Twitter</title>
-      <author><first>Chris</first> <last>Emmery</last></author>
-      <author><first>Grzegorz</first> <last>Chrupała</last></author>
-      <author><first>Walter</first> <last>Daelemans</last></author>
+      <author><first>Chris</first><last>Emmery</last></author>
+      <author><first>Grzegorz</first><last>Chrupała</last></author>
+      <author><first>Walter</first><last>Daelemans</last></author>
       <pages>50–55</pages>
       <url>W17-4407</url>
       <doi>10.18653/v1/W17-4407</doi>
@@ -7076,9 +7076,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>A Dataset and Classifier for Recognizing Social Media <fixed-case>E</fixed-case>nglish</title>
-      <author><first>Su Lin</first> <last>Blodgett</last></author>
-      <author><first>Johnny</first> <last>Wei</last></author>
-      <author><first>Brendan</first> <last>O’Connor</last></author>
+      <author><first>Su Lin</first><last>Blodgett</last></author>
+      <author><first>Johnny</first><last>Wei</last></author>
+      <author><first>Brendan</first><last>O’Connor</last></author>
       <pages>56–61</pages>
       <url>W17-4408</url>
       <doi>10.18653/v1/W17-4408</doi>
@@ -7086,8 +7086,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Evaluating hypotheses in geolocation on a very large sample of Twitter</title>
-      <author><first>Bahar</first> <last>Salehi</last></author>
-      <author><first>Anders</first> <last>Søgaard</last></author>
+      <author><first>Bahar</first><last>Salehi</last></author>
+      <author><first>Anders</first><last>Søgaard</last></author>
       <pages>62–67</pages>
       <url>W17-4409</url>
       <doi>10.18653/v1/W17-4409</doi>
@@ -7095,9 +7095,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>The Effect of Error Rate in Artificially Generated Data for Automatic Preposition and Determiner Correction</title>
-      <author><first>Fraser</first> <last>Bowen</last></author>
-      <author><first>Jon</first> <last>Dehdari</last></author>
-      <author><first>Josef</first> <last>van Genabith</last></author>
+      <author><first>Fraser</first><last>Bowen</last></author>
+      <author><first>Jon</first><last>Dehdari</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>68–76</pages>
       <url>W17-4410</url>
       <doi>10.18653/v1/W17-4410</doi>
@@ -7105,10 +7105,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>An Entity Resolution Approach to Isolate Instances of Human Trafficking Online</title>
-      <author><first>Chirag</first> <last>Nagpal</last></author>
-      <author><first>Kyle</first> <last>Miller</last></author>
-      <author><first>Benedikt</first> <last>Boecking</last></author>
-      <author><first>Artur</first> <last>Dubrawski</last></author>
+      <author><first>Chirag</first><last>Nagpal</last></author>
+      <author><first>Kyle</first><last>Miller</last></author>
+      <author><first>Benedikt</first><last>Boecking</last></author>
+      <author><first>Artur</first><last>Dubrawski</last></author>
       <pages>77–84</pages>
       <url>W17-4411</url>
       <doi>10.18653/v1/W17-4411</doi>
@@ -7116,8 +7116,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Noisy <fixed-case>U</fixed-case>yghur Text Normalization</title>
-      <author><first>Osman</first> <last>Tursun</last></author>
-      <author><first>Ruket</first> <last>Cakici</last></author>
+      <author><first>Osman</first><last>Tursun</last></author>
+      <author><first>Ruket</first><last>Cakici</last></author>
       <pages>85–93</pages>
       <url>W17-4412</url>
       <doi>10.18653/v1/W17-4412</doi>
@@ -7125,9 +7125,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Crowdsourcing Multiple Choice Science Questions</title>
-      <author><first>Johannes</first> <last>Welbl</last></author>
-      <author><first>Nelson F.</first> <last>Liu</last></author>
-      <author><first>Matt</first> <last>Gardner</last></author>
+      <author><first>Johannes</first><last>Welbl</last></author>
+      <author><first>Nelson F.</first><last>Liu</last></author>
+      <author><first>Matt</first><last>Gardner</last></author>
       <pages>94–106</pages>
       <url>W17-4413</url>
       <doi>10.18653/v1/W17-4413</doi>
@@ -7135,11 +7135,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>A Text Normalisation System for Non-Standard <fixed-case>E</fixed-case>nglish Words</title>
-      <author><first>Emma</first> <last>Flint</last></author>
-      <author><first>Elliot</first> <last>Ford</last></author>
-      <author><first>Olivia</first> <last>Thomas</last></author>
-      <author><first>Andrew</first> <last>Caines</last></author>
-      <author><first>Paula</first> <last>Buttery</last></author>
+      <author><first>Emma</first><last>Flint</last></author>
+      <author><first>Elliot</first><last>Ford</last></author>
+      <author><first>Olivia</first><last>Thomas</last></author>
+      <author><first>Andrew</first><last>Caines</last></author>
+      <author><first>Paula</first><last>Buttery</last></author>
       <pages>107–115</pages>
       <url>W17-4414</url>
       <doi>10.18653/v1/W17-4414</doi>
@@ -7147,10 +7147,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Huntsville, hospitals, and hockey teams: Names can reveal your location</title>
-      <author><first>Bahar</first> <last>Salehi</last></author>
-      <author><first>Dirk</first> <last>Hovy</last></author>
-      <author><first>Eduard</first> <last>Hovy</last></author>
-      <author><first>Anders</first> <last>Søgaard</last></author>
+      <author><first>Bahar</first><last>Salehi</last></author>
+      <author><first>Dirk</first><last>Hovy</last></author>
+      <author><first>Eduard</first><last>Hovy</last></author>
+      <author><first>Anders</first><last>Søgaard</last></author>
       <pages>116–121</pages>
       <url>W17-4415</url>
       <doi>10.18653/v1/W17-4415</doi>
@@ -7158,9 +7158,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="16">
       <title>Improving Document Clustering by Removing Unnatural Language</title>
-      <author><first>Myungha</first> <last>Jang</last></author>
-      <author><first>Jinho D.</first> <last>Choi</last></author>
-      <author><first>James</first> <last>Allan</last></author>
+      <author><first>Myungha</first><last>Jang</last></author>
+      <author><first>Jinho D.</first><last>Choi</last></author>
+      <author><first>James</first><last>Allan</last></author>
       <pages>122–130</pages>
       <url>W17-4416</url>
       <doi>10.18653/v1/W17-4416</doi>
@@ -7168,9 +7168,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="17">
       <title>Lithium <fixed-case>NLP</fixed-case>: A System for Rich Information Extraction from Noisy User Generated Text on Social Media</title>
-      <author><first>Preeti</first> <last>Bhargava</last></author>
-      <author><first>Nemanja</first> <last>Spasojevic</last></author>
-      <author><first>Guoning</first> <last>Hu</last></author>
+      <author><first>Preeti</first><last>Bhargava</last></author>
+      <author><first>Nemanja</first><last>Spasojevic</last></author>
+      <author><first>Guoning</first><last>Hu</last></author>
       <pages>131–139</pages>
       <url>W17-4417</url>
       <doi>10.18653/v1/W17-4417</doi>
@@ -7178,10 +7178,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="18">
       <title>Results of the <fixed-case>WNUT</fixed-case>2017 Shared Task on Novel and Emerging Entity Recognition</title>
-      <author><first>Leon</first> <last>Derczynski</last></author>
-      <author><first>Eric</first> <last>Nichols</last></author>
-      <author><first>Marieke</first> <last>van Erp</last></author>
-      <author><first>Nut</first> <last>Limsopatham</last></author>
+      <author><first>Leon</first><last>Derczynski</last></author>
+      <author><first>Eric</first><last>Nichols</last></author>
+      <author><first>Marieke</first><last>van Erp</last></author>
+      <author><first>Nut</first><last>Limsopatham</last></author>
       <pages>140–147</pages>
       <url>W17-4418</url>
       <doi>10.18653/v1/W17-4418</doi>
@@ -7189,10 +7189,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="19">
       <title>A Multi-task Approach for Named Entity Recognition in Social Media Data</title>
-      <author><first>Gustavo</first> <last>Aguilar</last></author>
-      <author><first>Suraj</first> <last>Maharjan</last></author>
-      <author><first>Adrian Pastor</first> <last>López-Monroy</last></author>
-      <author><first>Thamar</first> <last>Solorio</last></author>
+      <author><first>Gustavo</first><last>Aguilar</last></author>
+      <author><first>Suraj</first><last>Maharjan</last></author>
+      <author><first>Adrian Pastor</first><last>López-Monroy</last></author>
+      <author><first>Thamar</first><last>Solorio</last></author>
       <pages>148–153</pages>
       <url>W17-4419</url>
       <doi>10.18653/v1/W17-4419</doi>
@@ -7200,8 +7200,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="20">
       <title>Distributed Representation, <fixed-case>LDA</fixed-case> Topic Modelling and Deep Learning for Emerging Named Entity Recognition from Social Media</title>
-      <author><first>Patrick</first> <last>Jansson</last></author>
-      <author><first>Shuhua</first> <last>Liu</last></author>
+      <author><first>Patrick</first><last>Jansson</last></author>
+      <author><first>Shuhua</first><last>Liu</last></author>
       <pages>154–159</pages>
       <url>W17-4420</url>
       <doi>10.18653/v1/W17-4420</doi>
@@ -7209,10 +7209,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="21">
       <title>Multi-channel <fixed-case>B</fixed-case>i<fixed-case>LSTM</fixed-case>-<fixed-case>CRF</fixed-case> Model for Emerging Named Entity Recognition in Social Media</title>
-      <author><first>Bill Y.</first> <last>Lin</last></author>
-      <author><first>Frank</first> <last>Xu</last></author>
-      <author><first>Zhiyi</first> <last>Luo</last></author>
-      <author><first>Kenny</first> <last>Zhu</last></author>
+      <author><first>Bill Y.</first><last>Lin</last></author>
+      <author><first>Frank</first><last>Xu</last></author>
+      <author><first>Zhiyi</first><last>Luo</last></author>
+      <author><first>Kenny</first><last>Zhu</last></author>
       <pages>160–165</pages>
       <url>W17-4421</url>
       <doi>10.18653/v1/W17-4421</doi>
@@ -7220,8 +7220,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="22">
       <title>Transfer Learning and Sentence Level Features for Named Entity Recognition on Tweets</title>
-      <author><first>Pius</first> <last>von Däniken</last></author>
-      <author><first>Mark</first> <last>Cieliebak</last></author>
+      <author><first>Pius</first><last>von Däniken</last></author>
+      <author><first>Mark</first><last>Cieliebak</last></author>
       <pages>166–171</pages>
       <url>W17-4422</url>
       <doi>10.18653/v1/W17-4422</doi>
@@ -7229,8 +7229,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="23">
       <title>Context-Sensitive Recognition for Emerging and Rare Entities</title>
-      <author><first>Jake</first> <last>Williams</last></author>
-      <author><first>Giovanni</first> <last>Santia</last></author>
+      <author><first>Jake</first><last>Williams</last></author>
+      <author><first>Giovanni</first><last>Santia</last></author>
       <pages>172–176</pages>
       <url>W17-4423</url>
       <doi>10.18653/v1/W17-4423</doi>
@@ -7238,8 +7238,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="24">
       <title>A Feature-based Ensemble Approach to Recognition of Emerging and Rare Named Entities</title>
-      <author><first>Utpal Kumar</first> <last>Sikdar</last></author>
-      <author><first>Björn</first> <last>Gambäck</last></author>
+      <author><first>Utpal Kumar</first><last>Sikdar</last></author>
+      <author><first>Björn</first><last>Gambäck</last></author>
       <pages>177–181</pages>
       <url>W17-4424</url>
       <doi>10.18653/v1/W17-4424</doi>
@@ -7265,8 +7265,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Video Highlights Detection and Summarization with Lag-Calibration based on Concept-Emotion Mapping of Crowdsourced Time-Sync Comments</title>
-      <author><first>Qing</first> <last>Ping</last></author>
-      <author><first>Chaomei</first> <last>Chen</last></author>
+      <author><first>Qing</first><last>Ping</last></author>
+      <author><first>Chaomei</first><last>Chen</last></author>
       <pages>1–11</pages>
       <url>W17-4501</url>
       <doi>10.18653/v1/W17-4501</doi>
@@ -7274,8 +7274,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Multimedia Summary Generation from Online Conversations: Current Approaches and Future Directions</title>
-      <author><first>Enamul</first> <last>Hoque</last></author>
-      <author><first>Giuseppe</first> <last>Carenini</last></author>
+      <author><first>Enamul</first><last>Hoque</last></author>
+      <author><first>Giuseppe</first><last>Carenini</last></author>
       <pages>12–19</pages>
       <url>W17-4502</url>
       <doi>10.18653/v1/W17-4502</doi>
@@ -7283,8 +7283,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Low-Resource Neural Headline Generation</title>
-      <author><first>Ottokar</first> <last>Tilk</last></author>
-      <author><first>Tanel</first> <last>Alumäe</last></author>
+      <author><first>Ottokar</first><last>Tilk</last></author>
+      <author><first>Tanel</first><last>Alumäe</last></author>
       <pages>20–26</pages>
       <url>W17-4503</url>
       <doi>10.18653/v1/W17-4503</doi>
@@ -7292,9 +7292,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Towards Improving Abstractive Summarization via Entailment Generation</title>
-      <author><first>Ramakanth</first> <last>Pasunuru</last></author>
-      <author><first>Han</first> <last>Guo</last></author>
-      <author><first>Mohit</first> <last>Bansal</last></author>
+      <author><first>Ramakanth</first><last>Pasunuru</last></author>
+      <author><first>Han</first><last>Guo</last></author>
+      <author><first>Mohit</first><last>Bansal</last></author>
       <pages>27–32</pages>
       <url>W17-4504</url>
       <doi>10.18653/v1/W17-4504</doi>
@@ -7302,8 +7302,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Coarse-to-Fine Attention Models for Document Summarization</title>
-      <author><first>Jeffrey</first> <last>Ling</last></author>
-      <author><first>Alexander</first> <last>Rush</last></author>
+      <author><first>Jeffrey</first><last>Ling</last></author>
+      <author><first>Alexander</first><last>Rush</last></author>
       <pages>33–42</pages>
       <url>W17-4505</url>
       <doi>10.18653/v1/W17-4505</doi>
@@ -7311,11 +7311,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Automatic Community Creation for Abstractive Spoken Conversations Summarization</title>
-      <author><first>Karan</first> <last>Singla</last></author>
-      <author><first>Evgeny</first> <last>Stepanov</last></author>
-      <author><first>Ali Orkan</first> <last>Bayer</last></author>
-      <author><first>Giuseppe</first> <last>Carenini</last></author>
-      <author><first>Giuseppe</first> <last>Riccardi</last></author>
+      <author><first>Karan</first><last>Singla</last></author>
+      <author><first>Evgeny</first><last>Stepanov</last></author>
+      <author><first>Ali Orkan</first><last>Bayer</last></author>
+      <author><first>Giuseppe</first><last>Carenini</last></author>
+      <author><first>Giuseppe</first><last>Riccardi</last></author>
       <pages>43–47</pages>
       <url>W17-4506</url>
       <doi>10.18653/v1/W17-4506</doi>
@@ -7323,9 +7323,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Combining Graph Degeneracy and Submodularity for Unsupervised Extractive Summarization</title>
-      <author><first>Antoine</first> <last>Tixier</last></author>
-      <author><first>Polykarpos</first> <last>Meladianos</last></author>
-      <author><first>Michalis</first> <last>Vazirgiannis</last></author>
+      <author><first>Antoine</first><last>Tixier</last></author>
+      <author><first>Polykarpos</first><last>Meladianos</last></author>
+      <author><first>Michalis</first><last>Vazirgiannis</last></author>
       <pages>48–58</pages>
       <url>W17-4507</url>
       <doi>10.18653/v1/W17-4507</doi>
@@ -7333,10 +7333,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title><fixed-case>TL</fixed-case>;<fixed-case>DR</fixed-case>: Mining <fixed-case>R</fixed-case>eddit to Learn Automatic Summarization</title>
-      <author><first>Michael</first> <last>Völske</last></author>
-      <author><first>Martin</first> <last>Potthast</last></author>
-      <author><first>Shahbaz</first> <last>Syed</last></author>
-      <author><first>Benno</first> <last>Stein</last></author>
+      <author><first>Michael</first><last>Völske</last></author>
+      <author><first>Martin</first><last>Potthast</last></author>
+      <author><first>Shahbaz</first><last>Syed</last></author>
+      <author><first>Benno</first><last>Stein</last></author>
       <pages>59–63</pages>
       <url>W17-4508</url>
       <doi>10.18653/v1/W17-4508</doi>
@@ -7344,8 +7344,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Topic Model Stability for Hierarchical Summarization</title>
-      <author><first>John</first> <last>Miller</last></author>
-      <author><first>Kathleen</first> <last>McCoy</last></author>
+      <author><first>John</first><last>Miller</last></author>
+      <author><first>Kathleen</first><last>McCoy</last></author>
       <pages>64–73</pages>
       <url>W17-4509</url>
       <doi>10.18653/v1/W17-4509</doi>
@@ -7354,9 +7354,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Learning to Score System Summaries for Better Content Selection Evaluation.</title>
-      <author><first>Maxime</first> <last>Peyrard</last></author>
-      <author><first>Teresa</first> <last>Botschen</last></author>
-      <author><first>Iryna</first> <last>Gurevych</last></author>
+      <author><first>Maxime</first><last>Peyrard</last></author>
+      <author><first>Teresa</first><last>Botschen</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
       <pages>74–84</pages>
       <url>W17-4510</url>
       <doi>10.18653/v1/W17-4510</doi>
@@ -7364,7 +7364,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Revisiting the Centroid-based Method: A Strong Baseline for Multi-Document Summarization</title>
-      <author><first>Demian</first> <last>Gholipour Ghalandari</last></author>
+      <author><first>Demian</first><last>Gholipour Ghalandari</last></author>
       <pages>85–90</pages>
       <url>W17-4511</url>
       <doi>10.18653/v1/W17-4511</doi>
@@ -7372,9 +7372,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Reader-Aware Multi-Document Summarization: An Enhanced Model and The First Dataset</title>
-      <author><first>Piji</first> <last>Li</last></author>
-      <author><first>Lidong</first> <last>Bing</last></author>
-      <author><first>Wai</first> <last>Lam</last></author>
+      <author><first>Piji</first><last>Li</last></author>
+      <author><first>Lidong</first><last>Bing</last></author>
+      <author><first>Wai</first><last>Lam</last></author>
       <pages>91–99</pages>
       <url>W17-4512</url>
       <doi>10.18653/v1/W17-4512</doi>
@@ -7382,8 +7382,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>A Pilot Study of Domain Adaptation Effect for Neural Abstractive Summarization</title>
-      <author><first>Xinyu</first> <last>Hua</last></author>
-      <author><first>Lu</first> <last>Wang</last></author>
+      <author><first>Xinyu</first><last>Hua</last></author>
+      <author><first>Lu</first><last>Wang</last></author>
       <pages>100–106</pages>
       <url>W17-4513</url>
       <doi>10.18653/v1/W17-4513</doi>
@@ -7407,10 +7407,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Functions of Silences towards Information Flow in Spoken Conversation</title>
-      <author><first>Shammur Absar</first> <last>Chowdhury</last></author>
-      <author><first>Evgeny</first> <last>Stepanov</last></author>
-      <author><first>Morena</first> <last>Danieli</last></author>
-      <author><first>Giuseppe</first> <last>Riccardi</last></author>
+      <author><first>Shammur Absar</first><last>Chowdhury</last></author>
+      <author><first>Evgeny</first><last>Stepanov</last></author>
+      <author><first>Morena</first><last>Danieli</last></author>
+      <author><first>Giuseppe</first><last>Riccardi</last></author>
       <pages>1–9</pages>
       <url>W17-4601</url>
       <doi>10.18653/v1/W17-4601</doi>
@@ -7418,8 +7418,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Encoding Word Confusion Networks with Recurrent Neural Networks for Dialog State Tracking</title>
-      <author><first>Glorianna</first> <last>Jagfeld</last></author>
-      <author><first>Ngoc Thang</first> <last>Vu</last></author>
+      <author><first>Glorianna</first><last>Jagfeld</last></author>
+      <author><first>Ngoc Thang</first><last>Vu</last></author>
       <pages>10–17</pages>
       <url>W17-4602</url>
       <doi>10.18653/v1/W17-4602</doi>
@@ -7427,8 +7427,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Analyzing Human and Machine Performance In Resolving Ambiguous Spoken Sentences</title>
-      <author><first>Hussein</first> <last>Ghaly</last></author>
-      <author><first>Michael</first> <last>Mandel</last></author>
+      <author><first>Hussein</first><last>Ghaly</last></author>
+      <author><first>Michael</first><last>Mandel</last></author>
       <pages>18–26</pages>
       <url>W17-4603</url>
       <doi>10.18653/v1/W17-4603</doi>
@@ -7437,9 +7437,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Parsing transcripts of speech</title>
-      <author><first>Andrew</first> <last>Caines</last></author>
-      <author><first>Michael</first> <last>McCarthy</last></author>
-      <author><first>Paula</first> <last>Buttery</last></author>
+      <author><first>Andrew</first><last>Caines</last></author>
+      <author><first>Michael</first><last>McCarthy</last></author>
+      <author><first>Paula</first><last>Buttery</last></author>
       <pages>27–36</pages>
       <url>W17-4604</url>
       <doi>10.18653/v1/W17-4604</doi>
@@ -7447,8 +7447,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Enriching <fixed-case>ASR</fixed-case> Lattices with <fixed-case>POS</fixed-case> Tags for Dependency Parsing</title>
-      <author><first>Moritz</first> <last>Stiefel</last></author>
-      <author><first>Ngoc Thang</first> <last>Vu</last></author>
+      <author><first>Moritz</first><last>Stiefel</last></author>
+      <author><first>Ngoc Thang</first><last>Vu</last></author>
       <pages>37–47</pages>
       <url>W17-4605</url>
       <doi>10.18653/v1/W17-4605</doi>
@@ -7456,10 +7456,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>End-to-End Information Extraction without Token-Level Supervision</title>
-      <author><first>Rasmus Berg</first> <last>Palm</last></author>
-      <author><first>Dirk</first> <last>Hovy</last></author>
-      <author><first>Florian</first> <last>Laws</last></author>
-      <author><first>Ole</first> <last>Winther</last></author>
+      <author><first>Rasmus Berg</first><last>Palm</last></author>
+      <author><first>Dirk</first><last>Hovy</last></author>
+      <author><first>Florian</first><last>Laws</last></author>
+      <author><first>Ole</first><last>Winther</last></author>
       <pages>48–52</pages>
       <url>W17-4606</url>
       <doi>10.18653/v1/W17-4606</doi>
@@ -7467,11 +7467,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Spoken Term Discovery for Language Documentation using Translations</title>
-      <author><first>Antonios</first> <last>Anastasopoulos</last></author>
-      <author><first>Sameer</first> <last>Bansal</last></author>
-      <author><first>David</first> <last>Chiang</last></author>
-      <author><first>Sharon</first> <last>Goldwater</last></author>
-      <author><first>Adam</first> <last>Lopez</last></author>
+      <author><first>Antonios</first><last>Anastasopoulos</last></author>
+      <author><first>Sameer</first><last>Bansal</last></author>
+      <author><first>David</first><last>Chiang</last></author>
+      <author><first>Sharon</first><last>Goldwater</last></author>
+      <author><first>Adam</first><last>Lopez</last></author>
       <pages>53–58</pages>
       <url>W17-4607</url>
       <doi>10.18653/v1/W17-4607</doi>
@@ -7479,9 +7479,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title><fixed-case>A</fixed-case>mharic-<fixed-case>E</fixed-case>nglish Speech Translation in Tourism Domain</title>
-      <author><first>Michael</first> <last>Melese</last></author>
-      <author><first>Laurent</first> <last>Besacier</last></author>
-      <author><first>Million</first> <last>Meshesha</last></author>
+      <author><first>Michael</first><last>Melese</last></author>
+      <author><first>Laurent</first><last>Besacier</last></author>
+      <author><first>Million</first><last>Meshesha</last></author>
       <pages>59–66</pages>
       <url>W17-4608</url>
       <doi>10.18653/v1/W17-4608</doi>
@@ -7489,9 +7489,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Speech- and Text-driven Features for Automated Scoring of <fixed-case>E</fixed-case>nglish Speaking Tasks</title>
-      <author><first>Anastassia</first> <last>Loukina</last></author>
-      <author><first>Nitin</first> <last>Madnani</last></author>
-      <author><first>Aoife</first> <last>Cahill</last></author>
+      <author><first>Anastassia</first><last>Loukina</last></author>
+      <author><first>Nitin</first><last>Madnani</last></author>
+      <author><first>Aoife</first><last>Cahill</last></author>
       <pages>67–77</pages>
       <url>W17-4609</url>
       <doi>10.18653/v1/W17-4609</doi>
@@ -7499,10 +7499,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Improving coreference resolution with automatically predicted prosodic information</title>
-      <author><first>Ina</first> <last>Roesiger</last></author>
-      <author><first>Sabrina</first> <last>Stehwien</last></author>
-      <author><first>Arndt</first> <last>Riester</last></author>
-      <author><first>Ngoc Thang</first> <last>Vu</last></author>
+      <author><first>Ina</first><last>Roesiger</last></author>
+      <author><first>Sabrina</first><last>Stehwien</last></author>
+      <author><first>Arndt</first><last>Riester</last></author>
+      <author><first>Ngoc Thang</first><last>Vu</last></author>
       <pages>78–83</pages>
       <url>W17-4610</url>
       <doi>10.18653/v1/W17-4610</doi>
@@ -7534,456 +7534,456 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Sense-Aware Statistical Machine Translation using Adaptive Context-Dependent Clustering</title>
-      <author><first>Xiao</first> <last>Pu</last></author>
-      <author><first>Nikolaos</first> <last>Pappas</last></author>
-      <author><first>Andrei</first> <last>Popescu-Belis</last></author>
+      <author><first>Xiao</first><last>Pu</last></author>
+      <author><first>Nikolaos</first><last>Pappas</last></author>
+      <author><first>Andrei</first><last>Popescu-Belis</last></author>
       <pages>1–10</pages>
       <url>W17-4701</url>
       <doi>10.18653/v1/W17-4701</doi>
     </paper>
     <paper id="2">
       <title>Improving Word Sense Disambiguation in Neural Machine Translation with Sense Embeddings</title>
-      <author><first>Annette</first> <last>Rios Gonzales</last></author>
-      <author><first>Laura</first> <last>Mascarell</last></author>
-      <author><first>Rico</first> <last>Sennrich</last></author>
+      <author><first>Annette</first><last>Rios Gonzales</last></author>
+      <author><first>Laura</first><last>Mascarell</last></author>
+      <author><first>Rico</first><last>Sennrich</last></author>
       <pages>11–19</pages>
       <url>W17-4702</url>
       <doi>10.18653/v1/W17-4702</doi>
     </paper>
     <paper id="3">
       <title>Word Representations in Factored Neural Machine Translation</title>
-      <author><first>Franck</first> <last>Burlot</last></author>
-      <author><first>Mercedes</first> <last>García-Martínez</last></author>
-      <author><first>Loïc</first> <last>Barrault</last></author>
-      <author><first>Fethi</first> <last>Bougares</last></author>
-      <author><first>François</first> <last>Yvon</last></author>
+      <author><first>Franck</first><last>Burlot</last></author>
+      <author><first>Mercedes</first><last>García-Martínez</last></author>
+      <author><first>Loïc</first><last>Barrault</last></author>
+      <author><first>Fethi</first><last>Bougares</last></author>
+      <author><first>François</first><last>Yvon</last></author>
       <pages>20–31</pages>
       <url>W17-4703</url>
       <doi>10.18653/v1/W17-4703</doi>
     </paper>
     <paper id="4">
       <title>Modeling Target-Side Inflection in Neural Machine Translation</title>
-      <author><first>Aleš</first> <last>Tamchyna</last></author>
-      <author><first>Marion</first> <last>Weller-Di Marco</last></author>
-      <author><first>Alexander</first> <last>Fraser</last></author>
+      <author><first>Aleš</first><last>Tamchyna</last></author>
+      <author><first>Marion</first><last>Weller-Di Marco</last></author>
+      <author><first>Alexander</first><last>Fraser</last></author>
       <pages>32–42</pages>
       <url>W17-4704</url>
       <doi>10.18653/v1/W17-4704</doi>
     </paper>
     <paper id="5">
       <title>Evaluating the morphological competence of Machine Translation Systems</title>
-      <author><first>Franck</first> <last>Burlot</last></author>
-      <author><first>François</first> <last>Yvon</last></author>
+      <author><first>Franck</first><last>Burlot</last></author>
+      <author><first>François</first><last>Yvon</last></author>
       <pages>43–55</pages>
       <url>W17-4705</url>
       <doi>10.18653/v1/W17-4705</doi>
     </paper>
     <paper id="6">
       <title>Target-side Word Segmentation Strategies for Neural Machine Translation</title>
-      <author><first>Matthias</first> <last>Huck</last></author>
-      <author><first>Simon</first> <last>Riess</last></author>
-      <author><first>Alexander</first> <last>Fraser</last></author>
+      <author><first>Matthias</first><last>Huck</last></author>
+      <author><first>Simon</first><last>Riess</last></author>
+      <author><first>Alexander</first><last>Fraser</last></author>
       <pages>56–67</pages>
       <url>W17-4706</url>
       <doi>10.18653/v1/W17-4706</doi>
     </paper>
     <paper id="7">
       <title>Predicting Target Language <fixed-case>CCG</fixed-case> Supertags Improves Neural Machine Translation</title>
-      <author><first>Maria</first> <last>Nădejde</last></author>
-      <author><first>Siva</first> <last>Reddy</last></author>
-      <author><first>Rico</first> <last>Sennrich</last></author>
-      <author><first>Tomasz</first> <last>Dwojak</last></author>
-      <author><first>Marcin</first> <last>Junczys-Dowmunt</last></author>
-      <author><first>Philipp</first> <last>Koehn</last></author>
-      <author><first>Alexandra</first> <last>Birch</last></author>
+      <author><first>Maria</first><last>Nădejde</last></author>
+      <author><first>Siva</first><last>Reddy</last></author>
+      <author><first>Rico</first><last>Sennrich</last></author>
+      <author><first>Tomasz</first><last>Dwojak</last></author>
+      <author><first>Marcin</first><last>Junczys-Dowmunt</last></author>
+      <author><first>Philipp</first><last>Koehn</last></author>
+      <author><first>Alexandra</first><last>Birch</last></author>
       <pages>68–79</pages>
       <url>W17-4707</url>
       <doi>10.18653/v1/W17-4707</doi>
     </paper>
     <paper id="8">
       <title>Exploiting Linguistic Resources for Neural Machine Translation Using Multi-task Learning</title>
-      <author><first>Jan</first> <last>Niehues</last></author>
-      <author><first>Eunah</first> <last>Cho</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Eunah</first><last>Cho</last></author>
       <pages>80–89</pages>
       <url>W17-4708</url>
       <doi>10.18653/v1/W17-4708</doi>
     </paper>
     <paper id="9">
       <title>Tree as a Pivot: Syntactic Matching Methods in Pivot Translation</title>
-      <author><first>Akiva</first> <last>Miura</last></author>
-      <author><first>Graham</first> <last>Neubig</last></author>
-      <author><first>Katsuhito</first> <last>Sudoh</last></author>
-      <author><first>Satoshi</first> <last>Nakamura</last></author>
+      <author><first>Akiva</first><last>Miura</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <author><first>Katsuhito</first><last>Sudoh</last></author>
+      <author><first>Satoshi</first><last>Nakamura</last></author>
       <pages>90–98</pages>
       <url>W17-4709</url>
       <doi>10.18653/v1/W17-4709</doi>
     </paper>
     <paper id="10">
       <title>Deep architectures for Neural Machine Translation</title>
-      <author><first>Antonio Valerio</first> <last>Miceli Barone</last></author>
-      <author><first>Jindřich</first> <last>Helcl</last></author>
-      <author><first>Rico</first> <last>Sennrich</last></author>
-      <author><first>Barry</first> <last>Haddow</last></author>
-      <author><first>Alexandra</first> <last>Birch</last></author>
+      <author><first>Antonio Valerio</first><last>Miceli Barone</last></author>
+      <author><first>Jindřich</first><last>Helcl</last></author>
+      <author><first>Rico</first><last>Sennrich</last></author>
+      <author><first>Barry</first><last>Haddow</last></author>
+      <author><first>Alexandra</first><last>Birch</last></author>
       <pages>99–107</pages>
       <url>W17-4710</url>
       <doi>10.18653/v1/W17-4710</doi>
     </paper>
     <paper id="11">
       <title>Biasing Attention-Based Recurrent Neural Networks Using External Alignment Information</title>
-      <author><first>Tamer</first> <last>Alkhouli</last></author>
-      <author><first>Hermann</first> <last>Ney</last></author>
+      <author><first>Tamer</first><last>Alkhouli</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
       <pages>108–117</pages>
       <url>W17-4711</url>
       <doi>10.18653/v1/W17-4711</doi>
     </paper>
     <paper id="12">
       <title>Effective Domain Mixing for Neural Machine Translation</title>
-      <author><first>Denny</first> <last>Britz</last></author>
-      <author><first>Quoc</first> <last>Le</last></author>
-      <author><first>Reid</first> <last>Pryzant</last></author>
+      <author><first>Denny</first><last>Britz</last></author>
+      <author><first>Quoc</first><last>Le</last></author>
+      <author><first>Reid</first><last>Pryzant</last></author>
       <pages>118–126</pages>
       <url>W17-4712</url>
       <doi>10.18653/v1/W17-4712</doi>
     </paper>
     <paper id="13">
       <title>Multi-Domain Neural Machine Translation through Unsupervised Adaptation</title>
-      <author><first>M. Amin</first> <last>Farajian</last></author>
-      <author><first>Marco</first> <last>Turchi</last></author>
-      <author><first>Matteo</first> <last>Negri</last></author>
-      <author><first>Marcello</first> <last>Federico</last></author>
+      <author><first>M. Amin</first><last>Farajian</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
+      <author><first>Matteo</first><last>Negri</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
       <pages>127–137</pages>
       <url>W17-4713</url>
       <doi>10.18653/v1/W17-4713</doi>
     </paper>
     <paper id="14">
       <title>Adapting Neural Machine Translation with Parallel Synthetic Data</title>
-      <author><first>Mara</first> <last>Chinea-Ríos</last></author>
-      <author><first>Álvaro</first> <last>Peris</last></author>
-      <author><first>Francisco</first> <last>Casacuberta</last></author>
+      <author><first>Mara</first><last>Chinea-Ríos</last></author>
+      <author><first>Álvaro</first><last>Peris</last></author>
+      <author><first>Francisco</first><last>Casacuberta</last></author>
       <pages>138–147</pages>
       <url>W17-4714</url>
       <doi>10.18653/v1/W17-4714</doi>
     </paper>
     <paper id="15">
       <title>Copied Monolingual Data Improves Low-Resource Neural Machine Translation</title>
-      <author><first>Anna</first> <last>Currey</last></author>
-      <author><first>Antonio Valerio</first> <last>Miceli Barone</last></author>
-      <author><first>Kenneth</first> <last>Heafield</last></author>
+      <author><first>Anna</first><last>Currey</last></author>
+      <author><first>Antonio Valerio</first><last>Miceli Barone</last></author>
+      <author><first>Kenneth</first><last>Heafield</last></author>
       <pages>148–156</pages>
       <url>W17-4715</url>
       <doi>10.18653/v1/W17-4715</doi>
     </paper>
     <paper id="16">
       <title>Guiding Neural Machine Translation Decoding with External Knowledge</title>
-      <author><first>Rajen</first> <last>Chatterjee</last></author>
-      <author><first>Matteo</first> <last>Negri</last></author>
-      <author><first>Marco</first> <last>Turchi</last></author>
-      <author><first>Marcello</first> <last>Federico</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
-      <author><first>Frédéric</first> <last>Blain</last></author>
+      <author><first>Rajen</first><last>Chatterjee</last></author>
+      <author><first>Matteo</first><last>Negri</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
+      <author><first>Frédéric</first><last>Blain</last></author>
       <pages>157–168</pages>
       <url>W17-4716</url>
       <doi>10.18653/v1/W17-4716</doi>
     </paper>
     <paper id="17">
       <title>Findings of the 2017 Conference on Machine Translation (<fixed-case>WMT</fixed-case>17)</title>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
-      <author><first>Rajen</first> <last>Chatterjee</last></author>
-      <author><first>Christian</first> <last>Federmann</last></author>
-      <author><first>Yvette</first> <last>Graham</last></author>
-      <author><first>Barry</first> <last>Haddow</last></author>
-      <author><first>Shujian</first> <last>Huang</last></author>
-      <author><first>Matthias</first> <last>Huck</last></author>
-      <author><first>Philipp</first> <last>Koehn</last></author>
-      <author><first>Qun</first> <last>Liu</last></author>
-      <author><first>Varvara</first> <last>Logacheva</last></author>
-      <author><first>Christof</first> <last>Monz</last></author>
-      <author><first>Matteo</first> <last>Negri</last></author>
-      <author><first>Matt</first> <last>Post</last></author>
-      <author><first>Raphael</first> <last>Rubino</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
-      <author><first>Marco</first> <last>Turchi</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
+      <author><first>Rajen</first><last>Chatterjee</last></author>
+      <author><first>Christian</first><last>Federmann</last></author>
+      <author><first>Yvette</first><last>Graham</last></author>
+      <author><first>Barry</first><last>Haddow</last></author>
+      <author><first>Shujian</first><last>Huang</last></author>
+      <author><first>Matthias</first><last>Huck</last></author>
+      <author><first>Philipp</first><last>Koehn</last></author>
+      <author><first>Qun</first><last>Liu</last></author>
+      <author><first>Varvara</first><last>Logacheva</last></author>
+      <author><first>Christof</first><last>Monz</last></author>
+      <author><first>Matteo</first><last>Negri</last></author>
+      <author><first>Matt</first><last>Post</last></author>
+      <author><first>Raphael</first><last>Rubino</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
       <pages>169–214</pages>
       <url>W17-4717</url>
       <doi>10.18653/v1/W17-4717</doi>
     </paper>
     <paper id="18">
       <title>Findings of the Second Shared Task on Multimodal Machine Translation and Multilingual Image Description</title>
-      <author><first>Desmond</first> <last>Elliott</last></author>
-      <author><first>Stella</first> <last>Frank</last></author>
-      <author><first>Loïc</first> <last>Barrault</last></author>
-      <author><first>Fethi</first> <last>Bougares</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
+      <author><first>Desmond</first><last>Elliott</last></author>
+      <author><first>Stella</first><last>Frank</last></author>
+      <author><first>Loïc</first><last>Barrault</last></author>
+      <author><first>Fethi</first><last>Bougares</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
       <pages>215–233</pages>
       <url>W17-4718</url>
       <doi>10.18653/v1/W17-4718</doi>
     </paper>
     <paper id="19">
       <title>Findings of the <fixed-case>WMT</fixed-case> 2017 Biomedical Translation Shared Task</title>
-      <author><first>Antonio</first> <last>Jimeno Yepes</last></author>
-      <author><first>Aurélie</first> <last>Névéol</last></author>
-      <author><first>Mariana</first> <last>Neves</last></author>
-      <author><first>Karin</first> <last>Verspoor</last></author>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
-      <author><first>Arthur</first> <last>Boyer</last></author>
-      <author><first>Cristian</first> <last>Grozea</last></author>
-      <author><first>Barry</first> <last>Haddow</last></author>
-      <author><first>Madeleine</first> <last>Kittner</last></author>
-      <author><first>Yvonne</first> <last>Lichtblau</last></author>
-      <author><first>Pavel</first> <last>Pecina</last></author>
-      <author><first>Roland</first> <last>Roller</last></author>
-      <author><first>Rudolf</first> <last>Rosa</last></author>
-      <author><first>Amy</first> <last>Siu</last></author>
-      <author><first>Philippe</first> <last>Thomas</last></author>
-      <author><first>Saskia</first> <last>Trescher</last></author>
+      <author><first>Antonio</first><last>Jimeno Yepes</last></author>
+      <author><first>Aurélie</first><last>Névéol</last></author>
+      <author><first>Mariana</first><last>Neves</last></author>
+      <author><first>Karin</first><last>Verspoor</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
+      <author><first>Arthur</first><last>Boyer</last></author>
+      <author><first>Cristian</first><last>Grozea</last></author>
+      <author><first>Barry</first><last>Haddow</last></author>
+      <author><first>Madeleine</first><last>Kittner</last></author>
+      <author><first>Yvonne</first><last>Lichtblau</last></author>
+      <author><first>Pavel</first><last>Pecina</last></author>
+      <author><first>Roland</first><last>Roller</last></author>
+      <author><first>Rudolf</first><last>Rosa</last></author>
+      <author><first>Amy</first><last>Siu</last></author>
+      <author><first>Philippe</first><last>Thomas</last></author>
+      <author><first>Saskia</first><last>Trescher</last></author>
       <pages>234–247</pages>
       <url>W17-4719</url>
       <doi>10.18653/v1/W17-4719</doi>
     </paper>
     <paper id="20">
       <title><fixed-case>CUNI</fixed-case> submission in <fixed-case>WMT</fixed-case>17: Chimera goes neural</title>
-      <author><first>Roman</first> <last>Sudarikov</last></author>
-      <author><first>David</first> <last>Mareček</last></author>
-      <author><first>Tom</first> <last>Kocmi</last></author>
-      <author><first>Dušan</first> <last>Variš</last></author>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
+      <author><first>Roman</first><last>Sudarikov</last></author>
+      <author><first>David</first><last>Mareček</last></author>
+      <author><first>Tom</first><last>Kocmi</last></author>
+      <author><first>Dušan</first><last>Variš</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
       <pages>248–256</pages>
       <url>W17-4720</url>
       <doi>10.18653/v1/W17-4720</doi>
     </paper>
     <paper id="21">
       <title>LIMSI@WMT’17</title>
-      <author><first>Franck</first> <last>Burlot</last></author>
-      <author><first>Pooyan</first> <last>Safari</last></author>
-      <author><first>Matthieu</first> <last>Labeau</last></author>
-      <author><first>Alexandre</first> <last>Allauzen</last></author>
-      <author><first>François</first> <last>Yvon</last></author>
+      <author><first>Franck</first><last>Burlot</last></author>
+      <author><first>Pooyan</first><last>Safari</last></author>
+      <author><first>Matthieu</first><last>Labeau</last></author>
+      <author><first>Alexandre</first><last>Allauzen</last></author>
+      <author><first>François</first><last>Yvon</last></author>
       <pages>257–264</pages>
       <url>W17-4721</url>
       <doi>10.18653/v1/W17-4721</doi>
     </paper>
     <paper id="22">
       <title><fixed-case>SYSTRAN</fixed-case> Purely Neural <fixed-case>MT</fixed-case> Engines for <fixed-case>WMT</fixed-case>2017</title>
-      <author><first>Yongchao</first> <last>Deng</last></author>
-      <author><first>Jungi</first> <last>Kim</last></author>
-      <author><first>Guillaume</first> <last>Klein</last></author>
-      <author><first>Catherine</first> <last>Kobus</last></author>
-      <author><first>Natalia</first> <last>Segal</last></author>
-      <author><first>Christophe</first> <last>Servan</last></author>
-      <author><first>Bo</first> <last>Wang</last></author>
-      <author><first>Dakun</first> <last>Zhang</last></author>
-      <author><first>Josep</first> <last>Crego</last></author>
-      <author><first>Jean</first> <last>Senellart</last></author>
+      <author><first>Yongchao</first><last>Deng</last></author>
+      <author><first>Jungi</first><last>Kim</last></author>
+      <author><first>Guillaume</first><last>Klein</last></author>
+      <author><first>Catherine</first><last>Kobus</last></author>
+      <author><first>Natalia</first><last>Segal</last></author>
+      <author><first>Christophe</first><last>Servan</last></author>
+      <author><first>Bo</first><last>Wang</last></author>
+      <author><first>Dakun</first><last>Zhang</last></author>
+      <author><first>Josep</first><last>Crego</last></author>
+      <author><first>Jean</first><last>Senellart</last></author>
       <pages>265–270</pages>
       <url>W17-4722</url>
       <doi>10.18653/v1/W17-4722</doi>
     </paper>
     <paper id="23">
       <title><fixed-case>FBK</fixed-case>’s Participation to the <fixed-case>E</fixed-case>nglish-to-<fixed-case>G</fixed-case>erman News Translation Task of <fixed-case>WMT</fixed-case> 2017</title>
-      <author><first>Mattia Antonino</first> <last>Di Gangi</last></author>
-      <author><first>Nicola</first> <last>Bertoldi</last></author>
-      <author><first>Marcello</first> <last>Federico</last></author>
+      <author><first>Mattia Antonino</first><last>Di Gangi</last></author>
+      <author><first>Nicola</first><last>Bertoldi</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
       <pages>271–275</pages>
       <url>W17-4723</url>
       <doi>10.18653/v1/W17-4723</doi>
     </paper>
     <paper id="24">
       <title>The <fixed-case>JHU</fixed-case> Machine Translation Systems for <fixed-case>WMT</fixed-case> 2017</title>
-      <author><first>Shuoyang</first> <last>Ding</last></author>
-      <author><first>Huda</first> <last>Khayrallah</last></author>
-      <author><first>Philipp</first> <last>Koehn</last></author>
-      <author><first>Matt</first> <last>Post</last></author>
-      <author><first>Gaurav</first> <last>Kumar</last></author>
-      <author><first>Kevin</first> <last>Duh</last></author>
+      <author><first>Shuoyang</first><last>Ding</last></author>
+      <author><first>Huda</first><last>Khayrallah</last></author>
+      <author><first>Philipp</first><last>Koehn</last></author>
+      <author><first>Matt</first><last>Post</last></author>
+      <author><first>Gaurav</first><last>Kumar</last></author>
+      <author><first>Kevin</first><last>Duh</last></author>
       <pages>276–282</pages>
       <url>W17-4724</url>
       <doi>10.18653/v1/W17-4724</doi>
     </paper>
     <paper id="25">
       <title>The <fixed-case>TALP</fixed-case>-<fixed-case>UPC</fixed-case> Neural Machine Translation System for <fixed-case>G</fixed-case>erman/<fixed-case>F</fixed-case>innish-<fixed-case>E</fixed-case>nglish Using the Inverse Direction Model in Rescoring</title>
-      <author><first>Carlos</first> <last>Escolano</last></author>
-      <author><first>Marta R.</first> <last>Costa-jussà</last></author>
-      <author><first>José A. R.</first> <last>Fonollosa</last></author>
+      <author><first>Carlos</first><last>Escolano</last></author>
+      <author><first>Marta R.</first><last>Costa-jussà</last></author>
+      <author><first>José A. R.</first><last>Fonollosa</last></author>
       <pages>283–287</pages>
       <url>W17-4725</url>
       <doi>10.18653/v1/W17-4725</doi>
     </paper>
     <paper id="26">
       <title><fixed-case>LIUM</fixed-case> Machine Translation Systems for <fixed-case>WMT</fixed-case>17 News Translation Task</title>
-      <author><first>Mercedes</first> <last>García-Martínez</last></author>
-      <author><first>Ozan</first> <last>Caglayan</last></author>
-      <author><first>Walid</first> <last>Aransa</last></author>
-      <author><first>Adrien</first> <last>Bardet</last></author>
-      <author><first>Fethi</first> <last>Bougares</last></author>
-      <author><first>Loïc</first> <last>Barrault</last></author>
+      <author><first>Mercedes</first><last>García-Martínez</last></author>
+      <author><first>Ozan</first><last>Caglayan</last></author>
+      <author><first>Walid</first><last>Aransa</last></author>
+      <author><first>Adrien</first><last>Bardet</last></author>
+      <author><first>Fethi</first><last>Bougares</last></author>
+      <author><first>Loïc</first><last>Barrault</last></author>
       <pages>288–295</pages>
       <url>W17-4726</url>
       <doi>10.18653/v1/W17-4726</doi>
     </paper>
     <paper id="27">
       <title>Extending hybrid word-character neural machine translation with multi-task learning of morphological analysis</title>
-      <author><first>Stig-Arne</first> <last>Grönroos</last></author>
-      <author><first>Sami</first> <last>Virpioja</last></author>
-      <author><first>Mikko</first> <last>Kurimo</last></author>
+      <author><first>Stig-Arne</first><last>Grönroos</last></author>
+      <author><first>Sami</first><last>Virpioja</last></author>
+      <author><first>Mikko</first><last>Kurimo</last></author>
       <pages>296–302</pages>
       <url>W17-4727</url>
       <doi>10.18653/v1/W17-4727</doi>
     </paper>
     <paper id="28">
       <title>The <fixed-case>AFRL-MITLL</fixed-case> <fixed-case>WMT17</fixed-case> Systems: Old, New, Borrowed, <fixed-case>BLEU</fixed-case></title>
-      <author><first>Jeremy</first> <last>Gwinnup</last></author>
-      <author><first>Timothy</first> <last>Anderson</last></author>
-      <author><first>Grant</first> <last>Erdmann</last></author>
-      <author><first>Katherine</first> <last>Young</last></author>
-      <author><first>Michaeel</first> <last>Kazi</last></author>
-      <author><first>Elizabeth</first> <last>Salesky</last></author>
-      <author><first>Brian</first> <last>Thompson</last></author>
-      <author><first>Jonathan</first> <last>Taylor</last></author>
+      <author><first>Jeremy</first><last>Gwinnup</last></author>
+      <author><first>Timothy</first><last>Anderson</last></author>
+      <author><first>Grant</first><last>Erdmann</last></author>
+      <author><first>Katherine</first><last>Young</last></author>
+      <author><first>Michaeel</first><last>Kazi</last></author>
+      <author><first>Elizabeth</first><last>Salesky</last></author>
+      <author><first>Brian</first><last>Thompson</last></author>
+      <author><first>Jonathan</first><last>Taylor</last></author>
       <pages>303–309</pages>
       <url>W17-4728</url>
       <doi>10.18653/v1/W17-4728</doi>
     </paper>
     <paper id="29">
       <title>University of Rochester <fixed-case>WMT</fixed-case> 2017 <fixed-case>NMT</fixed-case> System Submission</title>
-      <author><first>Chester</first> <last>Holtz</last></author>
-      <author><first>Chuyang</first> <last>Ke</last></author>
-      <author><first>Daniel</first> <last>Gildea</last></author>
+      <author><first>Chester</first><last>Holtz</last></author>
+      <author><first>Chuyang</first><last>Ke</last></author>
+      <author><first>Daniel</first><last>Gildea</last></author>
       <pages>310–314</pages>
       <url>W17-4729</url>
       <doi>10.18653/v1/W17-4729</doi>
     </paper>
     <paper id="30">
       <title><fixed-case>LMU</fixed-case> Munich’s Neural Machine Translation Systems for News Articles and Health Information Texts</title>
-      <author><first>Matthias</first> <last>Huck</last></author>
-      <author><first>Fabienne</first> <last>Braune</last></author>
-      <author><first>Alexander</first> <last>Fraser</last></author>
+      <author><first>Matthias</first><last>Huck</last></author>
+      <author><first>Fabienne</first><last>Braune</last></author>
+      <author><first>Alexander</first><last>Fraser</last></author>
       <pages>315–322</pages>
       <url>W17-4730</url>
       <doi>10.18653/v1/W17-4730</doi>
     </paper>
     <paper id="31">
       <title>Rule-based Machine translation from <fixed-case>E</fixed-case>nglish to <fixed-case>F</fixed-case>innish</title>
-      <author><first>Arvi</first> <last>Hurskainen</last></author>
-      <author><first>Jörg</first> <last>Tiedemann</last></author>
+      <author><first>Arvi</first><last>Hurskainen</last></author>
+      <author><first>Jörg</first><last>Tiedemann</last></author>
       <pages>323–329</pages>
       <url>W17-4731</url>
       <doi>10.18653/v1/W17-4731</doi>
     </paper>
     <paper id="32">
       <title><fixed-case>NRC</fixed-case> Machine Translation System for <fixed-case>WMT</fixed-case> 2017</title>
-      <author><first>Chi-kiu</first> <last>Lo</last></author>
-      <author><first>Boxing</first> <last>Chen</last></author>
-      <author><first>Colin</first> <last>Cherry</last></author>
-      <author><first>George</first> <last>Foster</last></author>
-      <author><first>Samuel</first> <last>Larkin</last></author>
-      <author><first>Darlene</first> <last>Stewart</last></author>
-      <author><first>Roland</first> <last>Kuhn</last></author>
+      <author><first>Chi-kiu</first><last>Lo</last></author>
+      <author><first>Boxing</first><last>Chen</last></author>
+      <author><first>Colin</first><last>Cherry</last></author>
+      <author><first>George</first><last>Foster</last></author>
+      <author><first>Samuel</first><last>Larkin</last></author>
+      <author><first>Darlene</first><last>Stewart</last></author>
+      <author><first>Roland</first><last>Kuhn</last></author>
       <pages>330–337</pages>
       <url>W17-4732</url>
       <doi>10.18653/v1/W17-4732</doi>
     </paper>
     <paper id="33">
       <title>The <fixed-case>H</fixed-case>elsinki Neural Machine Translation System</title>
-      <author><first>Robert</first> <last>Östling</last></author>
-      <author><first>Yves</first> <last>Scherrer</last></author>
-      <author><first>Jörg</first> <last>Tiedemann</last></author>
-      <author><first>Gongbo</first> <last>Tang</last></author>
-      <author><first>Tommi</first> <last>Nieminen</last></author>
+      <author><first>Robert</first><last>Östling</last></author>
+      <author><first>Yves</first><last>Scherrer</last></author>
+      <author><first>Jörg</first><last>Tiedemann</last></author>
+      <author><first>Gongbo</first><last>Tang</last></author>
+      <author><first>Tommi</first><last>Nieminen</last></author>
       <pages>338–347</pages>
       <url>W17-4733</url>
       <doi>10.18653/v1/W17-4733</doi>
     </paper>
     <paper id="34">
       <title>The <fixed-case>QT</fixed-case>21 Combined Machine Translation System for <fixed-case>E</fixed-case>nglish to <fixed-case>L</fixed-case>atvian</title>
-      <author><first>Jan-Thorsten</first> <last>Peter</last></author>
-      <author><first>Hermann</first> <last>Ney</last></author>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
-      <author><first>Ngoc-Quan</first> <last>Pham</last></author>
-      <author><first>Jan</first> <last>Niehues</last></author>
-      <author><first>Alex</first> <last>Waibel</last></author>
-      <author><first>Franck</first> <last>Burlot</last></author>
-      <author><first>François</first> <last>Yvon</last></author>
-      <author><first>Mārcis</first> <last>Pinnis</last></author>
-      <author><first>Valters</first> <last>Šics</last></author>
-      <author><first>Joost</first> <last>Bastings</last></author>
-      <author><first>Miguel</first> <last>Rios</last></author>
-      <author><first>Wilker</first> <last>Aziz</last></author>
-      <author><first>Philip</first> <last>Williams</last></author>
-      <author><first>Frédéric</first> <last>Blain</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
+      <author><first>Jan-Thorsten</first><last>Peter</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
+      <author><first>Ngoc-Quan</first><last>Pham</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <author><first>Franck</first><last>Burlot</last></author>
+      <author><first>François</first><last>Yvon</last></author>
+      <author><first>Mārcis</first><last>Pinnis</last></author>
+      <author><first>Valters</first><last>Šics</last></author>
+      <author><first>Joost</first><last>Bastings</last></author>
+      <author><first>Miguel</first><last>Rios</last></author>
+      <author><first>Wilker</first><last>Aziz</last></author>
+      <author><first>Philip</first><last>Williams</last></author>
+      <author><first>Frédéric</first><last>Blain</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
       <pages>348–357</pages>
       <url>W17-4734</url>
       <doi>10.18653/v1/W17-4734</doi>
     </paper>
     <paper id="35">
       <title>The <fixed-case>RWTH</fixed-case> Aachen University <fixed-case>E</fixed-case>nglish-<fixed-case>G</fixed-case>erman and <fixed-case>G</fixed-case>erman-<fixed-case>E</fixed-case>nglish Machine Translation System for <fixed-case>WMT</fixed-case> 2017</title>
-      <author><first>Jan-Thorsten</first> <last>Peter</last></author>
-      <author><first>Andreas</first> <last>Guta</last></author>
-      <author><first>Tamer</first> <last>Alkhouli</last></author>
-      <author><first>Parnia</first> <last>Bahar</last></author>
-      <author><first>Jan</first> <last>Rosendahl</last></author>
-      <author><first>Nick</first> <last>Rossenbach</last></author>
-      <author><first>Miguel</first> <last>Graça</last></author>
-      <author><first>Hermann</first> <last>Ney</last></author>
+      <author><first>Jan-Thorsten</first><last>Peter</last></author>
+      <author><first>Andreas</first><last>Guta</last></author>
+      <author><first>Tamer</first><last>Alkhouli</last></author>
+      <author><first>Parnia</first><last>Bahar</last></author>
+      <author><first>Jan</first><last>Rosendahl</last></author>
+      <author><first>Nick</first><last>Rossenbach</last></author>
+      <author><first>Miguel</first><last>Graça</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
       <pages>358–365</pages>
       <url>W17-4735</url>
       <doi>10.18653/v1/W17-4735</doi>
     </paper>
     <paper id="36">
       <title>The Karlsruhe Institute of Technology Systems for the News Translation Task in <fixed-case>WMT</fixed-case> 2017</title>
-      <author><first>Ngoc-Quan</first> <last>Pham</last></author>
-      <author><first>Jan</first> <last>Niehues</last></author>
-      <author><first>Thanh-Le</first> <last>Ha</last></author>
-      <author><first>Eunah</first> <last>Cho</last></author>
-      <author><first>Matthias</first> <last>Sperber</last></author>
-      <author><first>Alexander</first> <last>Waibel</last></author>
+      <author><first>Ngoc-Quan</first><last>Pham</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Thanh-Le</first><last>Ha</last></author>
+      <author><first>Eunah</first><last>Cho</last></author>
+      <author><first>Matthias</first><last>Sperber</last></author>
+      <author><first>Alexander</first><last>Waibel</last></author>
       <pages>366–373</pages>
       <url>W17-4736</url>
       <doi>10.18653/v1/W17-4736</doi>
     </paper>
     <paper id="37">
       <title>Tilde’s Machine Translation Systems for <fixed-case>WMT</fixed-case> 2017</title>
-      <author><first>Mārcis</first> <last>Pinnis</last></author>
-      <author><first>Rihards</first> <last>Krišlauks</last></author>
-      <author><first>Toms</first> <last>Miks</last></author>
-      <author><first>Daiga</first> <last>Deksne</last></author>
-      <author><first>Valters</first> <last>Šics</last></author>
+      <author><first>Mārcis</first><last>Pinnis</last></author>
+      <author><first>Rihards</first><last>Krišlauks</last></author>
+      <author><first>Toms</first><last>Miks</last></author>
+      <author><first>Daiga</first><last>Deksne</last></author>
+      <author><first>Valters</first><last>Šics</last></author>
       <pages>374–381</pages>
       <url>W17-4737</url>
       <doi>10.18653/v1/W17-4737</doi>
     </paper>
     <paper id="38">
       <title>C-3<fixed-case>MA</fixed-case>: Tartu-<fixed-case>R</fixed-case>iga-<fixed-case>Z</fixed-case>urich Translation Systems for <fixed-case>WMT</fixed-case>17</title>
-      <author><first>Matīss</first> <last>Rikters</last></author>
-      <author><first>Chantal</first> <last>Amrhein</last></author>
-      <author><first>Maksym</first> <last>Del</last></author>
-      <author><first>Mark</first> <last>Fishel</last></author>
+      <author><first>Matīss</first><last>Rikters</last></author>
+      <author><first>Chantal</first><last>Amrhein</last></author>
+      <author><first>Maksym</first><last>Del</last></author>
+      <author><first>Mark</first><last>Fishel</last></author>
       <pages>382–388</pages>
       <url>W17-4738</url>
       <doi>10.18653/v1/W17-4738</doi>
     </paper>
     <paper id="39">
       <title>The University of <fixed-case>E</fixed-case>dinburgh’s Neural <fixed-case>MT</fixed-case> Systems for <fixed-case>WMT</fixed-case>17</title>
-      <author><first>Rico</first> <last>Sennrich</last></author>
-      <author><first>Alexandra</first> <last>Birch</last></author>
-      <author><first>Anna</first> <last>Currey</last></author>
-      <author><first>Ulrich</first> <last>Germann</last></author>
-      <author><first>Barry</first> <last>Haddow</last></author>
-      <author><first>Kenneth</first> <last>Heafield</last></author>
-      <author><first>Antonio Valerio</first> <last>Miceli Barone</last></author>
-      <author><first>Philip</first> <last>Williams</last></author>
+      <author><first>Rico</first><last>Sennrich</last></author>
+      <author><first>Alexandra</first><last>Birch</last></author>
+      <author><first>Anna</first><last>Currey</last></author>
+      <author><first>Ulrich</first><last>Germann</last></author>
+      <author><first>Barry</first><last>Haddow</last></author>
+      <author><first>Kenneth</first><last>Heafield</last></author>
+      <author><first>Antonio Valerio</first><last>Miceli Barone</last></author>
+      <author><first>Philip</first><last>Williams</last></author>
       <pages>389–399</pages>
       <url>W17-4739</url>
       <doi>10.18653/v1/W17-4739</doi>
     </paper>
     <paper id="40">
       <title><fixed-case>XMU</fixed-case> Neural Machine Translation Systems for <fixed-case>WMT</fixed-case> 17</title>
-      <author><first>Zhixing</first> <last>Tan</last></author>
-      <author><first>Boli</first> <last>Wang</last></author>
-      <author><first>Jinming</first> <last>Hu</last></author>
-      <author><first>Yidong</first> <last>Chen</last></author>
-      <author><first>Xiaodong</first> <last>Shi</last></author>
+      <author><first>Zhixing</first><last>Tan</last></author>
+      <author><first>Boli</first><last>Wang</last></author>
+      <author><first>Jinming</first><last>Hu</last></author>
+      <author><first>Yidong</first><last>Chen</last></author>
+      <author><first>Xiaodong</first><last>Shi</last></author>
       <pages>400–404</pages>
       <url>W17-4740</url>
       <doi>10.18653/v1/W17-4740</doi>
@@ -7991,32 +7991,32 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="41">
       <title>The <fixed-case>JAIST</fixed-case> Machine Translation Systems for <fixed-case>WMT</fixed-case> 17</title>
-      <author><first>Hai-Long</first> <last>Trieu</last></author>
-      <author><first>Trung-Tin</first> <last>Pham</last></author>
-      <author><first>Le-Minh</first> <last>Nguyen</last></author>
+      <author><first>Hai-Long</first><last>Trieu</last></author>
+      <author><first>Trung-Tin</first><last>Pham</last></author>
+      <author><first>Le-Minh</first><last>Nguyen</last></author>
       <pages>405–409</pages>
       <url>W17-4741</url>
       <doi>10.18653/v1/W17-4741</doi>
     </paper>
     <paper id="42">
       <title>Sogou Neural Machine Translation Systems for <fixed-case>WMT</fixed-case>17</title>
-      <author><first>Yuguang</first> <last>Wang</last></author>
-      <author><first>Shanbo</first> <last>Cheng</last></author>
-      <author><first>Liyang</first> <last>Jiang</last></author>
-      <author><first>Jiajun</first> <last>Yang</last></author>
-      <author><first>Wei</first> <last>Chen</last></author>
-      <author><first>Muze</first> <last>Li</last></author>
-      <author><first>Lin</first> <last>Shi</last></author>
-      <author><first>Yanfeng</first> <last>Wang</last></author>
-      <author><first>Hongtao</first> <last>Yang</last></author>
+      <author><first>Yuguang</first><last>Wang</last></author>
+      <author><first>Shanbo</first><last>Cheng</last></author>
+      <author><first>Liyang</first><last>Jiang</last></author>
+      <author><first>Jiajun</first><last>Yang</last></author>
+      <author><first>Wei</first><last>Chen</last></author>
+      <author><first>Muze</first><last>Li</last></author>
+      <author><first>Lin</first><last>Shi</last></author>
+      <author><first>Yanfeng</first><last>Wang</last></author>
+      <author><first>Hongtao</first><last>Yang</last></author>
       <pages>410–415</pages>
       <url>W17-4742</url>
       <doi>10.18653/v1/W17-4742</doi>
     </paper>
     <paper id="43">
       <title><fixed-case>PJIIT</fixed-case>’s systems for <fixed-case>WMT</fixed-case> 2017 Conference</title>
-      <author><first>Krzysztof</first> <last>Wolk</last></author>
-      <author><first>Krzysztof</first> <last>Marasek</last></author>
+      <author><first>Krzysztof</first><last>Wolk</last></author>
+      <author><first>Krzysztof</first><last>Marasek</last></author>
       <pages>416–421</pages>
       <url>W17-4743</url>
       <doi>10.18653/v1/W17-4743</doi>
@@ -8024,296 +8024,296 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="44">
       <title>Hunter <fixed-case>MT</fixed-case>: A Course for Young Researchers in <fixed-case>WMT</fixed-case>17</title>
-      <author><first>Jia</first> <last>Xu</last></author>
-      <author><first>Yi Zong</first> <last>Kuang</last></author>
-      <author><first>Shondell</first> <last>Baijoo</last></author>
-      <author><first>Jacob Hyun</first> <last>Lee</last></author>
-      <author><first>Uman</first> <last>Shahzad</last></author>
-      <author><first>Mir</first> <last>Ahmed</last></author>
-      <author><first>Meredith</first> <last>Lancaster</last></author>
-      <author><first>Chris</first> <last>Carlan</last></author>
+      <author><first>Jia</first><last>Xu</last></author>
+      <author><first>Yi Zong</first><last>Kuang</last></author>
+      <author><first>Shondell</first><last>Baijoo</last></author>
+      <author><first>Jacob Hyun</first><last>Lee</last></author>
+      <author><first>Uman</first><last>Shahzad</last></author>
+      <author><first>Mir</first><last>Ahmed</last></author>
+      <author><first>Meredith</first><last>Lancaster</last></author>
+      <author><first>Chris</first><last>Carlan</last></author>
       <pages>422–427</pages>
       <url>W17-4744</url>
       <doi>10.18653/v1/W17-4744</doi>
     </paper>
     <paper id="45">
       <title><fixed-case>CASICT</fixed-case>-<fixed-case>DCU</fixed-case> Neural Machine Translation Systems for <fixed-case>WMT</fixed-case>17</title>
-      <author><first>Jinchao</first> <last>Zhang</last></author>
-      <author><first>Peerachet</first> <last>Porkaew</last></author>
-      <author><first>Jiawei</first> <last>Hu</last></author>
-      <author><first>Qiuye</first> <last>Zhao</last></author>
-      <author><first>Qun</first> <last>Liu</last></author>
+      <author><first>Jinchao</first><last>Zhang</last></author>
+      <author><first>Peerachet</first><last>Porkaew</last></author>
+      <author><first>Jiawei</first><last>Hu</last></author>
+      <author><first>Qiuye</first><last>Zhao</last></author>
+      <author><first>Qun</first><last>Liu</last></author>
       <pages>428–431</pages>
       <url>W17-4745</url>
       <doi>10.18653/v1/W17-4745</doi>
     </paper>
     <paper id="46">
       <title><fixed-case>LIUM</fixed-case>-<fixed-case>CVC</fixed-case> Submissions for <fixed-case>WMT</fixed-case>17 Multimodal Translation Task</title>
-      <author><first>Ozan</first> <last>Caglayan</last></author>
-      <author><first>Walid</first> <last>Aransa</last></author>
-      <author><first>Adrien</first> <last>Bardet</last></author>
-      <author><first>Mercedes</first> <last>García-Martínez</last></author>
-      <author><first>Fethi</first> <last>Bougares</last></author>
-      <author><first>Loïc</first> <last>Barrault</last></author>
-      <author><first>Marc</first> <last>Masana</last></author>
-      <author><first>Luis</first> <last>Herranz</last></author>
-      <author><first>Joost</first> <last>van de Weijer</last></author>
+      <author><first>Ozan</first><last>Caglayan</last></author>
+      <author><first>Walid</first><last>Aransa</last></author>
+      <author><first>Adrien</first><last>Bardet</last></author>
+      <author><first>Mercedes</first><last>García-Martínez</last></author>
+      <author><first>Fethi</first><last>Bougares</last></author>
+      <author><first>Loïc</first><last>Barrault</last></author>
+      <author><first>Marc</first><last>Masana</last></author>
+      <author><first>Luis</first><last>Herranz</last></author>
+      <author><first>Joost</first><last>van de Weijer</last></author>
       <pages>432–439</pages>
       <url>W17-4746</url>
       <doi>10.18653/v1/W17-4746</doi>
     </paper>
     <paper id="47">
       <title><fixed-case>DCU</fixed-case> System Report on the <fixed-case>WMT</fixed-case> 2017 Multi-modal Machine Translation Task</title>
-      <author><first>Iacer</first> <last>Calixto</last></author>
-      <author><first>Koel</first> <last>Dutta Chowdhury</last></author>
-      <author><first>Qun</first> <last>Liu</last></author>
+      <author><first>Iacer</first><last>Calixto</last></author>
+      <author><first>Koel</first><last>Dutta Chowdhury</last></author>
+      <author><first>Qun</first><last>Liu</last></author>
       <pages>440–444</pages>
       <url>W17-4747</url>
       <doi>10.18653/v1/W17-4747</doi>
     </paper>
     <paper id="48">
       <title>The <fixed-case>AFRL</fixed-case>-<fixed-case>OSU</fixed-case> <fixed-case>WMT</fixed-case>17 Multimodal Translation System: An Image Processing Approach</title>
-      <author><first>John</first> <last>Duselis</last></author>
-      <author><first>Michael</first> <last>Hutt</last></author>
-      <author><first>Jeremy</first> <last>Gwinnup</last></author>
-      <author><first>James</first> <last>Davis</last></author>
-      <author><first>Joshua</first> <last>Sandvick</last></author>
+      <author><first>John</first><last>Duselis</last></author>
+      <author><first>Michael</first><last>Hutt</last></author>
+      <author><first>Jeremy</first><last>Gwinnup</last></author>
+      <author><first>James</first><last>Davis</last></author>
+      <author><first>Joshua</first><last>Sandvick</last></author>
       <pages>445–449</pages>
       <url>W17-4748</url>
       <doi>10.18653/v1/W17-4748</doi>
     </paper>
     <paper id="49">
       <title><fixed-case>CUNI</fixed-case> System for the <fixed-case>WMT</fixed-case>17 Multimodal Translation Task</title>
-      <author><first>Jindřich</first> <last>Helcl</last></author>
-      <author><first>Jindřich</first> <last>Libovický</last></author>
+      <author><first>Jindřich</first><last>Helcl</last></author>
+      <author><first>Jindřich</first><last>Libovický</last></author>
       <pages>450–457</pages>
       <url>W17-4749</url>
       <doi>10.18653/v1/W17-4749</doi>
     </paper>
     <paper id="50">
       <title>Generating Image Descriptions using Multilingual Data</title>
-      <author><first>Alan</first> <last>Jaffe</last></author>
+      <author><first>Alan</first><last>Jaffe</last></author>
       <pages>458–464</pages>
       <url>W17-4750</url>
       <doi>10.18653/v1/W17-4750</doi>
     </paper>
     <paper id="51">
       <title><fixed-case>OSU</fixed-case> Multimodal Machine Translation System Report</title>
-      <author><first>Mingbo</first> <last>Ma</last></author>
-      <author><first>Dapeng</first> <last>Li</last></author>
-      <author><first>Kai</first> <last>Zhao</last></author>
-      <author><first>Liang</first> <last>Huang</last></author>
+      <author><first>Mingbo</first><last>Ma</last></author>
+      <author><first>Dapeng</first><last>Li</last></author>
+      <author><first>Kai</first><last>Zhao</last></author>
+      <author><first>Liang</first><last>Huang</last></author>
       <pages>465–469</pages>
       <url>W17-4751</url>
       <doi>10.18653/v1/W17-4751</doi>
     </paper>
     <paper id="52">
       <title><fixed-case>S</fixed-case>heffield <fixed-case>M</fixed-case>ulti<fixed-case>MT</fixed-case>: Using Object Posterior Predictions for Multimodal Machine Translation</title>
-      <author><first>Pranava Swaroop</first> <last>Madhyastha</last></author>
-      <author><first>Josiah</first> <last>Wang</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
+      <author><first>Pranava Swaroop</first><last>Madhyastha</last></author>
+      <author><first>Josiah</first><last>Wang</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
       <pages>470–476</pages>
       <url>W17-4752</url>
       <doi>10.18653/v1/W17-4752</doi>
     </paper>
     <paper id="53">
       <title><fixed-case>NICT</fixed-case>-<fixed-case>NAIST</fixed-case> System for <fixed-case>WMT</fixed-case>17 Multimodal Translation Task</title>
-      <author><first>Jingyi</first> <last>Zhang</last></author>
-      <author><first>Masao</first> <last>Utiyama</last></author>
-      <author><first>Eiichro</first> <last>Sumita</last></author>
-      <author><first>Graham</first> <last>Neubig</last></author>
-      <author><first>Satoshi</first> <last>Nakamura</last></author>
+      <author><first>Jingyi</first><last>Zhang</last></author>
+      <author><first>Masao</first><last>Utiyama</last></author>
+      <author><first>Eiichro</first><last>Sumita</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <author><first>Satoshi</first><last>Nakamura</last></author>
       <pages>477–482</pages>
       <url>W17-4753</url>
       <doi>10.18653/v1/W17-4753</doi>
     </paper>
     <paper id="54">
       <title>Automatic Threshold Detection for Data Selection in Machine Translation</title>
-      <author><first>Mirela-Stefania</first> <last>Duma</last></author>
-      <author><first>Wolfgang</first> <last>Menzel</last></author>
+      <author><first>Mirela-Stefania</first><last>Duma</last></author>
+      <author><first>Wolfgang</first><last>Menzel</last></author>
       <pages>483–488</pages>
       <url>W17-4754</url>
       <doi>10.18653/v1/W17-4754</doi>
     </paper>
     <paper id="55">
       <title>Results of the <fixed-case>WMT</fixed-case>17 Metrics Shared Task</title>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
-      <author><first>Yvette</first> <last>Graham</last></author>
-      <author><first>Amir</first> <last>Kamran</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
+      <author><first>Yvette</first><last>Graham</last></author>
+      <author><first>Amir</first><last>Kamran</last></author>
       <pages>489–513</pages>
       <url>W17-4755</url>
       <doi>10.18653/v1/W17-4755</doi>
     </paper>
     <paper id="56">
       <title>A Shared Task on Bandit Learning for Machine Translation</title>
-      <author><first>Artem</first> <last>Sokolov</last></author>
-      <author><first>Julia</first> <last>Kreutzer</last></author>
-      <author><first>Kellen</first> <last>Sunderland</last></author>
-      <author><first>Pavel</first> <last>Danchenko</last></author>
-      <author><first>Witold</first> <last>Szymaniak</last></author>
-      <author><first>Hagen</first> <last>Fürstenau</last></author>
-      <author><first>Stefan</first> <last>Riezler</last></author>
+      <author><first>Artem</first><last>Sokolov</last></author>
+      <author><first>Julia</first><last>Kreutzer</last></author>
+      <author><first>Kellen</first><last>Sunderland</last></author>
+      <author><first>Pavel</first><last>Danchenko</last></author>
+      <author><first>Witold</first><last>Szymaniak</last></author>
+      <author><first>Hagen</first><last>Fürstenau</last></author>
+      <author><first>Stefan</first><last>Riezler</last></author>
       <pages>514–524</pages>
       <url>W17-4756</url>
       <doi>10.18653/v1/W17-4756</doi>
     </paper>
     <paper id="57">
       <title>Results of the <fixed-case>WMT</fixed-case>17 Neural <fixed-case>MT</fixed-case> Training Task</title>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
-      <author><first>Jindřich</first> <last>Helcl</last></author>
-      <author><first>Tom</first> <last>Kocmi</last></author>
-      <author><first>Jindřich</first> <last>Libovický</last></author>
-      <author><first>Tomáš</first> <last>Musil</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
+      <author><first>Jindřich</first><last>Helcl</last></author>
+      <author><first>Tom</first><last>Kocmi</last></author>
+      <author><first>Jindřich</first><last>Libovický</last></author>
+      <author><first>Tomáš</first><last>Musil</last></author>
       <pages>525–533</pages>
       <url>W17-4757</url>
       <doi>10.18653/v1/W17-4757</doi>
     </paper>
     <paper id="58">
       <title>Sentence-level quality estimation by predicting <fixed-case>HTER</fixed-case> as a multi-component metric</title>
-      <author><first>Eleftherios</first> <last>Avramidis</last></author>
+      <author><first>Eleftherios</first><last>Avramidis</last></author>
       <pages>534–539</pages>
       <url>W17-4758</url>
       <doi>10.18653/v1/W17-4758</doi>
     </paper>
     <paper id="59">
       <title>Predicting Translation Performance with Referential Translation Machines</title>
-      <author><first>Ergun</first> <last>Biçici</last></author>
+      <author><first>Ergun</first><last>Biçici</last></author>
       <pages>540–544</pages>
       <url>W17-4759</url>
       <doi>10.18653/v1/W17-4759</doi>
     </paper>
     <paper id="60">
       <title>Bilexical Embeddings for Quality Estimation</title>
-      <author><first>Frédéric</first> <last>Blain</last></author>
-      <author><first>Carolina</first> <last>Scarton</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
+      <author><first>Frédéric</first><last>Blain</last></author>
+      <author><first>Carolina</first><last>Scarton</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
       <pages>545–550</pages>
       <url>W17-4760</url>
       <doi>10.18653/v1/W17-4760</doi>
     </paper>
     <paper id="61">
       <title>Improving Machine Translation Quality Estimation with Neural Network Features</title>
-      <author><first>Zhiming</first> <last>Chen</last></author>
-      <author><first>Yiming</first> <last>Tan</last></author>
-      <author><first>Chenlin</first> <last>Zhang</last></author>
-      <author><first>Qingyu</first> <last>Xiang</last></author>
-      <author><first>Lilin</first> <last>Zhang</last></author>
-      <author><first>Maoxi</first> <last>Li</last></author>
-      <author><first>Mingwen</first> <last>Wang</last></author>
+      <author><first>Zhiming</first><last>Chen</last></author>
+      <author><first>Yiming</first><last>Tan</last></author>
+      <author><first>Chenlin</first><last>Zhang</last></author>
+      <author><first>Qingyu</first><last>Xiang</last></author>
+      <author><first>Lilin</first><last>Zhang</last></author>
+      <author><first>Maoxi</first><last>Li</last></author>
+      <author><first>Mingwen</first><last>Wang</last></author>
       <pages>551–555</pages>
       <url>W17-4761</url>
       <doi>10.18653/v1/W17-4761</doi>
     </paper>
     <paper id="62">
       <title><fixed-case>UHH</fixed-case> Submission to the <fixed-case>WMT</fixed-case>17 Quality Estimation Shared Task</title>
-      <author><first>Melania</first> <last>Duma</last></author>
-      <author><first>Wolfgang</first> <last>Menzel</last></author>
+      <author><first>Melania</first><last>Duma</last></author>
+      <author><first>Wolfgang</first><last>Menzel</last></author>
       <pages>556–561</pages>
       <url>W17-4762</url>
       <doi>10.18653/v1/W17-4762</doi>
     </paper>
     <paper id="63">
       <title>Predictor-Estimator using Multilevel Task Learning with Stack Propagation for Neural Quality Estimation</title>
-      <author><first>Hyun</first> <last>Kim</last></author>
-      <author><first>Jong-Hyeok</first> <last>Lee</last></author>
-      <author><first>Seung-Hoon</first> <last>Na</last></author>
+      <author><first>Hyun</first><last>Kim</last></author>
+      <author><first>Jong-Hyeok</first><last>Lee</last></author>
+      <author><first>Seung-Hoon</first><last>Na</last></author>
       <pages>562–568</pages>
       <url>W17-4763</url>
       <doi>10.18653/v1/W17-4763</doi>
     </paper>
     <paper id="64">
       <title>Unbabel’s Participation in the <fixed-case>WMT</fixed-case>17 Translation Quality Estimation Shared Task</title>
-      <author><first>André F. T.</first> <last>Martins</last></author>
-      <author><first>Fabio</first> <last>Kepler</last></author>
-      <author><first>José</first> <last>Monteiro</last></author>
+      <author><first>André F. T.</first><last>Martins</last></author>
+      <author><first>Fabio</first><last>Kepler</last></author>
+      <author><first>José</first><last>Monteiro</last></author>
       <pages>569–574</pages>
       <url>W17-4764</url>
       <doi>10.18653/v1/W17-4764</doi>
     </paper>
     <paper id="65">
       <title>Feature-Enriched Character-Level Convolutions for Text Regression</title>
-      <author><first>Gustavo</first> <last>Paetzold</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
+      <author><first>Gustavo</first><last>Paetzold</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
       <pages>575–581</pages>
       <url>W17-4765</url>
       <doi>10.18653/v1/W17-4765</doi>
     </paper>
     <paper id="66">
       <title><fixed-case>UHH</fixed-case> Submission to the <fixed-case>WMT</fixed-case>17 Metrics Shared Task</title>
-      <author><first>Melania</first> <last>Duma</last></author>
-      <author><first>Wolfgang</first> <last>Menzel</last></author>
+      <author><first>Melania</first><last>Duma</last></author>
+      <author><first>Wolfgang</first><last>Menzel</last></author>
       <pages>582–588</pages>
       <url>W17-4766</url>
       <doi>10.18653/v1/W17-4766</doi>
     </paper>
     <paper id="67">
       <title><fixed-case>MEANT</fixed-case> 2.0: Accurate semantic <fixed-case>MT</fixed-case> evaluation for any output language</title>
-      <author><first>Chi-kiu</first> <last>Lo</last></author>
+      <author><first>Chi-kiu</first><last>Lo</last></author>
       <pages>589–597</pages>
       <url>W17-4767</url>
       <doi>10.18653/v1/W17-4767</doi>
     </paper>
     <paper id="68">
       <title><fixed-case>B</fixed-case>lend: a Novel Combined <fixed-case>MT</fixed-case> Metric Based on Direct Assessment — <fixed-case>CASICT</fixed-case>-<fixed-case>DCU</fixed-case> submission to <fixed-case>WMT</fixed-case>17 Metrics Task</title>
-      <author><first>Qingsong</first> <last>Ma</last></author>
-      <author><first>Yvette</first> <last>Graham</last></author>
-      <author><first>Shugen</first> <last>Wang</last></author>
-      <author><first>Qun</first> <last>Liu</last></author>
+      <author><first>Qingsong</first><last>Ma</last></author>
+      <author><first>Yvette</first><last>Graham</last></author>
+      <author><first>Shugen</first><last>Wang</last></author>
+      <author><first>Qun</first><last>Liu</last></author>
       <pages>598–603</pages>
       <url>W17-4768</url>
       <doi>10.18653/v1/W17-4768</doi>
     </paper>
     <paper id="69">
       <title><fixed-case>CUNI</fixed-case> Experiments for <fixed-case>WMT</fixed-case>17 Metrics Task</title>
-      <author><first>David</first> <last>Mareček</last></author>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
-      <author><first>Ondřej</first> <last>Hübsch</last></author>
-      <author><first>Rudolf</first> <last>Rosa</last></author>
-      <author><first>Dušan</first> <last>Variš</last></author>
+      <author><first>David</first><last>Mareček</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
+      <author><first>Ondřej</first><last>Hübsch</last></author>
+      <author><first>Rudolf</first><last>Rosa</last></author>
+      <author><first>Dušan</first><last>Variš</last></author>
       <pages>604–611</pages>
       <url>W17-4769</url>
       <doi>10.18653/v1/W17-4769</doi>
     </paper>
     <paper id="70">
       <title>chr<fixed-case>F</fixed-case>++: words helping character n-grams</title>
-      <author><first>Maja</first> <last>Popović</last></author>
+      <author><first>Maja</first><last>Popović</last></author>
       <pages>612–618</pages>
       <url>W17-4770</url>
       <doi>10.18653/v1/W17-4770</doi>
     </paper>
     <paper id="71">
       <title>bleu2vec: the Painfully Familiar Metric on Continuous Vector Space Steroids</title>
-      <author><first>Andre</first> <last>Tättar</last></author>
-      <author><first>Mark</first> <last>Fishel</last></author>
+      <author><first>Andre</first><last>Tättar</last></author>
+      <author><first>Mark</first><last>Fishel</last></author>
       <pages>619–622</pages>
       <url>W17-4771</url>
       <doi>10.18653/v1/W17-4771</doi>
     </paper>
     <paper id="72">
       <title><fixed-case>LIG</fixed-case>-<fixed-case>CRIS</fixed-case>t<fixed-case>AL</fixed-case> Submission for the <fixed-case>WMT</fixed-case> 2017 Automatic Post-Editing Task</title>
-      <author><first>Alexandre</first> <last>Bérard</last></author>
-      <author><first>Laurent</first> <last>Besacier</last></author>
-      <author><first>Olivier</first> <last>Pietquin</last></author>
+      <author><first>Alexandre</first><last>Bérard</last></author>
+      <author><first>Laurent</first><last>Besacier</last></author>
+      <author><first>Olivier</first><last>Pietquin</last></author>
       <pages>623–629</pages>
       <url>W17-4772</url>
       <doi>10.18653/v1/W17-4772</doi>
     </paper>
     <paper id="73">
       <title>Multi-source Neural Automatic Post-Editing: <fixed-case>FBK</fixed-case>’s participation in the <fixed-case>WMT</fixed-case> 2017 <fixed-case>APE</fixed-case> shared task</title>
-      <author><first>Rajen</first> <last>Chatterjee</last></author>
-      <author><first>M. Amin</first> <last>Farajian</last></author>
-      <author><first>Matteo</first> <last>Negri</last></author>
-      <author><first>Marco</first> <last>Turchi</last></author>
-      <author><first>Ankit</first> <last>Srivastava</last></author>
-      <author><first>Santanu</first> <last>Pal</last></author>
+      <author><first>Rajen</first><last>Chatterjee</last></author>
+      <author><first>M. Amin</first><last>Farajian</last></author>
+      <author><first>Matteo</first><last>Negri</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
+      <author><first>Ankit</first><last>Srivastava</last></author>
+      <author><first>Santanu</first><last>Pal</last></author>
       <pages>630–638</pages>
       <url>W17-4773</url>
       <doi>10.18653/v1/W17-4773</doi>
     </paper>
     <paper id="74">
       <title>The <fixed-case>AMU</fixed-case>-<fixed-case>UE</fixed-case>din Submission to the <fixed-case>WMT</fixed-case> 2017 Shared Task on Automatic Post-Editing</title>
-      <author><first>Marcin</first> <last>Junczys-Dowmunt</last></author>
-      <author><first>Marcin</first> <last>Junczys-Dowmunt</last></author>
+      <author><first>Marcin</first><last>Junczys-Dowmunt</last></author>
+      <author><first>Marcin</first><last>Junczys-Dowmunt</last></author>
       <pages>639–646</pages>
       <url>W17-4774</url>
       <doi>10.18653/v1/W17-4774</doi>
@@ -8321,63 +8321,63 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="75">
       <title>Ensembling Factored Neural Machine Translation Models for Automatic Post-Editing and Quality Estimation</title>
-      <author><first>Chris</first> <last>Hokamp</last></author>
+      <author><first>Chris</first><last>Hokamp</last></author>
       <pages>647–654</pages>
       <url>W17-4775</url>
       <doi>10.18653/v1/W17-4775</doi>
     </paper>
     <paper id="76">
       <title>Neural Post-Editing Based on Quality Estimation</title>
-      <author><first>Yiming</first> <last>Tan</last></author>
-      <author><first>Zhiming</first> <last>Chen</last></author>
-      <author><first>Liu</first> <last>Huang</last></author>
-      <author><first>Lilin</first> <last>Zhang</last></author>
-      <author><first>Maoxi</first> <last>Li</last></author>
-      <author><first>Mingwen</first> <last>Wang</last></author>
+      <author><first>Yiming</first><last>Tan</last></author>
+      <author><first>Zhiming</first><last>Chen</last></author>
+      <author><first>Liu</first><last>Huang</last></author>
+      <author><first>Lilin</first><last>Zhang</last></author>
+      <author><first>Maoxi</first><last>Li</last></author>
+      <author><first>Mingwen</first><last>Wang</last></author>
       <pages>655–660</pages>
       <url>W17-4776</url>
       <doi>10.18653/v1/W17-4776</doi>
     </paper>
     <paper id="77">
       <title><fixed-case>CUNI</fixed-case> System for <fixed-case>WMT</fixed-case>17 Automatic Post-Editing Task</title>
-      <author><first>Dušan</first> <last>Variš</last></author>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
+      <author><first>Dušan</first><last>Variš</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
       <pages>661–666</pages>
       <url>W17-4777</url>
       <doi>10.18653/v1/W17-4777</doi>
     </paper>
     <paper id="78">
       <title>The <fixed-case>UMD</fixed-case> Neural Machine Translation Systems at <fixed-case>WMT</fixed-case>17 Bandit Learning Task</title>
-      <author><first>Amr</first> <last>Sharaf</last></author>
-      <author><first>Shi</first> <last>Feng</last></author>
-      <author><first>Khanh</first> <last>Nguyen</last></author>
-      <author><first>Kianté</first> <last>Brantley</last></author>
-      <author><first>Hal</first> <last>Daumé III</last></author>
+      <author><first>Amr</first><last>Sharaf</last></author>
+      <author><first>Shi</first><last>Feng</last></author>
+      <author><first>Khanh</first><last>Nguyen</last></author>
+      <author><first>Kianté</first><last>Brantley</last></author>
+      <author><first>Hal</first><last>Daumé III</last></author>
       <pages>667–673</pages>
       <url>W17-4778</url>
       <doi>10.18653/v1/W17-4778</doi>
     </paper>
     <paper id="79">
       <title><fixed-case>LIMSI</fixed-case> Submission for <fixed-case>WMT</fixed-case>’17 Shared Task on Bandit Learning</title>
-      <author><first>Guillaume</first> <last>Wisniewski</last></author>
+      <author><first>Guillaume</first><last>Wisniewski</last></author>
       <pages>674–679</pages>
       <url>W17-4779</url>
       <doi>10.18653/v1/W17-4779</doi>
     </paper>
     <paper id="80">
       <title>Variable Mini-Batch Sizing and Pre-Trained Embeddings</title>
-      <author><first>Mostafa</first> <last>Abdou</last></author>
-      <author><first>Vladan</first> <last>Glončák</last></author>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
+      <author><first>Mostafa</first><last>Abdou</last></author>
+      <author><first>Vladan</first><last>Glončák</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
       <pages>680–686</pages>
       <url>W17-4780</url>
       <doi>10.18653/v1/W17-4780</doi>
     </paper>
     <paper id="81">
       <title>The <fixed-case>AFRL</fixed-case> <fixed-case>WMT</fixed-case>17 Neural Machine Translation Training Task Submission</title>
-      <author><first>Jeremy</first> <last>Gwinnup</last></author>
-      <author><first>Grant</first> <last>Erdmann</last></author>
-      <author><first>Katherine</first> <last>Young</last></author>
+      <author><first>Jeremy</first><last>Gwinnup</last></author>
+      <author><first>Grant</first><last>Erdmann</last></author>
+      <author><first>Katherine</first><last>Young</last></author>
       <pages>687–691</pages>
       <url>W17-4781</url>
       <doi>10.18653/v1/W17-4781</doi>
@@ -8401,13 +8401,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Findings of the 2017 <fixed-case>D</fixed-case>isco<fixed-case>MT</fixed-case> Shared Task on Cross-lingual Pronoun Prediction</title>
-      <author><first>Sharid</first> <last>Loáiciga</last></author>
-      <author><first>Sara</first> <last>Stymne</last></author>
-      <author><first>Preslav</first> <last>Nakov</last></author>
-      <author><first>Christian</first> <last>Hardmeier</last></author>
-      <author><first>Jörg</first> <last>Tiedemann</last></author>
-      <author><first>Mauro</first> <last>Cettolo</last></author>
-      <author><first>Yannick</first> <last>Versley</last></author>
+      <author><first>Sharid</first><last>Loáiciga</last></author>
+      <author><first>Sara</first><last>Stymne</last></author>
+      <author><first>Preslav</first><last>Nakov</last></author>
+      <author><first>Christian</first><last>Hardmeier</last></author>
+      <author><first>Jörg</first><last>Tiedemann</last></author>
+      <author><first>Mauro</first><last>Cettolo</last></author>
+      <author><first>Yannick</first><last>Versley</last></author>
       <pages>1–16</pages>
       <url>W17-4801</url>
       <doi>10.18653/v1/W17-4801</doi>
@@ -8416,8 +8416,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Validation of an Automatic Metric for the Accuracy of Pronoun Translation (<fixed-case>APT</fixed-case>)</title>
-      <author><first>Lesly</first> <last>Miculicich Werlen</last></author>
-      <author><first>Andrei</first> <last>Popescu-Belis</last></author>
+      <author><first>Lesly</first><last>Miculicich Werlen</last></author>
+      <author><first>Andrei</first><last>Popescu-Belis</last></author>
       <pages>17–25</pages>
       <url>W17-4802</url>
       <doi>10.18653/v1/W17-4802</doi>
@@ -8425,9 +8425,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Using a Graph-based Coherence Model in Document-Level Machine Translation</title>
-      <author><first>Leo</first> <last>Born</last></author>
-      <author><first>Mohsen</first> <last>Mesgar</last></author>
-      <author><first>Michael</first> <last>Strube</last></author>
+      <author><first>Leo</first><last>Born</last></author>
+      <author><first>Mohsen</first><last>Mesgar</last></author>
+      <author><first>Michael</first><last>Strube</last></author>
       <pages>26–35</pages>
       <url>W17-4803</url>
       <doi>10.18653/v1/W17-4803</doi>
@@ -8435,7 +8435,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Treatment of Markup in Statistical Machine Translation</title>
-      <author><first>Mathias</first> <last>Müller</last></author>
+      <author><first>Mathias</first><last>Müller</last></author>
       <pages>36–46</pages>
       <url>W17-4804</url>
       <doi>10.18653/v1/W17-4804</doi>
@@ -8443,9 +8443,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>A <fixed-case>B</fixed-case>i<fixed-case>LSTM</fixed-case>-based System for Cross-lingual Pronoun Prediction</title>
-      <author><first>Sara</first> <last>Stymne</last></author>
-      <author><first>Sharid</first> <last>Loáiciga</last></author>
-      <author><first>Fabienne</first> <last>Cap</last></author>
+      <author><first>Sara</first><last>Stymne</last></author>
+      <author><first>Sharid</first><last>Loáiciga</last></author>
+      <author><first>Fabienne</first><last>Cap</last></author>
       <pages>47–53</pages>
       <url>W17-4805</url>
       <doi>10.18653/v1/W17-4805</doi>
@@ -8453,10 +8453,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Neural Machine Translation for Cross-Lingual Pronoun Prediction</title>
-      <author><first>Sebastien</first> <last>Jean</last></author>
-      <author><first>Stanislas</first> <last>Lauly</last></author>
-      <author><first>Orhan</first> <last>Firat</last></author>
-      <author><first>Kyunghyun</first> <last>Cho</last></author>
+      <author><first>Sebastien</first><last>Jean</last></author>
+      <author><first>Stanislas</first><last>Lauly</last></author>
+      <author><first>Orhan</first><last>Firat</last></author>
+      <author><first>Kyunghyun</first><last>Cho</last></author>
       <pages>54–57</pages>
       <url>W17-4806</url>
       <doi>10.18653/v1/W17-4806</doi>
@@ -8464,7 +8464,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Predicting Pronouns with a Convolutional Network and an N-gram Model</title>
-      <author><first>Christian</first> <last>Hardmeier</last></author>
+      <author><first>Christian</first><last>Hardmeier</last></author>
       <pages>58–62</pages>
       <url>W17-4807</url>
       <doi>10.18653/v1/W17-4807</doi>
@@ -8472,9 +8472,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Cross-Lingual Pronoun Prediction with Deep Recurrent Neural Networks v2.0</title>
-      <author><first>Juhani</first> <last>Luotolahti</last></author>
-      <author><first>Jenna</first> <last>Kanerva</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
+      <author><first>Juhani</first><last>Luotolahti</last></author>
+      <author><first>Jenna</first><last>Kanerva</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
       <pages>63–66</pages>
       <url>W17-4808</url>
       <doi>10.18653/v1/W17-4808</doi>
@@ -8482,7 +8482,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Combining the output of two coreference resolution systems for two source languages to improve annotation projection</title>
-      <author><first>Yulia</first> <last>Grishina</last></author>
+      <author><first>Yulia</first><last>Grishina</last></author>
       <pages>67–72</pages>
       <url>W17-4809</url>
       <doi>10.18653/v1/W17-4809</doi>
@@ -8490,8 +8490,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Discovery of Discourse-Related Language Contrasts through Alignment Discrepancies in <fixed-case>E</fixed-case>nglish-<fixed-case>G</fixed-case>erman Translation</title>
-      <author><first>Ekaterina</first> <last>Lapshinova-Koltunski</last></author>
-      <author><first>Christian</first> <last>Hardmeier</last></author>
+      <author><first>Ekaterina</first><last>Lapshinova-Koltunski</last></author>
+      <author><first>Christian</first><last>Hardmeier</last></author>
       <pages>73–81</pages>
       <url>W17-4810</url>
       <doi>10.18653/v1/W17-4810</doi>
@@ -8499,8 +8499,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Neural Machine Translation with Extended Context</title>
-      <author><first>Jörg</first> <last>Tiedemann</last></author>
-      <author><first>Yves</first> <last>Scherrer</last></author>
+      <author><first>Jörg</first><last>Tiedemann</last></author>
+      <author><first>Yves</first><last>Scherrer</last></author>
       <pages>82–92</pages>
       <url>W17-4811</url>
       <doi>10.18653/v1/W17-4811</doi>
@@ -8508,9 +8508,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Translating Implicit Discourse Connectives Based on Cross-lingual Annotation and Alignment</title>
-      <author><first>Hongzheng</first> <last>Li</last></author>
-      <author><first>Philippe</first> <last>Langlais</last></author>
-      <author><first>Yaohong</first> <last>Jin</last></author>
+      <author><first>Hongzheng</first><last>Li</last></author>
+      <author><first>Philippe</first><last>Langlais</last></author>
+      <author><first>Yaohong</first><last>Jin</last></author>
       <pages>93–98</pages>
       <url>W17-4812</url>
       <doi>10.18653/v1/W17-4812</doi>
@@ -8518,7 +8518,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Lexical Chains meet Word Embeddings in Document-level Statistical Machine Translation</title>
-      <author><first>Laura</first> <last>Mascarell</last></author>
+      <author><first>Laura</first><last>Mascarell</last></author>
       <pages>99–109</pages>
       <url>W17-4813</url>
       <doi>10.18653/v1/W17-4813</doi>
@@ -8526,7 +8526,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>On Integrating Discourse in Machine Translation</title>
-      <author><first>Karin</first> <last>Sim Smith</last></author>
+      <author><first>Karin</first><last>Sim Smith</last></author>
       <pages>110–121</pages>
       <url>W17-4814</url>
       <doi>10.18653/v1/W17-4814</doi>
@@ -8551,7 +8551,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>From Shakespeare to Twitter: What are Language Styles all about?</title>
-      <author><first>Wei</first> <last>Xu</last></author>
+      <author><first>Wei</first><last>Xu</last></author>
       <pages>1–9</pages>
       <url>W17-4901</url>
       <doi>10.18653/v1/W17-4901</doi>
@@ -8559,10 +8559,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Shakespearizing Modern Language Using Copy-Enriched Sequence to Sequence Models</title>
-      <author><first>Harsh</first> <last>Jhamtani</last></author>
-      <author><first>Varun</first> <last>Gangal</last></author>
-      <author><first>Eduard</first> <last>Hovy</last></author>
-      <author><first>Eric</first> <last>Nyberg</last></author>
+      <author><first>Harsh</first><last>Jhamtani</last></author>
+      <author><first>Varun</first><last>Gangal</last></author>
+      <author><first>Eduard</first><last>Hovy</last></author>
+      <author><first>Eric</first><last>Nyberg</last></author>
       <pages>10–19</pages>
       <url>W17-4902</url>
       <doi>10.18653/v1/W17-4902</doi>
@@ -8571,8 +8571,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Discovering Stylistic Variations in Distributional Vector Space Models via Lexical Paraphrases</title>
-      <author><first>Xing</first> <last>Niu</last></author>
-      <author><first>Marine</first> <last>Carpuat</last></author>
+      <author><first>Xing</first><last>Niu</last></author>
+      <author><first>Marine</first><last>Carpuat</last></author>
       <pages>20–27</pages>
       <url>W17-4903</url>
       <doi>10.18653/v1/W17-4903</doi>
@@ -8580,9 +8580,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Harvesting Creative Templates for Generating Stylistically Varied Restaurant Reviews</title>
-      <author><first>Shereen</first> <last>Oraby</last></author>
-      <author><first>Sheideh</first> <last>Homayon</last></author>
-      <author><first>Marilyn</first> <last>Walker</last></author>
+      <author><first>Shereen</first><last>Oraby</last></author>
+      <author><first>Sheideh</first><last>Homayon</last></author>
+      <author><first>Marilyn</first><last>Walker</last></author>
       <pages>28–36</pages>
       <url>W17-4904</url>
       <doi>10.18653/v1/W17-4904</doi>
@@ -8590,8 +8590,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Is writing style predictive of scientific fraud?</title>
-      <author><first>Chloé</first> <last>Braud</last></author>
-      <author><first>Anders</first> <last>Søgaard</last></author>
+      <author><first>Chloé</first><last>Braud</last></author>
+      <author><first>Anders</first><last>Søgaard</last></author>
       <pages>37–42</pages>
       <url>W17-4905</url>
       <doi>10.18653/v1/W17-4905</doi>
@@ -8599,9 +8599,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>“Deep” Learning : Detecting Metaphoricity in Adjective-Noun Pairs</title>
-      <author><first>Yuri</first> <last>Bizzoni</last></author>
-      <author><first>Stergios</first> <last>Chatzikyriakidis</last></author>
-      <author><first>Mehdi</first> <last>Ghanimifard</last></author>
+      <author><first>Yuri</first><last>Bizzoni</last></author>
+      <author><first>Stergios</first><last>Chatzikyriakidis</last></author>
+      <author><first>Mehdi</first><last>Ghanimifard</last></author>
       <pages>43–52</pages>
       <url>W17-4906</url>
       <doi>10.18653/v1/W17-4906</doi>
@@ -8609,9 +8609,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Authorship Attribution with Convolutional Neural Networks and <fixed-case>POS</fixed-case>-Eliding</title>
-      <author><first>Julian</first> <last>Hitschler</last></author>
-      <author><first>Esther</first> <last>van den Berg</last></author>
-      <author><first>Ines</first> <last>Rehbein</last></author>
+      <author><first>Julian</first><last>Hitschler</last></author>
+      <author><first>Esther</first><last>van den Berg</last></author>
+      <author><first>Ines</first><last>Rehbein</last></author>
       <pages>53–58</pages>
       <url>W17-4907</url>
       <doi>10.18653/v1/W17-4907</doi>
@@ -8619,9 +8619,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Topic and audience effects on distinctively <fixed-case>S</fixed-case>cottish vocabulary usage in Twitter data</title>
-      <author><first>Philippa</first> <last>Shoemark</last></author>
-      <author><first>James</first> <last>Kirby</last></author>
-      <author><first>Sharon</first> <last>Goldwater</last></author>
+      <author><first>Philippa</first><last>Shoemark</last></author>
+      <author><first>James</first><last>Kirby</last></author>
+      <author><first>Sharon</first><last>Goldwater</last></author>
       <pages>59–68</pages>
       <url>W17-4908</url>
       <doi>10.18653/v1/W17-4908</doi>
@@ -8629,10 +8629,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Differences in type-token ratio and part-of-speech frequencies in male and female <fixed-case>R</fixed-case>ussian written texts</title>
-      <author><first>Tatiana</first> <last>Litvinova</last></author>
-      <author><first>Pavel</first> <last>Seredin</last></author>
-      <author><first>Olga</first> <last>Litvinova</last></author>
-      <author><first>Olga</first> <last>Zagorovskaya</last></author>
+      <author><first>Tatiana</first><last>Litvinova</last></author>
+      <author><first>Pavel</first><last>Seredin</last></author>
+      <author><first>Olga</first><last>Litvinova</last></author>
+      <author><first>Olga</first><last>Zagorovskaya</last></author>
       <pages>69–73</pages>
       <url>W17-4909</url>
       <doi>10.18653/v1/W17-4909</doi>
@@ -8640,8 +8640,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Modeling Communicative Purpose with Functional Style: Corpus and Features for <fixed-case>G</fixed-case>erman Genre and Register Analysis</title>
-      <author><first>Thomas</first> <last>Haider</last></author>
-      <author><first>Alexis</first> <last>Palmer</last></author>
+      <author><first>Thomas</first><last>Haider</last></author>
+      <author><first>Alexis</first><last>Palmer</last></author>
       <pages>74–84</pages>
       <url>W17-4910</url>
       <doi>10.18653/v1/W17-4910</doi>
@@ -8649,8 +8649,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Stylistic Variation in Television Dialogue for Natural Language Generation</title>
-      <author><first>Grace</first> <last>Lin</last></author>
-      <author><first>Marilyn</first> <last>Walker</last></author>
+      <author><first>Grace</first><last>Lin</last></author>
+      <author><first>Marilyn</first><last>Walker</last></author>
       <pages>85–93</pages>
       <url>W17-4911</url>
       <doi>10.18653/v1/W17-4911</doi>
@@ -8658,8 +8658,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>Controlling Linguistic Style Aspects in Neural Language Generation</title>
-      <author><first>Jessica</first> <last>Ficler</last></author>
-      <author><first>Yoav</first> <last>Goldberg</last></author>
+      <author><first>Jessica</first><last>Ficler</last></author>
+      <author><first>Yoav</first><last>Goldberg</last></author>
       <pages>94–104</pages>
       <url>W17-4912</url>
       <doi>10.18653/v1/W17-4912</doi>
@@ -8667,8 +8667,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Approximating Style by N-gram-based Annotation</title>
-      <author><first>Melanie</first> <last>Andresen</last></author>
-      <author><first>Heike</first> <last>Zinsmeister</last></author>
+      <author><first>Melanie</first><last>Andresen</last></author>
+      <author><first>Heike</first><last>Zinsmeister</last></author>
       <pages>105–115</pages>
       <url>W17-4913</url>
       <doi>10.18653/v1/W17-4913</doi>
@@ -8676,10 +8676,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Assessing the Stylistic Properties of Neurally Generated Text in Authorship Attribution</title>
-      <author><first>Enrique</first> <last>Manjavacas</last></author>
-      <author><first>Jeroen</first> <last>De Gussem</last></author>
-      <author><first>Walter</first> <last>Daelemans</last></author>
-      <author><first>Mike</first> <last>Kestemont</last></author>
+      <author><first>Enrique</first><last>Manjavacas</last></author>
+      <author><first>Jeroen</first><last>De Gussem</last></author>
+      <author><first>Walter</first><last>Daelemans</last></author>
+      <author><first>Mike</first><last>Kestemont</last></author>
       <pages>116–125</pages>
       <url>W17-4914</url>
       <doi>10.18653/v1/W17-4914</doi>
@@ -8705,7 +8705,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Question Difficulty – How to Estimate Without Norming, How to Use for Automated Grading</title>
-      <author><first>Ulrike</first> <last>Padó</last></author>
+      <author><first>Ulrike</first><last>Padó</last></author>
       <pages>1–10</pages>
       <url>W17-5001</url>
       <doi>10.18653/v1/W17-5001</doi>
@@ -8713,11 +8713,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Combining <fixed-case>CNN</fixed-case>s and Pattern Matching for Question Interpretation in a Virtual Patient Dialogue System</title>
-      <author><first>Lifeng</first> <last>Jin</last></author>
-      <author><first>Michael</first> <last>White</last></author>
-      <author><first>Evan</first> <last>Jaffe</last></author>
-      <author><first>Laura</first> <last>Zimmerman</last></author>
-      <author><first>Douglas</first> <last>Danforth</last></author>
+      <author><first>Lifeng</first><last>Jin</last></author>
+      <author><first>Michael</first><last>White</last></author>
+      <author><first>Evan</first><last>Jaffe</last></author>
+      <author><first>Laura</first><last>Zimmerman</last></author>
+      <author><first>Douglas</first><last>Danforth</last></author>
       <pages>11–21</pages>
       <url>W17-5002</url>
       <doi>10.18653/v1/W17-5002</doi>
@@ -8725,10 +8725,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Continuous fluency tracking and the challenges of varying text complexity</title>
-      <author><first>Beata</first> <last>Beigman Klebanov</last></author>
-      <author><first>Anastassia</first> <last>Loukina</last></author>
-      <author><first>John</first> <last>Sabatini</last></author>
-      <author><first>Tenaha</first> <last>O’Reilly</last></author>
+      <author><first>Beata</first><last>Beigman Klebanov</last></author>
+      <author><first>Anastassia</first><last>Loukina</last></author>
+      <author><first>John</first><last>Sabatini</last></author>
+      <author><first>Tenaha</first><last>O’Reilly</last></author>
       <pages>22–32</pages>
       <url>W17-5003</url>
       <doi>10.18653/v1/W17-5003</doi>
@@ -8736,8 +8736,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Auxiliary Objectives for Neural Error Detection Models</title>
-      <author><first>Marek</first> <last>Rei</last></author>
-      <author><first>Helen</first> <last>Yannakoudakis</last></author>
+      <author><first>Marek</first><last>Rei</last></author>
+      <author><first>Helen</first><last>Yannakoudakis</last></author>
       <pages>33–43</pages>
       <url>W17-5004</url>
       <doi>10.18653/v1/W17-5004</doi>
@@ -8745,10 +8745,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Linked Data for Language-Learning Applications</title>
-      <author><first>Robyn</first> <last>Loughnane</last></author>
-      <author><first>Kate</first> <last>McCurdy</last></author>
-      <author><first>Peter</first> <last>Kolb</last></author>
-      <author><first>Stefan</first> <last>Selent</last></author>
+      <author><first>Robyn</first><last>Loughnane</last></author>
+      <author><first>Kate</first><last>McCurdy</last></author>
+      <author><first>Peter</first><last>Kolb</last></author>
+      <author><first>Stefan</first><last>Selent</last></author>
       <pages>44–51</pages>
       <url>W17-5005</url>
       <doi>10.18653/v1/W17-5005</doi>
@@ -8756,8 +8756,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Predicting Specificity in Classroom Discussion</title>
-      <author><first>Luca</first> <last>Lugini</last></author>
-      <author><first>Diane</first> <last>Litman</last></author>
+      <author><first>Luca</first><last>Lugini</last></author>
+      <author><first>Diane</first><last>Litman</last></author>
       <pages>52–61</pages>
       <url>W17-5006</url>
       <doi>10.18653/v1/W17-5006</doi>
@@ -8765,14 +8765,14 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>A Report on the 2017 Native Language Identification Shared Task</title>
-      <author><first>Shervin</first> <last>Malmasi</last></author>
-      <author><first>Keelan</first> <last>Evanini</last></author>
-      <author><first>Aoife</first> <last>Cahill</last></author>
-      <author><first>Joel</first> <last>Tetreault</last></author>
-      <author><first>Robert</first> <last>Pugh</last></author>
-      <author><first>Christopher</first> <last>Hamill</last></author>
-      <author><first>Diane</first> <last>Napolitano</last></author>
-      <author><first>Yao</first> <last>Qian</last></author>
+      <author><first>Shervin</first><last>Malmasi</last></author>
+      <author><first>Keelan</first><last>Evanini</last></author>
+      <author><first>Aoife</first><last>Cahill</last></author>
+      <author><first>Joel</first><last>Tetreault</last></author>
+      <author><first>Robert</first><last>Pugh</last></author>
+      <author><first>Christopher</first><last>Hamill</last></author>
+      <author><first>Diane</first><last>Napolitano</last></author>
+      <author><first>Yao</first><last>Qian</last></author>
       <pages>62–75</pages>
       <url>W17-5007</url>
       <doi>10.18653/v1/W17-5007</doi>
@@ -8780,8 +8780,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Evaluation of Automatically Generated Pronoun Reference Questions</title>
-      <author><first>Arief Yudha</first> <last>Satria</last></author>
-      <author><first>Takenobu</first> <last>Tokunaga</last></author>
+      <author><first>Arief Yudha</first><last>Satria</last></author>
+      <author><first>Takenobu</first><last>Tokunaga</last></author>
       <pages>76–85</pages>
       <url>W17-5008</url>
       <doi>10.18653/v1/W17-5008</doi>
@@ -8789,8 +8789,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Predicting Audience’s Laughter During Presentations Using Convolutional Neural Network</title>
-      <author><first>Lei</first> <last>Chen</last></author>
-      <author><first>Chong Min</first> <last>Lee</last></author>
+      <author><first>Lei</first><last>Chen</last></author>
+      <author><first>Chong Min</first><last>Lee</last></author>
       <pages>86–90</pages>
       <url>W17-5009</url>
       <doi>10.18653/v1/W17-5009</doi>
@@ -8798,9 +8798,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Collecting fluency corrections for spoken learner <fixed-case>E</fixed-case>nglish</title>
-      <author><first>Andrew</first> <last>Caines</last></author>
-      <author><first>Emma</first> <last>Flint</last></author>
-      <author><first>Paula</first> <last>Buttery</last></author>
+      <author><first>Andrew</first><last>Caines</last></author>
+      <author><first>Emma</first><last>Flint</last></author>
+      <author><first>Paula</first><last>Buttery</last></author>
       <pages>91–100</pages>
       <url>W17-5010</url>
       <doi>10.18653/v1/W17-5010</doi>
@@ -8808,10 +8808,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Exploring Relationships Between Writing &amp; Broader Outcomes With Automated Writing Evaluation</title>
-      <author><first>Jill</first> <last>Burstein</last></author>
-      <author><first>Dan</first> <last>McCaffrey</last></author>
-      <author><first>Beata</first> <last>Beigman Klebanov</last></author>
-      <author><first>Guangming</first> <last>Ling</last></author>
+      <author><first>Jill</first><last>Burstein</last></author>
+      <author><first>Dan</first><last>McCaffrey</last></author>
+      <author><first>Beata</first><last>Beigman Klebanov</last></author>
+      <author><first>Guangming</first><last>Ling</last></author>
       <pages>101–108</pages>
       <url>W17-5011</url>
       <doi>10.18653/v1/W17-5011</doi>
@@ -8819,10 +8819,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>An Investigation into the Pedagogical Features of Documents</title>
-      <author><first>Emily</first> <last>Sheng</last></author>
-      <author><first>Prem</first> <last>Natarajan</last></author>
-      <author><first>Jonathan</first> <last>Gordon</last></author>
-      <author><first>Gully</first> <last>Burns</last></author>
+      <author><first>Emily</first><last>Sheng</last></author>
+      <author><first>Prem</first><last>Natarajan</last></author>
+      <author><first>Jonathan</first><last>Gordon</last></author>
+      <author><first>Gully</first><last>Burns</last></author>
       <pages>109–120</pages>
       <url>W17-5012</url>
       <doi>10.18653/v1/W17-5012</doi>
@@ -8830,10 +8830,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Combining Multiple Corpora for Readability Assessment for People with Cognitive Disabilities</title>
-      <author><first>Victoria</first> <last>Yaneva</last></author>
-      <author><first>Constantin</first> <last>Orăsan</last></author>
-      <author><first>Richard</first> <last>Evans</last></author>
-      <author><first>Omid</first> <last>Rohanian</last></author>
+      <author><first>Victoria</first><last>Yaneva</last></author>
+      <author><first>Constantin</first><last>Orăsan</last></author>
+      <author><first>Richard</first><last>Evans</last></author>
+      <author><first>Omid</first><last>Rohanian</last></author>
       <pages>121–132</pages>
       <url>W17-5013</url>
       <doi>10.18653/v1/W17-5013</doi>
@@ -8841,8 +8841,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Automatic Extraction of High-Quality Example Sentences for Word Learning Using a Determinantal Point Process</title>
-      <author><first>Arseny</first> <last>Tolmachev</last></author>
-      <author><first>Sadao</first> <last>Kurohashi</last></author>
+      <author><first>Arseny</first><last>Tolmachev</last></author>
+      <author><first>Sadao</first><last>Kurohashi</last></author>
       <pages>133–142</pages>
       <url>W17-5014</url>
       <doi>10.18653/v1/W17-5014</doi>
@@ -8851,8 +8851,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Distractor Generation for <fixed-case>C</fixed-case>hinese Fill-in-the-blank Items</title>
-      <author><first>Shu</first> <last>Jiang</last></author>
-      <author><first>John</first> <last>Lee</last></author>
+      <author><first>Shu</first><last>Jiang</last></author>
+      <author><first>John</first><last>Lee</last></author>
       <pages>143–148</pages>
       <url>W17-5015</url>
       <doi>10.18653/v1/W17-5015</doi>
@@ -8860,9 +8860,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="16">
       <title>An Error-Oriented Approach to Word Embedding Pre-Training</title>
-      <author><first>Youmna</first> <last>Farag</last></author>
-      <author><first>Marek</first> <last>Rei</last></author>
-      <author><first>Ted</first> <last>Briscoe</last></author>
+      <author><first>Youmna</first><last>Farag</last></author>
+      <author><first>Marek</first><last>Rei</last></author>
+      <author><first>Ted</first><last>Briscoe</last></author>
       <pages>149–158</pages>
       <url>W17-5016</url>
       <doi>10.18653/v1/W17-5016</doi>
@@ -8870,11 +8870,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="17">
       <title>Investigating neural architectures for short answer scoring</title>
-      <author><first>Brian</first> <last>Riordan</last></author>
-      <author><first>Andrea</first> <last>Horbach</last></author>
-      <author><first>Aoife</first> <last>Cahill</last></author>
-      <author><first>Torsten</first> <last>Zesch</last></author>
-      <author><first>Chong Min</first> <last>Lee</last></author>
+      <author><first>Brian</first><last>Riordan</last></author>
+      <author><first>Andrea</first><last>Horbach</last></author>
+      <author><first>Aoife</first><last>Cahill</last></author>
+      <author><first>Torsten</first><last>Zesch</last></author>
+      <author><first>Chong Min</first><last>Lee</last></author>
       <pages>159–168</pages>
       <url>W17-5017</url>
       <doi>10.18653/v1/W17-5017</doi>
@@ -8882,10 +8882,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="18">
       <title>Human and Automated <fixed-case>CEFR</fixed-case>-based Grading of Short Answers</title>
-      <author><first>Anaïs</first> <last>Tack</last></author>
-      <author><first>Thomas</first> <last>François</last></author>
-      <author><first>Sophie</first> <last>Roekhaut</last></author>
-      <author><first>Cédrick</first> <last>Fairon</last></author>
+      <author><first>Anaïs</first><last>Tack</last></author>
+      <author><first>Thomas</first><last>François</last></author>
+      <author><first>Sophie</first><last>Roekhaut</last></author>
+      <author><first>Cédrick</first><last>Fairon</last></author>
       <pages>169–179</pages>
       <url>W17-5018</url>
       <doi>10.18653/v1/W17-5018</doi>
@@ -8893,9 +8893,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="19">
       <title><fixed-case>GEC</fixed-case> into the future: Where are we going and how do we get there?</title>
-      <author><first>Keisuke</first> <last>Sakaguchi</last></author>
-      <author><first>Courtney</first> <last>Napoles</last></author>
-      <author><first>Joel</first> <last>Tetreault</last></author>
+      <author><first>Keisuke</first><last>Sakaguchi</last></author>
+      <author><first>Courtney</first><last>Napoles</last></author>
+      <author><first>Joel</first><last>Tetreault</last></author>
       <pages>180–187</pages>
       <url>W17-5019</url>
       <doi>10.18653/v1/W17-5019</doi>
@@ -8903,7 +8903,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="20">
       <title>Detecting Off-topic Responses to Visual Prompts</title>
-      <author><first>Marek</first> <last>Rei</last></author>
+      <author><first>Marek</first><last>Rei</last></author>
       <pages>188–197</pages>
       <url>W17-5020</url>
       <doi>10.18653/v1/W17-5020</doi>
@@ -8911,11 +8911,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="21">
       <title>Combining Textual and Speech Features in the <fixed-case>NLI</fixed-case> Task Using State-of-the-Art Machine Learning Techniques</title>
-      <author><first>Pavel</first> <last>Ircing</last></author>
-      <author><first>Jan</first> <last>Švec</last></author>
-      <author><first>Zbyněk</first> <last>Zajíc</last></author>
-      <author><first>Barbora</first> <last>Hladká</last></author>
-      <author><first>Martin</first> <last>Holub</last></author>
+      <author><first>Pavel</first><last>Ircing</last></author>
+      <author><first>Jan</first><last>Švec</last></author>
+      <author><first>Zbyněk</first><last>Zajíc</last></author>
+      <author><first>Barbora</first><last>Hladká</last></author>
+      <author><first>Martin</first><last>Holub</last></author>
       <pages>198–209</pages>
       <url>W17-5021</url>
       <doi>10.18653/v1/W17-5021</doi>
@@ -8923,9 +8923,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="22">
       <title>Native Language Identification Using a Mixture of Character and Word N-grams</title>
-      <author><first>Elham</first> <last>Mohammadi</last></author>
-      <author><first>Hadi</first> <last>Veisi</last></author>
-      <author><first>Hessam</first> <last>Amini</last></author>
+      <author><first>Elham</first><last>Mohammadi</last></author>
+      <author><first>Hadi</first><last>Veisi</last></author>
+      <author><first>Hessam</first><last>Amini</last></author>
       <pages>210–216</pages>
       <url>W17-5022</url>
       <doi>10.18653/v1/W17-5022</doi>
@@ -8934,11 +8934,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="23">
       <title>Ensemble Methods for Native Language Identification</title>
-      <author><first>Sophia</first> <last>Chan</last></author>
-      <author><first>Maryam</first> <last>Honari Jahromi</last></author>
-      <author><first>Benjamin</first> <last>Benetti</last></author>
-      <author><first>Aazim</first> <last>Lakhani</last></author>
-      <author><first>Alona</first> <last>Fyshe</last></author>
+      <author><first>Sophia</first><last>Chan</last></author>
+      <author><first>Maryam</first><last>Honari Jahromi</last></author>
+      <author><first>Benjamin</first><last>Benetti</last></author>
+      <author><first>Aazim</first><last>Lakhani</last></author>
+      <author><first>Alona</first><last>Fyshe</last></author>
       <pages>217–223</pages>
       <url>W17-5023</url>
       <doi>10.18653/v1/W17-5023</doi>
@@ -8946,8 +8946,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="24">
       <title>Can string kernels pass the test of time in Native Language Identification?</title>
-      <author><first>Radu Tudor</first> <last>Ionescu</last></author>
-      <author><first>Marius</first> <last>Popescu</last></author>
+      <author><first>Radu Tudor</first><last>Ionescu</last></author>
+      <author><first>Marius</first><last>Popescu</last></author>
       <pages>224–234</pages>
       <url>W17-5024</url>
       <doi>10.18653/v1/W17-5024</doi>
@@ -8955,10 +8955,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="25">
       <title>Neural Networks and Spelling Features for Native Language Identification</title>
-      <author><first>Johannes</first> <last>Bjerva</last></author>
-      <author><first>Gintarė</first> <last>Grigonytė</last></author>
-      <author><first>Robert</first> <last>Östling</last></author>
-      <author><first>Barbara</first> <last>Plank</last></author>
+      <author><first>Johannes</first><last>Bjerva</last></author>
+      <author><first>Gintarė</first><last>Grigonytė</last></author>
+      <author><first>Robert</first><last>Östling</last></author>
+      <author><first>Barbara</first><last>Plank</last></author>
       <pages>235–239</pages>
       <url>W17-5025</url>
       <doi>10.18653/v1/W17-5025</doi>
@@ -8966,8 +8966,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="26">
       <title>A study of N-gram and Embedding Representations for Native Language Identification</title>
-      <author><first>Sowmya</first> <last>Vajjala</last></author>
-      <author><first>Sagnik</first> <last>Banerjee</last></author>
+      <author><first>Sowmya</first><last>Vajjala</last></author>
+      <author><first>Sagnik</first><last>Banerjee</last></author>
       <pages>240–248</pages>
       <url>W17-5026</url>
       <doi>10.18653/v1/W17-5026</doi>
@@ -8975,9 +8975,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="27">
       <title>A Shallow Neural Network for Native Language Identification with Character N-grams</title>
-      <author><first>Yunita</first> <last>Sari</last></author>
-      <author><first>Muhammad</first> <last>Rifqi Fatchurrahman</last></author>
-      <author><first>Meisyarah</first> <last>Dwiastuti</last></author>
+      <author><first>Yunita</first><last>Sari</last></author>
+      <author><first>Muhammad</first><last>Rifqi Fatchurrahman</last></author>
+      <author><first>Meisyarah</first><last>Dwiastuti</last></author>
       <pages>249–254</pages>
       <url>W17-5027</url>
       <doi>10.18653/v1/W17-5027</doi>
@@ -8985,8 +8985,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="28">
       <title>Fewer features perform well at Native Language Identification task</title>
-      <author><first>Taraka</first> <last>Rama</last></author>
-      <author><first>Çağrı</first> <last>Çöltekin</last></author>
+      <author><first>Taraka</first><last>Rama</last></author>
+      <author><first>Çağrı</first><last>Çöltekin</last></author>
       <pages>255–260</pages>
       <url>W17-5028</url>
       <doi>10.18653/v1/W17-5028</doi>
@@ -8994,10 +8994,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="29">
       <title>Structured Generation of Technical Reading Lists</title>
-      <author><first>Jonathan</first> <last>Gordon</last></author>
-      <author><first>Stephen</first> <last>Aguilar</last></author>
-      <author><first>Emily</first> <last>Sheng</last></author>
-      <author><first>Gully</first> <last>Burns</last></author>
+      <author><first>Jonathan</first><last>Gordon</last></author>
+      <author><first>Stephen</first><last>Aguilar</last></author>
+      <author><first>Emily</first><last>Sheng</last></author>
+      <author><first>Gully</first><last>Burns</last></author>
       <pages>261–270</pages>
       <url>W17-5029</url>
       <doi>10.18653/v1/W17-5029</doi>
@@ -9005,10 +9005,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="30">
       <title>Effects of Lexical Properties on Viewing Time per Word in Autistic and Neurotypical Readers</title>
-      <author><first>Sanja</first> <last>Štajner</last></author>
-      <author><first>Victoria</first> <last>Yaneva</last></author>
-      <author><first>Ruslan</first> <last>Mitkov</last></author>
-      <author><first>Simone Paolo</first> <last>Ponzetto</last></author>
+      <author><first>Sanja</first><last>Štajner</last></author>
+      <author><first>Victoria</first><last>Yaneva</last></author>
+      <author><first>Ruslan</first><last>Mitkov</last></author>
+      <author><first>Simone Paolo</first><last>Ponzetto</last></author>
       <pages>271–281</pages>
       <url>W17-5030</url>
       <doi>10.18653/v1/W17-5030</doi>
@@ -9016,8 +9016,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="31">
       <title>Transparent text quality assessment with convolutional neural networks</title>
-      <author><first>Robert</first> <last>Östling</last></author>
-      <author><first>Gintare</first> <last>Grigonyte</last></author>
+      <author><first>Robert</first><last>Östling</last></author>
+      <author><first>Gintare</first><last>Grigonyte</last></author>
       <pages>282–286</pages>
       <url>W17-5031</url>
       <doi>10.18653/v1/W17-5031</doi>
@@ -9025,10 +9025,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="32">
       <title>Artificial Error Generation with Machine Translation and Syntactic Patterns</title>
-      <author><first>Marek</first> <last>Rei</last></author>
-      <author><first>Mariano</first> <last>Felice</last></author>
-      <author><first>Zheng</first> <last>Yuan</last></author>
-      <author><first>Ted</first> <last>Briscoe</last></author>
+      <author><first>Marek</first><last>Rei</last></author>
+      <author><first>Mariano</first><last>Felice</last></author>
+      <author><first>Zheng</first><last>Yuan</last></author>
+      <author><first>Ted</first><last>Briscoe</last></author>
       <pages>287–292</pages>
       <url>W17-5032</url>
       <doi>10.18653/v1/W17-5032</doi>
@@ -9036,8 +9036,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="33">
       <title>Modelling semantic acquisition in second language learning</title>
-      <author><first>Ekaterina</first> <last>Kochmar</last></author>
-      <author><first>Ekaterina</first> <last>Shutova</last></author>
+      <author><first>Ekaterina</first><last>Kochmar</last></author>
+      <author><first>Ekaterina</first><last>Shutova</last></author>
       <pages>293–302</pages>
       <url>W17-5033</url>
       <doi>10.18653/v1/W17-5033</doi>
@@ -9045,8 +9045,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="34">
       <title>Multiple Choice Question Generation Utilizing An Ontology</title>
-      <author><first>Katherine</first> <last>Stasaski</last></author>
-      <author><first>Marti A.</first> <last>Hearst</last></author>
+      <author><first>Katherine</first><last>Stasaski</last></author>
+      <author><first>Marti A.</first><last>Hearst</last></author>
       <pages>303–312</pages>
       <url>W17-5034</url>
       <doi>10.18653/v1/W17-5034</doi>
@@ -9055,8 +9055,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="35">
       <title>Simplifying metaphorical language for young readers: A corpus study on news text</title>
-      <author><first>Magdalena</first> <last>Wolska</last></author>
-      <author><first>Yulia</first> <last>Clausen</last></author>
+      <author><first>Magdalena</first><last>Wolska</last></author>
+      <author><first>Yulia</first><last>Clausen</last></author>
       <pages>313–318</pages>
       <url>W17-5035</url>
       <doi>10.18653/v1/W17-5035</doi>
@@ -9064,8 +9064,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="36">
       <title>Language Based Mapping of Science Assessment Items to Skills</title>
-      <author><first>Farah</first> <last>Nadeem</last></author>
-      <author><first>Mari</first> <last>Ostendorf</last></author>
+      <author><first>Farah</first><last>Nadeem</last></author>
+      <author><first>Mari</first><last>Ostendorf</last></author>
       <pages>319–326</pages>
       <url>W17-5036</url>
       <doi>10.18653/v1/W17-5036</doi>
@@ -9074,8 +9074,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="37">
       <title>Connecting the Dots: Towards Human-Level Grammatical Error Correction</title>
-      <author><first>Shamil</first> <last>Chollampatt</last></author>
-      <author><first>Hwee Tou</first> <last>Ng</last></author>
+      <author><first>Shamil</first><last>Chollampatt</last></author>
+      <author><first>Hwee Tou</first><last>Ng</last></author>
       <pages>327–333</pages>
       <url>W17-5037</url>
       <doi>10.18653/v1/W17-5037</doi>
@@ -9083,8 +9083,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="38">
       <title>Question Generation for Language Learning: From ensuring texts are read to supporting learning</title>
-      <author><first>Maria</first> <last>Chinkina</last></author>
-      <author><first>Detmar</first> <last>Meurers</last></author>
+      <author><first>Maria</first><last>Chinkina</last></author>
+      <author><first>Detmar</first><last>Meurers</last></author>
       <pages>334–344</pages>
       <url>W17-5038</url>
       <doi>10.18653/v1/W17-5038</doi>
@@ -9092,8 +9092,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="39">
       <title>Systematically Adapting Machine Translation for Grammatical Error Correction</title>
-      <author><first>Courtney</first> <last>Napoles</last></author>
-      <author><first>Chris</first> <last>Callison-Burch</last></author>
+      <author><first>Courtney</first><last>Napoles</last></author>
+      <author><first>Chris</first><last>Callison-Burch</last></author>
       <pages>345–356</pages>
       <url>W17-5039</url>
       <doi>10.18653/v1/W17-5039</doi>
@@ -9101,10 +9101,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="40">
       <title>Fine-grained essay scoring of a complex writing task for native speakers</title>
-      <author><first>Andrea</first> <last>Horbach</last></author>
-      <author><first>Dirk</first> <last>Scholten-Akoun</last></author>
-      <author><first>Yuning</first> <last>Ding</last></author>
-      <author><first>Torsten</first> <last>Zesch</last></author>
+      <author><first>Andrea</first><last>Horbach</last></author>
+      <author><first>Dirk</first><last>Scholten-Akoun</last></author>
+      <author><first>Yuning</first><last>Ding</last></author>
+      <author><first>Torsten</first><last>Zesch</last></author>
       <pages>357–366</pages>
       <url>W17-5040</url>
       <doi>10.18653/v1/W17-5040</doi>
@@ -9112,8 +9112,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="41">
       <title>Exploring Optimal Voting in Native Language Identification</title>
-      <author><first>Cyril</first> <last>Goutte</last></author>
-      <author><first>Serge</first> <last>Léger</last></author>
+      <author><first>Cyril</first><last>Goutte</last></author>
+      <author><first>Serge</first><last>Léger</last></author>
       <pages>367–373</pages>
       <url>W17-5041</url>
       <doi>10.18653/v1/W17-5041</doi>
@@ -9121,10 +9121,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="42">
       <title><fixed-case>CIC</fixed-case>-<fixed-case>FBK</fixed-case> Approach to Native Language Identification</title>
-      <author><first>Ilia</first> <last>Markov</last></author>
-      <author><first>Lingzhen</first> <last>Chen</last></author>
-      <author><first>Carlo</first> <last>Strapparava</last></author>
-      <author><first>Grigori</first> <last>Sidorov</last></author>
+      <author><first>Ilia</first><last>Markov</last></author>
+      <author><first>Lingzhen</first><last>Chen</last></author>
+      <author><first>Carlo</first><last>Strapparava</last></author>
+      <author><first>Grigori</first><last>Sidorov</last></author>
       <pages>374–381</pages>
       <url>W17-5042</url>
       <doi>10.18653/v1/W17-5042</doi>
@@ -9132,13 +9132,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="43">
       <title>The Power of Character N-grams in Native Language Identification</title>
-      <author><first>Artur</first> <last>Kulmizev</last></author>
-      <author><first>Bo</first> <last>Blankers</last></author>
-      <author><first>Johannes</first> <last>Bjerva</last></author>
-      <author><first>Malvina</first> <last>Nissim</last></author>
-      <author><first>Gertjan</first> <last>van Noord</last></author>
-      <author><first>Barbara</first> <last>Plank</last></author>
-      <author><first>Martijn</first> <last>Wieling</last></author>
+      <author><first>Artur</first><last>Kulmizev</last></author>
+      <author><first>Bo</first><last>Blankers</last></author>
+      <author><first>Johannes</first><last>Bjerva</last></author>
+      <author><first>Malvina</first><last>Nissim</last></author>
+      <author><first>Gertjan</first><last>van Noord</last></author>
+      <author><first>Barbara</first><last>Plank</last></author>
+      <author><first>Martijn</first><last>Wieling</last></author>
       <pages>382–389</pages>
       <url>W17-5043</url>
       <doi>10.18653/v1/W17-5043</doi>
@@ -9146,8 +9146,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="44">
       <title>Classifier Stacking for Native Language Identification</title>
-      <author><first>Wen</first> <last>Li</last></author>
-      <author><first>Liang</first> <last>Zou</last></author>
+      <author><first>Wen</first><last>Li</last></author>
+      <author><first>Liang</first><last>Zou</last></author>
       <pages>390–397</pages>
       <url>W17-5044</url>
       <doi>10.18653/v1/W17-5044</doi>
@@ -9155,9 +9155,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="45">
       <title>Native Language Identification on Text and Speech</title>
-      <author><first>Marcos</first> <last>Zampieri</last></author>
-      <author><first>Alina Maria</first> <last>Ciobanu</last></author>
-      <author><first>Liviu P.</first> <last>Dinu</last></author>
+      <author><first>Marcos</first><last>Zampieri</last></author>
+      <author><first>Alina Maria</first><last>Ciobanu</last></author>
+      <author><first>Liviu P.</first><last>Dinu</last></author>
       <pages>398–404</pages>
       <url>W17-5045</url>
       <doi>10.18653/v1/W17-5045</doi>
@@ -9165,8 +9165,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="46">
       <title>Native Language Identification using Phonetic Algorithms</title>
-      <author><first>Charese</first> <last>Smiley</last></author>
-      <author><first>Sandra</first> <last>Kübler</last></author>
+      <author><first>Charese</first><last>Smiley</last></author>
+      <author><first>Sandra</first><last>Kübler</last></author>
       <pages>405–412</pages>
       <url>W17-5046</url>
       <doi>10.18653/v1/W17-5046</doi>
@@ -9174,12 +9174,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="47">
       <title>A deep-learning based native-language classification by using a latent semantic analysis for the <fixed-case>NLI</fixed-case> Shared Task 2017</title>
-      <author><first>Yoo Rhee</first> <last>Oh</last></author>
-      <author><first>Hyung-Bae</first> <last>Jeon</last></author>
-      <author><first>Hwa Jeon</first> <last>Song</last></author>
-      <author><first>Yun-Kyung</first> <last>Lee</last></author>
-      <author><first>Jeon-Gue</first> <last>Park</last></author>
-      <author><first>Yun-Keun</first> <last>Lee</last></author>
+      <author><first>Yoo Rhee</first><last>Oh</last></author>
+      <author><first>Hyung-Bae</first><last>Jeon</last></author>
+      <author><first>Hwa Jeon</first><last>Song</last></author>
+      <author><first>Yun-Kyung</first><last>Lee</last></author>
+      <author><first>Jeon-Gue</first><last>Park</last></author>
+      <author><first>Yun-Keun</first><last>Lee</last></author>
       <pages>413–422</pages>
       <url>W17-5047</url>
       <doi>10.18653/v1/W17-5047</doi>
@@ -9187,9 +9187,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="48">
       <title>Fusion of Simple Models for Native Language Identification</title>
-      <author><first>Fabio</first> <last>Kepler</last></author>
-      <author><first>Ramon</first> <last>Astudillo</last></author>
-      <author><first>Alberto</first> <last>Abad</last></author>
+      <author><first>Fabio</first><last>Kepler</last></author>
+      <author><first>Ramon</first><last>Astudillo</last></author>
+      <author><first>Alberto</first><last>Abad</last></author>
       <pages>423–429</pages>
       <url>W17-5048</url>
       <doi>10.18653/v1/W17-5048</doi>
@@ -9197,8 +9197,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="49">
       <title>Stacked Sentence-Document Classifier Approach for Improving Native Language Identification</title>
-      <author><first>Andrea</first> <last>Cimino</last></author>
-      <author><first>Felice</first> <last>Dell’Orletta</last></author>
+      <author><first>Andrea</first><last>Cimino</last></author>
+      <author><first>Felice</first><last>Dell’Orletta</last></author>
       <pages>430–437</pages>
       <url>W17-5049</url>
       <doi>10.18653/v1/W17-5049</doi>
@@ -9206,8 +9206,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="50">
       <title>Using Gaze to Predict Text Readability</title>
-      <author><first>Ana Valeria</first> <last>González-Garduño</last></author>
-      <author><first>Anders</first> <last>Søgaard</last></author>
+      <author><first>Ana Valeria</first><last>González-Garduño</last></author>
+      <author><first>Anders</first><last>Søgaard</last></author>
       <pages>438–443</pages>
       <url>W17-5050</url>
       <doi>10.18653/v1/W17-5050</doi>
@@ -9215,11 +9215,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="51">
       <title>Annotating Orthographic Target Hypotheses in a <fixed-case>G</fixed-case>erman <fixed-case>L</fixed-case>1 Learner Corpus</title>
-      <author><first>Ronja</first> <last>Laarmann-Quante</last></author>
-      <author><first>Katrin</first> <last>Ortmann</last></author>
-      <author><first>Anna</first> <last>Ehlert</last></author>
-      <author><first>Maurice</first> <last>Vogel</last></author>
-      <author><first>Stefanie</first> <last>Dipper</last></author>
+      <author><first>Ronja</first><last>Laarmann-Quante</last></author>
+      <author><first>Katrin</first><last>Ortmann</last></author>
+      <author><first>Anna</first><last>Ehlert</last></author>
+      <author><first>Maurice</first><last>Vogel</last></author>
+      <author><first>Stefanie</first><last>Dipper</last></author>
       <pages>444–456</pages>
       <url>W17-5051</url>
       <doi>10.18653/v1/W17-5051</doi>
@@ -9227,9 +9227,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="52">
       <title>A Large Scale Quantitative Exploration of Modeling Strategies for Content Scoring</title>
-      <author><first>Nitin</first> <last>Madnani</last></author>
-      <author><first>Anastassia</first> <last>Loukina</last></author>
-      <author><first>Aoife</first> <last>Cahill</last></author>
+      <author><first>Nitin</first><last>Madnani</last></author>
+      <author><first>Anastassia</first><last>Loukina</last></author>
+      <author><first>Aoife</first><last>Cahill</last></author>
       <pages>457–467</pages>
       <url>W17-5052</url>
       <doi>10.18653/v1/W17-5052</doi>
@@ -9261,10 +9261,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>200<fixed-case>K</fixed-case>+ Crowdsourced Political Arguments for a New <fixed-case>C</fixed-case>hilean Constitution</title>
-      <author><first>Constanza</first> <last>Fierro</last></author>
-      <author><first>Claudio</first> <last>Fuentes</last></author>
-      <author><first>Jorge</first> <last>Pérez</last></author>
-      <author><first>Mauricio</first> <last>Quezada</last></author>
+      <author><first>Constanza</first><last>Fierro</last></author>
+      <author><first>Claudio</first><last>Fuentes</last></author>
+      <author><first>Jorge</first><last>Pérez</last></author>
+      <author><first>Mauricio</first><last>Quezada</last></author>
       <pages>1–10</pages>
       <url>W17-5101</url>
       <doi>10.18653/v1/W17-5101</doi>
@@ -9272,11 +9272,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Analyzing the Semantic Types of Claims and Premises in an Online Persuasive Forum</title>
-      <author><first>Christopher</first> <last>Hidey</last></author>
-      <author><first>Elena</first> <last>Musi</last></author>
-      <author><first>Alyssa</first> <last>Hwang</last></author>
-      <author><first>Smaranda</first> <last>Muresan</last></author>
-      <author><first>Kathy</first> <last>McKeown</last></author>
+      <author><first>Christopher</first><last>Hidey</last></author>
+      <author><first>Elena</first><last>Musi</last></author>
+      <author><first>Alyssa</first><last>Hwang</last></author>
+      <author><first>Smaranda</first><last>Muresan</last></author>
+      <author><first>Kathy</first><last>McKeown</last></author>
       <pages>11–21</pages>
       <url>W17-5102</url>
       <doi>10.18653/v1/W17-5102</doi>
@@ -9284,9 +9284,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Annotation of argument structure in <fixed-case>J</fixed-case>apanese legal documents</title>
-      <author><first>Hiroaki</first> <last>Yamada</last></author>
-      <author><first>Simone</first> <last>Teufel</last></author>
-      <author><first>Takenobu</first> <last>Tokunaga</last></author>
+      <author><first>Hiroaki</first><last>Yamada</last></author>
+      <author><first>Simone</first><last>Teufel</last></author>
+      <author><first>Takenobu</first><last>Tokunaga</last></author>
       <pages>22–31</pages>
       <url>W17-5103</url>
       <doi>10.18653/v1/W17-5103</doi>
@@ -9294,10 +9294,10 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="4">
       <title>Improving Claim Stance Classification with Lexical Knowledge Expansion and Context Utilization</title>
-      <author><first>Roy</first> <last>Bar-Haim</last></author>
-      <author><first>Lilach</first> <last>Edelstein</last></author>
-      <author><first>Charles</first> <last>Jochim</last></author>
-      <author><first>Noam</first> <last>Slonim</last></author>
+      <author><first>Roy</first><last>Bar-Haim</last></author>
+      <author><first>Lilach</first><last>Edelstein</last></author>
+      <author><first>Charles</first><last>Jochim</last></author>
+      <author><first>Noam</first><last>Slonim</last></author>
       <pages>32–38</pages>
       <url>W17-5104</url>
       <doi>10.18653/v1/W17-5104</doi>
@@ -9305,8 +9305,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="5">
       <title>Mining Argumentative Structure from Natural Language text using Automatically Generated Premise-Conclusion Topic Models</title>
-      <author><first>John</first> <last>Lawrence</last></author>
-      <author><first>Chris</first> <last>Reed</last></author>
+      <author><first>John</first><last>Lawrence</last></author>
+      <author><first>Chris</first><last>Reed</last></author>
       <pages>39–48</pages>
       <url>W17-5105</url>
       <doi>10.18653/v1/W17-5105</doi>
@@ -9314,16 +9314,16 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="6">
       <title>Building an Argument Search Engine for the Web</title>
-      <author><first>Henning</first> <last>Wachsmuth</last></author>
-      <author><first>Martin</first> <last>Potthast</last></author>
-      <author><first>Khalid</first> <last>Al-Khatib</last></author>
-      <author><first>Yamen</first> <last>Ajjour</last></author>
-      <author><first>Jana</first> <last>Puschmann</last></author>
-      <author><first>Jiani</first> <last>Qu</last></author>
-      <author><first>Jonas</first> <last>Dorsch</last></author>
-      <author><first>Viorel</first> <last>Morari</last></author>
-      <author><first>Janek</first> <last>Bevendorff</last></author>
-      <author><first>Benno</first> <last>Stein</last></author>
+      <author><first>Henning</first><last>Wachsmuth</last></author>
+      <author><first>Martin</first><last>Potthast</last></author>
+      <author><first>Khalid</first><last>Al-Khatib</last></author>
+      <author><first>Yamen</first><last>Ajjour</last></author>
+      <author><first>Jana</first><last>Puschmann</last></author>
+      <author><first>Jiani</first><last>Qu</last></author>
+      <author><first>Jonas</first><last>Dorsch</last></author>
+      <author><first>Viorel</first><last>Morari</last></author>
+      <author><first>Janek</first><last>Bevendorff</last></author>
+      <author><first>Benno</first><last>Stein</last></author>
       <pages>49–59</pages>
       <url>W17-5106</url>
       <doi>10.18653/v1/W17-5106</doi>
@@ -9331,8 +9331,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="7">
       <title>Argument Relation Classification Using a Joint Inference Model</title>
-      <author><first>Yufang</first> <last>Hou</last></author>
-      <author><first>Charles</first> <last>Jochim</last></author>
+      <author><first>Yufang</first><last>Hou</last></author>
+      <author><first>Charles</first><last>Jochim</last></author>
       <pages>60–66</pages>
       <url>W17-5107</url>
       <doi>10.18653/v1/W17-5107</doi>
@@ -9340,8 +9340,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="8">
       <title>Projection of Argumentative Corpora from Source to Target Languages</title>
-      <author><first>Ahmet</first> <last>Aker</last></author>
-      <author><first>Huangpan</first> <last>Zhang</last></author>
+      <author><first>Ahmet</first><last>Aker</last></author>
+      <author><first>Huangpan</first><last>Zhang</last></author>
       <pages>67–72</pages>
       <url>W17-5108</url>
       <doi>10.18653/v1/W17-5108</doi>
@@ -9350,7 +9350,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="9">
       <title>Manual Identification of Arguments with Implicit Conclusions Using Semantic Rules for Argument Mining</title>
-      <author><first>Nancy</first> <last>Green</last></author>
+      <author><first>Nancy</first><last>Green</last></author>
       <pages>73–78</pages>
       <url>W17-5109</url>
       <doi>10.18653/v1/W17-5109</doi>
@@ -9358,12 +9358,12 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="10">
       <title>Unsupervised corpus–wide claim detection</title>
-      <author><first>Ran</first> <last>Levy</last></author>
-      <author><first>Shai</first> <last>Gretz</last></author>
-      <author><first>Benjamin</first> <last>Sznajder</last></author>
-      <author><first>Shay</first> <last>Hummel</last></author>
-      <author><first>Ranit</first> <last>Aharonov</last></author>
-      <author><first>Noam</first> <last>Slonim</last></author>
+      <author><first>Ran</first><last>Levy</last></author>
+      <author><first>Shai</first><last>Gretz</last></author>
+      <author><first>Benjamin</first><last>Sznajder</last></author>
+      <author><first>Shay</first><last>Hummel</last></author>
+      <author><first>Ranit</first><last>Aharonov</last></author>
+      <author><first>Noam</first><last>Slonim</last></author>
       <pages>79–84</pages>
       <url>W17-5110</url>
       <doi>10.18653/v1/W17-5110</doi>
@@ -9372,7 +9372,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="11">
       <title>Using Question-Answering Techniques to Implement a Knowledge-Driven Argument Mining Approach</title>
-      <author><first>Patrick</first> <last>Saint-Dizier</last></author>
+      <author><first>Patrick</first><last>Saint-Dizier</last></author>
       <pages>85–90</pages>
       <url>W17-5111</url>
       <doi>10.18653/v1/W17-5111</doi>
@@ -9380,13 +9380,13 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="12">
       <title>What works and what does not: Classifier and feature analysis for argument mining</title>
-      <author><first>Ahmet</first> <last>Aker</last></author>
-      <author><first>Alfred</first> <last>Sliwa</last></author>
-      <author><first>Yuan</first> <last>Ma</last></author>
-      <author><first>Ruishen</first> <last>Lui</last></author>
-      <author><first>Niravkumar</first> <last>Borad</last></author>
-      <author><first>Seyedeh</first> <last>Ziyaei</last></author>
-      <author><first>Mina</first> <last>Ghobadi</last></author>
+      <author><first>Ahmet</first><last>Aker</last></author>
+      <author><first>Alfred</first><last>Sliwa</last></author>
+      <author><first>Yuan</first><last>Ma</last></author>
+      <author><first>Ruishen</first><last>Lui</last></author>
+      <author><first>Niravkumar</first><last>Borad</last></author>
+      <author><first>Seyedeh</first><last>Ziyaei</last></author>
+      <author><first>Mina</first><last>Ghobadi</last></author>
       <pages>91–96</pages>
       <url>W17-5112</url>
       <doi>10.18653/v1/W17-5112</doi>
@@ -9394,9 +9394,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="13">
       <title>Unsupervised Detection of Argumentative Units though Topic Modeling Techniques</title>
-      <author><first>Alfio</first> <last>Ferrara</last></author>
-      <author><first>Stefano</first> <last>Montanelli</last></author>
-      <author><first>Georgios</first> <last>Petasis</last></author>
+      <author><first>Alfio</first><last>Ferrara</last></author>
+      <author><first>Stefano</first><last>Montanelli</last></author>
+      <author><first>Georgios</first><last>Petasis</last></author>
       <pages>97–107</pages>
       <url>W17-5113</url>
       <doi>10.18653/v1/W17-5113</doi>
@@ -9404,8 +9404,8 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="14">
       <title>Using Complex Argumentative Interactions to Reconstruct the Argumentative Structure of Large-Scale Debates</title>
-      <author><first>John</first> <last>Lawrence</last></author>
-      <author><first>Chris</first> <last>Reed</last></author>
+      <author><first>John</first><last>Lawrence</last></author>
+      <author><first>Chris</first><last>Reed</last></author>
       <pages>108–117</pages>
       <url>W17-5114</url>
       <doi>10.18653/v1/W17-5114</doi>
@@ -9413,11 +9413,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="15">
       <title>Unit Segmentation of Argumentative Texts</title>
-      <author><first>Yamen</first> <last>Ajjour</last></author>
-      <author><first>Wei-Fan</first> <last>Chen</last></author>
-      <author><first>Johannes</first> <last>Kiesel</last></author>
-      <author><first>Henning</first> <last>Wachsmuth</last></author>
-      <author><first>Benno</first> <last>Stein</last></author>
+      <author><first>Yamen</first><last>Ajjour</last></author>
+      <author><first>Wei-Fan</first><last>Chen</last></author>
+      <author><first>Johannes</first><last>Kiesel</last></author>
+      <author><first>Henning</first><last>Wachsmuth</last></author>
+      <author><first>Benno</first><last>Stein</last></author>
       <pages>118–128</pages>
       <url>W17-5115</url>
       <doi>10.18653/v1/W17-5115</doi>
@@ -9442,7 +9442,7 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </frontmatter>
     <paper id="1">
       <title>Detecting Sarcasm Using Different Forms Of Incongruity</title>
-      <author><first>Aditya</first> <last>Joshi</last></author>
+      <author><first>Aditya</first><last>Joshi</last></author>
       <pages>1</pages>
       <url>W17-5201</url>
       <doi>10.18653/v1/W17-5201</doi>
@@ -9450,9 +9450,9 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="2">
       <title>Assessing State-of-the-Art Sentiment Models on State-of-the-Art Sentiment Datasets</title>
-      <author><first>Jeremy</first> <last>Barnes</last></author>
-      <author><first>Roman</first> <last>Klinger</last></author>
-      <author><first>Sabine</first> <last>Schulte im Walde</last></author>
+      <author><first>Jeremy</first><last>Barnes</last></author>
+      <author><first>Roman</first><last>Klinger</last></author>
+      <author><first>Sabine</first><last>Schulte im Walde</last></author>
       <pages>2–12</pages>
       <url>W17-5202</url>
       <doi>10.18653/v1/W17-5202</doi>
@@ -9467,11 +9467,11 @@ is able to handle phenomena related to scope by means of an higher-order type th
     </paper>
     <paper id="3">
       <title>Annotation, Modelling and Analysis of Fine-Grained Emotions on a Stance and Sentiment Detection Corpus</title>
-      <author><first>Hendrik</first> <last>Schuff</last></author>
-      <author><first>Jeremy</first> <last>Barnes</last></author>
-      <author><first>Julian</first> <last>Mohme</last></author>
-      <author><first>Sebastian</first> <last>Padó</last></author>
-      <author><first>Roman</first> <last>Klinger</last></author>
+      <author><first>Hendrik</first><last>Schuff</last></author>
+      <author><first>Jeremy</first><last>Barnes</last></author>
+      <author><first>Julian</first><last>Mohme</last></author>
+      <author><first>Sebastian</first><last>Padó</last></author>
+      <author><first>Roman</first><last>Klinger</last></author>
       <pages>13–23</pages>
       <url>W17-5203</url>
       <doi>10.18653/v1/W17-5203</doi>
@@ -9482,10 +9482,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>Ranking Right-Wing Extremist Social Media Profiles by Similarity to Democratic and Extremist Groups</title>
-      <author><first>Matthias</first> <last>Hartung</last></author>
-      <author><first>Roman</first> <last>Klinger</last></author>
-      <author><first>Franziska</first> <last>Schmidtke</last></author>
-      <author><first>Lars</first> <last>Vogel</last></author>
+      <author><first>Matthias</first><last>Hartung</last></author>
+      <author><first>Roman</first><last>Klinger</last></author>
+      <author><first>Franziska</first><last>Schmidtke</last></author>
+      <author><first>Lars</first><last>Vogel</last></author>
       <pages>24–33</pages>
       <url>W17-5204</url>
       <doi>10.18653/v1/W17-5204</doi>
@@ -9493,8 +9493,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title><fixed-case>WASSA</fixed-case>-2017 Shared Task on Emotion Intensity</title>
-      <author><first>Saif</first> <last>Mohammad</last></author>
-      <author><first>Felipe</first> <last>Bravo-Marquez</last></author>
+      <author><first>Saif</first><last>Mohammad</last></author>
+      <author><first>Felipe</first><last>Bravo-Marquez</last></author>
       <pages>34–49</pages>
       <url>W17-5205</url>
       <doi>10.18653/v1/W17-5205</doi>
@@ -9502,9 +9502,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="6">
       <title><fixed-case>IMS</fixed-case> at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Emotion Intensity Prediction with Affective Norms, Automatically Extended Resources and Deep Learning</title>
-      <author><first>Maximilian</first> <last>Köper</last></author>
-      <author><first>Evgeny</first> <last>Kim</last></author>
-      <author><first>Roman</first> <last>Klinger</last></author>
+      <author><first>Maximilian</first><last>Köper</last></author>
+      <author><first>Evgeny</first><last>Kim</last></author>
+      <author><first>Roman</first><last>Klinger</last></author>
       <pages>50–57</pages>
       <url>W17-5206</url>
       <doi>10.18653/v1/W17-5206</doi>
@@ -9513,10 +9513,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Prayas at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt 2017: An Ensemble of Deep Neural Architectures for Emotion Intensity Prediction in Tweets</title>
-      <author><first>Pranav</first> <last>Goel</last></author>
-      <author><first>Devang</first> <last>Kulshreshtha</last></author>
-      <author><first>Prayas</first> <last>Jain</last></author>
-      <author><first>Kaushal Kumar</first> <last>Shukla</last></author>
+      <author><first>Pranav</first><last>Goel</last></author>
+      <author><first>Devang</first><last>Kulshreshtha</last></author>
+      <author><first>Prayas</first><last>Jain</last></author>
+      <author><first>Kaushal Kumar</first><last>Shukla</last></author>
       <pages>58–65</pages>
       <url>W17-5207</url>
       <doi>10.18653/v1/W17-5207</doi>
@@ -9524,7 +9524,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="8">
       <title>Latest News in Computational Argumentation: Surfing on the Deep Learning Wave, Scuba Diving in the Abyss of Fundamental Questions</title>
-      <author><first>Iryna</first> <last>Gurevych</last></author>
+      <author><first>Iryna</first><last>Gurevych</last></author>
       <pages>66</pages>
       <url>W17-5208</url>
       <doi>10.18653/v1/W17-5208</doi>
@@ -9532,10 +9532,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="9">
       <title>Towards Syntactic <fixed-case>I</fixed-case>berian Polarity Classification</title>
-      <author><first>David</first> <last>Vilares</last></author>
-      <author><first>Marcos</first> <last>Garcia</last></author>
-      <author><first>Miguel A.</first> <last>Alonso</last></author>
-      <author><first>Carlos</first> <last>Gómez-Rodríguez</last></author>
+      <author><first>David</first><last>Vilares</last></author>
+      <author><first>Marcos</first><last>Garcia</last></author>
+      <author><first>Miguel A.</first><last>Alonso</last></author>
+      <author><first>Carlos</first><last>Gómez-Rodríguez</last></author>
       <pages>67–73</pages>
       <url>W17-5209</url>
       <doi>10.18653/v1/W17-5209</doi>
@@ -9543,8 +9543,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="10">
       <title>Toward Stance Classification Based on Claim Microstructures</title>
-      <author><first>Filip</first> <last>Boltužić</last></author>
-      <author><first>Jan</first> <last>Šnajder</last></author>
+      <author><first>Filip</first><last>Boltužić</last></author>
+      <author><first>Jan</first><last>Šnajder</last></author>
       <pages>74–80</pages>
       <url>W17-5210</url>
       <doi>10.18653/v1/W17-5210</doi>
@@ -9552,10 +9552,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="11">
       <title>Linguistic Reflexes of Well-Being and Happiness in Echo</title>
-      <author><first>Jiaqi</first> <last>Wu</last></author>
-      <author><first>Marilyn</first> <last>Walker</last></author>
-      <author><first>Pranav</first> <last>Anand</last></author>
-      <author><first>Steve</first> <last>Whittaker</last></author>
+      <author><first>Jiaqi</first><last>Wu</last></author>
+      <author><first>Marilyn</first><last>Walker</last></author>
+      <author><first>Pranav</first><last>Anand</last></author>
+      <author><first>Steve</first><last>Whittaker</last></author>
       <pages>81–91</pages>
       <url>W17-5211</url>
       <doi>10.18653/v1/W17-5211</doi>
@@ -9563,8 +9563,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="12">
       <title>Forecasting Consumer Spending from Purchase Intentions Expressed on Social Media</title>
-      <author><first>Viktor</first> <last>Pekar</last></author>
-      <author><first>Jane</first> <last>Binner</last></author>
+      <author><first>Viktor</first><last>Pekar</last></author>
+      <author><first>Jane</first><last>Binner</last></author>
       <pages>92–101</pages>
       <url>W17-5212</url>
       <doi>10.18653/v1/W17-5212</doi>
@@ -9572,9 +9572,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="13">
       <title>Mining fine-grained opinions on closed captions of <fixed-case>Y</fixed-case>ou<fixed-case>T</fixed-case>ube videos with an attention-<fixed-case>RNN</fixed-case></title>
-      <author><first>Edison</first> <last>Marrese-Taylor</last></author>
-      <author><first>Jorge</first> <last>Balazs</last></author>
-      <author><first>Yutaka</first> <last>Matsuo</last></author>
+      <author><first>Edison</first><last>Marrese-Taylor</last></author>
+      <author><first>Jorge</first><last>Balazs</last></author>
+      <author><first>Yutaka</first><last>Matsuo</last></author>
       <pages>102–111</pages>
       <url>W17-5213</url>
       <doi>10.18653/v1/W17-5213</doi>
@@ -9582,7 +9582,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="14">
       <title>Understanding human values and their emotional effect</title>
-      <author><first>Alexandra</first> <last>Balahur</last></author>
+      <author><first>Alexandra</first><last>Balahur</last></author>
       <pages>112</pages>
       <url>W17-5214</url>
       <doi>10.18653/v1/W17-5214</doi>
@@ -9590,8 +9590,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="15">
       <title>Did you ever read about Frogs drinking Coffee? Investigating the Compositionality of Multi-Emoji Expressions</title>
-      <author><first>Rebeca</first> <last>Padilla López</last></author>
-      <author><first>Fabienne</first> <last>Cap</last></author>
+      <author><first>Rebeca</first><last>Padilla López</last></author>
+      <author><first>Fabienne</first><last>Cap</last></author>
       <pages>113–117</pages>
       <url>W17-5215</url>
       <doi>10.18653/v1/W17-5215</doi>
@@ -9599,8 +9599,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="16">
       <title>Investigating Redundancy in Emoji Use: Study on a Twitter Based Corpus</title>
-      <author><first>Giulia</first> <last>Donato</last></author>
-      <author><first>Patrizia</first> <last>Paggio</last></author>
+      <author><first>Giulia</first><last>Donato</last></author>
+      <author><first>Patrizia</first><last>Paggio</last></author>
       <pages>118–126</pages>
       <url>W17-5216</url>
       <doi>10.18653/v1/W17-5216</doi>
@@ -9608,9 +9608,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="17">
       <title>Modeling Temporal Progression of Emotional Status in Mental Health Forum: A Recurrent Neural Net Approach</title>
-      <author><first>Kishaloy</first> <last>Halder</last></author>
-      <author><first>Lahari</first> <last>Poddar</last></author>
-      <author><first>Min-Yen</first> <last>Kan</last></author>
+      <author><first>Kishaloy</first><last>Halder</last></author>
+      <author><first>Lahari</first><last>Poddar</last></author>
+      <author><first>Min-Yen</first><last>Kan</last></author>
       <pages>127–135</pages>
       <url>W17-5217</url>
       <doi>10.18653/v1/W17-5217</doi>
@@ -9618,11 +9618,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="18">
       <title>Towards an integrated pipeline for aspect-based sentiment analysis in various domains</title>
-      <author><first>Orphée</first> <last>De Clercq</last></author>
-      <author><first>Els</first> <last>Lefever</last></author>
-      <author><first>Gilles</first> <last>Jacobs</last></author>
-      <author><first>Tijl</first> <last>Carpels</last></author>
-      <author><first>Véronique</first> <last>Hoste</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
+      <author><first>Els</first><last>Lefever</last></author>
+      <author><first>Gilles</first><last>Jacobs</last></author>
+      <author><first>Tijl</first><last>Carpels</last></author>
+      <author><first>Véronique</first><last>Hoste</last></author>
       <pages>136–142</pages>
       <url>W17-5218</url>
       <doi>10.18653/v1/W17-5218</doi>
@@ -9630,9 +9630,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="19">
       <title>Building a <fixed-case>S</fixed-case>enti<fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et for <fixed-case>O</fixed-case>dia</title>
-      <author><first>Gaurav</first> <last>Mohanty</last></author>
-      <author><first>Abishek</first> <last>Kannan</last></author>
-      <author><first>Radhika</first> <last>Mamidi</last></author>
+      <author><first>Gaurav</first><last>Mohanty</last></author>
+      <author><first>Abishek</first><last>Kannan</last></author>
+      <author><first>Radhika</first><last>Mamidi</last></author>
       <pages>143–148</pages>
       <url>W17-5219</url>
       <doi>10.18653/v1/W17-5219</doi>
@@ -9640,9 +9640,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="20">
       <title>Lexicon Integrated <fixed-case>CNN</fixed-case> Models with Attention for Sentiment Analysis</title>
-      <author><first>Bonggun</first> <last>Shin</last></author>
-      <author><first>Timothy</first> <last>Lee</last></author>
-      <author><first>Jinho D.</first> <last>Choi</last></author>
+      <author><first>Bonggun</first><last>Shin</last></author>
+      <author><first>Timothy</first><last>Lee</last></author>
+      <author><first>Jinho D.</first><last>Choi</last></author>
       <pages>149–158</pages>
       <url>W17-5220</url>
       <doi>10.18653/v1/W17-5220</doi>
@@ -9650,10 +9650,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="21">
       <title>Explaining Recurrent Neural Network Predictions in Sentiment Analysis</title>
-      <author><first>Leila</first> <last>Arras</last></author>
-      <author><first>Grégoire</first> <last>Montavon</last></author>
-      <author><first>Klaus-Robert</first> <last>Müller</last></author>
-      <author><first>Wojciech</first> <last>Samek</last></author>
+      <author><first>Leila</first><last>Arras</last></author>
+      <author><first>Grégoire</first><last>Montavon</last></author>
+      <author><first>Klaus-Robert</first><last>Müller</last></author>
+      <author><first>Wojciech</first><last>Samek</last></author>
       <pages>159–168</pages>
       <url>W17-5221</url>
       <doi>10.18653/v1/W17-5221</doi>
@@ -9661,9 +9661,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="22">
       <title><fixed-case>G</fixed-case>rad<fixed-case>A</fixed-case>scent at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Character and Word Level Recurrent Neural Network Models for Tweet Emotion Intensity Detection</title>
-      <author><first>Egor</first> <last>Lakomkin</last></author>
-      <author><first>Chandrakant</first> <last>Bothe</last></author>
-      <author><first>Stefan</first> <last>Wermter</last></author>
+      <author><first>Egor</first><last>Lakomkin</last></author>
+      <author><first>Chandrakant</first><last>Bothe</last></author>
+      <author><first>Stefan</first><last>Wermter</last></author>
       <pages>169–174</pages>
       <url>W17-5222</url>
       <doi>10.18653/v1/W17-5222</doi>
@@ -9671,9 +9671,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="23">
       <title><fixed-case>NUIG</fixed-case> at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: <fixed-case>B</fixed-case>i<fixed-case>LSTM</fixed-case> and <fixed-case>SVR</fixed-case> Ensemble to Detect Emotion Intensity</title>
-      <author><first>Vladimir</first> <last>Andryushechkin</last></author>
-      <author><first>Ian</first> <last>Wood</last></author>
-      <author><first>James</first> <last>O’ Neill</last></author>
+      <author><first>Vladimir</first><last>Andryushechkin</last></author>
+      <author><first>Ian</first><last>Wood</last></author>
+      <author><first>James</first><last>O’ Neill</last></author>
       <pages>175–179</pages>
       <url>W17-5223</url>
       <doi>10.18653/v1/W17-5223</doi>
@@ -9681,10 +9681,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="24">
       <title>Unsupervised Aspect Term Extraction with B-<fixed-case>LSTM</fixed-case> &amp; <fixed-case>CRF</fixed-case> using Automatically Labelled Datasets</title>
-      <author><first>Athanasios</first> <last>Giannakopoulos</last></author>
-      <author><first>Claudiu</first> <last>Musat</last></author>
-      <author><first>Andreea</first> <last>Hossmann</last></author>
-      <author><first>Michael</first> <last>Baeriswyl</last></author>
+      <author><first>Athanasios</first><last>Giannakopoulos</last></author>
+      <author><first>Claudiu</first><last>Musat</last></author>
+      <author><first>Andreea</first><last>Hossmann</last></author>
+      <author><first>Michael</first><last>Baeriswyl</last></author>
       <pages>180–188</pages>
       <url>W17-5224</url>
       <doi>10.18653/v1/W17-5224</doi>
@@ -9692,8 +9692,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="25">
       <title><fixed-case>PLN</fixed-case>-<fixed-case>PUCRS</fixed-case> at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Psycholinguistic features for emotion intensity prediction in tweets</title>
-      <author><first>Henrique</first> <last>Santos</last></author>
-      <author><first>Renata</first> <last>Vieira</last></author>
+      <author><first>Henrique</first><last>Santos</last></author>
+      <author><first>Renata</first><last>Vieira</last></author>
       <pages>189–192</pages>
       <url>W17-5225</url>
       <doi>10.18653/v1/W17-5225</doi>
@@ -9701,10 +9701,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="26">
       <title>Textmining at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: A Deep Learning Approach to Sentiment Intensity Scoring of <fixed-case>E</fixed-case>nglish Tweets</title>
-      <author><first>Hardik</first> <last>Meisheri</last></author>
-      <author><first>Rupsa</first> <last>Saha</last></author>
-      <author><first>Priyanka</first> <last>Sinha</last></author>
-      <author><first>Lipika</first> <last>Dey</last></author>
+      <author><first>Hardik</first><last>Meisheri</last></author>
+      <author><first>Rupsa</first><last>Saha</last></author>
+      <author><first>Priyanka</first><last>Sinha</last></author>
+      <author><first>Lipika</first><last>Dey</last></author>
       <pages>193–199</pages>
       <url>W17-5226</url>
       <doi>10.18653/v1/W17-5226</doi>
@@ -9712,10 +9712,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="27">
       <title><fixed-case>YNU</fixed-case>-<fixed-case>HPCC</fixed-case> at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Using a <fixed-case>CNN</fixed-case>-<fixed-case>LSTM</fixed-case> Model for Sentiment Intensity Prediction</title>
-      <author><first>You</first> <last>Zhang</last></author>
-      <author><first>Hang</first> <last>Yuan</last></author>
-      <author><first>Jin</first> <last>Wang</last></author>
-      <author><first>Xuejie</first> <last>Zhang</last></author>
+      <author><first>You</first><last>Zhang</last></author>
+      <author><first>Hang</first><last>Yuan</last></author>
+      <author><first>Jin</first><last>Wang</last></author>
+      <author><first>Xuejie</first><last>Zhang</last></author>
       <pages>200–204</pages>
       <url>W17-5227</url>
       <doi>10.18653/v1/W17-5227</doi>
@@ -9723,8 +9723,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="28">
       <title>Seernet at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Tweet Emotion Intensity Estimator</title>
-      <author><first>Venkatesh</first> <last>Duppada</last></author>
-      <author><first>Sushant</first> <last>Hiray</last></author>
+      <author><first>Venkatesh</first><last>Duppada</last></author>
+      <author><first>Sushant</first><last>Hiray</last></author>
       <pages>205–211</pages>
       <url>W17-5228</url>
       <doi>10.18653/v1/W17-5228</doi>
@@ -9733,11 +9733,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="29">
       <title><fixed-case>IITP</fixed-case> at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Measuring Intensity of Emotions using Sentence Embeddings and Optimized Features</title>
-      <author><first>Md Shad</first> <last>Akhtar</last></author>
-      <author><first>Palaash</first> <last>Sawant</last></author>
-      <author><first>Asif</first> <last>Ekbal</last></author>
-      <author><first>Jyoti</first> <last>Pawar</last></author>
-      <author><first>Pushpak</first> <last>Bhattacharyya</last></author>
+      <author><first>Md Shad</first><last>Akhtar</last></author>
+      <author><first>Palaash</first><last>Sawant</last></author>
+      <author><first>Asif</first><last>Ekbal</last></author>
+      <author><first>Jyoti</first><last>Pawar</last></author>
+      <author><first>Pushpak</first><last>Bhattacharyya</last></author>
       <pages>212–218</pages>
       <url>W17-5229</url>
       <doi>10.18653/v1/W17-5229</doi>
@@ -9745,8 +9745,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="30">
       <title><fixed-case>NSE</fixed-case>mo at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: An Ensemble to Predict Emotion Intensity in Tweets</title>
-      <author><first>Sreekanth</first> <last>Madisetty</last></author>
-      <author><first>Maunendra Sankar</first> <last>Desarkar</last></author>
+      <author><first>Sreekanth</first><last>Madisetty</last></author>
+      <author><first>Maunendra Sankar</first><last>Desarkar</last></author>
       <pages>219–224</pages>
       <url>W17-5230</url>
       <doi>10.18653/v1/W17-5230</doi>
@@ -9754,7 +9754,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="31">
       <title><fixed-case>T</fixed-case>ecnolengua <fixed-case>L</fixed-case>ingmotif at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: A lexicon-based approach</title>
-      <author><first>Antonio</first> <last>Moreno-Ortiz</last></author>
+      <author><first>Antonio</first><last>Moreno-Ortiz</last></author>
       <pages>225–232</pages>
       <url>W17-5231</url>
       <doi>10.18653/v1/W17-5231</doi>
@@ -9762,8 +9762,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="32">
       <title><fixed-case>E</fixed-case>mo<fixed-case>A</fixed-case>tt at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Inner attention sentence embedding for Emotion Intensity</title>
-      <author><first>Edison</first> <last>Marrese-Taylor</last></author>
-      <author><first>Yutaka</first> <last>Matsuo</last></author>
+      <author><first>Edison</first><last>Marrese-Taylor</last></author>
+      <author><first>Yutaka</first><last>Matsuo</last></author>
       <pages>233–237</pages>
       <url>W17-5232</url>
       <doi>10.18653/v1/W17-5232</doi>
@@ -9771,10 +9771,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="33">
       <title><fixed-case>YZU</fixed-case>-<fixed-case>NLP</fixed-case> at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Determining Emotion Intensity Using a Bi-directional <fixed-case>LSTM</fixed-case>-<fixed-case>CNN</fixed-case> Model</title>
-      <author><first>Yuanye</first> <last>He</last></author>
-      <author><first>Liang-Chih</first> <last>Yu</last></author>
-      <author><first>K. Robert</first> <last>Lai</last></author>
-      <author><first>Weiyi</first> <last>Liu</last></author>
+      <author><first>Yuanye</first><last>He</last></author>
+      <author><first>Liang-Chih</first><last>Yu</last></author>
+      <author><first>K. Robert</first><last>Lai</last></author>
+      <author><first>Weiyi</first><last>Liu</last></author>
       <pages>238–242</pages>
       <url>W17-5233</url>
       <doi>10.18653/v1/W17-5233</doi>
@@ -9782,8 +9782,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="34">
       <title><fixed-case>DMG</fixed-case>roup at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Emotion Intensity Using Ensemble Method</title>
-      <author><first>Song</first> <last>Jiang</last></author>
-      <author><first>Xiaotian</first> <last>Han</last></author>
+      <author><first>Song</first><last>Jiang</last></author>
+      <author><first>Xiaotian</first><last>Han</last></author>
       <pages>243–248</pages>
       <url>W17-5234</url>
       <doi>10.18653/v1/W17-5234</doi>
@@ -9791,8 +9791,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="35">
       <title><fixed-case>UW</fixed-case>at-Emote at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Emotion Intensity Detection using Affect Clues, Sentiment Polarity and Word Embeddings</title>
-      <author><first>Vineet</first> <last>John</last></author>
-      <author><first>Olga</first> <last>Vechtomova</last></author>
+      <author><first>Vineet</first><last>John</last></author>
+      <author><first>Olga</first><last>Vechtomova</last></author>
       <pages>249–254</pages>
       <url>W17-5235</url>
       <doi>10.18653/v1/W17-5235</doi>
@@ -9800,8 +9800,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="36">
       <title><fixed-case>LIPN</fixed-case>-<fixed-case>UAM</fixed-case> at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017:Combination of Lexicon-based features and Sentence-level Vector Representations for Emotion Intensity Determination</title>
-      <author><first>Davide</first> <last>Buscaldi</last></author>
-      <author><first>Belem</first> <last>Priego</last></author>
+      <author><first>Davide</first><last>Buscaldi</last></author>
+      <author><first>Belem</first><last>Priego</last></author>
       <pages>255–258</pages>
       <url>W17-5236</url>
       <doi>10.18653/v1/W17-5236</doi>
@@ -9809,11 +9809,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="37">
       <title>deep<fixed-case>C</fixed-case>yb<fixed-case>E</fixed-case>r<fixed-case>N</fixed-case>et at <fixed-case>E</fixed-case>mo<fixed-case>I</fixed-case>nt-2017: Deep Emotion Intensities in Tweets</title>
-      <author><first>Vinayakumar</first> <last>R</last></author>
-      <author><first>Premjith</first> <last>B</last></author>
-      <author><first>Sachin Kumar</first> <last>S</last></author>
-      <author><first>Soman</first> <last>KP</last></author>
-      <author><first>Prabaharan</first> <last>Poornachandran</last></author>
+      <author><first>Vinayakumar</first><last>R</last></author>
+      <author><first>Premjith</first><last>B</last></author>
+      <author><first>Sachin Kumar</first><last>S</last></author>
+      <author><first>Soman</first><last>KP</last></author>
+      <author><first>Prabaharan</first><last>Poornachandran</last></author>
       <pages>259–263</pages>
       <url>W17-5237</url>
       <doi>10.18653/v1/W17-5237</doi>
@@ -9842,10 +9842,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>The <fixed-case>R</fixed-case>ep<fixed-case>E</fixed-case>val 2017 Shared Task: Multi-Genre Natural Language Inference with Sentence Representations</title>
-      <author><first>Nikita</first> <last>Nangia</last></author>
-      <author><first>Adina</first> <last>Williams</last></author>
-      <author><first>Angeliki</first> <last>Lazaridou</last></author>
-      <author><first>Samuel</first> <last>Bowman</last></author>
+      <author><first>Nikita</first><last>Nangia</last></author>
+      <author><first>Adina</first><last>Williams</last></author>
+      <author><first>Angeliki</first><last>Lazaridou</last></author>
+      <author><first>Samuel</first><last>Bowman</last></author>
       <pages>1–10</pages>
       <url>W17-5301</url>
       <doi>10.18653/v1/W17-5301</doi>
@@ -9853,11 +9853,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>Traversal-Free Word Vector Evaluation in Analogy Space</title>
-      <author><first>Xiaoyin</first> <last>Che</last></author>
-      <author><first>Nico</first> <last>Ring</last></author>
-      <author><first>Willi</first> <last>Raschkowski</last></author>
-      <author><first>Haojin</first> <last>Yang</last></author>
-      <author><first>Christoph</first> <last>Meinel</last></author>
+      <author><first>Xiaoyin</first><last>Che</last></author>
+      <author><first>Nico</first><last>Ring</last></author>
+      <author><first>Willi</first><last>Raschkowski</last></author>
+      <author><first>Haojin</first><last>Yang</last></author>
+      <author><first>Christoph</first><last>Meinel</last></author>
       <pages>11–15</pages>
       <url>W17-5302</url>
       <doi>10.18653/v1/W17-5302</doi>
@@ -9865,7 +9865,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>Hypothesis Testing based Intrinsic Evaluation of Word Embeddings</title>
-      <author><first>Nishant</first> <last>Gurnani</last></author>
+      <author><first>Nishant</first><last>Gurnani</last></author>
       <pages>16–20</pages>
       <url>W17-5303</url>
       <doi>10.18653/v1/W17-5303</doi>
@@ -9873,9 +9873,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>Evaluation of word embeddings against cognitive processes: primed reaction times in lexical decision and naming tasks</title>
-      <author><first>Jeremy</first> <last>Auguste</last></author>
-      <author><first>Arnaud</first> <last>Rey</last></author>
-      <author><first>Benoit</first> <last>Favre</last></author>
+      <author><first>Jeremy</first><last>Auguste</last></author>
+      <author><first>Arnaud</first><last>Rey</last></author>
+      <author><first>Benoit</first><last>Favre</last></author>
       <pages>21–26</pages>
       <url>W17-5304</url>
       <doi>10.18653/v1/W17-5304</doi>
@@ -9883,8 +9883,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title>Playing with Embeddings : Evaluating embeddings for Robot Language Learning through <fixed-case>MUD</fixed-case> Games</title>
-      <author><first>Anmol</first> <last>Gulati</last></author>
-      <author><first>Kumar Krishna</first> <last>Agrawal</last></author>
+      <author><first>Anmol</first><last>Gulati</last></author>
+      <author><first>Kumar Krishna</first><last>Agrawal</last></author>
       <pages>27–30</pages>
       <url>W17-5305</url>
       <doi>10.18653/v1/W17-5305</doi>
@@ -9892,7 +9892,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="6">
       <title>Recognizing Textual Entailment in Twitter Using Word Embeddings</title>
-      <author><first>Octavia-Maria</first> <last>Şulea</last></author>
+      <author><first>Octavia-Maria</first><last>Şulea</last></author>
       <pages>31–35</pages>
       <url>W17-5306</url>
       <doi>10.18653/v1/W17-5306</doi>
@@ -9900,12 +9900,12 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Recurrent Neural Network-Based Sentence Encoder with Gated Attention for Natural Language Inference</title>
-      <author><first>Qian</first> <last>Chen</last></author>
-      <author><first>Xiaodan</first> <last>Zhu</last></author>
-      <author><first>Zhen-Hua</first> <last>Ling</last></author>
-      <author><first>Si</first> <last>Wei</last></author>
-      <author><first>Hui</first> <last>Jiang</last></author>
-      <author><first>Diana</first> <last>Inkpen</last></author>
+      <author><first>Qian</first><last>Chen</last></author>
+      <author><first>Xiaodan</first><last>Zhu</last></author>
+      <author><first>Zhen-Hua</first><last>Ling</last></author>
+      <author><first>Si</first><last>Wei</last></author>
+      <author><first>Hui</first><last>Jiang</last></author>
+      <author><first>Diana</first><last>Inkpen</last></author>
       <pages>36–40</pages>
       <url>W17-5307</url>
       <doi>10.18653/v1/W17-5307</doi>
@@ -9913,8 +9913,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="8">
       <title>Shortcut-Stacked Sentence Encoders for Multi-Domain Inference</title>
-      <author><first>Yixin</first> <last>Nie</last></author>
-      <author><first>Mohit</first> <last>Bansal</last></author>
+      <author><first>Yixin</first><last>Nie</last></author>
+      <author><first>Mohit</first><last>Bansal</last></author>
       <pages>41–45</pages>
       <url>W17-5308</url>
       <doi>10.18653/v1/W17-5308</doi>
@@ -9922,9 +9922,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="9">
       <title>Character-level Intra Attention Network for Natural Language Inference</title>
-      <author><first>Han</first> <last>Yang</last></author>
-      <author><first>Marta R.</first> <last>Costa-jussà</last></author>
-      <author><first>José A. R.</first> <last>Fonollosa</last></author>
+      <author><first>Han</first><last>Yang</last></author>
+      <author><first>Marta R.</first><last>Costa-jussà</last></author>
+      <author><first>José A. R.</first><last>Fonollosa</last></author>
       <pages>46–50</pages>
       <url>W17-5309</url>
       <doi>10.18653/v1/W17-5309</doi>
@@ -9932,10 +9932,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="10">
       <title>Refining Raw Sentence Representations for Textual Entailment Recognition via Attention</title>
-      <author><first>Jorge</first> <last>Balazs</last></author>
-      <author><first>Edison</first> <last>Marrese-Taylor</last></author>
-      <author><first>Pablo</first> <last>Loyola</last></author>
-      <author><first>Yutaka</first> <last>Matsuo</last></author>
+      <author><first>Jorge</first><last>Balazs</last></author>
+      <author><first>Edison</first><last>Marrese-Taylor</last></author>
+      <author><first>Pablo</first><last>Loyola</last></author>
+      <author><first>Yutaka</first><last>Matsuo</last></author>
       <pages>51–55</pages>
       <url>W17-5310</url>
       <doi>10.18653/v1/W17-5310</doi>
@@ -9974,10 +9974,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Towards Linguistically Generalizable <fixed-case>NLP</fixed-case> Systems: A Workshop and Shared Task</title>
-      <author><first>Allyson</first> <last>Ettinger</last></author>
-      <author><first>Sudha</first> <last>Rao</last></author>
-      <author><first>Hal</first> <last>Daumé III</last></author>
-      <author><first>Emily M.</first> <last>Bender</last></author>
+      <author><first>Allyson</first><last>Ettinger</last></author>
+      <author><first>Sudha</first><last>Rao</last></author>
+      <author><first>Hal</first><last>Daumé III</last></author>
+      <author><first>Emily M.</first><last>Bender</last></author>
       <pages>1–10</pages>
       <url>W17-5401</url>
       <doi>10.18653/v1/W17-5401</doi>
@@ -9985,11 +9985,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>Analysing Errors of Open Information Extraction Systems</title>
-      <author><first>Rudolf</first> <last>Schneider</last></author>
-      <author><first>Tom</first> <last>Oberhauser</last></author>
-      <author><first>Tobias</first> <last>Klatt</last></author>
-      <author><first>Felix A.</first> <last>Gers</last></author>
-      <author><first>Alexander</first> <last>Löser</last></author>
+      <author><first>Rudolf</first><last>Schneider</last></author>
+      <author><first>Tom</first><last>Oberhauser</last></author>
+      <author><first>Tobias</first><last>Klatt</last></author>
+      <author><first>Felix A.</first><last>Gers</last></author>
+      <author><first>Alexander</first><last>Löser</last></author>
       <pages>11–18</pages>
       <url>W17-5402</url>
       <doi>10.18653/v1/W17-5402</doi>
@@ -9997,9 +9997,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>Massively Multilingual Neural Grapheme-to-Phoneme Conversion</title>
-      <author><first>Ben</first> <last>Peters</last></author>
-      <author><first>Jon</first> <last>Dehdari</last></author>
-      <author><first>Josef</first> <last>van Genabith</last></author>
+      <author><first>Ben</first><last>Peters</last></author>
+      <author><first>Jon</first><last>Dehdari</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>19–26</pages>
       <url>W17-5403</url>
       <doi>10.18653/v1/W17-5403</doi>
@@ -10007,9 +10007,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title><fixed-case>BIBI</fixed-case> System Description: Building with <fixed-case>CNN</fixed-case>s and Breaking with Deep Reinforcement Learning</title>
-      <author><first>Yitong</first> <last>Li</last></author>
-      <author><first>Trevor</first> <last>Cohn</last></author>
-      <author><first>Timothy</first> <last>Baldwin</last></author>
+      <author><first>Yitong</first><last>Li</last></author>
+      <author><first>Trevor</first><last>Cohn</last></author>
+      <author><first>Timothy</first><last>Baldwin</last></author>
       <pages>27–32</pages>
       <url>W17-5404</url>
       <doi>10.18653/v1/W17-5404</doi>
@@ -10017,14 +10017,14 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title>Breaking <fixed-case>NLP</fixed-case>: Using Morphosyntax, Semantics, Pragmatics and World Knowledge to Fool Sentiment Analysis Systems</title>
-      <author><first>Taylor</first> <last>Mahler</last></author>
-      <author><first>Willy</first> <last>Cheung</last></author>
-      <author><first>Micha</first> <last>Elsner</last></author>
-      <author><first>David</first> <last>King</last></author>
-      <author><first>Marie-Catherine</first> <last>de Marneffe</last></author>
-      <author><first>Cory</first> <last>Shain</last></author>
-      <author><first>Symon</first> <last>Stevens-Guille</last></author>
-      <author><first>Michael</first> <last>White</last></author>
+      <author><first>Taylor</first><last>Mahler</last></author>
+      <author><first>Willy</first><last>Cheung</last></author>
+      <author><first>Micha</first><last>Elsner</last></author>
+      <author><first>David</first><last>King</last></author>
+      <author><first>Marie-Catherine</first><last>de Marneffe</last></author>
+      <author><first>Cory</first><last>Shain</last></author>
+      <author><first>Symon</first><last>Stevens-Guille</last></author>
+      <author><first>Michael</first><last>White</last></author>
       <pages>33–39</pages>
       <url>W17-5405</url>
       <doi>10.18653/v1/W17-5405</doi>
@@ -10033,9 +10033,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="6">
       <title>An Adaptable Lexical Simplification Architecture for Major <fixed-case>I</fixed-case>bero-Romance Languages</title>
-      <author><first>Daniel</first> <last>Ferrés</last></author>
-      <author><first>Horacio</first> <last>Saggion</last></author>
-      <author><first>Xavier</first> <last>Gómez Guinovart</last></author>
+      <author><first>Daniel</first><last>Ferrés</last></author>
+      <author><first>Horacio</first><last>Saggion</last></author>
+      <author><first>Xavier</first><last>Gómez Guinovart</last></author>
       <pages>40–47</pages>
       <url>W17-5406</url>
       <doi>10.18653/v1/W17-5406</doi>
@@ -10043,8 +10043,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Cross-genre Document Retrieval: Matching between Conversational and Formal Writings</title>
-      <author><first>Tomasz</first> <last>Jurczyk</last></author>
-      <author><first>Jinho D.</first> <last>Choi</last></author>
+      <author><first>Tomasz</first><last>Jurczyk</last></author>
+      <author><first>Jinho D.</first><last>Choi</last></author>
       <pages>48–53</pages>
       <url>W17-5407</url>
       <doi>10.18653/v1/W17-5407</doi>
@@ -10052,8 +10052,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="8">
       <title><fixed-case>ACTSA</fixed-case>: Annotated Corpus for <fixed-case>T</fixed-case>elugu Sentiment Analysis</title>
-      <author><first>Sandeep Sricharan</first> <last>Mukku</last></author>
-      <author><first>Radhika</first> <last>Mamidi</last></author>
+      <author><first>Sandeep Sricharan</first><last>Mukku</last></author>
+      <author><first>Radhika</first><last>Mamidi</last></author>
       <pages>54–58</pages>
       <url>W17-5408</url>
       <doi>10.18653/v1/W17-5408</doi>
@@ -10061,7 +10061,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="9">
       <title><fixed-case>S</fixed-case>trawman: An Ensemble of Deep Bag-of-Ngrams for Sentiment Analysis</title>
-      <author><first>Kyunghyun</first> <last>Cho</last></author>
+      <author><first>Kyunghyun</first><last>Cho</last></author>
       <pages>59–60</pages>
       <url>W17-5409</url>
       <doi>10.18653/v1/W17-5409</doi>
@@ -10069,8 +10069,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="10">
       <title>Breaking Sentiment Analysis of Movie Reviews</title>
-      <author><first>Ieva</first> <last>Staliūnaitė</last></author>
-      <author><first>Ben</first> <last>Bonfil</last></author>
+      <author><first>Ieva</first><last>Staliūnaitė</last></author>
+      <author><first>Ben</first><last>Bonfil</last></author>
       <pages>61–64</pages>
       <url>W17-5410</url>
       <doi>10.18653/v1/W17-5410</doi>
@@ -10096,8 +10096,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Automatic Mapping of <fixed-case>F</fixed-case>rench Discourse Connectives to <fixed-case>PDTB</fixed-case> Discourse Relations</title>
-      <author><first>Majid</first> <last>Laali</last></author>
-      <author><first>Leila</first> <last>Kosseim</last></author>
+      <author><first>Majid</first><last>Laali</last></author>
+      <author><first>Leila</first><last>Kosseim</last></author>
       <pages>1–6</pages>
       <url>W17-5501</url>
       <doi>10.18653/v1/W17-5501</doi>
@@ -10105,9 +10105,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>Towards Full Text Shallow Discourse Relation Annotation: Experiments with Cross-Paragraph Implicit Relations in the <fixed-case>PDTB</fixed-case></title>
-      <author><first>Rashmi</first> <last>Prasad</last></author>
-      <author><first>Katherine</first> <last>Forbes Riley</last></author>
-      <author><first>Alan</first> <last>Lee</last></author>
+      <author><first>Rashmi</first><last>Prasad</last></author>
+      <author><first>Katherine</first><last>Forbes Riley</last></author>
+      <author><first>Alan</first><last>Lee</last></author>
       <pages>7–16</pages>
       <url>W17-5502</url>
       <doi>10.18653/v1/W17-5502</doi>
@@ -10115,7 +10115,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>User-initiated Sub-dialogues in State-of-the-art Dialogue Systems</title>
-      <author><first>Staffan</first> <last>Larsson</last></author>
+      <author><first>Staffan</first><last>Larsson</last></author>
       <pages>17–22</pages>
       <url>W17-5503</url>
       <doi>10.18653/v1/W17-5503</doi>
@@ -10123,11 +10123,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>A Multimodal Dialogue System for Medical Decision Support inside Virtual Reality</title>
-      <author><first>Alexander</first> <last>Prange</last></author>
-      <author><first>Margarita</first> <last>Chikobava</last></author>
-      <author><first>Peter</first> <last>Poller</last></author>
-      <author><first>Michael</first> <last>Barz</last></author>
-      <author><first>Daniel</first> <last>Sonntag</last></author>
+      <author><first>Alexander</first><last>Prange</last></author>
+      <author><first>Margarita</first><last>Chikobava</last></author>
+      <author><first>Peter</first><last>Poller</last></author>
+      <author><first>Michael</first><last>Barz</last></author>
+      <author><first>Daniel</first><last>Sonntag</last></author>
       <pages>23–26</pages>
       <url>W17-5504</url>
       <doi>10.18653/v1/W17-5504</doi>
@@ -10135,10 +10135,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title>Generative Encoder-Decoder Models for Task-Oriented Spoken Dialog Systems with Chatting Capability</title>
-      <author><first>Tiancheng</first> <last>Zhao</last></author>
-      <author><first>Allen</first> <last>Lu</last></author>
-      <author><first>Kyusong</first> <last>Lee</last></author>
-      <author><first>Maxine</first> <last>Eskenazi</last></author>
+      <author><first>Tiancheng</first><last>Zhao</last></author>
+      <author><first>Allen</first><last>Lu</last></author>
+      <author><first>Kyusong</first><last>Lee</last></author>
+      <author><first>Maxine</first><last>Eskenazi</last></author>
       <pages>27–36</pages>
       <url>W17-5505</url>
       <doi>10.18653/v1/W17-5505</doi>
@@ -10146,10 +10146,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="6">
       <title>Key-Value Retrieval Networks for Task-Oriented Dialogue</title>
-      <author><first>Mihail</first> <last>Eric</last></author>
-      <author><first>Lakshmi</first> <last>Krishnan</last></author>
-      <author><first>Francois</first> <last>Charette</last></author>
-      <author><first>Christopher D.</first> <last>Manning</last></author>
+      <author><first>Mihail</first><last>Eric</last></author>
+      <author><first>Lakshmi</first><last>Krishnan</last></author>
+      <author><first>Francois</first><last>Charette</last></author>
+      <author><first>Christopher D.</first><last>Manning</last></author>
       <pages>37–49</pages>
       <url>W17-5506</url>
       <doi>10.18653/v1/W17-5506</doi>
@@ -10157,11 +10157,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Lexical Acquisition through Implicit Confirmations over Multiple Dialogues</title>
-      <author><first>Kohei</first> <last>Ono</last></author>
-      <author><first>Ryu</first> <last>Takeda</last></author>
-      <author><first>Eric</first> <last>Nichols</last></author>
-      <author><first>Mikio</first> <last>Nakano</last></author>
-      <author><first>Kazunori</first> <last>Komatani</last></author>
+      <author><first>Kohei</first><last>Ono</last></author>
+      <author><first>Ryu</first><last>Takeda</last></author>
+      <author><first>Eric</first><last>Nichols</last></author>
+      <author><first>Mikio</first><last>Nakano</last></author>
+      <author><first>Kazunori</first><last>Komatani</last></author>
       <pages>50–59</pages>
       <url>W17-5507</url>
       <doi>10.18653/v1/W17-5507</doi>
@@ -10169,12 +10169,12 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="8">
       <title>Utterance Intent Classification of a Spoken Dialogue System with Efficiently Untied Recursive Autoencoders</title>
-      <author><first>Tsuneo</first> <last>Kato</last></author>
-      <author><first>Atsushi</first> <last>Nagai</last></author>
-      <author><first>Naoki</first> <last>Noda</last></author>
-      <author><first>Ryosuke</first> <last>Sumitomo</last></author>
-      <author><first>Jianming</first> <last>Wu</last></author>
-      <author><first>Seiichi</first> <last>Yamamoto</last></author>
+      <author><first>Tsuneo</first><last>Kato</last></author>
+      <author><first>Atsushi</first><last>Nagai</last></author>
+      <author><first>Naoki</first><last>Noda</last></author>
+      <author><first>Ryosuke</first><last>Sumitomo</last></author>
+      <author><first>Jianming</first><last>Wu</last></author>
+      <author><first>Seiichi</first><last>Yamamoto</last></author>
       <pages>60–64</pages>
       <url>W17-5508</url>
       <doi>10.18653/v1/W17-5508</doi>
@@ -10182,15 +10182,15 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="9">
       <title>Reward-Balancing for Statistical Spoken Dialogue Systems using Multi-objective Reinforcement Learning</title>
-      <author><first>Stefan</first> <last>Ultes</last></author>
-      <author><first>Paweł</first> <last>Budzianowski</last></author>
-      <author><first>Iñigo</first> <last>Casanueva</last></author>
-      <author><first>Nikola</first> <last>Mrkšić</last></author>
-      <author><first>Lina M.</first> <last>Rojas-Barahona</last></author>
-      <author><first>Pei-Hao</first> <last>Su</last></author>
-      <author><first>Tsung-Hsien</first> <last>Wen</last></author>
-      <author><first>Milica</first> <last>Gašić</last></author>
-      <author><first>Steve</first> <last>Young</last></author>
+      <author><first>Stefan</first><last>Ultes</last></author>
+      <author><first>Paweł</first><last>Budzianowski</last></author>
+      <author><first>Iñigo</first><last>Casanueva</last></author>
+      <author><first>Nikola</first><last>Mrkšić</last></author>
+      <author><first>Lina M.</first><last>Rojas-Barahona</last></author>
+      <author><first>Pei-Hao</first><last>Su</last></author>
+      <author><first>Tsung-Hsien</first><last>Wen</last></author>
+      <author><first>Milica</first><last>Gašić</last></author>
+      <author><first>Steve</first><last>Young</last></author>
       <pages>65–70</pages>
       <url>W17-5509</url>
       <doi>10.18653/v1/W17-5509</doi>
@@ -10198,9 +10198,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="10">
       <title>Automatic Measures to Characterise Verbal Alignment in Human-Agent Interaction</title>
-      <author><first>Guillaume</first> <last>Dubuisson Duplessis</last></author>
-      <author><first>Chloé</first> <last>Clavel</last></author>
-      <author><first>Frédéric</first> <last>Landragin</last></author>
+      <author><first>Guillaume</first><last>Dubuisson Duplessis</last></author>
+      <author><first>Chloé</first><last>Clavel</last></author>
+      <author><first>Frédéric</first><last>Landragin</last></author>
       <pages>71–81</pages>
       <url>W17-5510</url>
       <doi>10.18653/v1/W17-5510</doi>
@@ -10208,8 +10208,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="11">
       <title>Demonstration of interactive teaching for end-to-end dialog control with hybrid code networks</title>
-      <author><first>Jason D.</first> <last>Williams</last></author>
-      <author><first>Lars</first> <last>Liden</last></author>
+      <author><first>Jason D.</first><last>Williams</last></author>
+      <author><first>Lars</first><last>Liden</last></author>
       <pages>82–85</pages>
       <url>W17-5511</url>
       <doi>10.18653/v1/W17-5511</doi>
@@ -10217,14 +10217,14 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="12">
       <title>Sub-domain Modelling for Dialogue Management with Hierarchical Reinforcement Learning</title>
-      <author><first>Paweł</first> <last>Budzianowski</last></author>
-      <author><first>Stefan</first> <last>Ultes</last></author>
-      <author><first>Pei-Hao</first> <last>Su</last></author>
-      <author><first>Nikola</first> <last>Mrkšić</last></author>
-      <author><first>Tsung-Hsien</first> <last>Wen</last></author>
-      <author><first>Iñigo</first> <last>Casanueva</last></author>
-      <author><first>Lina M.</first> <last>Rojas-Barahona</last></author>
-      <author><first>Milica</first> <last>Gašić</last></author>
+      <author><first>Paweł</first><last>Budzianowski</last></author>
+      <author><first>Stefan</first><last>Ultes</last></author>
+      <author><first>Pei-Hao</first><last>Su</last></author>
+      <author><first>Nikola</first><last>Mrkšić</last></author>
+      <author><first>Tsung-Hsien</first><last>Wen</last></author>
+      <author><first>Iñigo</first><last>Casanueva</last></author>
+      <author><first>Lina M.</first><last>Rojas-Barahona</last></author>
+      <author><first>Milica</first><last>Gašić</last></author>
       <pages>86–92</pages>
       <url>W17-5512</url>
       <doi>10.18653/v1/W17-5512</doi>
@@ -10232,9 +10232,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="13">
       <title><fixed-case>MACA</fixed-case>: A Modular Architecture for Conversational Agents</title>
-      <author><first>Hoai Phuoc</first> <last>Truong</last></author>
-      <author><first>Prasanna</first> <last>Parthasarathi</last></author>
-      <author><first>Joelle</first> <last>Pineau</last></author>
+      <author><first>Hoai Phuoc</first><last>Truong</last></author>
+      <author><first>Prasanna</first><last>Parthasarathi</last></author>
+      <author><first>Joelle</first><last>Pineau</last></author>
       <pages>93–102</pages>
       <url>W17-5513</url>
       <doi>10.18653/v1/W17-5513</doi>
@@ -10242,10 +10242,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="14">
       <title>Sequential Dialogue Context Modeling for Spoken Language Understanding</title>
-      <author><first>Ankur</first> <last>Bapna</last></author>
-      <author><first>Gokhan</first> <last>Tür</last></author>
-      <author><first>Dilek</first> <last>Hakkani-Tür</last></author>
-      <author><first>Larry</first> <last>Heck</last></author>
+      <author><first>Ankur</first><last>Bapna</last></author>
+      <author><first>Gokhan</first><last>Tür</last></author>
+      <author><first>Dilek</first><last>Hakkani-Tür</last></author>
+      <author><first>Larry</first><last>Heck</last></author>
       <pages>103–114</pages>
       <url>W17-5514</url>
       <doi>10.18653/v1/W17-5514</doi>
@@ -10253,10 +10253,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="15">
       <title>Redundancy Localization for the Conversationalization of Unstructured Responses</title>
-      <author><first>Sebastian</first> <last>Krause</last></author>
-      <author><first>Mikhail</first> <last>Kozhevnikov</last></author>
-      <author><first>Eric</first> <last>Malmi</last></author>
-      <author><first>Daniele</first> <last>Pighin</last></author>
+      <author><first>Sebastian</first><last>Krause</last></author>
+      <author><first>Mikhail</first><last>Kozhevnikov</last></author>
+      <author><first>Eric</first><last>Malmi</last></author>
+      <author><first>Daniele</first><last>Pighin</last></author>
       <pages>115–126</pages>
       <url>W17-5515</url>
       <doi>10.18653/v1/W17-5515</doi>
@@ -10264,12 +10264,12 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="16">
       <title>Attentive listening system with backchanneling, response generation and flexible turn-taking</title>
-      <author><first>Divesh</first> <last>Lala</last></author>
-      <author><first>Pierrick</first> <last>Milhorat</last></author>
-      <author><first>Koji</first> <last>Inoue</last></author>
-      <author><first>Masanari</first> <last>Ishida</last></author>
-      <author><first>Katsuya</first> <last>Takanashi</last></author>
-      <author><first>Tatsuya</first> <last>Kawahara</last></author>
+      <author><first>Divesh</first><last>Lala</last></author>
+      <author><first>Pierrick</first><last>Milhorat</last></author>
+      <author><first>Koji</first><last>Inoue</last></author>
+      <author><first>Masanari</first><last>Ishida</last></author>
+      <author><first>Katsuya</first><last>Takanashi</last></author>
+      <author><first>Tatsuya</first><last>Kawahara</last></author>
       <pages>127–136</pages>
       <url>W17-5516</url>
       <doi>10.18653/v1/W17-5516</doi>
@@ -10277,8 +10277,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="17">
       <title>Natural Language Input for In-Car Spoken Dialog Systems: How Natural is Natural?</title>
-      <author><first>Patricia</first> <last>Braunger</last></author>
-      <author><first>Wolfgang</first> <last>Maier</last></author>
+      <author><first>Patricia</first><last>Braunger</last></author>
+      <author><first>Wolfgang</first><last>Maier</last></author>
       <pages>137–146</pages>
       <url>W17-5517</url>
       <doi>10.18653/v1/W17-5517</doi>
@@ -10286,11 +10286,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="18">
       <title>Sample-efficient Actor-Critic Reinforcement Learning with Supervised Data for Dialogue Management</title>
-      <author><first>Pei-Hao</first> <last>Su</last></author>
-      <author><first>Paweł</first> <last>Budzianowski</last></author>
-      <author><first>Stefan</first> <last>Ultes</last></author>
-      <author><first>Milica</first> <last>Gašić</last></author>
-      <author><first>Steve</first> <last>Young</last></author>
+      <author><first>Pei-Hao</first><last>Su</last></author>
+      <author><first>Paweł</first><last>Budzianowski</last></author>
+      <author><first>Stefan</first><last>Ultes</last></author>
+      <author><first>Milica</first><last>Gašić</last></author>
+      <author><first>Steve</first><last>Young</last></author>
       <pages>147–157</pages>
       <url>W17-5518</url>
       <doi>10.18653/v1/W17-5518</doi>
@@ -10298,8 +10298,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="19">
       <title>A surprisingly effective out-of-the-box char2char model on the <fixed-case>E</fixed-case>2<fixed-case>E</fixed-case> <fixed-case>NLG</fixed-case> Challenge dataset</title>
-      <author><first>Shubham</first> <last>Agarwal</last></author>
-      <author><first>Marc</first> <last>Dymetman</last></author>
+      <author><first>Shubham</first><last>Agarwal</last></author>
+      <author><first>Marc</first><last>Dymetman</last></author>
       <pages>158–163</pages>
       <url>W17-5519</url>
       <doi>10.18653/v1/W17-5519</doi>
@@ -10307,9 +10307,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="20">
       <title>Interaction Quality Estimation Using Long Short-Term Memories</title>
-      <author><first>Niklas</first> <last>Rach</last></author>
-      <author><first>Wolfgang</first> <last>Minker</last></author>
-      <author><first>Stefan</first> <last>Ultes</last></author>
+      <author><first>Niklas</first><last>Rach</last></author>
+      <author><first>Wolfgang</first><last>Minker</last></author>
+      <author><first>Stefan</first><last>Ultes</last></author>
       <pages>164–169</pages>
       <url>W17-5520</url>
       <doi>10.18653/v1/W17-5520</doi>
@@ -10317,18 +10317,18 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="21">
       <title><fixed-case>D</fixed-case>ial<fixed-case>P</fixed-case>ort, Gone Live: An Update After A Year of Development</title>
-      <author><first>Kyusong</first> <last>Lee</last></author>
-      <author><first>Tiancheng</first> <last>Zhao</last></author>
-      <author><first>Yulun</first> <last>Du</last></author>
-      <author><first>Edward</first> <last>Cai</last></author>
-      <author><first>Allen</first> <last>Lu</last></author>
-      <author><first>Eli</first> <last>Pincus</last></author>
-      <author><first>David</first> <last>Traum</last></author>
-      <author><first>Stefan</first> <last>Ultes</last></author>
-      <author><first>Lina M.</first> <last>Rojas-Barahona</last></author>
-      <author><first>Milica</first> <last>Gasic</last></author>
-      <author><first>Steve</first> <last>Young</last></author>
-      <author><first>Maxine</first> <last>Eskenazi</last></author>
+      <author><first>Kyusong</first><last>Lee</last></author>
+      <author><first>Tiancheng</first><last>Zhao</last></author>
+      <author><first>Yulun</first><last>Du</last></author>
+      <author><first>Edward</first><last>Cai</last></author>
+      <author><first>Allen</first><last>Lu</last></author>
+      <author><first>Eli</first><last>Pincus</last></author>
+      <author><first>David</first><last>Traum</last></author>
+      <author><first>Stefan</first><last>Ultes</last></author>
+      <author><first>Lina M.</first><last>Rojas-Barahona</last></author>
+      <author><first>Milica</first><last>Gasic</last></author>
+      <author><first>Steve</first><last>Young</last></author>
+      <author><first>Maxine</first><last>Eskenazi</last></author>
       <pages>170–173</pages>
       <url>W17-5521</url>
       <doi>10.18653/v1/W17-5521</doi>
@@ -10336,10 +10336,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="22">
       <title>Evaluating Natural Language Understanding Services for Conversational Question Answering Systems</title>
-      <author><first>Daniel</first> <last>Braun</last></author>
-      <author><first>Adrian</first> <last>Hernandez Mendez</last></author>
-      <author><first>Florian</first> <last>Matthes</last></author>
-      <author><first>Manfred</first> <last>Langen</last></author>
+      <author><first>Daniel</first><last>Braun</last></author>
+      <author><first>Adrian</first><last>Hernandez Mendez</last></author>
+      <author><first>Florian</first><last>Matthes</last></author>
+      <author><first>Manfred</first><last>Langen</last></author>
       <pages>174–185</pages>
       <url>W17-5522</url>
       <doi>10.18653/v1/W17-5522</doi>
@@ -10347,9 +10347,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="23">
       <title>The Role of Conversation Context for Sarcasm Detection in Online Interactions</title>
-      <author><first>Debanjan</first> <last>Ghosh</last></author>
-      <author><first>Alexander</first> <last>Richard Fabbri</last></author>
-      <author><first>Smaranda</first> <last>Muresan</last></author>
+      <author><first>Debanjan</first><last>Ghosh</last></author>
+      <author><first>Alexander</first><last>Richard Fabbri</last></author>
+      <author><first>Smaranda</first><last>Muresan</last></author>
       <pages>186–196</pages>
       <url>W17-5523</url>
       <doi>10.18653/v1/W17-5523</doi>
@@ -10357,9 +10357,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="24">
       <title><fixed-case>VOILA</fixed-case>: An Optimised Dialogue System for Interactively Learning Visually-Grounded Word Meanings (Demonstration System)</title>
-      <author><first>Yanchao</first> <last>Yu</last></author>
-      <author><first>Arash</first> <last>Eshghi</last></author>
-      <author><first>Oliver</first> <last>Lemon</last></author>
+      <author><first>Yanchao</first><last>Yu</last></author>
+      <author><first>Arash</first><last>Eshghi</last></author>
+      <author><first>Oliver</first><last>Lemon</last></author>
       <pages>197–200</pages>
       <url>W17-5524</url>
       <doi>10.18653/v1/W17-5524</doi>
@@ -10367,9 +10367,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="25">
       <title>The <fixed-case>E</fixed-case>2<fixed-case>E</fixed-case> Dataset: New Challenges For End-to-End Generation</title>
-      <author><first>Jekaterina</first> <last>Novikova</last></author>
-      <author><first>Ondřej</first> <last>Dušek</last></author>
-      <author><first>Verena</first> <last>Rieser</last></author>
+      <author><first>Jekaterina</first><last>Novikova</last></author>
+      <author><first>Ondřej</first><last>Dušek</last></author>
+      <author><first>Verena</first><last>Rieser</last></author>
       <pages>201–206</pages>
       <url>W17-5525</url>
       <doi>10.18653/v1/W17-5525</doi>
@@ -10377,14 +10377,14 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="26">
       <title><fixed-case>F</fixed-case>rames: a corpus for adding memory to goal-oriented dialogue systems</title>
-      <author><first>Layla</first> <last>El Asri</last></author>
-      <author><first>Hannes</first> <last>Schulz</last></author>
-      <author><first>Shikhar</first> <last>Sharma</last></author>
-      <author><first>Jeremie</first> <last>Zumer</last></author>
-      <author><first>Justin</first> <last>Harris</last></author>
-      <author><first>Emery</first> <last>Fine</last></author>
-      <author><first>Rahul</first> <last>Mehrotra</last></author>
-      <author><first>Kaheer</first> <last>Suleman</last></author>
+      <author><first>Layla</first><last>El Asri</last></author>
+      <author><first>Hannes</first><last>Schulz</last></author>
+      <author><first>Shikhar</first><last>Sharma</last></author>
+      <author><first>Jeremie</first><last>Zumer</last></author>
+      <author><first>Justin</first><last>Harris</last></author>
+      <author><first>Emery</first><last>Fine</last></author>
+      <author><first>Rahul</first><last>Mehrotra</last></author>
+      <author><first>Kaheer</first><last>Suleman</last></author>
       <pages>207–219</pages>
       <url>W17-5526</url>
       <doi>10.18653/v1/W17-5526</doi>
@@ -10393,7 +10393,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="27">
       <title>Towards a General, Continuous Model of Turn-taking in Spoken Dialogue using <fixed-case>LSTM</fixed-case> Recurrent Neural Networks</title>
-      <author><first>Gabriel</first> <last>Skantze</last></author>
+      <author><first>Gabriel</first><last>Skantze</last></author>
       <pages>220–230</pages>
       <url>W17-5527</url>
       <doi>10.18653/v1/W17-5527</doi>
@@ -10401,9 +10401,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="28">
       <title>Neural-based Natural Language Generation in Dialogue using <fixed-case>RNN</fixed-case> Encoder-Decoder with Semantic Aggregation</title>
-      <author><first>Van-Khanh</first> <last>Tran</last></author>
-      <author><first>Le-Minh</first> <last>Nguyen</last></author>
-      <author><first>Satoshi</first> <last>Tojo</last></author>
+      <author><first>Van-Khanh</first><last>Tran</last></author>
+      <author><first>Le-Minh</first><last>Nguyen</last></author>
+      <author><first>Satoshi</first><last>Tojo</last></author>
       <pages>231–240</pages>
       <url>W17-5528</url>
       <doi>10.18653/v1/W17-5528</doi>
@@ -10411,9 +10411,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="29">
       <title>Beyond On-hold Messages: Conversational Time-buying in Task-oriented Dialogue</title>
-      <author><first>Soledad</first> <last>López Gambino</last></author>
-      <author><first>Sina</first> <last>Zarrieß</last></author>
-      <author><first>David</first> <last>Schlangen</last></author>
+      <author><first>Soledad</first><last>López Gambino</last></author>
+      <author><first>Sina</first><last>Zarrieß</last></author>
+      <author><first>David</first><last>Schlangen</last></author>
       <pages>241–246</pages>
       <url>W17-5529</url>
       <doi>10.18653/v1/W17-5529</doi>
@@ -10421,8 +10421,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="30">
       <title>Neural-based Context Representation Learning for Dialog Act Classification</title>
-      <author><first>Daniel</first> <last>Ortega</last></author>
-      <author><first>Ngoc Thang</first> <last>Vu</last></author>
+      <author><first>Daniel</first><last>Ortega</last></author>
+      <author><first>Ngoc Thang</first><last>Vu</last></author>
       <pages>247–252</pages>
       <url>W17-5530</url>
       <doi>10.18653/v1/W17-5530</doi>
@@ -10430,9 +10430,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="31">
       <title>Predicting Success in Goal-Driven Human-Human Dialogues</title>
-      <author><first>Michael</first> <last>Noseworthy</last></author>
-      <author><first>Jackie Chi Kit</first> <last>Cheung</last></author>
-      <author><first>Joelle</first> <last>Pineau</last></author>
+      <author><first>Michael</first><last>Noseworthy</last></author>
+      <author><first>Jackie Chi Kit</first><last>Cheung</last></author>
+      <author><first>Joelle</first><last>Pineau</last></author>
       <pages>253–262</pages>
       <url>W17-5531</url>
       <doi>10.18653/v1/W17-5531</doi>
@@ -10440,10 +10440,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="32">
       <title>Generating and Evaluating Summaries for Partial Email Threads: Conversational <fixed-case>B</fixed-case>ayesian Surprise and Silver Standards</title>
-      <author><first>Jordon</first> <last>Johnson</last></author>
-      <author><first>Vaden</first> <last>Masrani</last></author>
-      <author><first>Giuseppe</first> <last>Carenini</last></author>
-      <author><first>Raymond</first> <last>Ng</last></author>
+      <author><first>Jordon</first><last>Johnson</last></author>
+      <author><first>Vaden</first><last>Masrani</last></author>
+      <author><first>Giuseppe</first><last>Carenini</last></author>
+      <author><first>Raymond</first><last>Ng</last></author>
       <pages>263–272</pages>
       <url>W17-5532</url>
       <doi>10.18653/v1/W17-5532</doi>
@@ -10451,8 +10451,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="33">
       <title>Enabling robust and fluid spoken dialogue with cognitively impaired users</title>
-      <author><first>Ramin</first> <last>Yaghoubzadeh</last></author>
-      <author><first>Stefan</first> <last>Kopp</last></author>
+      <author><first>Ramin</first><last>Yaghoubzadeh</last></author>
+      <author><first>Stefan</first><last>Kopp</last></author>
       <pages>273–283</pages>
       <url>W17-5533</url>
       <doi>10.18653/v1/W17-5533</doi>
@@ -10460,8 +10460,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="34">
       <title>Adversarial evaluation for open-domain dialogue generation</title>
-      <author><first>Elia</first> <last>Bruni</last></author>
-      <author><first>Raquel</first> <last>Fernández</last></author>
+      <author><first>Elia</first><last>Bruni</last></author>
+      <author><first>Raquel</first><last>Fernández</last></author>
       <pages>284–288</pages>
       <url>W17-5534</url>
       <doi>10.18653/v1/W17-5534</doi>
@@ -10469,9 +10469,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="35">
       <title>Exploring Joint Neural Model for Sentence Level Discourse Parsing and Sentiment Analysis</title>
-      <author><first>Bita</first> <last>Nejat</last></author>
-      <author><first>Giuseppe</first> <last>Carenini</last></author>
-      <author><first>Raymond</first> <last>Ng</last></author>
+      <author><first>Bita</first><last>Nejat</last></author>
+      <author><first>Giuseppe</first><last>Carenini</last></author>
+      <author><first>Raymond</first><last>Ng</last></author>
       <pages>289–298</pages>
       <url>W17-5535</url>
       <doi>10.18653/v1/W17-5535</doi>
@@ -10479,9 +10479,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="36">
       <title>Predicting Causes of Reformulation in Intelligent Assistants</title>
-      <author><first>Shumpei</first> <last>Sano</last></author>
-      <author><first>Nobuhiro</first> <last>Kaji</last></author>
-      <author><first>Manabu</first> <last>Sassano</last></author>
+      <author><first>Shumpei</first><last>Sano</last></author>
+      <author><first>Nobuhiro</first><last>Kaji</last></author>
+      <author><first>Manabu</first><last>Sassano</last></author>
       <pages>299–309</pages>
       <url>W17-5536</url>
       <doi>10.18653/v1/W17-5536</doi>
@@ -10489,11 +10489,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="37">
       <title>Are you serious?: Rhetorical Questions and Sarcasm in Social Media Dialog</title>
-      <author><first>Shereen</first> <last>Oraby</last></author>
-      <author><first>Vrindavan</first> <last>Harrison</last></author>
-      <author><first>Amita</first> <last>Misra</last></author>
-      <author><first>Ellen</first> <last>Riloff</last></author>
-      <author><first>Marilyn</first> <last>Walker</last></author>
+      <author><first>Shereen</first><last>Oraby</last></author>
+      <author><first>Vrindavan</first><last>Harrison</last></author>
+      <author><first>Amita</first><last>Misra</last></author>
+      <author><first>Ellen</first><last>Riloff</last></author>
+      <author><first>Marilyn</first><last>Walker</last></author>
       <pages>310–319</pages>
       <url>W17-5537</url>
       <doi>10.18653/v1/W17-5537</doi>
@@ -10502,10 +10502,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="38">
       <title>Finding Structure in Figurative Language: Metaphor Detection with Topic-based Frames</title>
-      <author><first>Hyeju</first> <last>Jang</last></author>
-      <author><first>Keith</first> <last>Maki</last></author>
-      <author><first>Eduard</first> <last>Hovy</last></author>
-      <author><first>Carolyn</first> <last>Rosé</last></author>
+      <author><first>Hyeju</first><last>Jang</last></author>
+      <author><first>Keith</first><last>Maki</last></author>
+      <author><first>Eduard</first><last>Hovy</last></author>
+      <author><first>Carolyn</first><last>Rosé</last></author>
       <pages>320–330</pages>
       <url>W17-5538</url>
       <doi>10.18653/v1/W17-5538</doi>
@@ -10513,9 +10513,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="39">
       <title>Using Reinforcement Learning to Model Incrementality in a Fast-Paced Dialogue Game</title>
-      <author><first>Ramesh</first> <last>Manuvinakurike</last></author>
-      <author><first>David</first> <last>DeVault</last></author>
-      <author><first>Kallirroi</first> <last>Georgila</last></author>
+      <author><first>Ramesh</first><last>Manuvinakurike</last></author>
+      <author><first>David</first><last>DeVault</last></author>
+      <author><first>Kallirroi</first><last>Georgila</last></author>
       <pages>331–341</pages>
       <url>W17-5539</url>
       <doi>10.18653/v1/W17-5539</doi>
@@ -10523,8 +10523,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="40">
       <title>Inferring Narrative Causality between Event Pairs in Films</title>
-      <author><first>Zhichao</first> <last>Hu</last></author>
-      <author><first>Marilyn</first> <last>Walker</last></author>
+      <author><first>Zhichao</first><last>Hu</last></author>
+      <author><first>Marilyn</first><last>Walker</last></author>
       <pages>342–351</pages>
       <url>W17-5540</url>
       <doi>10.18653/v1/W17-5540</doi>
@@ -10533,8 +10533,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="41">
       <title>Lessons in Dialogue System Deployment</title>
-      <author><first>Anton</first> <last>Leuski</last></author>
-      <author><first>Ron</first> <last>Artstein</last></author>
+      <author><first>Anton</first><last>Leuski</last></author>
+      <author><first>Ron</first><last>Artstein</last></author>
       <pages>352–355</pages>
       <url>W17-5541</url>
       <doi>10.18653/v1/W17-5541</doi>
@@ -10542,9 +10542,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="42">
       <title>Information Navigation System with Discovering User Interests</title>
-      <author><first>Koichiro</first> <last>Yoshino</last></author>
-      <author><first>Yu</first> <last>Suzuki</last></author>
-      <author><first>Satoshi</first> <last>Nakamura</last></author>
+      <author><first>Koichiro</first><last>Yoshino</last></author>
+      <author><first>Yu</first><last>Suzuki</last></author>
+      <author><first>Satoshi</first><last>Nakamura</last></author>
       <pages>356–359</pages>
       <url>W17-5542</url>
       <doi>10.18653/v1/W17-5542</doi>
@@ -10552,11 +10552,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="43">
       <title>Modelling Protagonist Goals and Desires in First-Person Narrative</title>
-      <author><first>Elahe</first> <last>Rahimtoroghi</last></author>
-      <author><first>Jiaqi</first> <last>Wu</last></author>
-      <author><first>Ruimin</first> <last>Wang</last></author>
-      <author><first>Pranav</first> <last>Anand</last></author>
-      <author><first>Marilyn</first> <last>Walker</last></author>
+      <author><first>Elahe</first><last>Rahimtoroghi</last></author>
+      <author><first>Jiaqi</first><last>Wu</last></author>
+      <author><first>Ruimin</first><last>Wang</last></author>
+      <author><first>Pranav</first><last>Anand</last></author>
+      <author><first>Marilyn</first><last>Walker</last></author>
       <pages>360–369</pages>
       <url>W17-5543</url>
       <doi>10.18653/v1/W17-5543</doi>
@@ -10565,14 +10565,14 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="44">
       <title><fixed-case>SHIH</fixed-case>bot: A <fixed-case>F</fixed-case>acebook chatbot for Sexual Health Information on <fixed-case>HIV</fixed-case>/<fixed-case>AIDS</fixed-case></title>
-      <author><first>Jacqueline</first> <last>Brixey</last></author>
-      <author><first>Rens</first> <last>Hoegen</last></author>
-      <author><first>Wei</first> <last>Lan</last></author>
-      <author><first>Joshua</first> <last>Rusow</last></author>
-      <author><first>Karan</first> <last>Singla</last></author>
-      <author><first>Xusen</first> <last>Yin</last></author>
-      <author><first>Ron</first> <last>Artstein</last></author>
-      <author><first>Anton</first> <last>Leuski</last></author>
+      <author><first>Jacqueline</first><last>Brixey</last></author>
+      <author><first>Rens</first><last>Hoegen</last></author>
+      <author><first>Wei</first><last>Lan</last></author>
+      <author><first>Joshua</first><last>Rusow</last></author>
+      <author><first>Karan</first><last>Singla</last></author>
+      <author><first>Xusen</first><last>Yin</last></author>
+      <author><first>Ron</first><last>Artstein</last></author>
+      <author><first>Anton</first><last>Leuski</last></author>
       <pages>370–373</pages>
       <url>W17-5544</url>
       <doi>10.18653/v1/W17-5544</doi>
@@ -10580,12 +10580,12 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="45">
       <title>How Would You Say It? Eliciting Lexically Diverse Dialogue for Supervised Semantic Parsing</title>
-      <author><first>Abhilasha</first> <last>Ravichander</last></author>
-      <author><first>Thomas</first> <last>Manzini</last></author>
-      <author><first>Matthias</first> <last>Grabmair</last></author>
-      <author><first>Graham</first> <last>Neubig</last></author>
-      <author><first>Jonathan</first> <last>Francis</last></author>
-      <author><first>Eric</first> <last>Nyberg</last></author>
+      <author><first>Abhilasha</first><last>Ravichander</last></author>
+      <author><first>Thomas</first><last>Manzini</last></author>
+      <author><first>Matthias</first><last>Grabmair</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <author><first>Jonathan</first><last>Francis</last></author>
+      <author><first>Eric</first><last>Nyberg</last></author>
       <pages>374–383</pages>
       <url>W17-5545</url>
       <doi>10.18653/v1/W17-5545</doi>
@@ -10593,8 +10593,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="46">
       <title>Not All Dialogues are Created Equal: Instance Weighting for Neural Conversational Models</title>
-      <author><first>Pierre</first> <last>Lison</last></author>
-      <author><first>Serge</first> <last>Bibauw</last></author>
+      <author><first>Pierre</first><last>Lison</last></author>
+      <author><first>Serge</first><last>Bibauw</last></author>
       <pages>384–394</pages>
       <url>W17-5546</url>
       <doi>10.18653/v1/W17-5546</doi>
@@ -10602,7 +10602,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="47">
       <title>A data-driven model of explanations for a chatbot that helps to practice conversation in a foreign language</title>
-      <author><first>Sviatlana</first> <last>Höhn</last></author>
+      <author><first>Sviatlana</first><last>Höhn</last></author>
       <pages>395–405</pages>
       <url>W17-5547</url>
       <doi>10.18653/v1/W17-5547</doi>
@@ -10625,29 +10625,29 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Building a Better Bitext for Structurally Different Languages through Self-training</title>
-      <author><first>Jungyeul</first> <last>Park</last></author>
-      <author><first>Loïc</first> <last>Dugast</last></author>
-      <author><first>Jeen-Pyo</first> <last>Hong</last></author>
-      <author><first>Chang-Uk</first> <last>Shin</last></author>
-      <author><first>Jeong-Won</first> <last>Cha</last></author>
+      <author><first>Jungyeul</first><last>Park</last></author>
+      <author><first>Loïc</first><last>Dugast</last></author>
+      <author><first>Jeen-Pyo</first><last>Hong</last></author>
+      <author><first>Chang-Uk</first><last>Shin</last></author>
+      <author><first>Jeong-Won</first><last>Cha</last></author>
       <pages>1–10</pages>
       <url>W17-5601</url>
       <abstract>We propose a novel method to bootstrap the construction of parallel corpora for new pairs of structurally different languages. We do so by combining the use of a pivot language and self-training. A pivot language enables the use of existing translation models to bootstrap the alignment and a self-training procedure enables to achieve better alignment, both at the document and sentence level. We also propose several evaluation methods for the resulting alignment.</abstract>
     </paper>
     <paper id="2">
       <title><fixed-case>M</fixed-case>ulti<fixed-case>N</fixed-case>ews: A Web collection of an Aligned Multimodal and Multilingual Corpus</title>
-      <author><first>Haithem</first> <last>Afli</last></author>
-      <author><first>Pintu</first> <last>Lohar</last></author>
-      <author><first>Andy</first> <last>Way</last></author>
+      <author><first>Haithem</first><last>Afli</last></author>
+      <author><first>Pintu</first><last>Lohar</last></author>
+      <author><first>Andy</first><last>Way</last></author>
       <pages>11–15</pages>
       <url>W17-5602</url>
       <abstract>Integrating Natural Language Processing (NLP) and computer vision is a promising effort. However, the applicability of these methods directly depends on the availability of a specific multimodal data that includes images and texts. In this paper, we present a collection of a Multimodal corpus of comparable texts and their images in 9 languages from the web news articles of Euronews website. This corpus has found widespread use in the NLP community in Multilingual and multimodal tasks. Here, we focus on its acquisition of the images and text data and their multilingual alignment.</abstract>
     </paper>
     <paper id="3">
       <title>Learning Phrase Embeddings from Paraphrases with <fixed-case>GRU</fixed-case>s</title>
-      <author><first>Zhihao</first> <last>Zhou</last></author>
-      <author><first>Lifu</first> <last>Huang</last></author>
-      <author><first>Heng</first> <last>Ji</last></author>
+      <author><first>Zhihao</first><last>Zhou</last></author>
+      <author><first>Lifu</first><last>Huang</last></author>
+      <author><first>Heng</first><last>Ji</last></author>
       <pages>16–23</pages>
       <url>W17-5603</url>
       <abstract>Learning phrase representations has been widely explored in many Natural Language Processing tasks (e.g., Sentiment Analysis, Machine Translation) and has shown promising improvements. Previous studies either learn non-compositional phrase representations with general word embedding learning techniques or learn compositional phrase representations based on syntactic structures, which either require huge amounts of human annotations or cannot be easily generalized to all phrases. In this work, we propose to take advantage of large-scaled paraphrase database and present a pairwise-GRU framework to generate compositional phrase representations. Our framework can be re-used to generate representations for any phrases. Experimental results show that our framework achieves state-of-the-art results on several phrase similarity tasks.</abstract>
@@ -10669,24 +10669,24 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Overview of the 4th Workshop on <fixed-case>A</fixed-case>sian Translation</title>
-      <author><first>Toshiaki</first> <last>Nakazawa</last></author>
-      <author><first>Shohei</first> <last>Higashiyama</last></author>
-      <author><first>Chenchen</first> <last>Ding</last></author>
-      <author><first>Hideya</first> <last>Mino</last></author>
-      <author><first>Isao</first> <last>Goto</last></author>
-      <author><first>Hideto</first> <last>Kazawa</last></author>
-      <author><first>Yusuke</first> <last>Oda</last></author>
-      <author><first>Graham</first> <last>Neubig</last></author>
-      <author><first>Sadao</first> <last>Kurohashi</last></author>
+      <author><first>Toshiaki</first><last>Nakazawa</last></author>
+      <author><first>Shohei</first><last>Higashiyama</last></author>
+      <author><first>Chenchen</first><last>Ding</last></author>
+      <author><first>Hideya</first><last>Mino</last></author>
+      <author><first>Isao</first><last>Goto</last></author>
+      <author><first>Hideto</first><last>Kazawa</last></author>
+      <author><first>Yusuke</first><last>Oda</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <author><first>Sadao</first><last>Kurohashi</last></author>
       <pages>1–54</pages>
       <url>W17-5701</url>
       <abstract>This paper presents the results of the shared tasks from the 4th workshop on Asian translation (WAT2017) including J↔E, J↔C scientific paper translation subtasks, C↔J, K↔J, E↔J patent translation subtasks, H↔E mixed domain subtasks, J↔E newswire subtasks and J↔E recipe subtasks. For the WAT2017, 12 institutions participated in the shared tasks. About 300 translation results have been submitted to the automatic evaluation server, and selected submissions were manually evaluated.</abstract>
     </paper>
     <paper id="2">
       <title>Controlling Target Features in Neural Machine Translation via Prefix Constraints</title>
-      <author><first>Shunsuke</first> <last>Takeno</last></author>
-      <author><first>Masaaki</first> <last>Nagata</last></author>
-      <author><first>Kazuhide</first> <last>Yamamoto</last></author>
+      <author><first>Shunsuke</first><last>Takeno</last></author>
+      <author><first>Masaaki</first><last>Nagata</last></author>
+      <author><first>Kazuhide</first><last>Yamamoto</last></author>
       <pages>55–63</pages>
       <url>W17-5702</url>
       <abstract>We propose <i>prefix constraints</i>, a novel method to enforce constraints on
@@ -10705,141 +10705,141 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>Improving <fixed-case>J</fixed-case>apanese-to-<fixed-case>E</fixed-case>nglish Neural Machine Translation by Paraphrasing the Target Language</title>
-      <author><first>Yuuki</first> <last>Sekizawa</last></author>
-      <author><first>Tomoyuki</first> <last>Kajiwara</last></author>
-      <author><first>Mamoru</first> <last>Komachi</last></author>
+      <author><first>Yuuki</first><last>Sekizawa</last></author>
+      <author><first>Tomoyuki</first><last>Kajiwara</last></author>
+      <author><first>Mamoru</first><last>Komachi</last></author>
       <pages>64–69</pages>
       <url>W17-5703</url>
       <abstract>Neural machine translation (NMT) produces sentences that are more fluent than those produced by statistical machine translation (SMT). However, NMT has a very high computational cost because of the high dimensionality of the output layer. Generally, NMT restricts the size of vocabulary, which results in infrequent words being treated as out-of-vocabulary (OOV) and degrades the performance of the translation. In evaluation, we achieved a statistically significant BLEU score improvement of 0.55-0.77 over the baselines including the state-of-the-art method.</abstract>
     </paper>
     <paper id="4">
       <title>Improving Low-Resource Neural Machine Translation with Filtered Pseudo-Parallel Corpus</title>
-      <author><first>Aizhan</first> <last>Imankulova</last></author>
-      <author><first>Takayuki</first> <last>Sato</last></author>
-      <author><first>Mamoru</first> <last>Komachi</last></author>
+      <author><first>Aizhan</first><last>Imankulova</last></author>
+      <author><first>Takayuki</first><last>Sato</last></author>
+      <author><first>Mamoru</first><last>Komachi</last></author>
       <pages>70–78</pages>
       <url>W17-5704</url>
       <abstract>Large-scale parallel corpora are indispensable to train highly accurate machine translators. However, manually constructed large-scale parallel corpora are not freely available in many language pairs. In previous studies, training data have been expanded using a pseudo-parallel corpus obtained using machine translation of the monolingual corpus in the target language. However, in low-resource language pairs in which only low-accuracy machine translation systems can be used, translation quality is reduces when a pseudo-parallel corpus is used naively. To improve machine translation performance with low-resource language pairs, we propose a method to expand the training data effectively via filtering the pseudo-parallel corpus using a quality estimation based on back-translation. As a result of experiments with three language pairs using small, medium, and large parallel corpora, language pairs with fewer training data filtered out more sentence pairs and improved BLEU scores more significantly.</abstract>
     </paper>
     <paper id="5">
       <title><fixed-case>J</fixed-case>apanese to <fixed-case>E</fixed-case>nglish/<fixed-case>C</fixed-case>hinese/<fixed-case>K</fixed-case>orean Datasets for Translation Quality Estimation and Automatic Post-Editing</title>
-      <author><first>Atsushi</first> <last>Fujita</last></author>
-      <author><first>Eiichiro</first> <last>Sumita</last></author>
+      <author><first>Atsushi</first><last>Fujita</last></author>
+      <author><first>Eiichiro</first><last>Sumita</last></author>
       <pages>79–88</pages>
       <url>W17-5705</url>
       <abstract>Aiming at facilitating the research on quality estimation (QE) and automatic post-editing (APE) of machine translation (MT) outputs, especially for those among Asian languages, we have created new datasets for Japanese to English, Chinese, and Korean translations. As the source text, actual utterances in Japanese were extracted from the log data of our speech translation service. MT outputs were then given by phrase-based statistical MT systems. Finally, human evaluators were employed to grade the quality of MT outputs and to post-edit them. This paper describes the characteristics of the created datasets and reports on our benchmarking experiments on word-level QE, sentence-level QE, and APE conducted using the created datasets.</abstract>
     </paper>
     <paper id="6">
       <title><fixed-case>NTT</fixed-case> Neural Machine Translation Systems at <fixed-case>WAT</fixed-case> 2017</title>
-      <author><first>Makoto</first> <last>Morishita</last></author>
-      <author><first>Jun</first> <last>Suzuki</last></author>
-      <author><first>Masaaki</first> <last>Nagata</last></author>
+      <author><first>Makoto</first><last>Morishita</last></author>
+      <author><first>Jun</first><last>Suzuki</last></author>
+      <author><first>Masaaki</first><last>Nagata</last></author>
       <pages>89–94</pages>
       <url>W17-5706</url>
       <abstract>In this year, we participated in four translation subtasks at WAT 2017. Our model structure is quite simple but we used it with well-tuned hyper-parameters, leading to a significant improvement compared to the previous state-of-the-art system. We also tried to make use of the unreliable part of the provided parallel corpus by back-translating and making a synthetic corpus. Our submitted system achieved the new state-of-the-art performance in terms of the BLEU score, as well as human evaluation.</abstract>
     </paper>
     <paper id="7">
       <title><fixed-case>XMU</fixed-case> Neural Machine Translation Systems for <fixed-case>WAT</fixed-case> 2017</title>
-      <author><first>Boli</first> <last>Wang</last></author>
-      <author><first>Zhixing</first> <last>Tan</last></author>
-      <author><first>Jinming</first> <last>Hu</last></author>
-      <author><first>Yidong</first> <last>Chen</last></author>
-      <author><first>Xiaodong</first> <last>Shi</last></author>
+      <author><first>Boli</first><last>Wang</last></author>
+      <author><first>Zhixing</first><last>Tan</last></author>
+      <author><first>Jinming</first><last>Hu</last></author>
+      <author><first>Yidong</first><last>Chen</last></author>
+      <author><first>Xiaodong</first><last>Shi</last></author>
       <pages>95–98</pages>
       <url>W17-5707</url>
       <abstract>This paper describes the Neural Machine Translation systems of Xiamen University for the shared translation tasks of WAT 2017. Our systems are based on the Encoder-Decoder framework with attention. We participated in three subtasks. We experimented subword segmentation, synthetic training data and model ensembling. Experiments show that all these methods can give substantial improvements.</abstract>
     </paper>
     <paper id="8">
       <title>A Bag of Useful Tricks for Practical Neural Machine Translation: Embedding Layer Initialization and Large Batch Size</title>
-      <author><first>Masato</first> <last>Neishi</last></author>
-      <author><first>Jin</first> <last>Sakuma</last></author>
-      <author><first>Satoshi</first> <last>Tohda</last></author>
-      <author><first>Shonosuke</first> <last>Ishiwatari</last></author>
-      <author><first>Naoki</first> <last>Yoshinaga</last></author>
-      <author><first>Masashi</first> <last>Toyoda</last></author>
+      <author><first>Masato</first><last>Neishi</last></author>
+      <author><first>Jin</first><last>Sakuma</last></author>
+      <author><first>Satoshi</first><last>Tohda</last></author>
+      <author><first>Shonosuke</first><last>Ishiwatari</last></author>
+      <author><first>Naoki</first><last>Yoshinaga</last></author>
+      <author><first>Masashi</first><last>Toyoda</last></author>
       <pages>99–109</pages>
       <url>W17-5708</url>
       <abstract>In this paper, we describe the team UT-IIS’s system and results for the WAT 2017 translation tasks. We further investigated several tricks including a novel technique for initializing embedding layers using only the parallel corpus, which increased the BLEU score by 1.28, found a practical large batch size of 256, and gained insights regarding hyperparameter settings. Ultimately, our system obtained a better result than the state-of-the-art system of WAT 2016. Our code is available on <url>https://github.com/nem6ishi/wat17</url>. </abstract>
     </paper>
     <paper id="9">
       <title>Patent <fixed-case>NMT</fixed-case> integrated with Large Vocabulary Phrase Translation by <fixed-case>SMT</fixed-case> at <fixed-case>WAT</fixed-case> 2017</title>
-      <author><first>Zi</first> <last>Long</last></author>
-      <author><first>Ryuichiro</first> <last>Kimura</last></author>
-      <author><first>Takehito</first> <last>Utsuro</last></author>
-      <author><first>Tomoharu</first> <last>Mitsuhashi</last></author>
-      <author><first>Mikio</first> <last>Yamamoto</last></author>
+      <author><first>Zi</first><last>Long</last></author>
+      <author><first>Ryuichiro</first><last>Kimura</last></author>
+      <author><first>Takehito</first><last>Utsuro</last></author>
+      <author><first>Tomoharu</first><last>Mitsuhashi</last></author>
+      <author><first>Mikio</first><last>Yamamoto</last></author>
       <pages>110–118</pages>
       <url>W17-5709</url>
       <abstract>Neural machine translation (NMT) cannot handle a larger vocabulary because the training complexity and decoding complexity proportionally increase with the number of target words. This problem becomes even more serious when translating patent documents, which contain many technical terms that are observed infrequently. Long et al.(2017) proposed to select phrases that contain out-of-vocabulary words using the statistical approach of branching entropy. The selected phrases are then replaced with tokens during training and post-translated by the phrase translation table of SMT. In this paper, we apply the method proposed by Long et al. (2017) to the WAT 2017 Japanese-Chinese and Japanese-English patent datasets. Evaluation on Japanese-to-Chinese, Chinese-to-Japanese, Japanese-to-English and English-to-Japanese patent sentence translation proved the effectiveness of phrases selected with branching entropy, where the NMT model of Long et al.(2017) achieves a substantial improvement over a baseline NMT model without the technique proposed by Long et al.(2017).</abstract>
     </paper>
     <paper id="10">
       <title>SMT reranked NMT</title>
-      <author><first>Terumasa</first> <last>Ehara</last></author>
+      <author><first>Terumasa</first><last>Ehara</last></author>
       <pages>119–126</pages>
       <url>W17-5710</url>
       <abstract>System architecture, experimental settings and experimental results of the EHR team for the WAT2017 tasks are described. We participate in three tasks: JPCen-ja, JPCzh-ja and JPCko-ja. Although the basic architecture of our system is NMT, reranking technique is conducted using SMT results. One of the major drawback of NMT is under-translation and over-translation. On the other hand, SMT infrequently makes such translations. So, using reranking of n-best NMT outputs by the SMT output, discarding such translations can be expected. We can improve BLEU score from 46.03 to 47.08 by this technique in JPCzh-ja task.</abstract>
     </paper>
     <paper id="11">
       <title>Ensemble and Reranking: Using Multiple Models in the <fixed-case>NICT</fixed-case>-2 Neural Machine Translation System at <fixed-case>WAT</fixed-case>2017</title>
-      <author><first>Kenji</first> <last>Imamura</last></author>
-      <author><first>Eiichiro</first> <last>Sumita</last></author>
+      <author><first>Kenji</first><last>Imamura</last></author>
+      <author><first>Eiichiro</first><last>Sumita</last></author>
       <pages>127–134</pages>
       <url>W17-5711</url>
       <abstract>In this paper, we describe the NICT-2 neural machine translation system evaluated at WAT2017. This system uses multiple models as an ensemble and combines models with opposite decoding directions by reranking (called bi-directional reranking). In our experimental results on small data sets, the translation quality improved when the number of models was increased to 32 in total and did not saturate. In the experiments on large data sets, improvements of 1.59-3.32 BLEU points were achieved when six-model ensembles were combined by the bi-directional reranking.</abstract>
     </paper>
     <paper id="12">
       <title>A Simple and Strong Baseline: <fixed-case>NAIST</fixed-case>-<fixed-case>NICT</fixed-case> Neural Machine Translation System for <fixed-case>WAT</fixed-case>2017 <fixed-case>E</fixed-case>nglish-<fixed-case>J</fixed-case>apanese Translation Task</title>
-      <author><first>Yusuke</first> <last>Oda</last></author>
-      <author><first>Katsuhito</first> <last>Sudoh</last></author>
-      <author><first>Satoshi</first> <last>Nakamura</last></author>
-      <author><first>Masao</first> <last>Utiyama</last></author>
-      <author><first>Eiichiro</first> <last>Sumita</last></author>
+      <author><first>Yusuke</first><last>Oda</last></author>
+      <author><first>Katsuhito</first><last>Sudoh</last></author>
+      <author><first>Satoshi</first><last>Nakamura</last></author>
+      <author><first>Masao</first><last>Utiyama</last></author>
+      <author><first>Eiichiro</first><last>Sumita</last></author>
       <pages>135–139</pages>
       <url>W17-5712</url>
       <abstract>This paper describes the details about the NAIST-NICT machine translation system for WAT2017 English-Japanese Scientific Paper Translation Task. The system consists of a language-independent tokenizer and an attentional encoder-decoder style neural machine translation model. According to the official results, our system achieves higher translation accuracy than any systems submitted previous campaigns despite simple model architecture.</abstract>
     </paper>
     <paper id="13">
       <title>Comparison of <fixed-case>SMT</fixed-case> and <fixed-case>NMT</fixed-case> trained with large Patent Corpora: <fixed-case>J</fixed-case>apio at <fixed-case>WAT</fixed-case>2017</title>
-      <author><first>Satoshi</first> <last>Kinoshita</last></author>
-      <author><first>Tadaaki</first> <last>Oshio</last></author>
-      <author><first>Tomoharu</first> <last>Mitsuhashi</last></author>
+      <author><first>Satoshi</first><last>Kinoshita</last></author>
+      <author><first>Tadaaki</first><last>Oshio</last></author>
+      <author><first>Tomoharu</first><last>Mitsuhashi</last></author>
       <pages>140–145</pages>
       <url>W17-5713</url>
       <abstract>Japio participates in patent subtasks (JPC-EJ/JE/CJ/KJ) with phrase-based statistical machine translation (SMT) and neural machine translation (NMT) systems which are trained with its own patent corpora in addition to the subtask corpora provided by organizers of WAT2017. In EJ and CJ subtasks, SMT and NMT systems whose sizes of training corpora are about 50 million and 10 million sentence pairs respectively achieved comparable scores for automatic evaluations, but NMT systems were superior to SMT systems for both official and in-house human evaluations.</abstract>
     </paper>
     <paper id="14">
       <title><fixed-case>K</fixed-case>yoto University Participation to <fixed-case>WAT</fixed-case> 2017</title>
-      <author><first>Fabien</first> <last>Cromieres</last></author>
-      <author><first>Raj</first> <last>Dabre</last></author>
-      <author><first>Toshiaki</first> <last>Nakazawa</last></author>
-      <author><first>Sadao</first> <last>Kurohashi</last></author>
+      <author><first>Fabien</first><last>Cromieres</last></author>
+      <author><first>Raj</first><last>Dabre</last></author>
+      <author><first>Toshiaki</first><last>Nakazawa</last></author>
+      <author><first>Sadao</first><last>Kurohashi</last></author>
       <pages>146–153</pages>
       <url>W17-5714</url>
       <abstract>We describe here our approaches and results on the WAT 2017 shared translation tasks. Following our good results with Neural Machine Translation in the previous shared task, we continue this approach this year, with incremental improvements in models and training methods. We focused on the ASPEC dataset and could improve the state-of-the-art results for Chinese-to-Japanese and Japanese-to-Chinese translations.</abstract>
     </paper>
     <paper id="15">
       <title><fixed-case>CUNI</fixed-case> <fixed-case>NMT</fixed-case> System for <fixed-case>WAT</fixed-case> 2017 Translation Tasks</title>
-      <author><first>Tom</first> <last>Kocmi</last></author>
-      <author><first>Dušan</first> <last>Variš</last></author>
-      <author><first>Ondřej</first> <last>Bojar</last></author>
+      <author><first>Tom</first><last>Kocmi</last></author>
+      <author><first>Dušan</first><last>Variš</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
       <pages>154–159</pages>
       <url>W17-5715</url>
       <abstract>The paper presents this year’s CUNI submissions to the WAT 2017 Translation Task focusing on the Japanese-English translation, namely Scientific papers subtask, Patents subtask and Newswire subtask. We compare two neural network architectures, the standard sequence-to-sequence with attention (Seq2Seq) and an architecture using convolutional sentence encoder (FBConv2Seq), both implemented in the NMT framework Neural Monkey that we currently participate in developing. We also compare various types of preprocessing of the source Japanese sentences and their impact on the overall results. Furthermore, we include the results of our experiments with out-of-domain data obtained by combining the corpora provided for each subtask.</abstract>
     </paper>
     <paper id="16">
       <title><fixed-case>T</fixed-case>okyo Metropolitan University Neural Machine Translation System for <fixed-case>WAT</fixed-case> 2017</title>
-      <author><first>Yukio</first> <last>Matsumura</last></author>
-      <author><first>Mamoru</first> <last>Komachi</last></author>
+      <author><first>Yukio</first><last>Matsumura</last></author>
+      <author><first>Mamoru</first><last>Komachi</last></author>
       <pages>160–166</pages>
       <url>W17-5716</url>
       <abstract>In this paper, we describe our neural machine translation (NMT) system, which is based on the attention-based NMT and uses long short-term memories (LSTM) as RNN. We implemented beam search and ensemble decoding in the NMT system. The system was tested on the 4th Workshop on Asian Translation (WAT 2017) shared tasks. In our experiments, we participated in the scientific paper subtasks and attempted Japanese-English, English-Japanese, and Japanese-Chinese translation tasks. The experimental results showed that implementation of beam search and ensemble decoding can effectively improve the translation quality.</abstract>
     </paper>
     <paper id="17">
       <title>Comparing Recurrent and Convolutional Architectures for <fixed-case>E</fixed-case>nglish-<fixed-case>H</fixed-case>indi Neural Machine Translation</title>
-      <author><first>Sandhya</first> <last>Singh</last></author>
-      <author><first>Ritesh</first> <last>Panjwani</last></author>
-      <author><first>Anoop</first> <last>Kunchukuttan</last></author>
-      <author><first>Pushpak</first> <last>Bhattacharyya</last></author>
+      <author><first>Sandhya</first><last>Singh</last></author>
+      <author><first>Ritesh</first><last>Panjwani</last></author>
+      <author><first>Anoop</first><last>Kunchukuttan</last></author>
+      <author><first>Pushpak</first><last>Bhattacharyya</last></author>
       <pages>167–170</pages>
       <url>W17-5717</url>
       <abstract>In this paper, we empirically compare the two encoder-decoder neural machine translation architectures: convolutional sequence to sequence model (ConvS2S) and recurrent sequence to sequence model (RNNS2S) for English-Hindi language pair as part of IIT Bombay’s submission to WAT2017 shared task. We report the results for both English-Hindi and Hindi-English direction of language pair.</abstract>
@@ -10862,100 +10862,100 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Automatic detection of stance towards vaccination in online discussion forums</title>
-      <author><first>Maria</first> <last>Skeppstedt</last></author>
-      <author><first>Andreas</first> <last>Kerren</last></author>
-      <author><first>Manfred</first> <last>Stede</last></author>
+      <author><first>Maria</first><last>Skeppstedt</last></author>
+      <author><first>Andreas</first><last>Kerren</last></author>
+      <author><first>Manfred</first><last>Stede</last></author>
       <pages>1–8</pages>
       <url>W17-5801</url>
       <abstract>A classifier for automatic detection of stance towards vaccination in online forums was trained and evaluated. Debate posts from six discussion threads on the British parental website Mumsnet were manually annotated for stance ‘against’ or ‘for’ vaccination, or as ‘undecided’. A support vector machine, trained to detect the three classes, achieved a macro F-score of 0.44, while a macro F-score of 0.62 was obtained by the same type of classifier on the binary classification task of distinguishing stance ‘against’ vaccination from stance ‘for’ vaccination. These results show that vaccine stance detection in online forums is a difficult task, at least for the type of model investigated and for the relatively small training corpus that was used. Future work will therefore include an expansion of the training data and an evaluation of other types of classifiers and features.</abstract>
     </paper>
     <paper id="2">
       <title>Analysing the Causes of Depressed Mood from Depression Vulnerable Individuals</title>
-      <author><first>Noor Fazilla</first> <last>Abd Yusof</last></author>
-      <author><first>Chenghua</first> <last>Lin</last></author>
-      <author><first>Frank</first> <last>Guerin</last></author>
+      <author><first>Noor Fazilla</first><last>Abd Yusof</last></author>
+      <author><first>Chenghua</first><last>Lin</last></author>
+      <author><first>Frank</first><last>Guerin</last></author>
       <pages>9–17</pages>
       <url>W17-5802</url>
       <abstract>We develop a computational model to discover the potential causes of depression by analysing the topics in a usergenerated text. We show the most prominent causes, and how these causes evolve over time. Also, we highlight the differences in causes between students with low and high neuroticism. Our studies demonstrate that the topics reveal valuable clues about the causes contributing to depressed mood. Identifying causes can have a significant impact on improving the quality of depression care; thereby providing greater insights into a patient’s state for pertinent treatment recommendations. Hence, this study significantly expands the ability to discover the potential factors that trigger depression, making it possible to increase the efficiency of depression treatment.</abstract>
     </paper>
     <paper id="3">
       <title>Multivariate Linear Regression of Symptoms-related Tweets for Infectious Gastroenteritis Scale Estimation</title>
-      <author><first>Ryo</first> <last>Takeuchi</last></author>
-      <author><first>Hayate</first> <last>Iso</last></author>
-      <author><first>Kaoru</first> <last>Ito</last></author>
-      <author><first>Shoko</first> <last>Wakamiya</last></author>
-      <author><first>Eiji</first> <last>Aramaki</last></author>
+      <author><first>Ryo</first><last>Takeuchi</last></author>
+      <author><first>Hayate</first><last>Iso</last></author>
+      <author><first>Kaoru</first><last>Ito</last></author>
+      <author><first>Shoko</first><last>Wakamiya</last></author>
+      <author><first>Eiji</first><last>Aramaki</last></author>
       <pages>18–25</pages>
       <url>W17-5803</url>
       <abstract>To date, various Twitter-based event detection systems have been proposed. Most of their targets, however, share common characteristics. They are seasonal or global events such as earthquakes and flu pandemics. In contrast, this study targets unseasonal and local disease events. Our system investigates the frequencies of disease-related words such as “nausea”,“chill”,and “diarrhea” and estimates the number of patients using regression of these word frequencies. Experiments conducted using Japanese 47 areas from January 2017 to April 2017 revealed that the detection of small and unseasonal event is extremely difficult (overall performance: 0.13). However, we found that the event scale and the detection performance show high correlation in the specified cases (in the phase of patient increasing or decreasing). The results also suggest that when 150 and more patients appear in a high population area, we can expect that our social sensors detect this outbreak. Based on these results, we can infer that social sensors can reliably detect unseasonal and local disease events under certain conditions, just as they can for seasonal or global events.</abstract>
     </paper>
     <paper id="4">
       <title>Incorporating Dependency Trees Improve Identification of Pregnant Women on Social Media Platforms</title>
-      <author><first>Yi-Jie</first> <last>Huang</last></author>
-      <author><first>Chu Hsien</first> <last>Su</last></author>
-      <author><first>Yi-Chun</first> <last>Chang</last></author>
-      <author><first>Tseng-Hsin</first> <last>Ting</last></author>
-      <author><first>Tzu-Yuan</first> <last>Fu</last></author>
-      <author><first>Rou-Min</first> <last>Wang</last></author>
-      <author><first>Hong-Jie</first> <last>Dai</last></author>
-      <author><first>Yung-Chun</first> <last>Chang</last></author>
-      <author><first>Jitendra</first> <last>Jonnagaddala</last></author>
-      <author><first>Wen-Lian</first> <last>Hsu</last></author>
+      <author><first>Yi-Jie</first><last>Huang</last></author>
+      <author><first>Chu Hsien</first><last>Su</last></author>
+      <author><first>Yi-Chun</first><last>Chang</last></author>
+      <author><first>Tseng-Hsin</first><last>Ting</last></author>
+      <author><first>Tzu-Yuan</first><last>Fu</last></author>
+      <author><first>Rou-Min</first><last>Wang</last></author>
+      <author><first>Hong-Jie</first><last>Dai</last></author>
+      <author><first>Yung-Chun</first><last>Chang</last></author>
+      <author><first>Jitendra</first><last>Jonnagaddala</last></author>
+      <author><first>Wen-Lian</first><last>Hsu</last></author>
       <pages>26–32</pages>
       <url>W17-5804</url>
       <abstract>The increasing popularity of social media lead users to share enormous information on the internet. This information has various application like, it can be used to develop models to understand or predict user behavior on social media platforms. For example, few online retailers have studied the shopping patterns to predict shopper’s pregnancy stage. Another interesting application is to use the social media platforms to analyze users’ health-related information. In this study, we developed a tree kernel-based model to classify tweets conveying pregnancy related information using this corpus. The developed pregnancy classification model achieved an accuracy of 0.847 and an F-score of 0.565. A new corpus from popular social media platform Twitter was developed for the purpose of this study. In future, we would like to improve this corpus by reducing noise such as retweets.</abstract>
     </paper>
     <paper id="5">
       <title>Using a Recurrent Neural Network Model for Classification of Tweets Conveyed Influenza-related Information</title>
-      <author><first>Chen-Kai</first> <last>Wang</last></author>
-      <author><first>Onkar</first> <last>Singh</last></author>
-      <author><first>Zhao-Li</first> <last>Tang</last></author>
-      <author><first>Hong-Jie</first> <last>Dai</last></author>
+      <author><first>Chen-Kai</first><last>Wang</last></author>
+      <author><first>Onkar</first><last>Singh</last></author>
+      <author><first>Zhao-Li</first><last>Tang</last></author>
+      <author><first>Hong-Jie</first><last>Dai</last></author>
       <pages>33–38</pages>
       <url>W17-5805</url>
       <abstract>Traditional disease surveillance systems depend on outpatient reporting and virological test results released by hospitals. These data have valid and accurate information about emerging outbreaks but it’s often not timely. In recent years the exponential growth of users getting connected to social media provides immense knowledge about epidemics by sharing related information. Social media can now flag more immediate concerns related to out-breaks in real time. In this paper we apply the long short-term memory recurrent neural net-work (RNN) architecture to classify tweets conveyed influenza-related information and compare its performance with baseline algorithms including support vector machine (SVM), decision tree, naive Bayes, simple logistics, and naive Bayes multinomial. The developed RNN model achieved an F-score of 0.845 on the MedWeb task test set, which outperforms the F-score of SVM without applying the synthetic minority oversampling technique by 0.08. The F-score of the RNN model is within 1% of the highest score achieved by SVM with oversampling technique.</abstract>
     </paper>
     <paper id="6">
       <title><fixed-case>Z</fixed-case>ika<fixed-case>H</fixed-case>ack 2016: A digital disease detection competition</title>
-      <author><first>Dillon C</first> <last>Adam</last></author>
-      <author><first>Jitendra</first> <last>Jonnagaddala</last></author>
-      <author><first>Daniel</first> <last>Han-Chen</last></author>
-      <author><first>Sean</first> <last>Batongbacal</last></author>
-      <author><first>Luan</first> <last>Almeida</last></author>
-      <author><first>Jing Z</first> <last>Zhu</last></author>
-      <author><first>Jenny J</first> <last>Yang</last></author>
-      <author><first>Jumail M</first> <last>Mundekkat</last></author>
-      <author><first>Steven</first> <last>Badman</last></author>
-      <author><first>Abrar</first> <last>Chughtai</last></author>
-      <author><first>C Raina</first> <last>MacIntyre</last></author>
+      <author><first>Dillon C</first><last>Adam</last></author>
+      <author><first>Jitendra</first><last>Jonnagaddala</last></author>
+      <author><first>Daniel</first><last>Han-Chen</last></author>
+      <author><first>Sean</first><last>Batongbacal</last></author>
+      <author><first>Luan</first><last>Almeida</last></author>
+      <author><first>Jing Z</first><last>Zhu</last></author>
+      <author><first>Jenny J</first><last>Yang</last></author>
+      <author><first>Jumail M</first><last>Mundekkat</last></author>
+      <author><first>Steven</first><last>Badman</last></author>
+      <author><first>Abrar</first><last>Chughtai</last></author>
+      <author><first>C Raina</first><last>MacIntyre</last></author>
       <pages>39–46</pages>
       <url>W17-5806</url>
       <abstract>Effective response to infectious diseases outbreaks relies on the rapid and early detection of those outbreaks. Invalidated, yet timely and openly available digital information can be used for the early detection of outbreaks. Public health surveillance authorities can exploit these early warnings to plan and co-ordinate rapid surveillance and emergency response programs. In 2016, a digital disease detection competition named ZikaHack was launched. The objective of the competition was for multidisciplinary teams to design, develop and demonstrate innovative digital disease detection solutions to retrospectively detect the 2015-16 Brazilian Zika virus outbreak earlier than traditional surveillance methods. In this paper, an overview of the ZikaHack competition is provided. The challenges and lessons learned in organizing this competition are also discussed for use by other researchers interested in organizing similar competitions.</abstract>
     </paper>
     <paper id="7">
       <title>A Method to Generate a Machine-Labeled Data for Biomedical Named Entity Recognition with Various Sub-Domains</title>
-      <author><first>Juae</first> <last>Kim</last></author>
-      <author><first>Sunjae</first> <last>Kwon</last></author>
-      <author><first>Youngjoong</first> <last>Ko</last></author>
-      <author><first>Jungyun</first> <last>Seo</last></author>
+      <author><first>Juae</first><last>Kim</last></author>
+      <author><first>Sunjae</first><last>Kwon</last></author>
+      <author><first>Youngjoong</first><last>Ko</last></author>
+      <author><first>Jungyun</first><last>Seo</last></author>
       <pages>47–51</pages>
       <url>W17-5807</url>
       <abstract>Biomedical Named Entity (NE) recognition is a core technique for various works in the biomedical domain. In previous studies, using machine learning algorithm shows better performance than dictionary-based and rule-based approaches because there are too many terminological variations of biomedical NEs and new biomedical NEs are constantly generated. To achieve the high performance with a machine-learning algorithm, good-quality corpora are required. However, it is difficult to obtain the good-quality corpora because an-notating a biomedical corpus for ma-chine-learning is extremely time-consuming and costly. In addition, most previous corpora are insufficient for high-level tasks because they cannot cover various domains. Therefore, we propose a method for generating a large amount of machine-labeled data that covers various domains. To generate a large amount of machine-labeled data, firstly we generate an initial machine-labeled data by using a chunker and MetaMap. The chunker is developed to extract only biomedical NEs with manually annotated data. MetaMap is used to annotate the category of bio-medical NE. Then we apply the self-training approach to bootstrap the performance of initial machine-labeled data. In our experiments, the biomedical NE recognition system that is trained with our proposed machine-labeled data achieves much high performance. As a result, our system outperforms biomedical NE recognition system that using MetaMap only with 26.03%p improvements on F1-score.</abstract>
     </paper>
     <paper id="8">
       <title>Enhancing Drug-Drug Interaction Classification with Corpus-level Feature and Classifier Ensemble</title>
-      <author><first>Jing Cyun</first> <last>Tu</last></author>
-      <author><first>Po-Ting</first> <last>Lai</last></author>
-      <author><first>Richard Tzong-Han</first> <last>Tsai</last></author>
+      <author><first>Jing Cyun</first><last>Tu</last></author>
+      <author><first>Po-Ting</first><last>Lai</last></author>
+      <author><first>Richard Tzong-Han</first><last>Tsai</last></author>
       <pages>52–56</pages>
       <url>W17-5808</url>
       <abstract>The study of drug-drug interaction (DDI) is important in the drug discovering. Both PubMed and DrugBank are rich resources to retrieve DDI information which is usually represented in plain text. Automatically extracting DDI pairs from text improves the quality of drug discov-ering. In this paper, we presented a study that focuses on the DDI classification. We normalized the drug names, and developed both sentence-level and corpus-level features for DDI classification. A classifier ensemble approach is used for the unbalance DDI labels problem. Our approach achieved an F-score of 65.4% on SemEval 2013 DDI test set. The experimental results also show the effects of proposed corpus-level features in the DDI task.</abstract>
     </paper>
     <paper id="9">
       <title>Chemical-Induced Disease Detection Using Invariance-based Pattern Learning Model</title>
-      <author><first>Neha</first> <last>Warikoo</last></author>
-      <author><first>Yung-Chun</first> <last>Chang</last></author>
-      <author><first>Wen-Lian</first> <last>Hsu</last></author>
+      <author><first>Neha</first><last>Warikoo</last></author>
+      <author><first>Yung-Chun</first><last>Chang</last></author>
+      <author><first>Wen-Lian</first><last>Hsu</last></author>
       <pages>57–64</pages>
       <url>W17-5809</url>
       <abstract>In this work, we introduce a novel feature engineering approach named “algebraic invariance” to identify discriminative patterns for learning relation pair features for the chemical-disease relation (CDR) task of BioCreative V. Our method exploits the existing structural similarity of the key concepts of relation descriptions from the CDR corpus to generate robust linguistic patterns for SVM tree kernel-based learning. Preprocessing of the training data classifies the entity pairs as either related or unrelated to build instance types for both inter-sentential and intra-sentential scenarios. An invariant function is proposed to process and optimally cluster similar patterns for both positive and negative instances. The learning model for CDR pairs is based on the SVM tree kernel approach, which generates feature trees and vectors and is modeled on suitable invariance based patterns, bringing brevity, precision and context to the identifier features. Results demonstrate that our method outperformed other compared approaches, achieved a high recall rate of 85.08%, and averaged an F1-score of 54.34% without the use of any additional knowledge bases.</abstract>
@@ -10979,123 +10979,123 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title><fixed-case>NTUCLE</fixed-case>: Developing a Corpus of Learner <fixed-case>E</fixed-case>nglish to Provide Writing Support for Engineering Students</title>
-      <author><first>Roger Vivek Placidus</first> <last>Winder</last></author>
-      <author><first>Joseph</first> <last>MacKinnon</last></author>
-      <author><first>Shu Yun</first> <last>Li</last></author>
-      <author><first>Benedict Christopher Tzer Liang</first> <last>Lin</last></author>
-      <author><first>Carmel Lee Hah</first> <last>Heah</last></author>
-      <author><first>Luís</first> <last>Morgado da Costa</last></author>
-      <author><first>Takayuki</first> <last>Kuribayashi</last></author>
-      <author><first>Francis</first> <last>Bond</last></author>
+      <author><first>Roger Vivek Placidus</first><last>Winder</last></author>
+      <author><first>Joseph</first><last>MacKinnon</last></author>
+      <author><first>Shu Yun</first><last>Li</last></author>
+      <author><first>Benedict Christopher Tzer Liang</first><last>Lin</last></author>
+      <author><first>Carmel Lee Hah</first><last>Heah</last></author>
+      <author><first>Luís</first><last>Morgado da Costa</last></author>
+      <author><first>Takayuki</first><last>Kuribayashi</last></author>
+      <author><first>Francis</first><last>Bond</last></author>
       <pages>1–11</pages>
       <url>W17-5901</url>
       <abstract>This paper describes the creation of a new annotated learner corpus. The aim is to use this corpus to develop an automated system for corrective feedback on students’ writing. With this system, students will be able to receive timely feedback on language errors before they submit their assignments for grading. A corpus of assignments submitted by first year engineering students was compiled, and a new error tag set for the NTU Corpus of Learner English (NTUCLE) was developed based on that of the NUS Corpus of Learner English (NUCLE), as well as marking rubrics used at NTU. After a description of the corpus, error tag set and annotation process, the paper presents the results of the annotation exercise as well as follow up actions. The final error tag set, which is significantly larger than that for the NUCLE error categories, is then presented before a brief conclusion summarising our experience and future plans.</abstract>
     </paper>
     <paper id="2">
       <title>Understanding Non-Native Writings: Can a Parser Help?</title>
-      <author><first>Jirka</first> <last>Hana</last></author>
-      <author><first>Barbora</first> <last>Hladká</last></author>
+      <author><first>Jirka</first><last>Hana</last></author>
+      <author><first>Barbora</first><last>Hladká</last></author>
       <pages>12–16</pages>
       <url>W17-5902</url>
       <abstract>We present a pilot study on parsing non-native texts written by learners of Czech. We performed experiments that have shown that at least high-level syntactic functions, like subject, predicate, and object, can be assigned based on a parser trained on standard native language.</abstract>
     </paper>
     <paper id="3">
       <title>Carrier Sentence Selection for Fill-in-the-blank Items</title>
-      <author><first>Shu</first> <last>Jiang</last></author>
-      <author><first>John</first> <last>Lee</last></author>
+      <author><first>Shu</first><last>Jiang</last></author>
+      <author><first>John</first><last>Lee</last></author>
       <pages>17–22</pages>
       <url>W17-5903</url>
       <abstract>Fill-in-the-blank items are a common form of exercise in computer-assisted language learning systems. To automatically generate an effective item, the system must be able to select a high-quality carrier sentence that illustrates the usage of the target word. Previous approaches for carrier sentence selection have considered sentence length, vocabulary difficulty, the position of the target word and the presence of finite verbs. This paper investigates the utility of word co-occurrence statistics and lexical similarity as selection criteria. In an evaluation on generating fill-in-the-blank items for learning Chinese as a foreign language, we show that these two criteria can improve carrier sentence quality.</abstract>
     </paper>
     <paper id="4">
       <title><fixed-case>H</fixed-case>indi Shabdamitra: A <fixed-case>W</fixed-case>ordnet based E-Learning Tool for Language Learning and Teaching</title>
-      <author><first>Hanumant</first> <last>Redkar</last></author>
-      <author><first>Sandhya</first> <last>Singh</last></author>
-      <author><first>Meenakshi</first> <last>Somasundaram</last></author>
-      <author><first>Dhara</first> <last>Gorasia</last></author>
-      <author><first>Malhar</first> <last>Kulkarni</last></author>
-      <author><first>Pushpak</first> <last>Bhattacharyya</last></author>
+      <author><first>Hanumant</first><last>Redkar</last></author>
+      <author><first>Sandhya</first><last>Singh</last></author>
+      <author><first>Meenakshi</first><last>Somasundaram</last></author>
+      <author><first>Dhara</first><last>Gorasia</last></author>
+      <author><first>Malhar</first><last>Kulkarni</last></author>
+      <author><first>Pushpak</first><last>Bhattacharyya</last></author>
       <pages>23–28</pages>
       <url>W17-5904</url>
       <abstract>In today’s technology driven digital era, education domain is undergoing a transformation from traditional approaches to more learner controlled and flexible methods of learning. This transformation has opened the new avenues for interdisciplinary research in the field of educational technology and natural language processing in developing quality digital aids for learning and teaching. The tool presented here - Hindi Shabhadamitra, developed using Hindi Wordnet for Hindi language learning, is one such e-learning tool. It has been developed as a teaching and learning aid suitable for formal school based curriculum and informal setup for self learning users. Besides vocabulary, it also provides word based grammar along with images and pronunciation for better learning and retention. This aid demonstrates that how a rich lexical resource like wordnet can be systematically remodeled for practical usage in the educational domain.</abstract>
     </paper>
     <paper id="5">
       <title><fixed-case>NLPTEA</fixed-case> 2017 Shared Task – <fixed-case>C</fixed-case>hinese Spelling Check</title>
-      <author><first>Gabriel</first> <last>Fung</last></author>
-      <author><first>Maxime</first> <last>Debosschere</last></author>
-      <author><first>Dingmin</first> <last>Wang</last></author>
-      <author id="bo-li"><first>Bo</first> <last>Li</last></author>
-      <author><first>Jia</first> <last>Zhu</last></author>
-      <author><first>Kam-Fai</first> <last>Wong</last></author>
+      <author><first>Gabriel</first><last>Fung</last></author>
+      <author><first>Maxime</first><last>Debosschere</last></author>
+      <author><first>Dingmin</first><last>Wang</last></author>
+      <author id="bo-li"><first>Bo</first><last>Li</last></author>
+      <author><first>Jia</first><last>Zhu</last></author>
+      <author><first>Kam-Fai</first><last>Wong</last></author>
       <pages>29–34</pages>
       <url>W17-5905</url>
       <abstract>This paper provides an overview along with our findings of the Chinese Spelling Check shared task at NLPTEA 2017. The goal of this task is to develop a computer-assisted system to automatically diagnose typing errors in traditional Chinese sentences written by students. We defined six types of errors which belong to two categories. Given a sentence, the system should detect where the errors are, and for each detected error determine its type and provide correction suggestions. We designed, constructed, and released a benchmark dataset for this task.</abstract>
     </paper>
     <paper id="6">
       <title><fixed-case>C</fixed-case>hinese Spelling Check based on N-gram and String Matching Algorithm</title>
-      <author><first>Jui-Feng</first> <last>Yeh</last></author>
-      <author><first>Li-Ting</first> <last>Chang</last></author>
-      <author><first>Chan-Yi</first> <last>Liu</last></author>
-      <author><first>Tsung-Wei</first> <last>Hsu</last></author>
+      <author><first>Jui-Feng</first><last>Yeh</last></author>
+      <author><first>Li-Ting</first><last>Chang</last></author>
+      <author><first>Chan-Yi</first><last>Liu</last></author>
+      <author><first>Tsung-Wei</first><last>Hsu</last></author>
       <pages>35–38</pages>
       <url>W17-5906</url>
       <abstract>This paper presents a Chinese spelling check approach based on language models combined with string match algorithm to treat the problems resulted from the influence caused by Cantonese mother tone. N-grams first used to detecting the probability of sentence constructed by the writers, a string matching algorithm called Knuth-Morris-Pratt (KMP) Algorithm is used to detect and correct the error. According to the experimental results, the proposed approach can detect the error and provide the corresponding correction.</abstract>
     </paper>
     <paper id="7">
       <title>N-gram Model for <fixed-case>C</fixed-case>hinese Grammatical Error Diagnosis</title>
-      <author><first>Jianbo</first> <last>Zhao</last></author>
-      <author><first>Hao</first> <last>Liu</last></author>
-      <author><first>Zuyi</first> <last>Bao</last></author>
-      <author><first>Xiaopeng</first> <last>Bai</last></author>
-      <author><first>Si</first> <last>Li</last></author>
-      <author><first>Zhiqing</first> <last>Lin</last></author>
+      <author><first>Jianbo</first><last>Zhao</last></author>
+      <author><first>Hao</first><last>Liu</last></author>
+      <author><first>Zuyi</first><last>Bao</last></author>
+      <author><first>Xiaopeng</first><last>Bai</last></author>
+      <author><first>Si</first><last>Li</last></author>
+      <author><first>Zhiqing</first><last>Lin</last></author>
       <pages>39–44</pages>
       <url>W17-5907</url>
       <abstract>Detection and correction of Chinese grammatical errors have been two of major challenges for Chinese automatic grammatical error diagnosis.This paper presents an N-gram model for automatic detection and correction of Chinese grammatical errors in NLPTEA 2017 task. The experiment results show that the proposed method is good at correction of Chinese grammatical errors.</abstract>
     </paper>
     <paper id="8">
       <title>The Influence of Spelling Errors on Content Scoring Performance</title>
-      <author><first>Andrea</first> <last>Horbach</last></author>
-      <author><first>Yuning</first> <last>Ding</last></author>
-      <author><first>Torsten</first> <last>Zesch</last></author>
+      <author><first>Andrea</first><last>Horbach</last></author>
+      <author><first>Yuning</first><last>Ding</last></author>
+      <author><first>Torsten</first><last>Zesch</last></author>
       <pages>45–53</pages>
       <url>W17-5908</url>
       <abstract>Spelling errors occur frequently in educational settings, but their influence on automatic scoring is largely unknown. We therefore investigate the influence of spelling errors on content scoring performance using the example of the ASAP corpus. We conduct an annotation study on the nature of spelling errors in the ASAP dataset and utilize these finding in machine learning experiments that measure the influence of spelling errors on automatic content scoring. Our main finding is that scoring methods using both token and character n-gram features are robust against spelling errors up to the error frequency in ASAP.</abstract>
     </paper>
     <paper id="9">
       <title>Analyzing the Impact of Spelling Errors on <fixed-case>POS</fixed-case>-Tagging and Chunking in Learner <fixed-case>E</fixed-case>nglish</title>
-      <author><first>Tomoya</first> <last>Mizumoto</last></author>
-      <author><first>Ryo</first> <last>Nagata</last></author>
+      <author><first>Tomoya</first><last>Mizumoto</last></author>
+      <author><first>Ryo</first><last>Nagata</last></author>
       <pages>54–58</pages>
       <url>W17-5909</url>
       <abstract>Part-of-speech (POS) tagging and chunking have been used in tasks targeting learner English; however, to the best our knowledge, few studies have evaluated their performance and no studies have revealed the causes of POS-tagging/chunking errors in detail. Therefore, we investigate performance and analyze the causes of failure. We focus on spelling errors that occur frequently in learner English. We demonstrate that spelling errors reduced POS-tagging performance by 0.23% owing to spelling errors, and that a spell checker is not necessary for POS-tagging/chunking of learner English.</abstract>
     </paper>
     <paper id="10">
       <title>Complex Word Identification: Challenges in Data Annotation and System Performance</title>
-      <author><first>Marcos</first> <last>Zampieri</last></author>
-      <author><first>Shervin</first> <last>Malmasi</last></author>
-      <author><first>Gustavo</first> <last>Paetzold</last></author>
-      <author><first>Lucia</first> <last>Specia</last></author>
+      <author><first>Marcos</first><last>Zampieri</last></author>
+      <author><first>Shervin</first><last>Malmasi</last></author>
+      <author><first>Gustavo</first><last>Paetzold</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
       <pages>59–63</pages>
       <url>W17-5910</url>
       <abstract>This paper revisits the problem of complex word identification (CWI) following up the SemEval CWI shared task. We use ensemble classifiers to investigate how well computational methods can discriminate between complex and non-complex words. Furthermore, we analyze the classification performance to understand what makes lexical complexity challenging. Our findings show that most systems performed poorly on the SemEval CWI dataset, and one of the reasons for that is the way in which human annotation was performed.</abstract>
     </paper>
     <paper id="11">
       <title>Suggesting Sentences for <fixed-case>ESL</fixed-case> using Kernel Embeddings</title>
-      <author><first>Kent</first> <last>Shioda</last></author>
-      <author><first>Mamoru</first> <last>Komachi</last></author>
-      <author><first>Rue</first> <last>Ikeya</last></author>
-      <author><first>Daichi</first> <last>Mochihashi</last></author>
+      <author><first>Kent</first><last>Shioda</last></author>
+      <author><first>Mamoru</first><last>Komachi</last></author>
+      <author><first>Rue</first><last>Ikeya</last></author>
+      <author><first>Daichi</first><last>Mochihashi</last></author>
       <pages>64–68</pages>
       <url>W17-5911</url>
       <abstract>Sentence retrieval is an important NLP application for English as a Second Language (ESL) learners. ESL learners are familiar with web search engines, but generic web search results may not be adequate for composing documents in a specific domain. However, if we build our own search system specialized to a domain, it may be subject to the data sparseness problem. Recently proposed word2vec partially addresses the data sparseness problem, but fails to extract sentences relevant to queries owing to the modeling of the latent intent of the query. Thus, we propose a method of retrieving example sentences using kernel embeddings and N-gram windows. This method implicitly models latent intent of query and sentences, and alleviates the problem of noisy alignment. Our results show that our method achieved higher precision in sentence retrieval for ESL in the domain of a university press release corpus, as compared to a previous unsupervised method used for a semantic textual similarity task.</abstract>
     </paper>
     <paper id="12">
       <title>Event Timeline Generation from History Textbooks</title>
-      <author><first>Harsimran</first> <last>Bedi</last></author>
-      <author><first>Sangameshwar</first> <last>Patil</last></author>
-      <author><first>Swapnil</first> <last>Hingmire</last></author>
-      <author><first>Girish</first> <last>Palshikar</last></author>
+      <author><first>Harsimran</first><last>Bedi</last></author>
+      <author><first>Sangameshwar</first><last>Patil</last></author>
+      <author><first>Swapnil</first><last>Hingmire</last></author>
+      <author><first>Girish</first><last>Palshikar</last></author>
       <pages>69–77</pages>
       <url>W17-5912</url>
       <abstract>Event timeline serves as the basic structure of history, and it is used as a disposition of key phenomena in studying history as a subject in secondary school. In order to enable a student to understand a historical phenomenon as a series of connected events, we present a system for automatic event timeline generation from history textbooks. Additionally, we propose Message Sequence Chart (MSC) and time-map based visualization techniques to visualize an event timeline. We also identify key computational challenges in developing natural language processing based applications for history textbooks.</abstract>
@@ -11117,52 +11117,52 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Group Linguistic Bias Aware Neural Response Generation</title>
-      <author><first>Jianan</first> <last>Wang</last></author>
-      <author><first>Xin</first> <last>Wang</last></author>
-      <author><first>Fang</first> <last>Li</last></author>
-      <author><first>Zhen</first> <last>Xu</last></author>
-      <author><first>Zhuoran</first> <last>Wang</last></author>
-      <author><first>Baoxun</first> <last>Wang</last></author>
+      <author><first>Jianan</first><last>Wang</last></author>
+      <author><first>Xin</first><last>Wang</last></author>
+      <author><first>Fang</first><last>Li</last></author>
+      <author><first>Zhen</first><last>Xu</last></author>
+      <author><first>Zhuoran</first><last>Wang</last></author>
+      <author><first>Baoxun</first><last>Wang</last></author>
       <pages>1–10</pages>
       <url>W17-6001</url>
       <abstract>For practical chatbots, one of the essential factor for improving user experience is the capability of customizing the talking style of the agents, that is, to make chatbots provide responses meeting users’ preference on language styles, topics, etc. To address this issue, this paper proposes to incorporate linguistic biases, which implicitly involved in the conversation corpora generated by human groups in the Social Network Services (SNS), into the encoder-decoder based response generator. By attaching a specially designed neural component to dynamically control the impact of linguistic biases in response generation, a Group Linguistic Bias Aware Neural Response Generation (GLBA-NRG) model is eventually presented. The experimental results on the dataset from the Chinese SNS show that the proposed architecture outperforms the current response generating models by producing both meaningful and vivid responses with customized styles.</abstract>
     </paper>
     <paper id="2">
       <title>Neural Regularized Domain Adaptation for <fixed-case>C</fixed-case>hinese Word Segmentation</title>
-      <author><first>Zuyi</first> <last>Bao</last></author>
-      <author><first>Si</first> <last>Li</last></author>
-      <author><first>Weiran</first> <last>Xu</last></author>
-      <author><first>Sheng</first> <last>Gao</last></author>
+      <author><first>Zuyi</first><last>Bao</last></author>
+      <author><first>Si</first><last>Li</last></author>
+      <author><first>Weiran</first><last>Xu</last></author>
+      <author><first>Sheng</first><last>Gao</last></author>
       <pages>11–20</pages>
       <url>W17-6002</url>
       <abstract>For Chinese word segmentation, the large-scale annotated corpora mainly focus on newswire and only a handful of annotated data is available in other domains such as patents and literature. Considering the limited amount of annotated target domain data, it is a challenge for segmenters to learn domain-specific information while avoid getting over-fitted at the same time. In this paper, we propose a neural regularized domain adaptation method for Chinese word segmentation. The teacher networks trained in source domain are employed to regularize the training process of the student network by preserving the general knowledge. In the experiments, our neural regularized domain adaptation method achieves a better performance comparing to previous methods.</abstract>
     </paper>
     <paper id="3">
       <title>The Sentimental Value of <fixed-case>C</fixed-case>hinese Sub-Character Components</title>
-      <author><first>Yassine</first> <last>Benajiba</last></author>
-      <author><first>Or</first> <last>Biran</last></author>
-      <author><first>Zhiliang</first> <last>Weng</last></author>
-      <author><first>Yong</first> <last>Zhang</last></author>
-      <author><first>Jin</first> <last>Sun</last></author>
+      <author><first>Yassine</first><last>Benajiba</last></author>
+      <author><first>Or</first><last>Biran</last></author>
+      <author><first>Zhiliang</first><last>Weng</last></author>
+      <author><first>Yong</first><last>Zhang</last></author>
+      <author><first>Jin</first><last>Sun</last></author>
       <pages>21–29</pages>
       <url>W17-6003</url>
       <abstract>Sub-character components of Chinese characters carry important semantic information, and recent studies have shown that utilizing this information can improve performance on core semantic tasks. In this paper, we hypothesize that in addition to semantic information, sub-character components may also carry emotional information, and that utilizing it should improve performance on sentiment analysis tasks. We conduct a series of experiments on four Chinese sentiment data sets and show that we can significantly improve the performance in various tasks over that of a character-level embeddings baseline. We then focus on qualitatively assessing multiple examples and trying to explain how the sub-character components affect the results in each case.</abstract>
     </paper>
     <paper id="4">
       <title><fixed-case>C</fixed-case>hinese Answer Extraction Based on <fixed-case>POS</fixed-case> Tree and Genetic Algorithm</title>
-      <author><first>Shuihua</first> <last>Li</last></author>
-      <author><first>Xiaoming</first> <last>Zhang</last></author>
-      <author><first>Zhoujun</first> <last>Li</last></author>
+      <author><first>Shuihua</first><last>Li</last></author>
+      <author><first>Xiaoming</first><last>Zhang</last></author>
+      <author><first>Zhoujun</first><last>Li</last></author>
       <pages>30–36</pages>
       <url>W17-6004</url>
       <abstract>Answer extraction is the most important part of a chinese web-based question answering system. In order to enhance the robustness and adaptability of answer extraction to new domains and eliminate the influence of the incomplete and noisy search snippets, we propose two new answer exraction methods. We utilize text patterns to generate Part-of-Speech (POS) patterns. In addition, a method is proposed to construct a POS tree by using these POS patterns. The POS tree is useful to candidate answer extraction of web-based question answering. To retrieve a efficient POS tree, the similarities between questions are used to select the question-answer pairs whose questions are similar to the unanswered question. Then, the POS tree is improved based on these question-answer pairs. In order to rank these candidate answers, the weights of the leaf nodes of the POS tree are calculated using a heuristic method. Moreover, the Genetic Algorithm (GA) is used to train the weights. The experimental results of 10-fold crossvalidation show that the weighted POS tree trained by GA can improve the accuracy of answer extraction.</abstract>
     </paper>
     <paper id="5">
       <title>Learning from Parenthetical Sentences for Term Translation in Machine Translation</title>
-      <author><first>Guoping</first> <last>Huang</last></author>
-      <author><first>Jiajun</first> <last>Zhang</last></author>
-      <author><first>Yu</first> <last>Zhou</last></author>
-      <author><first>Chengqing</first> <last>Zong</last></author>
+      <author><first>Guoping</first><last>Huang</last></author>
+      <author><first>Jiajun</first><last>Zhang</last></author>
+      <author><first>Yu</first><last>Zhou</last></author>
+      <author><first>Chengqing</first><last>Zong</last></author>
       <pages>37–45</pages>
       <url>W17-6005</url>
       <abstract>Terms extensively exist in specific domains, and term translation plays a critical role in domain-specific machine translation (MT) tasks. However, it’s a challenging task to translate them correctly for the huge number of pre-existing terms and the endless new terms. To achieve better term translation quality, it is necessary to inject external term knowledge into the underlying MT system. Fortunately, there are plenty of term translation knowledge in parenthetical sentences on the Internet. In this paper, we propose a simple, straightforward and effective framework to improve term translation by learning from parenthetical sentences. This framework includes: (1) a focused web crawler; (2) a parenthetical sentence filter, acquiring parenthetical sentences including bilingual term pairs; (3) a term translation knowledge extractor, extracting bilingual term translation candidates; (4) a probability learner, generating the term translation table for MT decoders. The extensive experiments demonstrate that our proposed framework significantly improves the translation quality of terms and sentences.</abstract>
@@ -11184,108 +11184,108 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>A Feature Structure Algebra for <fixed-case>FTAG</fixed-case></title>
-      <author><first>Alexander</first> <last>Koller</last></author>
+      <author><first>Alexander</first><last>Koller</last></author>
       <pages>1–10</pages>
       <url>W17-6201</url>
     </paper>
     <paper id="2">
       <title>Parsing Minimalist Languages with Interpreted Regular Tree Grammars</title>
-      <author><first>Meaghan</first> <last>Fowlie</last></author>
-      <author><first>Alexander</first> <last>Koller</last></author>
+      <author><first>Meaghan</first><last>Fowlie</last></author>
+      <author><first>Alexander</first><last>Koller</last></author>
       <pages>11–20</pages>
       <url>W17-6202</url>
     </paper>
     <paper id="3">
       <title>Depictives in <fixed-case>E</fixed-case>nglish: An <fixed-case>LTAG</fixed-case> Approach</title>
-      <author><first>Benjamin</first> <last>Burkhardt</last></author>
-      <author><first>Timm</first> <last>Lichte</last></author>
-      <author><first>Laura</first> <last>Kallmeyer</last></author>
+      <author><first>Benjamin</first><last>Burkhardt</last></author>
+      <author><first>Timm</first><last>Lichte</last></author>
+      <author><first>Laura</first><last>Kallmeyer</last></author>
       <pages>21–30</pages>
       <url>W17-6203</url>
     </paper>
     <paper id="4">
       <title>Reflexives and Reciprocals in Synchronous Tree Adjoining Grammar</title>
-      <author><first>Cristina</first> <last>Aggazzotti</last></author>
-      <author><first>Stuart M.</first> <last>Shieber</last></author>
+      <author><first>Cristina</first><last>Aggazzotti</last></author>
+      <author><first>Stuart M.</first><last>Shieber</last></author>
       <pages>31–42</pages>
       <url>W17-6204</url>
     </paper>
     <paper id="5">
       <title>Coordination in <fixed-case>TAG</fixed-case> without the Conjoin Operation</title>
-      <author><first>Chung-hye</first> <last>Han</last></author>
-      <author><first>Anoop</first> <last>Sarkar</last></author>
+      <author><first>Chung-hye</first><last>Han</last></author>
+      <author><first>Anoop</first><last>Sarkar</last></author>
       <pages>43–52</pages>
       <url>W17-6205</url>
     </paper>
     <paper id="6">
       <title>Scope, Time, and Predicate Restriction in Blackfoot using <fixed-case>MC</fixed-case>-<fixed-case>STAG</fixed-case></title>
-      <author><first>Dennis Ryan</first> <last>Storoshenko</last></author>
+      <author><first>Dennis Ryan</first><last>Storoshenko</last></author>
       <pages>53–60</pages>
       <url>W17-6206</url>
     </paper>
     <paper id="7">
       <title>Combining Predicate-Argument Structure and Operator Projection: Clause Structure in Role and Reference Grammar</title>
-      <author><first>Laura</first> <last>Kallmeyer</last></author>
-      <author><first>Rainer</first> <last>Osswald</last></author>
+      <author><first>Laura</first><last>Kallmeyer</last></author>
+      <author><first>Rainer</first><last>Osswald</last></author>
       <pages>61–70</pages>
       <url>W17-6207</url>
     </paper>
     <paper id="8">
       <title>Parsing with Dynamic Continuized <fixed-case>CCG</fixed-case></title>
-      <author><first>Michael</first> <last>White</last></author>
-      <author><first>Simon</first> <last>Charlow</last></author>
-      <author><first>Jordan</first> <last>Needle</last></author>
-      <author><first>Dylan</first> <last>Bumford</last></author>
+      <author><first>Michael</first><last>White</last></author>
+      <author><first>Simon</first><last>Charlow</last></author>
+      <author><first>Jordan</first><last>Needle</last></author>
+      <author><first>Dylan</first><last>Bumford</last></author>
       <pages>71–83</pages>
       <url>W17-6208</url>
     </paper>
     <paper id="9">
       <title>Multiword Expression-Aware <fixed-case>A</fixed-case>* <fixed-case>TAG</fixed-case> Parsing Revisited</title>
-      <author><first>Jakub</first> <last>Waszczuk</last></author>
-      <author><first>Agata</first> <last>Savary</last></author>
-      <author><first>Yannick</first> <last>Parmentier</last></author>
+      <author><first>Jakub</first><last>Waszczuk</last></author>
+      <author><first>Agata</first><last>Savary</last></author>
+      <author><first>Yannick</first><last>Parmentier</last></author>
       <pages>84–93</pages>
       <url>W17-6209</url>
     </paper>
     <paper id="10">
       <title>Single-Rooted <fixed-case>DAG</fixed-case>s in Regular <fixed-case>DAG</fixed-case> Languages: <fixed-case>P</fixed-case>arikh Image and Path Languages</title>
-      <author><first>Martin</first> <last>Berglund</last></author>
-      <author><first>Henrik</first> <last>Björklund</last></author>
-      <author><first>Frank</first> <last>Drewes</last></author>
+      <author><first>Martin</first><last>Berglund</last></author>
+      <author><first>Henrik</first><last>Björklund</last></author>
+      <author><first>Frank</first><last>Drewes</last></author>
       <pages>94–101</pages>
       <url>W17-6210</url>
     </paper>
     <paper id="11">
       <title>Contextual Hyperedge Replacement Grammars for Abstract Meaning Representations</title>
-      <author><first>Frank</first> <last>Drewes</last></author>
-      <author><first>Anna</first> <last>Jonsson</last></author>
+      <author><first>Frank</first><last>Drewes</last></author>
+      <author><first>Anna</first><last>Jonsson</last></author>
       <pages>102–111</pages>
       <url>W17-6211</url>
     </paper>
     <paper id="12">
       <title>Transforming Dependency Structures to <fixed-case>LTAG</fixed-case> Derivation Trees</title>
-      <author><first>Caio</first> <last>Corro</last></author>
-      <author><first>Joseph</first> <last>Le Roux</last></author>
+      <author><first>Caio</first><last>Corro</last></author>
+      <author><first>Joseph</first><last>Le Roux</last></author>
       <pages>112–121</pages>
       <url>W17-6212</url>
     </paper>
     <paper id="13">
       <title>Linguistically Rich Vector Representations of Supertags for <fixed-case>TAG</fixed-case> Parsing</title>
-      <author><first>Dan</first> <last>Friedman</last></author>
-      <author><first>Jungo</first> <last>Kasai</last></author>
-      <author><first>R. Thomas</first> <last>McCoy</last></author>
-      <author><first>Robert</first> <last>Frank</last></author>
-      <author><first>Forrest</first> <last>Davis</last></author>
-      <author><first>Owen</first> <last>Rambow</last></author>
+      <author><first>Dan</first><last>Friedman</last></author>
+      <author><first>Jungo</first><last>Kasai</last></author>
+      <author><first>R. Thomas</first><last>McCoy</last></author>
+      <author><first>Robert</first><last>Frank</last></author>
+      <author><first>Forrest</first><last>Davis</last></author>
+      <author><first>Owen</first><last>Rambow</last></author>
       <pages>122–131</pages>
       <url>W17-6213</url>
     </paper>
     <paper id="14">
       <title><fixed-case>TAG</fixed-case> Parser Evaluation using Textual Entailments</title>
-      <author><first>Pauli</first> <last>Xu</last></author>
-      <author><first>Robert</first> <last>Frank</last></author>
-      <author><first>Jungo</first> <last>Kasai</last></author>
-      <author><first>Owen</first> <last>Rambow</last></author>
+      <author><first>Pauli</first><last>Xu</last></author>
+      <author><first>Robert</first><last>Frank</last></author>
+      <author><first>Jungo</first><last>Kasai</last></author>
+      <author><first>Owen</first><last>Rambow</last></author>
       <pages>132–141</pages>
       <url>W17-6214</url>
     </paper>
@@ -11306,121 +11306,121 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Automatically Acquired Lexical Knowledge Improves <fixed-case>J</fixed-case>apanese Joint Morphological and Dependency Analysis</title>
-      <author><first>Daisuke</first> <last>Kawahara</last></author>
-      <author><first>Yuta</first> <last>Hayashibe</last></author>
-      <author><first>Hajime</first> <last>Morita</last></author>
-      <author><first>Sadao</first> <last>Kurohashi</last></author>
+      <author><first>Daisuke</first><last>Kawahara</last></author>
+      <author><first>Yuta</first><last>Hayashibe</last></author>
+      <author><first>Hajime</first><last>Morita</last></author>
+      <author><first>Sadao</first><last>Kurohashi</last></author>
       <pages>1–10</pages>
       <url>W17-6301</url>
       <abstract>This paper presents a joint model for morphological and dependency analysis based on automatically acquired lexical knowledge. This model takes advantage of rich lexical knowledge to simultaneously resolve word segmentation, POS, and dependency ambiguities. In our experiments on Japanese, we show the effectiveness of our joint model over conventional pipeline models.</abstract>
     </paper>
     <paper id="2">
       <title>Dependency Language Models for Transition-based Dependency Parsing</title>
-      <author><first>Juntao</first> <last>Yu</last></author>
-      <author><first>Bernd</first> <last>Bohnet</last></author>
+      <author><first>Juntao</first><last>Yu</last></author>
+      <author><first>Bernd</first><last>Bohnet</last></author>
       <pages>11–17</pages>
       <url>W17-6302</url>
       <abstract>In this paper, we present an approach to improve the accuracy of a strong transition-based dependency parser by exploiting dependency language models that are extracted from a large parsed corpus. We integrated a small number of features based on the dependency language models into the parser. To demonstrate the effectiveness of the proposed approach, we evaluate our parser on standard English and Chinese data where the base parser could achieve competitive accuracy scores. Our enhanced parser achieved state-of-the-art accuracy on Chinese data and competitive results on English data. We gained a large absolute improvement of one point (UAS) on Chinese and 0.5 points for English.</abstract>
     </paper>
     <paper id="3">
       <title>Lexicalized vs. Delexicalized Parsing in Low-Resource Scenarios</title>
-      <author><first>Agnieszka</first> <last>Falenska</last></author>
-      <author><first>Özlem</first> <last>Çetinoğlu</last></author>
+      <author><first>Agnieszka</first><last>Falenska</last></author>
+      <author><first>Özlem</first><last>Çetinoğlu</last></author>
       <pages>18–24</pages>
       <url>W17-6303</url>
       <abstract>We present a systematic analysis of lexicalized vs. delexicalized parsing in low-resource scenarios, and propose a methodology to choose one method over another under certain conditions. We create a set of simulation experiments on 41 languages and apply our findings to 9 low-resource languages. Experimental results show that our methodology chooses the best approach in 8 out of 9 cases.</abstract>
     </paper>
     <paper id="4">
       <title>Improving neural tagging with lexical information</title>
-      <author><first>Benoît</first> <last>Sagot</last></author>
-      <author><first>Héctor</first> <last>Martínez Alonso</last></author>
+      <author><first>Benoît</first><last>Sagot</last></author>
+      <author><first>Héctor</first><last>Martínez Alonso</last></author>
       <pages>25–31</pages>
       <url>W17-6304</url>
       <abstract>Neural part-of-speech tagging has achieved competitive results with the incorporation of character-based and pre-trained word embeddings. In this paper, we show that a state-of-the-art bi-LSTM tagger can benefit from using information from morphosyntactic lexicons as additional input. The tagger, trained on several dozen languages, shows a consistent, average improvement when using lexical information, even when also using character-based embeddings, thus showing the complementarity of the different sources of lexical information. The improvements are particularly important for the smaller datasets.</abstract>
     </paper>
     <paper id="5">
       <title>Prepositional Phrase Attachment over Word Embedding Products</title>
-      <author><first>Pranava Swaroop</first> <last>Madhyastha</last></author>
-      <author><first>Xavier</first> <last>Carreras</last></author>
-      <author><first>Ariadna</first> <last>Quattoni</last></author>
+      <author><first>Pranava Swaroop</first><last>Madhyastha</last></author>
+      <author><first>Xavier</first><last>Carreras</last></author>
+      <author><first>Ariadna</first><last>Quattoni</last></author>
       <pages>32–43</pages>
       <url>W17-6305</url>
       <abstract>We present a low-rank multi-linear model for the task of solving prepositional phrase attachment ambiguity (PP task). Our model exploits tensor products of word embeddings, capturing all possible conjunctions of latent embeddings. Our results on a wide range of datasets and task settings show that tensor products are the best compositional operation and that a relatively simple multi-linear model that uses only word embeddings of lexical features can outperform more complex non-linear architectures that exploit the same information. Our proposed model gives the current best reported performance on an out-of-domain evaluation and performs competively on out-of-domain dependency parsing datasets.</abstract>
     </paper>
     <paper id="6">
       <title><fixed-case>L</fixed-case>1-<fixed-case>L</fixed-case>2 Parallel Dependency Treebank as Learner Corpus</title>
-      <author><first>John</first> <last>Lee</last></author>
-      <author><first>Keying</first> <last>Li</last></author>
-      <author><first>Herman</first> <last>Leung</last></author>
+      <author><first>John</first><last>Lee</last></author>
+      <author><first>Keying</first><last>Li</last></author>
+      <author><first>Herman</first><last>Leung</last></author>
       <pages>44–49</pages>
       <url>W17-6306</url>
       <abstract>This opinion paper proposes the use of parallel treebank as learner corpus. We show how an L1-L2 parallel treebank — i.e., parse trees of non-native sentences, aligned to the parse trees of their target hypotheses — can facilitate retrieval of sentences with specific learner errors. We argue for its benefits, in terms of corpus re-use and interoperability, over a conventional learner corpus annotated with error tags. As a proof of concept, we conduct a case study on word-order errors made by learners of Chinese as a foreign language. We report precision and recall in retrieving a range of word-order error categories from L1-L2 tree pairs annotated in the Universal Dependency framework.</abstract>
     </paper>
     <paper id="7">
       <title>Splitting Complex <fixed-case>E</fixed-case>nglish Sentences</title>
-      <author><first>John</first> <last>Lee</last></author>
-      <author><first>J. Buddhika K. Pathirage</first> <last>Don</last></author>
+      <author><first>John</first><last>Lee</last></author>
+      <author><first>J. Buddhika K. Pathirage</first><last>Don</last></author>
       <pages>50–55</pages>
       <url>W17-6307</url>
       <abstract>This paper applies parsing technology to the task of syntactic simplification of English sentences, focusing on the identification of text spans that can be removed from a complex sentence. We report the most comprehensive evaluation to-date on this task, using a dataset of sentences that exhibit simplification based on coordination, subordination, punctuation/parataxis, adjectival clauses, participial phrases, and appositive phrases. We train a decision tree with features derived from text span length, POS tags and dependency relations, and show that it significantly outperforms a parser-only baseline.</abstract>
     </paper>
     <paper id="8">
       <title>Hierarchical Word Structure-based Parsing: A Feasibility Study on <fixed-case>UD</fixed-case>-style Dependency Parsing in <fixed-case>J</fixed-case>apanese</title>
-      <author><first>Takaaki</first> <last>Tanaka</last></author>
-      <author><first>Katsuhiko</first> <last>Hayashi</last></author>
-      <author><first>Masaaki</first> <last>Nagata</last></author>
+      <author><first>Takaaki</first><last>Tanaka</last></author>
+      <author><first>Katsuhiko</first><last>Hayashi</last></author>
+      <author><first>Masaaki</first><last>Nagata</last></author>
       <pages>56–60</pages>
       <url>W17-6308</url>
       <abstract>In applying word-based dependency parsing such as Universal Dependencies (UD) to Japanese, the uncertainty of word segmentation emerges for defining a word unit of the dependencies. We introduce the following hierarchical word structures to dependency parsing in Japanese: morphological units (a short unit word, SUW) and syntactic units (a long unit word, LUW). An SUW can be used to segment a sentence consistently, while it is too short to represent syntactic construction. An LUW is a unit including functional multiwords and LUW-based analysis facilitates the capturing of syntactic structure and makes parsing results more precise than SUW-based analysis. This paper describes the results of a feasibility study on the ability and the effectiveness of parsing methods based on hierarchical word structure (LUW chunking+parsing) in comparison to single layer word structure (SUW parsing). We also show joint analysis of LUW-chunking and dependency parsing improves the performance of identifying predicate-argument structures, while there is not much difference between overall results of them. not much difference between overall results of them.</abstract>
     </paper>
     <paper id="9">
       <title>Leveraging Newswire Treebanks for Parsing Conversational Data with Argument Scrambling</title>
-      <author><first>Riyaz A.</first> <last>Bhat</last></author>
-      <author><first>Irshad</first> <last>Bhat</last></author>
-      <author><first>Dipti</first> <last>Sharma</last></author>
+      <author><first>Riyaz A.</first><last>Bhat</last></author>
+      <author><first>Irshad</first><last>Bhat</last></author>
+      <author><first>Dipti</first><last>Sharma</last></author>
       <pages>61–66</pages>
       <url>W17-6309</url>
       <abstract>We investigate the problem of parsing conversational data of morphologically-rich languages such as Hindi where argument scrambling occurs frequently. We evaluate a state-of-the-art non-linear transition-based parsing system on a new dataset containing 506 dependency trees for sentences from Bollywood (Hindi) movie scripts and Twitter posts of Hindi monolingual speakers. We show that a dependency parser trained on a newswire treebank is strongly biased towards the canonical structures and degrades when applied to conversational data. Inspired by Transformational Generative Grammar (Chomsky, 1965), we mitigate the sampling bias by generating all theoretically possible alternative word orders of a clause from the existing (kernel) structures in the treebank. Training our parser on canonical and transformed structures improves performance on conversational data by around 9% LAS over the baseline newswire parser.</abstract>
     </paper>
     <paper id="10">
       <title>Using hyperlinks to improve multilingual partial parsers</title>
-      <author><first>Anders</first> <last>Søgaard</last></author>
+      <author><first>Anders</first><last>Søgaard</last></author>
       <pages>67–71</pages>
       <url>W17-6310</url>
       <abstract>Syntactic annotation is costly and not available for the vast majority of the world’s languages. We show that sometimes we can do away with less labeled data by exploiting more readily available forms of mark-up. Specifically, we revisit an idea from Valentin Spitkovsky’s work (2010), namely that hyperlinks typically bracket syntactic constituents or chunks. We strengthen his results by showing that not only can hyperlinks help in low resource scenarios, exemplified here by Quechua, but learning from hyperlinks can also improve state-of-the-art NLP models for English newswire. We also present out-of-domain evaluation on English Ontonotes 4.0.</abstract>
     </paper>
     <paper id="11">
       <title>Correcting prepositional phrase attachments using multimodal corpora</title>
-      <author><first>Sebastien</first> <last>Delecraz</last></author>
-      <author><first>Alexis</first> <last>Nasr</last></author>
-      <author><first>Frederic</first> <last>Bechet</last></author>
-      <author><first>Benoit</first> <last>Favre</last></author>
+      <author><first>Sebastien</first><last>Delecraz</last></author>
+      <author><first>Alexis</first><last>Nasr</last></author>
+      <author><first>Frederic</first><last>Bechet</last></author>
+      <author><first>Benoit</first><last>Favre</last></author>
       <pages>72–77</pages>
       <url>W17-6311</url>
       <abstract>PP-attachments are an important source of errors in parsing natural language. We propose in this article to use data coming from a multimodal corpus, combining textual, visual and conceptual information, as well as a correction strategy, to propose alternative attachments in the output of a parser.</abstract>
     </paper>
     <paper id="12">
       <title>Exploiting Structure in Parsing to 1-Endpoint-Crossing Graphs</title>
-      <author><first>Robin</first> <last>Kurtz</last></author>
-      <author><first>Marco</first> <last>Kuhlmann</last></author>
+      <author><first>Robin</first><last>Kurtz</last></author>
+      <author><first>Marco</first><last>Kuhlmann</last></author>
       <pages>78–87</pages>
       <url>W17-6312</url>
       <abstract>Deep dependency parsing can be cast as the search for maximum acyclic subgraphs in weighted digraphs. Because this search problem is intractable in the general case, we consider its restriction to the class of 1-endpoint-crossing (1ec) graphs, which has high coverage on standard data sets. Our main contribution is a characterization of 1ec graphs as a subclass of the graphs with pagenumber at most 3. Building on this we show how to extend an existing parsing algorithm for 1-endpoint-crossing trees to the full class. While the runtime complexity of the extended algorithm is polynomial in the length of the input sentence, it features a large constant, which poses a challenge for practical implementations.</abstract>
     </paper>
     <paper id="13">
       <title>Effective Online Reordering with Arc-Eager Transitions</title>
-      <author><first>Ryosuke</first> <last>Kohita</last></author>
-      <author><first>Hiroshi</first> <last>Noji</last></author>
-      <author><first>Yuji</first> <last>Matsumoto</last></author>
+      <author><first>Ryosuke</first><last>Kohita</last></author>
+      <author><first>Hiroshi</first><last>Noji</last></author>
+      <author><first>Yuji</first><last>Matsumoto</last></author>
       <pages>88–98</pages>
       <url>W17-6313</url>
       <abstract>We present a new transition system with word reordering for unrestricted non-projective dependency parsing. Our system is based on decomposed arc-eager rather than arc-standard, which allows more flexible ambiguity resolution between a local projective and non-local crossing attachment. In our experiment on Universal Dependencies 2.0, we find our parser outperforms the ordinary swap-based parser particularly on languages with a large amount of non-projectivity.</abstract>
     </paper>
     <paper id="14">
       <title>Arc-Hybrid Non-Projective Dependency Parsing with a Static-Dynamic Oracle</title>
-      <author><first>Miryam</first> <last>de Lhoneux</last></author>
-      <author><first>Sara</first> <last>Stymne</last></author>
-      <author><first>Joakim</first> <last>Nivre</last></author>
+      <author><first>Miryam</first><last>de Lhoneux</last></author>
+      <author><first>Sara</first><last>Stymne</last></author>
+      <author><first>Joakim</first><last>Nivre</last></author>
       <pages>99–104</pages>
       <url>W17-6314</url>
       <abstract>In this paper, we extend the arc-hybrid system for transition-based parsing with a swap transition that enables reordering of the words and construction of non-projective trees. Although this extension breaks the arc-decomposability of the transition system, we show how the existing dynamic oracle for this system can be modified and combined with a static oracle only for the swap transition. Experiments on 5 languages show that the new system gives competitive accuracy and is significantly better than a system trained with a purely static oracle.</abstract>
@@ -11428,33 +11428,33 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="15">
       <title>Encoder-Decoder Shift-Reduce Syntactic Parsing</title>
-      <author><first>Jiangming</first> <last>Liu</last></author>
-      <author><first>Yue</first> <last>Zhang</last></author>
+      <author><first>Jiangming</first><last>Liu</last></author>
+      <author><first>Yue</first><last>Zhang</last></author>
       <pages>105–114</pages>
       <url>W17-6315</url>
       <abstract>Encoder-decoder neural networks have been used for many NLP tasks, such as neural machine translation. They have also been applied to constituent parsing by using bracketed tree structures as a target language, translating input sentences into syntactic trees. A more commonly used method to linearize syntactic trees is the shift-reduce system, which uses a sequence of transition-actions to build trees. We empirically investigate the effectiveness of applying the encoder-decoder network to transition-based parsing. On standard benchmarks, our system gives comparable results to the stack LSTM parser for dependency parsing, and significantly better results compared to the aforementioned parser for constituent parsing, which uses bracketed tree formats.</abstract>
     </paper>
     <paper id="16">
       <title>Arc-Standard Spinal Parsing with Stack-<fixed-case>LSTM</fixed-case>s</title>
-      <author><first>Miguel</first> <last>Ballesteros</last></author>
-      <author><first>Xavier</first> <last>Carreras</last></author>
+      <author><first>Miguel</first><last>Ballesteros</last></author>
+      <author><first>Xavier</first><last>Carreras</last></author>
       <pages>115–121</pages>
       <url>W17-6316</url>
       <abstract>We present a neural transition-based parser for spinal trees, a dependency representation of constituent trees. The parser uses Stack-LSTMs that compose constituent nodes with dependency-based derivations. In experiments, we show that this model adapts to different styles of dependency relations, but this choice has little effect for predicting constituent structure, suggesting that LSTMs induce useful states by themselves.</abstract>
     </paper>
     <paper id="17">
       <title>Coarse-To-Fine Parsing for Expressive Grammar Formalisms</title>
-      <author><first>Christoph</first> <last>Teichmann</last></author>
-      <author><first>Alexander</first> <last>Koller</last></author>
-      <author><first>Jonas</first> <last>Groschwitz</last></author>
+      <author><first>Christoph</first><last>Teichmann</last></author>
+      <author><first>Alexander</first><last>Koller</last></author>
+      <author><first>Jonas</first><last>Groschwitz</last></author>
       <pages>122–127</pages>
       <url>W17-6317</url>
       <abstract>We generalize coarse-to-fine parsing to grammar formalisms that are more expressive than PCFGs and/or describe languages of trees or graphs. We evaluate our algorithm on PCFG, PTAG, and graph parsing. While we achieve the expected performance gains on PCFGs, coarse-to-fine does not help for PTAG and can even slow down parsing for graphs. We discuss the implications of this finding.</abstract>
     </paper>
     <paper id="18">
       <title>Evaluating <fixed-case>LSTM</fixed-case> models for grammatical function labelling</title>
-      <author><first>Bich-Ngoc</first> <last>Do</last></author>
-      <author><first>Ines</first> <last>Rehbein</last></author>
+      <author><first>Bich-Ngoc</first><last>Do</last></author>
+      <author><first>Ines</first><last>Rehbein</last></author>
       <pages>128–133</pages>
       <url>W17-6318</url>
       <abstract>To improve grammatical function labelling for German, we augment the labelling component of a neural dependency parser with a decision history. We present different ways to encode the history, using different LSTM architectures, and show that our models yield significant improvements, resulting in a LAS for German that is close to the best result from the SPMRL 2014 shared task (without the reranker).</abstract>
@@ -11476,236 +11476,236 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Capturing Dependency Syntax with “Deep” Sequential Models</title>
-      <author><first>Yoav</first> <last>Goldberg</last></author>
+      <author><first>Yoav</first><last>Goldberg</last></author>
       <pages>1</pages>
       <url>W17-6501</url>
     </paper>
     <paper id="2">
       <title>Syntax-Semantics Interface: A Plea for a Deep Dependency Sentence Structure</title>
-      <author><first>Eva</first> <last>Hajičová</last></author>
+      <author><first>Eva</first><last>Hajičová</last></author>
       <pages>2–3</pages>
       <url>W17-6502</url>
     </paper>
     <paper id="3">
       <title>The Benefit of Syntactic vs. Linear N-grams for Linguistic Description</title>
-      <author><first>Melanie</first> <last>Andresen</last></author>
-      <author><first>Heike</first> <last>Zinsmeister</last></author>
+      <author><first>Melanie</first><last>Andresen</last></author>
+      <author><first>Heike</first><last>Zinsmeister</last></author>
       <pages>4–14</pages>
       <url>W17-6503</url>
     </paper>
     <paper id="4">
       <title>On the Predicate-Argument Structure: Internal and Absorbing Scope</title>
-      <author><first>Igor</first> <last>Boguslavsky</last></author>
+      <author><first>Igor</first><last>Boguslavsky</last></author>
       <pages>15–24</pages>
       <url>W17-6504</url>
     </paper>
     <paper id="5">
       <title>On the order of Words in <fixed-case>I</fixed-case>talian: a Study on Genre vs Complexity</title>
-      <author><first>Dominique</first> <last>Brunato</last></author>
-      <author><first>Felice</first> <last>Dell’Orletta</last></author>
+      <author><first>Dominique</first><last>Brunato</last></author>
+      <author><first>Felice</first><last>Dell’Orletta</last></author>
       <pages>25–31</pages>
       <url>W17-6505</url>
     </paper>
     <paper id="6">
       <title>Revising the <fixed-case>METU</fixed-case>-Sabancı <fixed-case>T</fixed-case>urkish Treebank: An Exercise in Surface-Syntactic Annotation of Agglutinative Languages</title>
-      <author><first>Alicia</first> <last>Burga</last></author>
-      <author><first>Alp</first> <last>Öktem</last></author>
-      <author><first>Leo</first> <last>Wanner</last></author>
+      <author><first>Alicia</first><last>Burga</last></author>
+      <author><first>Alp</first><last>Öktem</last></author>
+      <author><first>Leo</first><last>Wanner</last></author>
       <pages>32–41</pages>
       <url>W17-6506</url>
     </paper>
     <paper id="7">
       <title>Enhanced <fixed-case>UD</fixed-case> Dependencies with Neutralized Diathesis Alternation</title>
-      <author><first>Marie</first> <last>Candito</last></author>
-      <author><first>Bruno</first> <last>Guillaume</last></author>
-      <author><first>Guy</first> <last>Perrier</last></author>
-      <author><first>Djamé</first> <last>Seddah</last></author>
+      <author><first>Marie</first><last>Candito</last></author>
+      <author><first>Bruno</first><last>Guillaume</last></author>
+      <author><first>Guy</first><last>Perrier</last></author>
+      <author><first>Djamé</first><last>Seddah</last></author>
       <pages>42–53</pages>
       <url>W17-6507</url>
     </paper>
     <paper id="8">
       <title>Classifying Languages by Dependency Structure. Typologies of Delexicalized Universal Dependency Treebanks</title>
-      <author><first>Xinying</first> <last>Chen</last></author>
-      <author><first>Kim</first> <last>Gerdes</last></author>
+      <author><first>Xinying</first><last>Chen</last></author>
+      <author><first>Kim</first><last>Gerdes</last></author>
       <pages>54–63</pages>
       <url>W17-6508</url>
     </paper>
     <paper id="9">
       <title>A Dependency Treebank for <fixed-case>K</fixed-case>urmanji <fixed-case>K</fixed-case>urdish</title>
-      <author><first>Memduh</first> <last>Gökırmak</last></author>
-      <author><first>Francis M.</first> <last>Tyers</last></author>
+      <author><first>Memduh</first><last>Gökırmak</last></author>
+      <author><first>Francis M.</first><last>Tyers</last></author>
       <pages>64–72</pages>
       <url>W17-6509</url>
     </paper>
     <paper id="10">
       <title>What are the limitations on the flux of syntactic dependencies? Evidence from <fixed-case>UD</fixed-case> treebanks</title>
-      <author><first>Sylvain</first> <last>Kahane</last></author>
-      <author><first>Chunxiao</first> <last>Yan</last></author>
-      <author><first>Marie-Amélie</first> <last>Botalla</last></author>
+      <author><first>Sylvain</first><last>Kahane</last></author>
+      <author><first>Chunxiao</first><last>Yan</last></author>
+      <author><first>Marie-Amélie</first><last>Botalla</last></author>
       <pages>73–82</pages>
       <url>W17-6510</url>
     </paper>
     <paper id="11">
       <title>Fully Delexicalized Contexts for Syntax-Based Word Embeddings</title>
-      <author><first>Jenna</first> <last>Kanerva</last></author>
-      <author><first>Sampo</first> <last>Pyysalo</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
+      <author><first>Jenna</first><last>Kanerva</last></author>
+      <author><first>Sampo</first><last>Pyysalo</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
       <pages>83–91</pages>
       <url>W17-6511</url>
     </paper>
     <paper id="12">
       <title>Universal Dependencies for Dargwa Mehweb</title>
-      <author><first>Alexandra</first> <last>Kozhukhar</last></author>
+      <author><first>Alexandra</first><last>Kozhukhar</last></author>
       <pages>92–99</pages>
       <url>W17-6512</url>
     </paper>
     <paper id="13">
       <title>Menzerath-Altmann Law in Syntactic Dependency Structure</title>
-      <author><first>Ján</first> <last>Mačutek</last></author>
-      <author><first>Radek</first> <last>Čech</last></author>
-      <author><first>Jiří</first> <last>Milička</last></author>
+      <author><first>Ján</first><last>Mačutek</last></author>
+      <author><first>Radek</first><last>Čech</last></author>
+      <author><first>Jiří</first><last>Milička</last></author>
       <pages>100–107</pages>
       <url>W17-6513</url>
     </paper>
     <paper id="14">
       <title>Assessing the Annotation Consistency of the Universal Dependencies Corpora</title>
-      <author><first>Marie-Catherine</first> <last>de Marneffe</last></author>
-      <author><first>Matias</first> <last>Grioni</last></author>
-      <author><first>Jenna</first> <last>Kanerva</last></author>
-      <author><first>Filip</first> <last>Ginter</last></author>
+      <author><first>Marie-Catherine</first><last>de Marneffe</last></author>
+      <author><first>Matias</first><last>Grioni</last></author>
+      <author><first>Jenna</first><last>Kanerva</last></author>
+      <author><first>Filip</first><last>Ginter</last></author>
       <pages>108–115</pages>
       <url>W17-6514</url>
     </paper>
     <paper id="15">
       <title>To What Extent is Immediate Constituency Analysis Dependency-Based? A Survey of Foundational Texts</title>
-      <author><first>Nicolas</first> <last>Mazziotta</last></author>
-      <author><first>Sylvain</first> <last>Kahane</last></author>
+      <author><first>Nicolas</first><last>Mazziotta</last></author>
+      <author><first>Sylvain</first><last>Kahane</last></author>
       <pages>116–126</pages>
       <url>W17-6515</url>
     </paper>
     <paper id="16">
       <title>Dependency Structure of Binary Conjunctions(of the <fixed-case>IF</fixed-case>…, <fixed-case>THEN</fixed-case>… Type)</title>
-      <author><first>Igor</first> <last>Mel’čuk</last></author>
+      <author><first>Igor</first><last>Mel’čuk</last></author>
       <pages>127–134</pages>
       <url>W17-6516</url>
     </paper>
     <paper id="17">
       <title>Non-Projectivity in <fixed-case>S</fixed-case>erbian: Analysis of Formal and Linguistic Properties</title>
-      <author><first>Aleksandra</first> <last>Miletic</last></author>
-      <author><first>Assaf</first> <last>Urieli</last></author>
+      <author><first>Aleksandra</first><last>Miletic</last></author>
+      <author><first>Assaf</first><last>Urieli</last></author>
       <pages>135–144</pages>
       <url>W17-6517</url>
     </paper>
     <paper id="18">
       <title>Prices go Up, Surge, Jump, Spike, Skyrocket, Go through the Roof… Intensifier Collocations with Parametric Nouns of Type <fixed-case>PRICE</fixed-case></title>
-      <author><first>Jasmina</first> <last>Milićević</last></author>
+      <author><first>Jasmina</first><last>Milićević</last></author>
       <pages>145–153</pages>
       <url>W17-6518</url>
     </paper>
     <paper id="19">
       <title><fixed-case>C</fixed-case>hinese Descriptive and Resultative V-de Constructions. A Dependency-based Analysis</title>
-      <author><first>Ruochen</first> <last>Niu</last></author>
+      <author><first>Ruochen</first><last>Niu</last></author>
       <pages>154–164</pages>
       <url>W17-6519</url>
     </paper>
     <paper id="20">
       <title>The Component Unit. Introducing a Novel Unit of Syntactic Analysis</title>
-      <author><first>Timothy</first> <last>Osborne</last></author>
-      <author><first>Ruochen</first> <last>Niu</last></author>
+      <author><first>Timothy</first><last>Osborne</last></author>
+      <author><first>Ruochen</first><last>Niu</last></author>
       <pages>165–175</pages>
       <url>W17-6520</url>
     </paper>
     <paper id="21">
       <title>Control vs. Raising in <fixed-case>E</fixed-case>nglish. A Dependency Grammar Account</title>
-      <author><first>Timothy</first> <last>Osborne</last></author>
-      <author><first>Matthew</first> <last>Reeve</last></author>
+      <author><first>Timothy</first><last>Osborne</last></author>
+      <author><first>Matthew</first><last>Reeve</last></author>
       <pages>176–186</pages>
       <url>W17-6521</url>
     </paper>
     <paper id="22">
       <title>Segmentation Granularity in Dependency Representations for <fixed-case>K</fixed-case>orean</title>
-      <author><first>Jungyeul</first> <last>Park</last></author>
+      <author><first>Jungyeul</first><last>Park</last></author>
       <pages>187–196</pages>
       <url>W17-6522</url>
     </paper>
     <paper id="23">
       <title>Universal Dependencies for <fixed-case>P</fixed-case>ortuguese</title>
-      <author><first>Alexandre</first> <last>Rademaker</last></author>
-      <author><first>Fabricio</first> <last>Chalub</last></author>
-      <author><first>Livy</first> <last>Real</last></author>
-      <author><first>Cláudia</first> <last>Freitas</last></author>
-      <author><first>Eckhard</first> <last>Bick</last></author>
-      <author><first>Valeria</first> <last>de Paiva</last></author>
+      <author><first>Alexandre</first><last>Rademaker</last></author>
+      <author><first>Fabricio</first><last>Chalub</last></author>
+      <author><first>Livy</first><last>Real</last></author>
+      <author><first>Cláudia</first><last>Freitas</last></author>
+      <author><first>Eckhard</first><last>Bick</last></author>
+      <author><first>Valeria</first><last>de Paiva</last></author>
       <pages>197–206</pages>
       <url>W17-6523</url>
     </paper>
     <paper id="24">
       <title><fixed-case>UDL</fixed-case>ex: Towards Cross-language Subcategorization Lexicons</title>
-      <author><first>Giulia</first> <last>Rambelli</last></author>
-      <author><first>Alessandro</first> <last>Lenci</last></author>
-      <author><first>Thierry</first> <last>Poibeau</last></author>
+      <author><first>Giulia</first><last>Rambelli</last></author>
+      <author><first>Alessandro</first><last>Lenci</last></author>
+      <author><first>Thierry</first><last>Poibeau</last></author>
       <pages>207–2017</pages>
       <url>W17-6524</url>
     </paper>
     <paper id="25">
       <title>Universal Dependencies are Hard to Parse – or are They?</title>
-      <author><first>Ines</first> <last>Rehbein</last></author>
-      <author><first>Julius</first> <last>Steen</last></author>
-      <author><first>Bich-Ngoc</first> <last>Do</last></author>
-      <author><first>Anette</first> <last>Frank</last></author>
+      <author><first>Ines</first><last>Rehbein</last></author>
+      <author><first>Julius</first><last>Steen</last></author>
+      <author><first>Bich-Ngoc</first><last>Do</last></author>
+      <author><first>Anette</first><last>Frank</last></author>
       <pages>218–228</pages>
       <url>W17-6525</url>
     </paper>
     <paper id="26">
       <title>Annotating <fixed-case>I</fixed-case>talian Social Media Texts in Universal Dependencies</title>
-      <author><first>Manuela</first> <last>Sanguinetti</last></author>
-      <author><first>Cristina</first> <last>Bosco</last></author>
-      <author><first>Alessandro</first> <last>Mazzei</last></author>
-      <author><first>Alberto</first> <last>Lavelli</last></author>
-      <author><first>Fabio</first> <last>Tamburini</last></author>
+      <author><first>Manuela</first><last>Sanguinetti</last></author>
+      <author><first>Cristina</first><last>Bosco</last></author>
+      <author><first>Alessandro</first><last>Mazzei</last></author>
+      <author><first>Alberto</first><last>Lavelli</last></author>
+      <author><first>Fabio</first><last>Tamburini</last></author>
       <pages>229–239</pages>
       <url>W17-6526</url>
     </paper>
     <paper id="27">
       <title><fixed-case>H</fixed-case>ungarian Copula Constructions in Dependency Syntax and Parsing</title>
-      <author><first>Katalin Ilona</first> <last>Simkó</last></author>
-      <author><first>Veronika</first> <last>Vincze</last></author>
+      <author><first>Katalin Ilona</first><last>Simkó</last></author>
+      <author><first>Veronika</first><last>Vincze</last></author>
       <pages>240–247</pages>
       <url>W17-6527</url>
     </paper>
     <paper id="28">
       <title>Semgrex-Plus: a Tool for Automatic Dependency-Graph Rewriting</title>
-      <author><first>Fabio</first> <last>Tamburini</last></author>
+      <author><first>Fabio</first><last>Tamburini</last></author>
       <pages>248–254</pages>
       <url>W17-6528</url>
     </paper>
     <paper id="29">
       <title>Unity in Diversity: A Unified Parsing Strategy for Major <fixed-case>I</fixed-case>ndian Languages</title>
-      <author><first>Juhi</first> <last>Tandon</last></author>
-      <author><first>Dipti Misra</first> <last>Sharma</last></author>
+      <author><first>Juhi</first><last>Tandon</last></author>
+      <author><first>Dipti Misra</first><last>Sharma</last></author>
       <pages>255–265</pages>
       <url>W17-6529</url>
     </paper>
     <paper id="30">
       <title>Quantitative Comparative Syntax on the <fixed-case>C</fixed-case>antonese-<fixed-case>M</fixed-case>andarin Parallel Dependency Treebank</title>
-      <author><first>Tak-sum</first> <last>Wong</last></author>
-      <author><first>Kim</first> <last>Gerdes</last></author>
-      <author><first>Herman</first> <last>Leung</last></author>
-      <author><first>John</first> <last>Lee</last></author>
+      <author><first>Tak-sum</first><last>Wong</last></author>
+      <author><first>Kim</first><last>Gerdes</last></author>
+      <author><first>Herman</first><last>Leung</last></author>
+      <author><first>John</first><last>Lee</last></author>
       <pages>266–275</pages>
       <url>W17-6530</url>
     </paper>
     <paper id="31">
       <title>Understanding Constraints on Non-Projectivity Using Novel Measures</title>
-      <author><first>Himanshu</first> <last>Yadav</last></author>
-      <author><first>Ashwini</first> <last>Vaidya</last></author>
-      <author><first>Samar</first> <last>Husain</last></author>
+      <author><first>Himanshu</first><last>Yadav</last></author>
+      <author><first>Ashwini</first><last>Vaidya</last></author>
+      <author><first>Samar</first><last>Husain</last></author>
       <pages>276–286</pages>
       <url>W17-6531</url>
     </paper>
     <paper id="32">
       <title>Core Arguments in Universal Dependencies</title>
-      <author><first>Daniel</first> <last>Zeman</last></author>
+      <author><first>Daniel</first><last>Zeman</last></author>
       <pages>287–296</pages>
       <url>W17-6532</url>
     </paper>
@@ -12417,11 +12417,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
   <volume id="70">
     <meta>
       <booktitle>Proceedings of Language, Ontology, Terminology and Knowledge Structures Workshop (<fixed-case>LOTKS</fixed-case> 2017)</booktitle>
-      <editor><first>Francesca</first> <last>Frontini</last></editor>
-      <editor><first>Larisa</first> <last>Grčić Simeunović</last></editor>
-      <editor><first>Špela</first> <last>Vintar</last></editor>
-      <editor><first>Anas Fahad</first> <last>Khan</last></editor>
-      <editor><first>Artemis</first> <last>Parvisi</last></editor>
+      <editor><first>Francesca</first><last>Frontini</last></editor>
+      <editor><first>Larisa</first><last>Grčić Simeunović</last></editor>
+      <editor><first>Špela</first><last>Vintar</last></editor>
+      <editor><first>Anas Fahad</first><last>Khan</last></editor>
+      <editor><first>Artemis</first><last>Parvisi</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Montpellier, France</address>
       <month>September</month>
@@ -12432,77 +12432,77 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Exploratory Analysis for Ontology Learning from Social Events on Social Media Streaming in <fixed-case>S</fixed-case>panish</title>
-      <author><first>Enrique</first> <last>Valeriano</last></author>
-      <author><first>Arturo</first> <last>Oncevay-Marcos</last></author>
+      <author><first>Enrique</first><last>Valeriano</last></author>
+      <author><first>Arturo</first><last>Oncevay-Marcos</last></author>
       <url>W17-7001</url>
     </paper>
     <paper id="2">
       <title>Creating a gold standard corpus for terminological annotation from online forum data</title>
-      <author><first>Anna</first> <last>Hätty</last></author>
-      <author><first>Simon</first> <last>Tannert</last></author>
-      <author><first>Ulrich</first> <last>Heid</last></author>
+      <author><first>Anna</first><last>Hätty</last></author>
+      <author><first>Simon</first><last>Tannert</last></author>
+      <author><first>Ulrich</first><last>Heid</last></author>
       <url>W17-7002</url>
     </paper>
     <paper id="3">
       <title>A conceptual ontology in the water domain of knowledge to bridge the lexical semantics of stratified discursive strata</title>
-      <author><first>Jean-Louis</first> <last>Janin</last></author>
-      <author><first>Henri</first> <last>Portine</last></author>
+      <author><first>Jean-Louis</first><last>Janin</last></author>
+      <author><first>Henri</first><last>Portine</last></author>
       <url>W17-7003</url>
     </paper>
     <paper id="4">
       <title><fixed-case>G</fixed-case>eo<fixed-case>D</fixed-case>ict: an integrated gazetteer</title>
-      <author><first>Jacques</first> <last>Fize</last></author>
-      <author><first>Gaurav</first> <last>Shrivastava</last></author>
-      <author><first>Pierre André</first> <last>Ménard</last></author>
+      <author><first>Jacques</first><last>Fize</last></author>
+      <author><first>Gaurav</first><last>Shrivastava</last></author>
+      <author><first>Pierre André</first><last>Ménard</last></author>
       <url>W17-7004</url>
     </paper>
     <paper id="5">
       <title>Fine-grained domain classification of text using <fixed-case>TERMIUM</fixed-case> Plus</title>
-      <author><first>Gabriel</first> <last>Bernier-Colborne</last></author>
-      <author><first>Caroline</first> <last>Barrière</last></author>
-      <author><first>Pierre André</first> <last>Ménard</last></author>
+      <author><first>Gabriel</first><last>Bernier-Colborne</last></author>
+      <author><first>Caroline</first><last>Barrière</last></author>
+      <author><first>Pierre André</first><last>Ménard</last></author>
       <url>W17-7005</url>
     </paper>
     <paper id="6">
       <title><fixed-case>TBX</fixed-case> in <fixed-case>ODD</fixed-case>: Schema-agnostic specification and documentation for <fixed-case>T</fixed-case>erm<fixed-case>B</fixed-case>ase e<fixed-case>X</fixed-case>change</title>
-      <author><first>Stefan</first> <last>Pernes</last></author>
-      <author><first>Laurent</first> <last>Romary</last></author>
+      <author><first>Stefan</first><last>Pernes</last></author>
+      <author><first>Laurent</first><last>Romary</last></author>
       <url>W17-7006</url>
     </paper>
     <paper id="7">
       <title>Enrichment of <fixed-case>F</fixed-case>rench Biomedical Ontologies with <fixed-case>UMLS</fixed-case> Concepts and Semantic Types for Biomedical Named Entity Recognition Though Ontological Semantic Annotation</title>
-      <author><first>Andon</first> <last>Tchechmedjiev</last></author>
-      <author><first>Clément</first> <last>Jonquet</last></author>
+      <author><first>Andon</first><last>Tchechmedjiev</last></author>
+      <author><first>Clément</first><last>Jonquet</last></author>
       <url>W17-7007</url>
     </paper>
     <paper id="8">
       <title>Experiments in taxonomy induction in <fixed-case>S</fixed-case>panish and <fixed-case>F</fixed-case>rench</title>
-      <author><first>Irene</first> <last>Renau</last></author>
-      <author><first>Rogelio</first> <last>Nazar</last></author>
-      <author><first>Rafael</first> <last>Marín</last></author>
+      <author><first>Irene</first><last>Renau</last></author>
+      <author><first>Rogelio</first><last>Nazar</last></author>
+      <author><first>Rafael</first><last>Marín</last></author>
       <url>W17-7008</url>
     </paper>
     <paper id="9">
       <title>A statistical model for morphology inspired by the Amis language</title>
-      <author><first>Isabelle</first> <last>Bril</last></author>
-      <author><first>Achraf</first> <last>Lassoued</last></author>
-      <author><first>Michel</first> <last>de Rougemont</last></author>
+      <author><first>Isabelle</first><last>Bril</last></author>
+      <author><first>Achraf</first><last>Lassoued</last></author>
+      <author><first>Michel</first><last>de Rougemont</last></author>
       <url>W17-7009</url>
     </paper>
     <paper id="10">
       <title>Developing <fixed-case>L</fixed-case>ex<fixed-case>O</fixed-case>: a Collaborative Editor of Multilingual Lexica and Termino-Ontological Resources in the Humanities</title>
-      <author><first>Andrea</first> <last>Bellandi</last></author>
-      <author><first>Emiliano</first> <last>Giovannetti</last></author>
-      <author><first>Silvia</first> <last>Piccini</last></author>
-      <author><first>Anja</first> <last>Weingart</last></author>
+      <author><first>Andrea</first><last>Bellandi</last></author>
+      <author><first>Emiliano</first><last>Giovannetti</last></author>
+      <author><first>Silvia</first><last>Piccini</last></author>
+      <author><first>Anja</first><last>Weingart</last></author>
       <url>W17-7010</url>
     </paper>
     <paper id="11">
       <title>Designing an Ontology for the Study of Ritual in Ancient <fixed-case>G</fixed-case>reek Tragedy</title>
-      <author><first>Gloria</first> <last>Mugelli</last></author>
-      <author><first>Andrea</first> <last>Bellandi</last></author>
-      <author><first>Federico</first> <last>Boschetti</last></author>
-      <author><first>Anas Fahad</first> <last>Khan</last></author>
+      <author><first>Gloria</first><last>Mugelli</last></author>
+      <author><first>Andrea</first><last>Bellandi</last></author>
+      <author><first>Federico</first><last>Boschetti</last></author>
+      <author><first>Anas Fahad</first><last>Khan</last></author>
       <url>W17-7011</url>
     </paper>
   </volume>
@@ -12608,56 +12608,56 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>The Effect of Negative Sampling Strategy on Capturing Semantic Similarity in Document Embeddings</title>
-      <author><first>Marzieh</first> <last>Saeidi</last></author>
-      <author><first>Ritwik</first> <last>Kulkarni</last></author>
-      <author><first>Theodosia</first> <last>Togia</last></author>
-      <author><first>Michele</first> <last>Sama</last></author>
+      <author><first>Marzieh</first><last>Saeidi</last></author>
+      <author><first>Ritwik</first><last>Kulkarni</last></author>
+      <author><first>Theodosia</first><last>Togia</last></author>
+      <author><first>Michele</first><last>Sama</last></author>
       <pages>1–8</pages>
       <url>W17-7301</url>
     </paper>
     <paper id="2">
       <title>Building Graph Representations of Deep Vector Embeddings</title>
-      <author><first>Dario</first> <last>Garcia-Gasulla</last></author>
-      <author><first>Armand</first> <last>Vilalta</last></author>
-      <author><first>Ferran</first> <last>Parés</last></author>
-      <author><first>Jonathan</first> <last>Moreno</last></author>
-      <author><first>Eduard</first> <last>Ayguadé</last></author>
-      <author><first>Jesús</first> <last>Labarta</last></author>
-      <author><first>Ulises</first> <last>Cortés</last></author>
-      <author><first>Toyotaro</first> <last>Suzumura</last></author>
+      <author><first>Dario</first><last>Garcia-Gasulla</last></author>
+      <author><first>Armand</first><last>Vilalta</last></author>
+      <author><first>Ferran</first><last>Parés</last></author>
+      <author><first>Jonathan</first><last>Moreno</last></author>
+      <author><first>Eduard</first><last>Ayguadé</last></author>
+      <author><first>Jesús</first><last>Labarta</last></author>
+      <author><first>Ulises</first><last>Cortés</last></author>
+      <author><first>Toyotaro</first><last>Suzumura</last></author>
       <pages>9–15</pages>
       <url>W17-7302</url>
     </paper>
     <paper id="3">
       <title>Class Disjointness Constraints as Specific Objective Functions in Neural Network Classifiers</title>
-      <author><first>François</first> <last>Scharffe</last></author>
+      <author><first>François</first><last>Scharffe</last></author>
       <pages>16–23</pages>
       <url>W17-7303</url>
     </paper>
     <paper id="4">
       <title>Full-Network Embedding in a Multimodal Embedding Pipeline</title>
-      <author><first>Armand</first> <last>Vilalta</last></author>
-      <author><first>Dario</first> <last>Garcia-Gasulla</last></author>
-      <author><first>Ferran</first> <last>Parés</last></author>
-      <author><first>Jonathan</first> <last>Moreno</last></author>
-      <author><first>Eduard</first> <last>Ayguadé</last></author>
-      <author><first>Jesus</first> <last>Labarta</last></author>
-      <author><first>Ulises</first> <last>Cortés</last></author>
-      <author><first>Toyotaro</first> <last>Suzumura</last></author>
+      <author><first>Armand</first><last>Vilalta</last></author>
+      <author><first>Dario</first><last>Garcia-Gasulla</last></author>
+      <author><first>Ferran</first><last>Parés</last></author>
+      <author><first>Jonathan</first><last>Moreno</last></author>
+      <author><first>Eduard</first><last>Ayguadé</last></author>
+      <author><first>Jesus</first><last>Labarta</last></author>
+      <author><first>Ulises</first><last>Cortés</last></author>
+      <author><first>Toyotaro</first><last>Suzumura</last></author>
       <pages>24–32</pages>
       <url>W17-7304</url>
     </paper>
     <paper id="5">
       <title>Extracting Tags from Large Raw Texts Using End-to-End Memory Networks</title>
-      <author><first>Feras</first> <last>Al Kassar</last></author>
-      <author><first>Frédéric</first> <last>Armetta</last></author>
+      <author><first>Feras</first><last>Al Kassar</last></author>
+      <author><first>Frédéric</first><last>Armetta</last></author>
       <pages>33–40</pages>
       <url>W17-7305</url>
     </paper>
     <paper id="6">
       <title>Dealing with Co-reference in Neural Semantic Parsing</title>
-      <author><first>Rik</first> <last>van Noord</last></author>
-      <author><first>Johan</first> <last>Bos</last></author>
+      <author><first>Rik</first><last>van Noord</last></author>
+      <author><first>Johan</first><last>Bos</last></author>
       <pages>41–49</pages>
       <url>W17-7306</url>
     </paper>
@@ -13275,7 +13275,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     <meta>
       <booktitle>Proceedings of the 16th International Workshop on Treebanks and Linguistic Theories</booktitle>
       <url>W17-76</url>
-      <editor><first>Jan</first> <last>Hajič</last></editor>
+      <editor><first>Jan</first><last>Hajič</last></editor>
       <address>Prague, Czech Republic</address>
       <year>2017</year>
     </meta>
@@ -13284,177 +13284,177 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Annotating and parsing to semantic frames: feedback from the <fixed-case>F</fixed-case>rench <fixed-case>F</fixed-case>rame<fixed-case>N</fixed-case>et project</title>
-      <author><first>Marie</first> <last>Candito</last></author>
+      <author><first>Marie</first><last>Candito</last></author>
       <pages>v</pages>
       <url>W17-7601</url>
     </paper>
     <paper id="2">
       <title>Downstream use of syntactic analysis: does representation matter?</title>
-      <author><first>Lilja</first> <last>Øvrelid</last></author>
+      <author><first>Lilja</first><last>Øvrelid</last></author>
       <pages>vi</pages>
       <url>W17-7602</url>
     </paper>
     <paper id="3">
       <title>Distributional regularities of verbs and verbal adjectives: Treebank evidence and broader implications</title>
-      <author><first>Daniël</first> <last>de Kok</last></author>
-      <author><first>Patricia</first> <last>Fischer</last></author>
-      <author><first>Corina</first> <last>Dima</last></author>
-      <author><first>Erhard</first> <last>Hinrichs</last></author>
+      <author><first>Daniël</first><last>de Kok</last></author>
+      <author><first>Patricia</first><last>Fischer</last></author>
+      <author><first>Corina</first><last>Dima</last></author>
+      <author><first>Erhard</first><last>Hinrichs</last></author>
       <pages>1–9</pages>
       <url>W17-7603</url>
     </paper>
     <paper id="4">
       <title><fixed-case>UD</fixed-case> Annotatrix: An annotation tool for Universal Dependencies</title>
-      <author><first>Francis M.</first> <last>Tyers</last></author>
-      <author><first>Mariya</first> <last>Sheyanova</last></author>
-      <author><first>Jonathan North</first> <last>Washington</last></author>
+      <author><first>Francis M.</first><last>Tyers</last></author>
+      <author><first>Mariya</first><last>Sheyanova</last></author>
+      <author><first>Jonathan North</first><last>Washington</last></author>
       <pages>10–17</pages>
       <url>W17-7604</url>
     </paper>
     <paper id="5">
       <title>The Treebanked Conspiracy. Actors and Actions in Bellum Catilinae</title>
-      <author><first>Marco</first> <last>Passarotti</last></author>
-      <author><first>Berta</first> <last>González Saavedra</last></author>
+      <author><first>Marco</first><last>Passarotti</last></author>
+      <author><first>Berta</first><last>González Saavedra</last></author>
       <pages>18–26</pages>
       <url>W17-7605</url>
     </paper>
     <paper id="6">
       <title>Universal Dependencies-based syntactic features in detecting human translation varieties</title>
-      <author><first>Maria</first> <last>Kunilovskaya</last></author>
-      <author><first>Andrey</first> <last>Kutuzov</last></author>
+      <author><first>Maria</first><last>Kunilovskaya</last></author>
+      <author><first>Andrey</first><last>Kutuzov</last></author>
       <pages>27–36</pages>
       <url>W17-7606</url>
     </paper>
     <paper id="7">
       <title>Graph Convolutional Networks for Named Entity Recognition</title>
-      <author><first>Alberto</first> <last>Cetoli</last></author>
-      <author><first>Stefano</first> <last>Bragaglia</last></author>
-      <author><first>Andrew</first> <last>O’Harney</last></author>
-      <author><first>Marc</first> <last>Sloan</last></author>
+      <author><first>Alberto</first><last>Cetoli</last></author>
+      <author><first>Stefano</first><last>Bragaglia</last></author>
+      <author><first>Andrew</first><last>O’Harney</last></author>
+      <author><first>Marc</first><last>Sloan</last></author>
       <pages>37–45</pages>
       <url>W17-7607</url>
     </paper>
     <paper id="8">
       <title>Extensions to the <fixed-case>G</fixed-case>r<fixed-case>ETEL</fixed-case> Treebank Query Application</title>
-      <author><first>Jan</first> <last>Odijk</last></author>
-      <author><first>Martijn</first> <last>van der Klis</last></author>
-      <author><first>Sheean</first> <last>Spoel</last></author>
+      <author><first>Jan</first><last>Odijk</last></author>
+      <author><first>Martijn</first><last>van der Klis</last></author>
+      <author><first>Sheean</first><last>Spoel</last></author>
       <pages>46–55</pages>
       <url>W17-7608</url>
     </paper>
     <paper id="9">
       <title>The Relation of Form and Function in Linguistic Theory and in a Multilayer Treebank</title>
-      <author><first>Eduard</first> <last>Bejček</last></author>
-      <author><first>Eva</first> <last>Hajičová</last></author>
-      <author><first>Marie</first> <last>Mikulová</last></author>
-      <author><first>Jarmila</first> <last>Panevová</last></author>
+      <author><first>Eduard</first><last>Bejček</last></author>
+      <author><first>Eva</first><last>Hajičová</last></author>
+      <author><first>Marie</first><last>Mikulová</last></author>
+      <author><first>Jarmila</first><last>Panevová</last></author>
       <pages>56–63</pages>
       <url>W17-7609</url>
     </paper>
     <paper id="10">
       <title>Literal readings of multiword expressions: as scarce as hen’s teeth</title>
-      <author><first>Agata</first> <last>Savary</last></author>
-      <author><first>Silvio Ricardo</first> <last>Cordeiro</last></author>
+      <author><first>Agata</first><last>Savary</last></author>
+      <author><first>Silvio Ricardo</first><last>Cordeiro</last></author>
       <pages>64–72</pages>
       <url>W17-7610</url>
     </paper>
     <paper id="11">
       <title>Querying Multi-word Expressions Annotation with <fixed-case>CQL</fixed-case></title>
-      <author><first>Natalia</first> <last>Klyueva</last></author>
-      <author><first>Anna</first> <last>Vernerová</last></author>
-      <author><first>Behrang</first> <last>Qasemizadeh</last></author>
+      <author><first>Natalia</first><last>Klyueva</last></author>
+      <author><first>Anna</first><last>Vernerová</last></author>
+      <author><first>Behrang</first><last>Qasemizadeh</last></author>
       <pages>73–79</pages>
       <url>W17-7611</url>
     </paper>
     <paper id="12">
       <title><fixed-case>REALEC</fixed-case> learner treebank: annotation principles and evaluation of automatic parsing</title>
-      <author><first>Olga</first> <last>Lyashevskaya</last></author>
-      <author><first>Irina</first> <last>Panteleeva</last></author>
+      <author><first>Olga</first><last>Lyashevskaya</last></author>
+      <author><first>Irina</first><last>Panteleeva</last></author>
       <pages>80–87</pages>
       <url>W17-7612</url>
     </paper>
     <paper id="13">
       <title>A semiautomatic lemmatisation procedure for treebanks. Old <fixed-case>E</fixed-case>nglish strong and weak verbs</title>
-      <author><first>Marta</first> <last>Tío Sáenz</last></author>
-      <author><first>Darío</first> <last>Metola Rodríguez</last></author>
+      <author><first>Marta</first><last>Tío Sáenz</last></author>
+      <author><first>Darío</first><last>Metola Rodríguez</last></author>
       <pages>88–94</pages>
       <url>W17-7613</url>
     </paper>
     <paper id="14">
       <title>Data point selection for genre-aware parsing</title>
-      <author><first>Ines</first> <last>Rehbein</last></author>
-      <author><first>Felix</first> <last>Bildhauer</last></author>
+      <author><first>Ines</first><last>Rehbein</last></author>
+      <author><first>Felix</first><last>Bildhauer</last></author>
       <pages>95–105</pages>
       <url>W17-7614</url>
     </paper>
     <paper id="15">
       <title>Error Analysis of Cross-lingual Tagging and Parsing</title>
-      <author><first>Rudolf</first> <last>Rosa</last></author>
-      <author><first>Zdeněk</first> <last>Žabokrtský</last></author>
+      <author><first>Rudolf</first><last>Rosa</last></author>
+      <author><first>Zdeněk</first><last>Žabokrtský</last></author>
       <pages>106–118</pages>
       <url>W17-7615</url>
     </paper>
     <paper id="16">
       <title>A <fixed-case>T</fixed-case>elugu treebank based on a grammar book</title>
-      <author><first>Taraka</first> <last>Rama</last></author>
-      <author><first>Sowmya</first> <last>Vajjala</last></author>
+      <author><first>Taraka</first><last>Rama</last></author>
+      <author><first>Sowmya</first><last>Vajjala</last></author>
       <pages>119–128</pages>
       <url>W17-7616</url>
     </paper>
     <paper id="17">
       <title>Recent Developments within <fixed-case>B</fixed-case>ul<fixed-case>T</fixed-case>ree<fixed-case>B</fixed-case>ank</title>
-      <author><first>Petya</first> <last>Osenova</last></author>
-      <author><first>Kiril</first> <last>Simov</last></author>
+      <author><first>Petya</first><last>Osenova</last></author>
+      <author><first>Kiril</first><last>Simov</last></author>
       <pages>129–137</pages>
       <url>W17-7617</url>
     </paper>
     <paper id="18">
       <title>Towards a dependency-annotated treebank for <fixed-case>B</fixed-case>ambara</title>
-      <author><first>Ekaterina</first> <last>Aplonova</last></author>
-      <author><first>Francis M.</first> <last>Tyers</last></author>
+      <author><first>Ekaterina</first><last>Aplonova</last></author>
+      <author><first>Francis M.</first><last>Tyers</last></author>
       <pages>138–145</pages>
       <url>W17-7618</url>
     </paper>
     <paper id="19">
       <title>Merging the Trees - Building a Morphological Treebank for <fixed-case>G</fixed-case>erman from Two Resources</title>
-      <author><first>Petra</first> <last>Steiner</last></author>
+      <author><first>Petra</first><last>Steiner</last></author>
       <pages>146–160</pages>
       <url>W17-7619</url>
     </paper>
     <paper id="20">
       <title>What <fixed-case>I</fixed-case> think when <fixed-case>I</fixed-case> think about treebanks</title>
-      <author><first>Anders</first> <last>Søgaard</last></author>
+      <author><first>Anders</first><last>Søgaard</last></author>
       <pages>161–166</pages>
       <url>W17-7620</url>
     </paper>
     <paper id="21">
       <title>Syntactic Semantic Correspondence in Dependency Grammar</title>
-      <author><first>Cătălina</first> <last>Mărănduc</last></author>
-      <author><first>Cătălin</first> <last>Mititelu</last></author>
-      <author><first>Victoria</first> <last>Bobicev</last></author>
+      <author><first>Cătălina</first><last>Mărănduc</last></author>
+      <author><first>Cătălin</first><last>Mititelu</last></author>
+      <author><first>Victoria</first><last>Bobicev</last></author>
       <pages>167–180</pages>
       <url>W17-7621</url>
     </paper>
     <paper id="22">
       <title>Multi-word annotation in syntactic treebanks - Propositions for Universal Dependencies</title>
-      <author><first>Sylvain</first> <last>Kahane</last></author>
-      <author><first>Marine</first> <last>Courtin</last></author>
-      <author><first>Kim</first> <last>Gerdes</last></author>
+      <author><first>Sylvain</first><last>Kahane</last></author>
+      <author><first>Marine</first><last>Courtin</last></author>
+      <author><first>Kim</first><last>Gerdes</last></author>
       <pages>181–189</pages>
       <url>W17-7622</url>
     </paper>
     <paper id="23">
       <title>A Universal Dependencies Treebank for <fixed-case>M</fixed-case>arathi</title>
-      <author><first>Vinit</first> <last>Ravishankar</last></author>
+      <author><first>Vinit</first><last>Ravishankar</last></author>
       <pages>190–200</pages>
       <url>W17-7623</url>
     </paper>
     <paper id="24">
       <title>Dangerous Relations in Dependency Treebanks</title>
-      <author><first>Chiara</first> <last>Alzetta</last></author>
-      <author><first>Felice</first> <last>Dell’Orletta</last></author>
-      <author><first>Simonetta</first> <last>Montemagni</last></author>
-      <author><first>Giulia</first> <last>Venturi</last></author>
+      <author><first>Chiara</first><last>Alzetta</last></author>
+      <author><first>Felice</first><last>Dell’Orletta</last></author>
+      <author><first>Simonetta</first><last>Montemagni</last></author>
+      <author><first>Giulia</first><last>Venturi</last></author>
       <pages>201–210</pages>
       <url>W17-7624</url>
     </paper>
@@ -13472,8 +13472,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
   <volume id="77">
     <meta>
       <booktitle>Proceedings of the 1st Workshop on Natural Language Processing and Information Retrieval associated with <fixed-case>RANLP</fixed-case> 2017</booktitle>
-      <editor><first>Mireille</first> <last>Makary</last></editor>
-      <editor><first>Michael</first> <last>Oakes</last></editor>
+      <editor><first>Mireille</first><last>Makary</last></editor>
+      <editor><first>Michael</first><last>Oakes</last></editor>
       <publisher>INCOMA Inc.</publisher>
       <address>Varna, Bulgaria</address>
       <month>September</month>
@@ -13484,9 +13484,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Deception Detection for the <fixed-case>R</fixed-case>ussian Language: Lexical and Syntactic Parameters</title>
-      <author><first>Dina</first> <last>Pisarevskaya</last></author>
-      <author><first>Tatiana</first> <last>Litvinova</last></author>
-      <author><first>Olga</first> <last>Litvinova</last></author>
+      <author><first>Dina</first><last>Pisarevskaya</last></author>
+      <author><first>Tatiana</first><last>Litvinova</last></author>
+      <author><first>Olga</first><last>Litvinova</last></author>
       <pages>1–10</pages>
       <doi>10.26615/978-954-452-038-0_001</doi>
       <url>https://doi.org/10.26615/978-954-452-038-0_001</url>
@@ -13494,10 +13494,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>o<fixed-case>IQ</fixed-case>a: An Opinion Influence Oriented Question Answering Framework with Applications to Marketing Domain</title>
-      <author><first>Dumitru-Clementin</first> <last>Cercel</last></author>
-      <author><first>Cristian</first> <last>Onose</last></author>
-      <author><first>Stefan</first> <last>Trausan-Matu</last></author>
-      <author><first>Florin</first> <last>Pop</last></author>
+      <author><first>Dumitru-Clementin</first><last>Cercel</last></author>
+      <author><first>Cristian</first><last>Onose</last></author>
+      <author><first>Stefan</first><last>Trausan-Matu</last></author>
+      <author><first>Florin</first><last>Pop</last></author>
       <pages>11–18</pages>
       <doi>10.26615/978-954-452-038-0_002</doi>
       <url>https://doi.org/10.26615/978-954-452-038-0_002</url>
@@ -13505,9 +13505,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>Automatic Summarization of Online Debates</title>
-      <author><first>Nattapong</first> <last>Sanchan</last></author>
-      <author><first>Ahmet</first> <last>Aker</last></author>
-      <author><first>Kalina</first> <last>Bontcheva</last></author>
+      <author><first>Nattapong</first><last>Sanchan</last></author>
+      <author><first>Ahmet</first><last>Aker</last></author>
+      <author><first>Kalina</first><last>Bontcheva</last></author>
       <pages>19–27</pages>
       <doi>10.26615/978-954-452-038-0_003</doi>
       <url>https://doi.org/10.26615/978-954-452-038-0_003</url>
@@ -13515,10 +13515,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>A Game with a Purpose for Automatic Detection of Children’s Speech Disabilities using Limited Speech Resources</title>
-      <author><first>Reem</first> <last>Salem</last></author>
-      <author><first>Mohamed</first> <last>Elmahdy</last></author>
-      <author><first>Slim</first> <last>Abdennadher</last></author>
-      <author><first>Injy</first> <last>Hamed</last></author>
+      <author><first>Reem</first><last>Salem</last></author>
+      <author><first>Mohamed</first><last>Elmahdy</last></author>
+      <author><first>Slim</first><last>Abdennadher</last></author>
+      <author><first>Injy</first><last>Hamed</last></author>
       <pages>28–34</pages>
       <doi>10.26615/978-954-452-038-0_004</doi>
       <url>https://doi.org/10.26615/978-954-452-038-0_004</url>
@@ -13530,8 +13530,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
       <booktitle>Proceedings of the Workshop Knowledge Resources for the Socio-Economic Sciences and Humanities associated with <fixed-case>RANLP</fixed-case> 2017</booktitle>
       <editor><first>Kalliopi</first><last>Zervanou</last></editor>
       <editor><first>Petya</first><last>Osenova</last></editor>
-      <editor><first>Eveline</first> <last>Wandl-Vogt</last></editor>
-      <editor><first>Dan</first> <last>Cristea</last></editor>
+      <editor><first>Eveline</first><last>Wandl-Vogt</last></editor>
+      <editor><first>Dan</first><last>Cristea</last></editor>
       <publisher>INCOMA Inc.</publisher>
       <address>Varna</address>
       <month>September</month>
@@ -13542,8 +13542,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Connecting people digitally - a semantic web based approach to linking heterogeneous data sets</title>
-      <author><first>Katalin</first> <last>Lejtovicz</last></author>
-      <author><first>Amelie</first> <last>Dorn</last></author>
+      <author><first>Katalin</first><last>Lejtovicz</last></author>
+      <author><first>Amelie</first><last>Dorn</last></author>
       <pages>1–8</pages>
       <doi>10.26615/978-954-452-040-3_001</doi>
       <url>https://doi.org/10.26615/978-954-452-040-3_001</url>
@@ -13551,9 +13551,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>A Multiform Balanced Dependency Treebank for <fixed-case>R</fixed-case>omanian</title>
-      <author><first>Mihaela</first> <last>Colhon</last></author>
-      <author><first>Cătălina</first> <last>Mărănduc</last></author>
-      <author><first>Cătălin</first> <last>Mititelu</last></author>
+      <author><first>Mihaela</first><last>Colhon</last></author>
+      <author><first>Cătălina</first><last>Mărănduc</last></author>
+      <author><first>Cătălin</first><last>Mititelu</last></author>
       <pages>9–18</pages>
       <doi>10.26615/978-954-452-040-3_002</doi>
       <url>https://doi.org/10.26615/978-954-452-040-3_002</url>
@@ -13561,11 +13561,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title><fixed-case>GR</fixed-case>a<fixed-case>SP</fixed-case>: Grounded Representation and Source Perspective</title>
-      <author><first>Antske</first> <last>Fokkens</last></author>
-      <author><first>Piek</first> <last>Vossen</last></author>
-      <author><first>Marco</first> <last>Rospocher</last></author>
-      <author><first>Rinke</first> <last>Hoekstra</last></author>
-      <author><first>Willem Robert</first> <last>van Hage</last></author>
+      <author><first>Antske</first><last>Fokkens</last></author>
+      <author><first>Piek</first><last>Vossen</last></author>
+      <author><first>Marco</first><last>Rospocher</last></author>
+      <author><first>Rinke</first><last>Hoekstra</last></author>
+      <author><first>Willem Robert</first><last>van Hage</last></author>
       <pages>19–25</pages>
       <doi>10.26615/978-954-452-040-3_003</doi>
       <url>https://doi.org/10.26615/978-954-452-040-3_003</url>
@@ -13573,7 +13573,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>Educational Content Generation for Business and Administration <fixed-case>FL</fixed-case> Courses with the <fixed-case>NBU</fixed-case> <fixed-case>PLT</fixed-case> Platform</title>
-      <author><first>Maria</first> <last>Stambolieva</last></author>
+      <author><first>Maria</first><last>Stambolieva</last></author>
       <pages>26–30</pages>
       <doi>10.26615/978-954-452-040-3_004</doi>
       <url>https://doi.org/10.26615/978-954-452-040-3_004</url>
@@ -13581,15 +13581,15 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title>Machine Learning Models of Universal Grammar Parameter Dependencies</title>
-      <author><first>Dimitar</first> <last>Kazakov</last></author>
-      <author><first>Guido</first> <last>Cordoni</last></author>
-      <author><first>Andrea</first> <last>Ceolin</last></author>
-      <author><first>Monica-Alexandrina</first> <last>Irimia</last></author>
-      <author><first>Shin-Sook</first> <last>Kim</last></author>
-      <author><first>Dimitris</first> <last>Michelioudakis</last></author>
-      <author><first>Nina</first> <last>Radkevich</last></author>
-      <author><first>Cristina</first> <last>Guardiano</last></author>
-      <author><first>Giuseppe</first> <last>Longobardi</last></author>
+      <author><first>Dimitar</first><last>Kazakov</last></author>
+      <author><first>Guido</first><last>Cordoni</last></author>
+      <author><first>Andrea</first><last>Ceolin</last></author>
+      <author><first>Monica-Alexandrina</first><last>Irimia</last></author>
+      <author><first>Shin-Sook</first><last>Kim</last></author>
+      <author><first>Dimitris</first><last>Michelioudakis</last></author>
+      <author><first>Nina</first><last>Radkevich</last></author>
+      <author><first>Cristina</first><last>Guardiano</last></author>
+      <author><first>Giuseppe</first><last>Longobardi</last></author>
       <pages>31–37</pages>
       <doi>10.26615/978-954-452-040-3_005</doi>
       <url>https://doi.org/10.26615/978-954-452-040-3_005</url>
@@ -13613,11 +13613,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Enhancing Machine Translation of Academic Course Catalogues with Terminological Resources</title>
-      <author><first>Randy</first> <last>Scansani</last></author>
-      <author><first>Silvia</first> <last>Bernardini</last></author>
-      <author><first>Adriano</first> <last>Ferraresi</last></author>
-      <author><first>Federico</first> <last>Gaspari</last></author>
-      <author><first>Marcello</first> <last>Soffritti</last></author>
+      <author><first>Randy</first><last>Scansani</last></author>
+      <author><first>Silvia</first><last>Bernardini</last></author>
+      <author><first>Adriano</first><last>Ferraresi</last></author>
+      <author><first>Federico</first><last>Gaspari</last></author>
+      <author><first>Marcello</first><last>Soffritti</last></author>
       <pages>1–10</pages>
       <doi>10.26615/978-954-452-042-7_001</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_001</url>
@@ -13625,9 +13625,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>Experiments in Non-Coherent Post-editing</title>
-      <author><first>Cristina</first> <last>Toledo Báez</last></author>
-      <author><first>Moritz</first> <last>Schaeffer</last></author>
-      <author><first>Michael</first> <last>Carl</last></author>
+      <author><first>Cristina</first><last>Toledo Báez</last></author>
+      <author><first>Moritz</first><last>Schaeffer</last></author>
+      <author><first>Michael</first><last>Carl</last></author>
       <pages>11–20</pages>
       <doi>10.26615/978-954-452-042-7_002</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_002</url>
@@ -13635,7 +13635,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>Comparing Machine Translation and Human Translation: A Case Study</title>
-      <author><first>Lars</first> <last>Ahrenberg</last></author>
+      <author><first>Lars</first><last>Ahrenberg</last></author>
       <pages>21–28</pages>
       <doi>10.26615/978-954-452-042-7_003</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_003</url>
@@ -13643,8 +13643,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title><fixed-case>T</fixed-case>rans<fixed-case>B</fixed-case>ank: Metadata as the Missing Link between <fixed-case>NLP</fixed-case> and Traditional Translation Studies</title>
-      <author><first>Michael</first> <last>Ustaszewski</last></author>
-      <author><first>Andy</first> <last>Stauder</last></author>
+      <author><first>Michael</first><last>Ustaszewski</last></author>
+      <author><first>Andy</first><last>Stauder</last></author>
       <pages>29–35</pages>
       <doi>10.26615/978-954-452-042-7_004</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_004</url>
@@ -13652,11 +13652,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title>Interpreting Strategies Annotation in the <fixed-case>WAW</fixed-case> Corpus</title>
-      <author><first>Irina</first> <last>Temnikova</last></author>
-      <author><first>Ahmed</first> <last>Abdelali</last></author>
-      <author><first>Samy</first> <last>Hedaya</last></author>
-      <author><first>Stephan</first> <last>Vogel</last></author>
-      <author><first>Aishah</first> <last>Al Daher</last></author>
+      <author><first>Irina</first><last>Temnikova</last></author>
+      <author><first>Ahmed</first><last>Abdelali</last></author>
+      <author><first>Samy</first><last>Hedaya</last></author>
+      <author><first>Stephan</first><last>Vogel</last></author>
+      <author><first>Aishah</first><last>Al Daher</last></author>
       <pages>36–43</pages>
       <doi>10.26615/978-954-452-042-7_005</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_005</url>
@@ -13664,8 +13664,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="6">
       <title>Translation Memory Systems Have a Long Way to Go</title>
-      <author><first>Andrea</first> <last>Silvestre Baquero</last></author>
-      <author><first>Ruslan</first> <last>Mitkov</last></author>
+      <author><first>Andrea</first><last>Silvestre Baquero</last></author>
+      <author><first>Ruslan</first><last>Mitkov</last></author>
       <pages>44–51</pages>
       <doi>10.26615/978-954-452-042-7_006</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_006</url>
@@ -13673,8 +13673,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Building Dialectal <fixed-case>A</fixed-case>rabic Corpora</title>
-      <author><first>Hani</first> <last>Elgabou</last></author>
-      <author><first>Dimitar</first> <last>Kazakov</last></author>
+      <author><first>Hani</first><last>Elgabou</last></author>
+      <author><first>Dimitar</first><last>Kazakov</last></author>
       <pages>52–57</pages>
       <doi>10.26615/978-954-452-042-7_007</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_007</url>
@@ -13682,8 +13682,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="8">
       <title>Towards Producing Human-Validated Translation Resources for the <fixed-case>F</fixed-case>ula language through <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Linking</title>
-      <author><first>Khalil</first> <last>Mrini</last></author>
-      <author><first>Martin</first> <last>Benjamin</last></author>
+      <author><first>Khalil</first><last>Mrini</last></author>
+      <author><first>Martin</first><last>Benjamin</last></author>
       <pages>58–64</pages>
       <doi>10.26615/978-954-452-042-7_008</doi>
       <url>https://doi.org/10.26615/978-954-452-042-7_008</url>
@@ -13707,7 +13707,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>Document retrieval and question answering in medical documents. A large-scale corpus challenge.</title>
-      <author><first>Curea</first> <last>Eric</last></author>
+      <author><first>Curea</first><last>Eric</last></author>
       <pages>1–7</pages>
       <doi>10.26615/978-954-452-044-1_001</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_001</url>
@@ -13715,8 +13715,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>Adapting the <fixed-case>TTL</fixed-case> <fixed-case>R</fixed-case>omanian <fixed-case>POS</fixed-case> Tagger to the Biomedical Domain</title>
-      <author><first>Maria</first> <last>Mitrofan</last></author>
-      <author><first>Radu</first> <last>Ion</last></author>
+      <author><first>Maria</first><last>Mitrofan</last></author>
+      <author><first>Radu</first><last>Ion</last></author>
       <pages>8–14</pages>
       <doi>10.26615/978-954-452-044-1_002</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_002</url>
@@ -13724,9 +13724,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>Discourse-Wide Extraction of Assay Frames from the Biological Literature</title>
-      <author><first>Dayne</first> <last>Freitag</last></author>
-      <author><first>Paul</first> <last>Kalmar</last></author>
-      <author><first>Eric</first> <last>Yeh</last></author>
+      <author><first>Dayne</first><last>Freitag</last></author>
+      <author><first>Paul</first><last>Kalmar</last></author>
+      <author><first>Eric</first><last>Yeh</last></author>
       <pages>15–23</pages>
       <doi>10.26615/978-954-452-044-1_003</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_003</url>
@@ -13734,7 +13734,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>Classification based extraction of numeric values from clinical narratives</title>
-      <author><first>Maximilian</first> <last>Zubke</last></author>
+      <author><first>Maximilian</first><last>Zubke</last></author>
       <pages>24–31</pages>
       <doi>10.26615/978-954-452-044-1_004</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_004</url>
@@ -13742,8 +13742,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title>Understanding of unknown medical words</title>
-      <author><first>Natalia</first> <last>Grabar</last></author>
-      <author><first>Thierry</first> <last>Hamon</last></author>
+      <author><first>Natalia</first><last>Grabar</last></author>
+      <author><first>Thierry</first><last>Hamon</last></author>
       <pages>32–41</pages>
       <doi>10.26615/978-954-452-044-1_005</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_005</url>
@@ -13751,11 +13751,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="6">
       <title>Entity-Centric Information Access with Human in the Loop for the Biomedical Domain</title>
-      <author><first>Seid Muhie</first> <last>Yimam</last></author>
-      <author><first>Steffen</first> <last>Remus</last></author>
-      <author><first>Alexander</first> <last>Panchenko</last></author>
-      <author><first>Andreas</first> <last>Holzinger</last></author>
-      <author><first>Chris</first> <last>Biemann</last></author>
+      <author><first>Seid Muhie</first><last>Yimam</last></author>
+      <author><first>Steffen</first><last>Remus</last></author>
+      <author><first>Alexander</first><last>Panchenko</last></author>
+      <author><first>Andreas</first><last>Holzinger</last></author>
+      <author><first>Chris</first><last>Biemann</last></author>
       <pages>42–48</pages>
       <doi>10.26615/978-954-452-044-1_006</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_006</url>
@@ -13763,8 +13763,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>One model per entity: using hundreds of machine learning models to recognize and normalize biomedical names in text</title>
-      <author><first>Victor</first> <last>Bellon</last></author>
-      <author><first>Raul</first> <last>Rodriguez-Esteban</last></author>
+      <author><first>Victor</first><last>Bellon</last></author>
+      <author><first>Raul</first><last>Rodriguez-Esteban</last></author>
       <pages>49–54</pages>
       <doi>10.26615/978-954-452-044-1_007</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_007</url>
@@ -13772,8 +13772,8 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="8">
       <title>Towards Confidence Estimation for Typed Protein-Protein Relation Extraction</title>
-      <author><first>Camilo</first> <last>Thorne</last></author>
-      <author><first>Roman</first> <last>Klinger</last></author>
+      <author><first>Camilo</first><last>Thorne</last></author>
+      <author><first>Roman</first><last>Klinger</last></author>
       <pages>55–63</pages>
       <doi>10.26615/978-954-452-044-1_008</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_008</url>
@@ -13781,10 +13781,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="9">
       <title>Identification of Risk Factors in Clinical Texts through Association Rules</title>
-      <author><first>Svetla</first> <last>Boytcheva</last></author>
-      <author><first>Ivelina</first> <last>Nikolova</last></author>
-      <author><first>Galia</first> <last>Angelova</last></author>
-      <author><first>Zhivko</first> <last>Angelov</last></author>
+      <author><first>Svetla</first><last>Boytcheva</last></author>
+      <author><first>Ivelina</first><last>Nikolova</last></author>
+      <author><first>Galia</first><last>Angelova</last></author>
+      <author><first>Zhivko</first><last>Angelov</last></author>
       <pages>64–72</pages>
       <doi>10.26615/978-954-452-044-1_009</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_009</url>
@@ -13792,11 +13792,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="10">
       <title><fixed-case>POMELO</fixed-case>: <fixed-case>M</fixed-case>edline corpus with manually annotated food-drug interactions</title>
-      <author><first>Thierry</first> <last>Hamon</last></author>
-      <author><first>Vincent</first> <last>Tabanou</last></author>
-      <author><first>Fleur</first> <last>Mougin</last></author>
-      <author><first>Natalia</first> <last>Grabar</last></author>
-      <author><first>Frantz</first> <last>Thiessard</last></author>
+      <author><first>Thierry</first><last>Hamon</last></author>
+      <author><first>Vincent</first><last>Tabanou</last></author>
+      <author><first>Fleur</first><last>Mougin</last></author>
+      <author><first>Natalia</first><last>Grabar</last></author>
+      <author><first>Frantz</first><last>Thiessard</last></author>
       <pages>73–80</pages>
       <doi>10.26615/978-954-452-044-1_010</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_010</url>
@@ -13804,10 +13804,10 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="11">
       <title>Annotation of Clinical Narratives in <fixed-case>B</fixed-case>ulgarian language</title>
-      <author><first>Ivajlo</first> <last>Radev</last></author>
-      <author><first>Kiril</first> <last>Simov</last></author>
-      <author><first>Galia</first> <last>Angelova</last></author>
-      <author><first>Svetla</first> <last>Boytcheva</last></author>
+      <author><first>Ivajlo</first><last>Radev</last></author>
+      <author><first>Kiril</first><last>Simov</last></author>
+      <author><first>Galia</first><last>Angelova</last></author>
+      <author><first>Svetla</first><last>Boytcheva</last></author>
       <pages>81–87</pages>
       <doi>10.26615/978-954-452-044-1_011</doi>
       <url>https://doi.org/10.26615/978-954-452-044-1_011</url>
@@ -13830,9 +13830,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </frontmatter>
     <paper id="1">
       <title>A Diachronic Corpus for <fixed-case>R</fixed-case>omanian (<fixed-case>R</fixed-case>o<fixed-case>D</fixed-case>ia)</title>
-      <author><first>Ludmila</first> <last>Malahov</last></author>
-      <author><first>Cătălina</first> <last>Mărănduc</last></author>
-      <author><first>Alexandru</first> <last>Colesnicov</last></author>
+      <author><first>Ludmila</first><last>Malahov</last></author>
+      <author><first>Cătălina</first><last>Mărănduc</last></author>
+      <author><first>Alexandru</first><last>Colesnicov</last></author>
       <pages>1–9</pages>
       <doi>0.26615/978-954-452-046-5_001</doi>
       <url>http://doi.org/10.26615/978-954-452-046-5_001</url>
@@ -13840,9 +13840,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="2">
       <title>Tools for Building a Corpus to Study the Historical and Geographical Variation of the <fixed-case>R</fixed-case>omanian Language</title>
-      <author><first>Victoria</first> <last>Bobicev</last></author>
-      <author><first>Cătălina</first> <last>Mărănduc</last></author>
-      <author><first>Cenel Augusto</first> <last>Perez</last></author>
+      <author><first>Victoria</first><last>Bobicev</last></author>
+      <author><first>Cătălina</first><last>Mărănduc</last></author>
+      <author><first>Cenel Augusto</first><last>Perez</last></author>
       <pages>10–19</pages>
       <doi>0.26615/978-954-452-046-5_002</doi>
       <url>http://doi.org/10.26615/978-954-452-046-5_002</url>
@@ -13850,12 +13850,12 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="3">
       <title>Multilingual Ontologies for the Representation and Processing of Folktales</title>
-      <author><first>Thierry</first> <last>Declerck</last></author>
-      <author><first>Anastasija</first> <last>Aman</last></author>
-      <author><first>Martin</first> <last>Banzer</last></author>
-      <author><first>Dominik</first> <last>Macháček</last></author>
-      <author><first>Lisa</first> <last>Schäfer</last></author>
-      <author><first>Natalia</first> <last>Skachkova</last></author>
+      <author><first>Thierry</first><last>Declerck</last></author>
+      <author><first>Anastasija</first><last>Aman</last></author>
+      <author><first>Martin</first><last>Banzer</last></author>
+      <author><first>Dominik</first><last>Macháček</last></author>
+      <author><first>Lisa</first><last>Schäfer</last></author>
+      <author><first>Natalia</first><last>Skachkova</last></author>
       <pages>20–23</pages>
       <doi>0.26615/978-954-452-046-5_003</doi>
       <url>http://doi.org/10.26615/978-954-452-046-5_003</url>
@@ -13863,9 +13863,9 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>On the annotation of vague expressions: a case study on <fixed-case>R</fixed-case>omanian historical texts</title>
-      <author><first>Anca</first> <last>Dinu</last></author>
-      <author><first>Walther</first> <last>von Hahn</last></author>
-      <author><first>Cristina</first> <last>Vertan</last></author>
+      <author><first>Anca</first><last>Dinu</last></author>
+      <author><first>Walther</first><last>von Hahn</last></author>
+      <author><first>Cristina</first><last>Vertan</last></author>
       <pages>24–31</pages>
       <doi>0.26615/978-954-452-046-5_004</doi>
       <url>http://doi.org/10.26615/978-954-452-046-5_004</url>
@@ -13873,11 +13873,11 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="5">
       <title>Language Technologies in Teaching Bugarian at Primary and Secondary School Level: the <fixed-case>NBU</fixed-case> Platform of Language Teaching (<fixed-case>PLT</fixed-case>)</title>
-      <author><first>Maria</first> <last>Stambolieva</last></author>
-      <author><first>Valentina</first> <last>Ivanova</last></author>
-      <author><first>Mariana</first> <last>Raykova</last></author>
-      <author><first>Milka</first> <last>Hadjikoteva</last></author>
-      <author><first>Mariya</first> <last>Neykova</last></author>
+      <author><first>Maria</first><last>Stambolieva</last></author>
+      <author><first>Valentina</first><last>Ivanova</last></author>
+      <author><first>Mariana</first><last>Raykova</last></author>
+      <author><first>Milka</first><last>Hadjikoteva</last></author>
+      <author><first>Mariya</first><last>Neykova</last></author>
       <pages>32–38</pages>
       <doi>0.26615/978-954-452-046-5_005</doi>
       <url>http://doi.org/10.26615/978-954-452-046-5_005</url>
@@ -13885,7 +13885,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="6">
       <title>Natural Language Processing in Political Campaigns</title>
-      <author><first>Cristina</first> <last>Moise</last></author>
+      <author><first>Cristina</first><last>Moise</last></author>
       <pages>39–43</pages>
       <doi>0.26615/978-954-452-046-5_006</doi>
       <url>http://doi.org/10.26615/978-954-452-046-5_006</url>


### PR DESCRIPTION
Fixed name spelling (first commit) and removed redundant spacing (second commit).