### PR TITLE
Fix TACL/anthology out-of-sync (closes #723)

### DIFF
--- a/data/xml/Q18.xml
+++ b/data/xml/Q18.xml
@@ -318,6 +318,16 @@
       <url>Q18-1029</url>
     </paper>
     <paper id="30">
+      <title>Universal Word Segmentation: Implementation and Interpretation</title>
+      <author><first>Yan</first><last>Shao</last></author>
+      <author><first>Christian</first><last>Hardmeier</last></author>
+      <author><first>Joakim</first><last>Nivre</last></author>
+      <doi>10.1162/tacl_a_00033</doi>
+      <abstract>Word segmentation is a low-level NLP task that is non-trivial for a considerable number of languages. In this paper, we present a sequence tagging framework and apply it to word segmentation for a wide range of languages with different writing systems and typological characteristics. Additionally, we investigate the correlations between various typological factors and word segmentation accuracy. The experimental results indicate that segmentation accuracy is positively related to word boundary markers and negatively to the number of unique non-segmental terms. Based on the analysis, we design a small set of language-specific settings and extensively evaluate the segmentation system on the Universal Dependencies datasets. Our model obtains state-of-the-art accuracies on all the UD languages. It performs substantially better on languages that are non-trivial to segment, such as Chinese, Japanese, Arabic and Hebrew, when compared to previous work.</abstract>
+      <pages>421–435</pages>
+      <url>Q18-1030</url>
+    </paper>
+    <paper id="31">
       <title>Generating Sentences by Editing Prototypes</title>
       <author><first>Kelvin</first><last>Guu</last></author>
       <author><first>Tatsunori B.</first><last>Hashimoto</last></author>
@@ -326,21 +336,6 @@
       <doi>10.1162/tacl_a_00030</doi>
       <abstract>We propose a new generative language model for sentences that first samples a prototype sentence from the training corpus and then edits it into a new sentence. Compared to traditional language models that generate from scratch either left-to-right or by first sampling a latent sentence vector, our prototype-then-edit model improves perplexity on language modeling and generates higher quality outputs according to human evaluation. Furthermore, the model gives rise to a latent edit vector that captures interpretable semantics such as sentence similarity and sentence-level analogies.</abstract>
       <pages>437–450</pages>
-      <url>Q18-1030</url>
-      <video href="https://vimeo.com/285801187" tag="video"/>
-    </paper>
-    <paper id="31">
-      <title>Detecting Institutional Dialog Acts in Police Traffic Stops</title>
-      <author><first>Vinodkumar</first><last>Prabhakaran</last></author>
-      <author><first>Camilla</first><last>Griffiths</last></author>
-      <author><first>Hang</first><last>Su</last></author>
-      <author><first>Prateek</first><last>Verma</last></author>
-      <author><first>Nelson</first><last>Morgan</last></author>
-      <author><first>Jennifer L.</first><last>Eberhardt</last></author>
-      <author><first>Dan</first><last>Jurafsky</last></author>
-      <doi>10.1162/tacl_a_00031</doi>
-      <abstract>We apply computational dialog methods to police body-worn camera footage to model conversations between police officers and community members in traffic stops. Relying on the theory of institutional talk, we develop a labeling scheme for police speech during traffic stops, and a tagger to detect institutional dialog acts (Reasons, Searches, Offering Help) from transcribed text at the turn (78% F-score) and stop (89% F-score) level. We then develop speech recognition and segmentation algorithms to detect these acts at the stop level from raw camera audio (81% F-score, with even higher accuracy for crucial acts like conveying the reason for the stop). We demonstrate that the dialog structures produced by our tagger could reveal whether officers follow law enforcement norms like introducing themselves, explaining the reason for the stop, and asking permission for searches. This work may therefore inform and aid efforts to ensure the procedural justice of police-community interactions.</abstract>
-      <pages>467–481</pages>
       <url>Q18-1031</url>
       <video href="https://vimeo.com/285801187" tag="video"/>
     </paper>
@@ -358,13 +353,17 @@
       <url>Q18-1032</url>
     </paper>
     <paper id="33">
-      <title>Universal Word Segmentation: Implementation and Interpretation</title>
-      <author><first>Yan</first><last>Shao</last></author>
-      <author><first>Christian</first><last>Hardmeier</last></author>
-      <author><first>Joakim</first><last>Nivre</last></author>
-      <doi>10.1162/tacl_a_00033</doi>
-      <abstract>Word segmentation is a low-level NLP task that is non-trivial for a considerable number of languages. In this paper, we present a sequence tagging framework and apply it to word segmentation for a wide range of languages with different writing systems and typological characteristics. Additionally, we investigate the correlations between various typological factors and word segmentation accuracy. The experimental results indicate that segmentation accuracy is positively related to word boundary markers and negatively to the number of unique non-segmental terms. Based on the analysis, we design a small set of language-specific settings and extensively evaluate the segmentation system on the Universal Dependencies datasets. Our model obtains state-of-the-art accuracies on all the UD languages. It performs substantially better on languages that are non-trivial to segment, such as Chinese, Japanese, Arabic and Hebrew, when compared to previous work.</abstract>
-      <pages>421–435</pages>
+      <title>Detecting Institutional Dialog Acts in Police Traffic Stops</title>
+      <author><first>Vinodkumar</first><last>Prabhakaran</last></author>
+      <author><first>Camilla</first><last>Griffiths</last></author>
+      <author><first>Hang</first><last>Su</last></author>
+      <author><first>Prateek</first><last>Verma</last></author>
+      <author><first>Nelson</first><last>Morgan</last></author>
+      <author><first>Jennifer L.</first><last>Eberhardt</last></author>
+      <author><first>Dan</first><last>Jurafsky</last></author>
+      <doi>10.1162/tacl_a_00031</doi>
+      <abstract>We apply computational dialog methods to police body-worn camera footage to model conversations between police officers and community members in traffic stops. Relying on the theory of institutional talk, we develop a labeling scheme for police speech during traffic stops, and a tagger to detect institutional dialog acts (Reasons, Searches, Offering Help) from transcribed text at the turn (78% F-score) and stop (89% F-score) level. We then develop speech recognition and segmentation algorithms to detect these acts at the stop level from raw camera audio (81% F-score, with even higher accuracy for crucial acts like conveying the reason for the stop). We demonstrate that the dialog structures produced by our tagger could reveal whether officers follow law enforcement norms like introducing themselves, explaining the reason for the stop, and asking permission for searches. This work may therefore inform and aid efforts to ensure the procedural justice of police-community interactions.</abstract>
+      <pages>467–481</pages>
       <url>Q18-1033</url>
       <video href="https://vimeo.com/285803587" tag="video"/>
     </paper>


### PR DESCRIPTION
Reorders the text in the Anthology to match the PDFs and their previous order. (Note that this is a different order than the TACL IDs, to match how we had things in the past.)