### PR TITLE
corrected main volume book title

### DIFF
--- a/data/xml/R19.xml
+++ b/data/xml/R19.xml
@@ -2,7 +2,7 @@
 <collection id="R19">
   <volume id="1" ingest-date="2020-01-15">
     <meta>
-      <booktitle>Natural Language Processing in a Deep Learning World</booktitle>
+      <booktitle>Proceedings of the International Conference Recent Advances in Natural Language Processing (RANLP 2019)</booktitle>
       <url>R19-1</url>
       <editor><first>Ruslan</first><last>Mitkov</last></editor>
       <editor><first>Galia</first><last>Angelova</last></editor>

--- a/data/xml/R19.xml
+++ b/data/xml/R19.xml
@@ -2,7 +2,7 @@
 <collection id="R19">
   <volume id="1" ingest-date="2020-01-15">
     <meta>
-      <booktitle>Proceedings of the International Conference Recent Advances in Natural Language Processing (RANLP 2019)</booktitle>
+      <booktitle>Proceedings of the International Conference on Recent Advances in Natural Language Processing (RANLP 2019)</booktitle>
       <url>R19-1</url>
       <editor><first>Ruslan</first><last>Mitkov</last></editor>
       <editor><first>Galia</first><last>Angelova</last></editor>


### PR DESCRIPTION
The main volume name is incorrect, and I missed this when I did the ingestion. I chose this new name for consistency with [past volumes](https://www.aclweb.org/anthology/venues/ranlp/), but have not yet confirmed with the volume editor that it is okay. However, I think we should adopt this variant right away since it would be good to have the correction in and this is clearly a step in the right direction.

I have also created a [rudimentary ingestion checklist](https://github.com/acl-org/acl-anthology/wiki/Ingestion-Checklist) to help me avoid overlooking this kind of mistake in the future.