### PR TITLE
Move "von" particles into last name.

### DIFF
--- a/bin/auto_name_variants.py
+++ b/bin/auto_name_variants.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
 
     for filename in sys.argv[1:]:
         volume = etree.parse(filename).getroot()
-        for paper in volume.findall("paper"):
+        for paper in volume.findall(".//paper"):
             for person in paper.xpath("./author|./editor"):
                 first = text(person.find("first"))
                 last = text(person.find("last"))

--- a/data/xml/A88.xml
+++ b/data/xml/A88.xml
@@ -91,7 +91,7 @@
     <paper id="11">
       <title>Triphone Analysis: A Combined Method for the Correction of Orthographical and Typographical Errors.</title>
       <author><first>Brigitte</first><last>van Berkel</last></author>
-      <author><first>Koenraad De</first><last>Smedt</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <doi>10.3115/974235.974250</doi>
       <pages>77–83</pages>
       <url>A88-1011</url>

--- a/data/xml/C00.xml
+++ b/data/xml/C00.xml
@@ -221,7 +221,7 @@
     </paper>
     <paper id="35">
       <title>Aspects of Pattern-matching in Data-Oriented Parsing</title>
-      <author><first>Guy De</first><last>Pauw</last></author>
+      <author><first>Guy</first><last>De Pauw</last></author>
       <url>C00-1035</url>
     </paper>
     <paper id="36">

--- a/data/xml/C02.xml
+++ b/data/xml/C02.xml
@@ -1172,7 +1172,7 @@
     </paper>
     <paper id="11">
       <title>Semantic Case Role Detection for Information Extraction</title>
-      <author><first>Rik De</first><last>Busser</last></author>
+      <author><first>Rik</first><last>De Busser</last></author>
       <author><first>Roxana</first><last>Angheluta</last></author>
       <author><first>Marie-Francine</first><last>Moens</last></author>
       <url>C02-2011</url>

--- a/data/xml/C69.xml
+++ b/data/xml/C69.xml
@@ -1050,7 +1050,7 @@
     </paper>
     <paper id="9">
       <title>Towards an automatic morphological segmentation</title>
-      <author><first>Josse De</first><last>Kock</last></author>
+      <author><first>Josse</first><last>De Kock</last></author>
       <author><first>Walter</first><last>Bossaert</last></author>
       <url>C69-6209</url>
     </paper>

--- a/data/xml/C69.xml
+++ b/data/xml/C69.xml
@@ -259,7 +259,7 @@
     <paper id="1">
       <title>Computational Analysis of Interference Phenomena on the Lexical Level</title>
       <author id="wojciech-skalmowski"><first>W.</first><last>Skalmowski</last></author>
-      <author><first>M. Van</first><last>Overbeke</last></author>
+      <author><first>M.</first><last>Van Overbeke</last></author>
       <url>C69-1601</url>
     </paper>
   </volume>

--- a/data/xml/C73.xml
+++ b/data/xml/C73.xml
@@ -207,7 +207,7 @@
       <title>Verbal Behaviour of the Psychotic and Psychoneurotic Patients: An Approach According to the Methodology of Computational Linguistics</title>
       <author><first>P.</first><last>Castrogiovanni</last></author>
       <author id="lorenzo-moretti"><first>L.</first><last>Moretti</last></author>
-      <author><first>G. De</first><last>Lisio</last></author>
+      <author><first>G.</first><last>De Lisio</last></author>
       <url>C73-2006</url>
     </paper>
     <paper id="7">

--- a/data/xml/C82.xml
+++ b/data/xml/C82.xml
@@ -507,7 +507,7 @@
     </paper>
     <paper id="18">
       <title>A Semantic Analyser of Natural <fixed-case>I</fixed-case>talian Sentences</title>
-      <author><first>M. Del</first><last>Canto</last></author>
+      <author><first>M.</first><last>Del Canto</last></author>
       <author><first>F.</first><last>Fusconi</last></author>
       <author><first>L.</first><last>Stringa</last></author>
       <url>C82-2018</url>

--- a/data/xml/C82.xml
+++ b/data/xml/C82.xml
@@ -525,7 +525,7 @@
     </paper>
     <paper id="21">
       <title>Merging - The Art of Representing Different Levels of Sentence Structure in a Single Analysis Tree</title>
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <url>C82-2021</url>
     </paper>
     <paper id="22">

--- a/data/xml/C86.xml
+++ b/data/xml/C86.xml
@@ -790,7 +790,7 @@
     </paper>
     <paper id="136">
       <title>Generating <fixed-case>E</fixed-case>nglish Paraphrases From Formal Relational Calculus Expressions</title>
-      <author><first>A.N. De</first><last>Roeck</last></author>
+      <author><first>A.N.</first><last>De Roeck</last></author>
       <author><first>B.G.T.</first><last>Lowden</last></author>
       <url>C86-1136</url>
     </paper>

--- a/data/xml/C98.xml
+++ b/data/xml/C98.xml
@@ -331,7 +331,7 @@
     <paper id="50">
       <title>Error Driven Word Sense Disambiguation</title>
       <author><first>Luca</first><last>Dini</last></author>
-      <author><first>Vittorio Di</first><last>Tomaso</last></author>
+      <author><first>Vittorio</first><last> Tomaso</last></author>
       <author><first>Frederique</first><last>Segond</last></author>
       <url>C98-1050</url>
     </paper>

--- a/data/xml/C98.xml
+++ b/data/xml/C98.xml
@@ -331,7 +331,7 @@
     <paper id="50">
       <title>Error Driven Word Sense Disambiguation</title>
       <author><first>Luca</first><last>Dini</last></author>
-      <author><first>Vittorio Di</first><last>Tomaso</last></author>
+      <author><first>Vittorio</first><last>Di Tomaso</last></author>
       <author><first>Frederique</first><last>Segond</last></author>
       <url>C98-1050</url>
     </paper>

--- a/data/xml/C98.xml
+++ b/data/xml/C98.xml
@@ -331,7 +331,7 @@
     <paper id="50">
       <title>Error Driven Word Sense Disambiguation</title>
       <author><first>Luca</first><last>Dini</last></author>
-      <author><first>Vittorio</first><last> Tomaso</last></author>
+      <author><first>Vittorio Di</first><last>Tomaso</last></author>
       <author><first>Frederique</first><last>Segond</last></author>
       <url>C98-1050</url>
     </paper>

--- a/data/xml/E03.xml
+++ b/data/xml/E03.xml
@@ -121,7 +121,7 @@
       <author><first>A.</first><last>Cadeau</last></author>
       <author><first>M.</first><last>Calberg</last></author>
       <author><first>A.</first><last>Delale</last></author>
-      <author><first>L. De</first><last>Temmerman</last></author>
+      <author><first>L.</first><last>De Temmerman</last></author>
       <author><first>A.-L.</first><last>Guenet</last></author>
       <author><first>D.</first><last>Huis</last></author>
       <author><first>M.</first><last>Jamalpour</last></author>
@@ -565,7 +565,7 @@
       <author><first>A.</first><last>Cadeau</last></author>
       <author><first>M.</first><last>Calberg</last></author>
       <author><first>A.</first><last>Delale</last></author>
-      <author><first>L. De</first><last>Temmerman</last></author>
+      <author><first>L.</first><last>De Temmerman</last></author>
       <author><first>A.-L.</first><last>Guenet</last></author>
       <author><first>D.</first><last>Huis</last></author>
       <author><first>M.</first><last>Jamalpour</last></author>

--- a/data/xml/E83.xml
+++ b/data/xml/E83.xml
@@ -175,7 +175,7 @@
     <paper id="29">
       <title>Natural Language Input for Scene Generation</title>
       <author><first>Giovanni</first><last>Adorni</last></author>
-      <author><first>Mauro</first><last> Manzo</last></author>
+      <author><first>Mauro Di</first><last>Manzo</last></author>
       <url>E83-1029</url>
     </paper>
     <paper id="30">

--- a/data/xml/E83.xml
+++ b/data/xml/E83.xml
@@ -175,7 +175,7 @@
     <paper id="29">
       <title>Natural Language Input for Scene Generation</title>
       <author><first>Giovanni</first><last>Adorni</last></author>
-      <author><first>Mauro Di</first><last>Manzo</last></author>
+      <author><first>Mauro</first><last>Di Manzo</last></author>
       <url>E83-1029</url>
     </paper>
     <paper id="30">

--- a/data/xml/E83.xml
+++ b/data/xml/E83.xml
@@ -175,7 +175,7 @@
     <paper id="29">
       <title>Natural Language Input for Scene Generation</title>
       <author><first>Giovanni</first><last>Adorni</last></author>
-      <author><first>Mauro Di</first><last>Manzo</last></author>
+      <author><first>Mauro</first><last> Manzo</last></author>
       <url>E83-1029</url>
     </paper>
     <paper id="30">

--- a/data/xml/E91.xml
+++ b/data/xml/E91.xml
@@ -258,7 +258,7 @@
     </paper>
     <paper id="45">
       <title>Helpful Answers to Modal and Hypothetical Questions</title>
-      <author><first>Anne De</first><last>Roeck</last></author>
+      <author><first>Anne</first><last>De Roeck</last></author>
       <author><first>Richard</first><last>Ball</last></author>
       <author><first>Keith</first><last>Brown</last></author>
       <author><first>Chris</first><last>Fox</last></author>

--- a/data/xml/F13.xml
+++ b/data/xml/F13.xml
@@ -55,7 +55,7 @@
       <title><fixed-case>W</fixed-case>o<fixed-case>N</fixed-case>e<fixed-case>F</fixed-case>, an improved, extended and evaluated automatic <fixed-case>F</fixed-case>rench translation of <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et (<fixed-case>W</fixed-case>o<fixed-case>N</fixed-case>e<fixed-case>F</fixed-case> : amélioration, extension et évaluation d’une traduction française automatique de <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et) [in <fixed-case>F</fixed-case>rench]</title>
       <author><first>Quentin</first><last>Pradet</last></author>
       <author><first>Jeanne</first><last>Baguenier-Desormeaux</last></author>
-      <author><first>Gaël de</first><last>Chalendar</last></author>
+      <author><first>Gaël</first><last>de Chalendar</last></author>
       <author><first>Laurence</first><last>Danlos</last></author>
       <pages>76-89</pages>
       <url>F13-1006</url>

--- a/data/xml/F13.xml
+++ b/data/xml/F13.xml
@@ -483,8 +483,8 @@
       <title>Lexicons from Comparable Corpora for Multilingual Information Retrieval (Lexiques de corpus comparables et recherche d’information multilingue) [in <fixed-case>F</fixed-case>rench]</title>
       <author><first>Frederik</first><last>Cailliau</last></author>
       <author><first>Ariane</first><last>Cavet</last></author>
-      <author><first>Clément De</first><last>Groc</last></author>
-      <author><first>Claude De</first><last>Loupy</last></author>
+      <author><first>Clément</first><last>De Groc</last></author>
+      <author><first>Claude</first><last>De Loupy</last></author>
       <pages>691-698</pages>
       <url>F13-2024</url>
     </paper>

--- a/data/xml/H93.xml
+++ b/data/xml/H93.xml
@@ -409,7 +409,7 @@
     </paper>
     <paper id="55">
       <title>Session 9: Government Panel</title>
-      <author><first>Carol J. Van</first><last>Ess-Dykema</last></author>
+      <author><first>Carol J.</first><last>Van Ess-Dykema</last></author>
       <url>H93-1055</url>
     </paper>
     <paper id="56">

--- a/data/xml/I11.xml
+++ b/data/xml/I11.xml
@@ -1071,7 +1071,7 @@
     </paper>
     <paper id="128">
       <title>Automatic Analysis of Semantic Coherence in Academic Abstracts Written in <fixed-case>P</fixed-case>ortuguese</title>
-      <author><first>Vinícius Mourão Alves de</first><last>Souza</last></author>
+      <author><first>Vinícius Mourão Alves</first><last>de Souza</last></author>
       <author><first>Valéria Delisandra</first><last>Feltrim</last></author>
       <pages>1144–1152</pages>
       <url>I11-1128</url>

--- a/data/xml/J00.xml
+++ b/data/xml/J00.xml
@@ -190,7 +190,7 @@
       <author><first>Daniel</first><last>Jurafsky</last></author>
       <author><first>Paul</first><last>Taylor</last></author>
       <author><first>Rachel</first><last>Martin</last></author>
-      <author><first>Carol Van</first><last>Ess-Dykema</last></author>
+      <author><first>Carol</first><last>Van Ess-Dykema</last></author>
       <author><first>Marie</first><last>Meteer</last></author>
       <pages>339-374</pages>
       <url>J00-3003</url>

--- a/data/xml/J01.xml
+++ b/data/xml/J01.xml
@@ -96,7 +96,7 @@
     </paper>
     <paper id="2">
       <title>Improving Accuracy in word class tagging through the Combination of Machine Learning Systems</title>
-      <author><first>Hans Van</first><last>Halteren</last></author>
+      <author><first>Hans</first><last>Van Halteren</last></author>
       <author><first>Jakub</first><last>Zavrel</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
       <pages>199-229</pages>

--- a/data/xml/J10.xml
+++ b/data/xml/J10.xml
@@ -194,7 +194,7 @@
     </paper>
     <paper id="8">
       <title>Hierarchical Phrase-Based Translation with Weighted Finite-State Transducers and Shallow-n Grammars</title>
-      <author><first>Adrià de</first><last>Gispert</last></author>
+      <author><first>Adrià</first><last>de Gispert</last></author>
       <author><first>Gonzalo</first><last>Iglesias</last></author>
       <author><first>Graeme</first><last>Blackwood</last></author>
       <author><first>Eduardo R.</first><last>Banga</last></author>

--- a/data/xml/J12.xml
+++ b/data/xml/J12.xml
@@ -89,7 +89,7 @@
     </paper>
     <paper id="3">
       <title>Did It Happen? The Pragmatic Complexity of Veridicality Assessment</title>
-      <author><first>Marie-Catherine de</first><last>Marneffe</last></author>
+      <author><first>Marie-Catherine</first><last>de Marneffe</last></author>
       <author><first>Christopher D.</first><last>Manning</last></author>
       <author><first>Christopher</first><last>Potts</last></author>
       <doi>10.1162/COLI_a_00097</doi>

--- a/data/xml/J13.xml
+++ b/data/xml/J13.xml
@@ -227,7 +227,7 @@
     </paper>
     <paper id="8">
       <title>Clustering and Diversifying Web Search Results with Graph-Based Word Sense Induction</title>
-      <author><first>Antonio</first><last> Marco</last></author>
+      <author><first>Antonio Di</first><last>Marco</last></author>
       <author><first>Roberto</first><last>Navigli</last></author>
       <doi>10.1162/COLI_a_00148</doi>
       <url>J13-3008</url>

--- a/data/xml/J13.xml
+++ b/data/xml/J13.xml
@@ -227,7 +227,7 @@
     </paper>
     <paper id="8">
       <title>Clustering and Diversifying Web Search Results with Graph-Based Word Sense Induction</title>
-      <author><first>Antonio Di</first><last>Marco</last></author>
+      <author><first>Antonio</first><last>Di Marco</last></author>
       <author><first>Roberto</first><last>Navigli</last></author>
       <doi>10.1162/COLI_a_00148</doi>
       <url>J13-3008</url>

--- a/data/xml/J13.xml
+++ b/data/xml/J13.xml
@@ -227,7 +227,7 @@
     </paper>
     <paper id="8">
       <title>Clustering and Diversifying Web Search Results with Graph-Based Word Sense Induction</title>
-      <author><first>Antonio Di</first><last>Marco</last></author>
+      <author><first>Antonio</first><last> Marco</last></author>
       <author><first>Roberto</first><last>Navigli</last></author>
       <doi>10.1162/COLI_a_00148</doi>
       <url>J13-3008</url>

--- a/data/xml/J13.xml
+++ b/data/xml/J13.xml
@@ -77,7 +77,7 @@
     <paper id="9">
       <title>Parsing Models for Identifying Multiword Expressions</title>
       <author><first>Spence</first><last>Green</last></author>
-      <author><first>Marie-Catherine de</first><last>Marneffe</last></author>
+      <author><first>Marie-Catherine</first><last>de Marneffe</last></author>
       <author><first>Christopher D.</first><last>Manning</last></author>
       <doi>10.1162/COLI_a_00139</doi>
       <url>J13-1009</url>

--- a/data/xml/J14.xml
+++ b/data/xml/J14.xml
@@ -28,7 +28,7 @@
     <paper id="3">
       <title>Random Walks for Knowledge-Based Word Sense Disambiguation</title>
       <author><first>Eneko</first><last>Agirre</last></author>
-      <author><first>Oier López de</first><last>Lacalle</last></author>
+      <author><first>Oier López</first><last>de Lacalle</last></author>
       <author><first>Aitor</first><last>Soroa</last></author>
       <pages>57-84</pages>
       <doi>10.1162/COLI_a_00164</doi>
@@ -260,7 +260,7 @@
       <title>Pushdown Automata in Statistical Machine Translation</title>
       <author><first>Cyril</first><last>Allauzen</last></author>
       <author><first>Bill</first><last>Byrne</last></author>
-      <author><first>Adrià de</first><last>Gispert</last></author>
+      <author><first>Adrià</first><last>de Gispert</last></author>
       <author><first>Gonzalo</first><last>Iglesias</last></author>
       <author><first>Michael</first><last>Riley</last></author>
       <pages>687-723</pages>

--- a/data/xml/J16.xml
+++ b/data/xml/J16.xml
@@ -236,7 +236,7 @@
     <paper id="5">
       <title>Integrating Type Theory and Distributional Semantics: A Case Study on Adjective–Noun Compositions</title>
       <author><first>Nicholas</first><last>Asher</last></author>
-      <author><first>Tim Van de</first><last>Cruys</last></author>
+      <author><first>Tim</first><last>Van de Cruys</last></author>
       <author><first>Antoine</first><last>Bride</last></author>
       <author><first>Márta</first><last>Abrusán</last></author>
       <pages>703–725</pages>

--- a/data/xml/J17.xml
+++ b/data/xml/J17.xml
@@ -278,7 +278,7 @@
       <author><first>Mathieu</first><last>Constant</last></author>
       <author><first>Gülşen</first><last>Eryiǧit</last></author>
       <author><first>Johanna</first><last>Monti</last></author>
-      <author><first>Lonneke van der</first><last>Plas</last></author>
+      <author><first>Lonneke</first><last>van der Plas</last></author>
       <author><first>Carlos</first><last>Ramisch</last></author>
       <author><first>Michael</first><last>Rosner</last></author>
       <author><first>Amalia</first><last>Todirascu</last></author>

--- a/data/xml/J17.xml
+++ b/data/xml/J17.xml
@@ -146,7 +146,7 @@
       <title><fixed-case>S</fixed-case>quib: Effects of Cognitive Effort on the Resolution of Overspecified Descriptions</title>
       <author><first>Ivandré</first><last>Paraboni</last></author>
       <author><first>Alex Gwo Jen</first><last>Lan</last></author>
-      <author><first>Matheus Mendes de</first><last>Sant’Ana</last></author>
+      <author><first>Matheus Mendes</first><last>de Sant’Ana</last></author>
       <author><first>Flávio Luiz</first><last>Coutinho</last></author>
       <abstract>Studies in referring expression generation (REG) have shown different effects of referential overspecification on the resolution of certain descriptions. To further investigate effects of this kind, this article reports two eye-tracking experiments that measure the time required to recognize target objects based on different kinds of information. Results suggest that referential overspecification may be either helpful or detrimental to identification depending on the kind of information that is actually overspecified, an insight that may be useful for the design of more informed hearer-oriented REG algorithms.</abstract>
       <pages>451–459</pages>

--- a/data/xml/J18.xml
+++ b/data/xml/J18.xml
@@ -315,7 +315,7 @@
     </paper>
     <paper id="10">
       <title>We Usually Don’t Like Going to the Dentist: Using Common Sense to Detect Irony on Twitter</title>
-      <author><first>Cynthia Van</first><last>Hee</last></author>
+      <author><first>Cynthia</first><last>Van Hee</last></author>
       <author><first>Els</first><last>Lefever</last></author>
       <author><first>Véronique</first><last>Hoste</last></author>
       <abstract>Although common sense and connotative knowledge come naturally to most people, computers still struggle to perform well on tasks for which such extratextual information is required. Automatic approaches to sentiment analysis and irony detection have revealed that the lack of such world knowledge undermines classification performance. In this article, we therefore address the challenge of modeling implicit or prototypical sentiment in the framework of automatic irony detection. Starting from manually annotated connoted situation phrases (e.g., “flight delays,” “sitting the whole day at the doctor’s office”), we defined the implicit sentiment held towards such situations automatically by using both a lexico-semantic knowledge base and a data-driven method. We further investigate how such implicit sentiment information affects irony detection by assessing a state-of-the-art irony classifier before and after it is informed with implicit sentiment information.</abstract>

--- a/data/xml/J91.xml
+++ b/data/xml/J91.xml
@@ -51,7 +51,7 @@
     </paper>
     <paper id="8">
       <title>Practical <fixed-case>SGML</fixed-case></title>
-      <author><first>Carol Van</first><last>Ess-Dykema</last></author>
+      <author><first>Carol</first><last>Van Ess-Dykema</last></author>
       <url>J91-1008</url>
     </paper>
     <paper id="9">

--- a/data/xml/J92.xml
+++ b/data/xml/J92.xml
@@ -122,7 +122,7 @@
     <paper id="4">
       <title>Inheritance in Natural Language Processing</title>
       <author><first>Walter</first><last>Daelemans</last></author>
-      <author><first>Koenraad De</first><last>Smedt</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <author><first>Gerald</first><last>Gazdar</last></author>
       <pages>205-218</pages>
       <url>J92-2004</url>

--- a/data/xml/J98.xml
+++ b/data/xml/J98.xml
@@ -236,7 +236,7 @@
     </paper>
     <paper id="9">
       <title>Book Review: Machine Translation and Translation Theory</title>
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <url>J98-3009</url>
     </paper>
     <paper id="10">

--- a/data/xml/L00.xml
+++ b/data/xml/L00.xml
@@ -775,7 +775,7 @@
     <paper id="109">
       <author><first>Giorgio</first><last>Micca</last></author>
       <author><first>Alessandra</first><last>Frasca</last></author>
-      <author><first>Maria Gabriella Di</first><last>Benedetto</last></author>
+      <author><first>Maria Gabriella</first><last> Benedetto</last></author>
       <title>Cross-lingual Interpolation of Speech Recognition Models</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2000/pdf/147.pdf</url>
     </paper>

--- a/data/xml/L00.xml
+++ b/data/xml/L00.xml
@@ -775,7 +775,7 @@
     <paper id="109">
       <author><first>Giorgio</first><last>Micca</last></author>
       <author><first>Alessandra</first><last>Frasca</last></author>
-      <author><first>Maria Gabriella</first><last> Benedetto</last></author>
+      <author><first>Maria Gabriella Di</first><last>Benedetto</last></author>
       <title>Cross-lingual Interpolation of Speech Recognition Models</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2000/pdf/147.pdf</url>
     </paper>

--- a/data/xml/L00.xml
+++ b/data/xml/L00.xml
@@ -775,7 +775,7 @@
     <paper id="109">
       <author><first>Giorgio</first><last>Micca</last></author>
       <author><first>Alessandra</first><last>Frasca</last></author>
-      <author><first>Maria Gabriella Di</first><last>Benedetto</last></author>
+      <author><first>Maria Gabriella</first><last>Di Benedetto</last></author>
       <title>Cross-lingual Interpolation of Speech Recognition Models</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2000/pdf/147.pdf</url>
     </paper>

--- a/data/xml/L00.xml
+++ b/data/xml/L00.xml
@@ -1155,7 +1155,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2000/pdf/215.pdf</url>
     </paper>
     <paper id="164">
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <author><first>Jakub</first><last>Zavrel</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
       <title>Part of Speech Tagging and Lemmatisation for the Spoken <fixed-case>D</fixed-case>utch Corpus</title>
@@ -1579,7 +1579,7 @@
     </paper>
     <paper id="221">
       <author><first>Catia</first><last>Cucchiarini</last></author>
-      <author><first>Johan Van</first><last>Hoorde</last></author>
+      <author><first>Johan</first><last>Van Hoorde</last></author>
       <author><first>Elizabeth</first><last>D’Halleweyn</last></author>
       <title><fixed-case>NL</fixed-case>-Translex: Machine Translation for <fixed-case>D</fixed-case>utch</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2000/pdf/294.pdf</url>

--- a/data/xml/L02.xml
+++ b/data/xml/L02.xml
@@ -650,7 +650,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2002/pdf/94.pdf</url>
     </paper>
     <paper id="95">
-      <author><first>Tristan Van</first><last>Rullen</last></author>
+      <author><first>Tristan</first><last>Van Rullen</last></author>
       <author><first>Philippe</first><last>Blache</last></author>
       <title>An evaluation of different symbolic shallow parsing techniques</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2002/pdf/95.pdf</url>
@@ -669,7 +669,7 @@
       <author><first>Jean-Pierre</first><last>Martens</last></author>
       <author><first>Diana</first><last>Binnenpoorte</last></author>
       <author><first>Kris</first><last>Demuynck</last></author>
-      <author><first>Ruben Van</first><last>Parys</last></author>
+      <author><first>Ruben</first><last>Van Parys</last></author>
       <author><first>Tom</first><last>Laureys</last></author>
       <author><first>Wim</first><last>Goedertier</last></author>
       <author><first>Jacques</first><last>Duchateau</last></author>

--- a/data/xml/L04.xml
+++ b/data/xml/L04.xml
@@ -1459,7 +1459,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2004/pdf/358.pdf</url>
     </paper>
     <paper id="202">
-      <author><first>Christophe Van</first><last>Bael</last></author>
+      <author><first>Christophe</first><last>Van Bael</last></author>
       <author><first>Helmer</first><last>Strik</last></author>
       <author><first>Henk</first><last>van den Heuvel</last></author>
       <title>On the Usefulness of Large Spoken Language Corpora for Linguistic Research</title>
@@ -1791,7 +1791,7 @@
       <author><first>Guy De</first><last>Pauw</last></author>
       <author><first>Hugo</first><last>Van hamme</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
-      <author><first>Dirk Van</first><last>Compernolle</last></author>
+      <author><first>Dirk</first><last>Van Compernolle</last></author>
       <title>Evaluation and Adaptation of the Celex <fixed-case>D</fixed-case>utch Morphological Database</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2004/pdf/421.pdf</url>
     </paper>
@@ -1911,7 +1911,7 @@
       <author><first>Kris</first><last>Demuynck</last></author>
       <author><first>Tom</first><last>Laureys</last></author>
       <author><first>Patrick</first><last>Wambacq</last></author>
-      <author><first>Dirk Van</first><last>Compernolle</last></author>
+      <author><first>Dirk</first><last>Van Compernolle</last></author>
       <title>Automatic Phonemic Labeling and Segmentation of Spoken <fixed-case>D</fixed-case>utch</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2004/pdf/447.pdf</url>
     </paper>
@@ -3119,7 +3119,7 @@
     <paper id="429">
       <author><first>Anna</first><last>Kupść</last></author>
       <author><first>Teruko</first><last>Mitamura</last></author>
-      <author><first>Benjamin Van</first><last>Durme</last></author>
+      <author><first>Benjamin</first><last>Van Durme</last></author>
       <author><first>Eric</first><last>Nyberg</last></author>
       <title>Pronominal Anaphora Resolution for Unrestricted Text</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2004/pdf/671.pdf</url>

--- a/data/xml/L04.xml
+++ b/data/xml/L04.xml
@@ -1788,7 +1788,7 @@
     </paper>
     <paper id="247">
       <author><first>Tom</first><last>Laureys</last></author>
-      <author><first>Guy De</first><last>Pauw</last></author>
+      <author><first>Guy</first><last>De Pauw</last></author>
       <author><first>Hugo</first><last>Van hamme</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
       <author><first>Dirk</first><last>Van Compernolle</last></author>
@@ -2086,7 +2086,7 @@
     </paper>
     <paper id="288">
       <author><first>Avik</first><last>Sarkar</last></author>
-      <author><first>Anne De</first><last>Roeck</last></author>
+      <author><first>Anne</first><last>De Roeck</last></author>
       <title>A Framework for Evaluating the Suitability of Non-<fixed-case>E</fixed-case>nglish Corpora for Language Engineering</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2004/pdf/485.pdf</url>
     </paper>
@@ -2861,7 +2861,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2004/pdf/627.pdf</url>
     </paper>
     <paper id="395">
-      <author><first>Anne De</first><last>Roeck</last></author>
+      <author><first>Anne</first><last>De Roeck</last></author>
       <author><first>Avik</first><last>Sarkar</last></author>
       <author><first>Paul</first><last>Garthwaite</last></author>
       <title>Frequent Term Distribution Measures for Dataset Profiling</title>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -270,7 +270,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/80_pdf.pdf</url>
     </paper>
     <paper id="39">
-      <author><first>Henk van den</first><last>Heuvel</last></author>
+      <author><first>Henk</first><last>van den Heuvel</last></author>
       <author><first>Khalid</first><last>Choukri</last></author>
       <author><first>Christian</first><last>Gollan</last></author>
       <author><first>Asuncion</first><last>Moreno</last></author>
@@ -535,7 +535,7 @@
       <author><first>Daan</first><last>Broeder</last></author>
       <author><first>Freddy</first><last>Offenga</last></author>
       <author><first>Peter</first><last>Wittenburg</last></author>
-      <author><first>Peter van der</first><last>Kamp</last></author>
+      <author><first>Peter</first><last>van der Kamp</last></author>
       <author><first>David</first><last>Nathan</last></author>
       <author><first>Sven</first><last>Strömqvist</last></author>
       <title>Technologies for a Federation of Language Resource Archives</title>
@@ -626,14 +626,14 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/163_pdf.pdf</url>
     </paper>
     <paper id="86">
-      <author><first>Mark van</first><last>Assem</last></author>
+      <author><first>Mark</first><last>van Assem</last></author>
       <author><first>Aldo</first><last>Gangemi</last></author>
       <author><first>Guus</first><last>Schreiber</last></author>
       <title>Conversion of <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et to a standard <fixed-case>RDF</fixed-case>/<fixed-case>OWL</fixed-case> representation</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/165_pdf.pdf</url>
     </paper>
     <paper id="87">
-      <author><first>Antal van den</first><last>Bosch</last></author>
+      <author><first>Antal</first><last>van den Bosch</last></author>
       <author><first>Ineke</first><last>Schuurman</last></author>
       <author><first>Vincent</first><last>Vandeghinste</last></author>
       <title>Transferring <fixed-case>P</fixed-case>o<fixed-case>S</fixed-case>-tagging and lemmatization tools from spoken to written <fixed-case>D</fixed-case>utch corpus development</title>
@@ -732,8 +732,8 @@
     <paper id="102">
       <author><first>Folkert de</first><last>Vriend</last></author>
       <author><first>Lou</first><last>Boves</last></author>
-      <author><first>Henk van den</first><last>Heuvel</last></author>
-      <author><first>Roeland van</first><last>Hout</last></author>
+      <author><first>Henk</first><last>van den Heuvel</last></author>
+      <author><first>Roeland</first><last>van Hout</last></author>
       <author><first>Joep</first><last>Kruijsen</last></author>
       <author><first>Jos</first><last>Swanenberg</last></author>
       <title>A Unified Structure for <fixed-case>D</fixed-case>utch Dialect Dictionary Data</title>
@@ -991,7 +991,7 @@
       <author><first>Qian</first><last>Yang</last></author>
       <author><first>Jean-Pierre</first><last>Martens</last></author>
       <author><first>Nanneke</first><last>Konings</last></author>
-      <author><first>Henk van den</first><last>Heuvel</last></author>
+      <author><first>Henk</first><last>van den Heuvel</last></author>
       <title>Development of a phoneme-to-phoneme (p2p) converter to improve the grapheme-to-phoneme (g2p) conversion of names</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/248_pdf.pdf</url>
     </paper>
@@ -1005,7 +1005,7 @@
     <paper id="141">
       <author><first>Catia</first><last>Cucchiarini</last></author>
       <author><first>Hugo</first><last>Van hamme</last></author>
-      <author><first>Olga van</first><last>Herwijnen</last></author>
+      <author><first>Olga</first><last>van Herwijnen</last></author>
       <author><first>Felix</first><last>Smits</last></author>
       <title><fixed-case>JASMIN</fixed-case>-<fixed-case>CGN</fixed-case>: Extension of the Spoken <fixed-case>D</fixed-case>utch Corpus with Speech of Elderly People, Children and Non-natives in the Human-Machine Interaction Modality</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/254_pdf.pdf</url>
@@ -1352,7 +1352,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/328_pdf.pdf</url>
     </paper>
     <paper id="190">
-      <author><first>Gertjan van</first><last>Noord</last></author>
+      <author><first>Gertjan</first><last>van Noord</last></author>
       <author><first>Ineke</first><last>Schuurman</last></author>
       <author><first>Vincent</first><last>Vandeghinste</last></author>
       <title>Syntactic Annotation of Large Corpora in <fixed-case>STEVIN</fixed-case></title>
@@ -2009,7 +2009,7 @@
     <paper id="285">
       <author><first>Michel</first><last>Boekestein</last></author>
       <author><first>Griet</first><last>Depoorter</last></author>
-      <author><first>Remco van</first><last>Veenendaal</last></author>
+      <author><first>Remco</first><last>van Veenendaal</last></author>
       <title>Functioning of the Centre for <fixed-case>D</fixed-case>utch Language and Speech Technology</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/478_pdf.pdf</url>
     </paper>
@@ -2036,9 +2036,9 @@
     </paper>
     <paper id="288">
       <author><first>Caroline</first><last>Sporleder</last></author>
-      <author><first>Marieke van</first><last>Erp</last></author>
+      <author><first>Marieke</first><last>van Erp</last></author>
       <author><first>Tijn</first><last>Porcelijn</last></author>
-      <author><first>Antal van den</first><last>Bosch</last></author>
+      <author><first>Antal</first><last>van den Bosch</last></author>
       <author><first>Pim</first><last>Arntzen</last></author>
       <title>Identifying Named Entities in Text Databases from the Natural History Domain</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/482_pdf.pdf</url>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -730,7 +730,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/190_pdf.pdf</url>
     </paper>
     <paper id="102">
-      <author><first>Folkert de</first><last>Vriend</last></author>
+      <author><first>Folkert</first><last>de Vriend</last></author>
       <author><first>Lou</first><last>Boves</last></author>
       <author><first>Henk</first><last>van den Heuvel</last></author>
       <author><first>Roeland</first><last>van Hout</last></author>
@@ -1580,7 +1580,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/376_pdf.pdf</url>
     </paper>
     <paper id="222">
-      <author><first>Maria Clara Paixão de</first><last>Sousa</last></author>
+      <author><first>Maria Clara Paixão</first><last>de Sousa</last></author>
       <author><first>Thorsten</first><last>Trippel</last></author>
       <title>Building a historical corpus for Classical <fixed-case>P</fixed-case>ortuguese: some technological aspects</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/378_pdf.pdf</url>
@@ -3109,7 +3109,7 @@
     <paper id="429">
       <author><first>Jorge</first><last>Kinoshita</last></author>
       <author><first>Laís do Nascimento</first><last>Salvador</last></author>
-      <author><first>Carlos Eduardo Dantas de</first><last>Menezes</last></author>
+      <author><first>Carlos Eduardo Dantas</first><last>de Menezes</last></author>
       <title><fixed-case>C</fixed-case>o<fixed-case>G</fixed-case>r<fixed-case>OO</fixed-case>: a <fixed-case>B</fixed-case>razilian-<fixed-case>P</fixed-case>ortuguese Grammar Checker based on the <fixed-case>CETENFOLHA</fixed-case> Corpus</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/689_pdf.pdf</url>
     </paper>
@@ -3189,7 +3189,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/708_pdf.pdf</url>
     </paper>
     <paper id="441">
-      <author><first>Philippe Boula de</first><last>Mareüil</last></author>
+      <author><first>Philippe Boula</first><last>de Mareüil</last></author>
       <author><first>Christophe</first><last>d’Alessandro</last></author>
       <author><first>Alexander</first><last>Raake</last></author>
       <author><first>Gérard</first><last>Bailly</last></author>
@@ -3269,7 +3269,7 @@
       <author><first>Udo</first><last>Hahn</last></author>
       <author><first>Susanne</first><last>Hanser</last></author>
       <author><first>Percy</first><last>Nohama</last></author>
-      <author><first>Roosewelt Leite de</first><last>Andrade</last></author>
+      <author><first>Roosewelt Leite</first><last>de Andrade</last></author>
       <author><first>Edson</first><last>Pacheco</last></author>
       <author><first>Martin</first><last>Romacker</last></author>
       <title>Semantic Atomicity and Multilinguality in the Medical Domain: Design Considerations for the <fixed-case>M</fixed-case>orpho<fixed-case>S</fixed-case>aurus Subword Lexicon</title>
@@ -3722,7 +3722,7 @@
       <author><first>Christelle</first><last>Ayache</last></author>
       <author><first>Petya</first><last>Osenova</last></author>
       <author><first>Anselmo</first><last>Peñas</last></author>
-      <author><first>Maarten de</first><last>Rijke</last></author>
+      <author><first>Maarten</first><last>de Rijke</last></author>
       <author><first>Bogdan</first><last>Sacaleanu</last></author>
       <author><first>Diana</first><last>Santos</last></author>
       <author><first>Richard</first><last>Sutcliffe</last></author>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -2548,7 +2548,7 @@
     <paper id="353">
       <author><first>Joris</first><last>Vaneyghen</last></author>
       <author><first>Guy De</first><last>Pauw</last></author>
-      <author><first>Dirk Van</first><last>Compernolle</last></author>
+      <author><first>Dirk</first><last>Van Compernolle</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
       <title>A mixed word / morphological approach for extending <fixed-case>CELEX</fixed-case> for high coverage on contemporary large corpora</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/583_pdf.pdf</url>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -1416,7 +1416,7 @@
     </paper>
     <paper id="198">
       <author><first>Véronique</first><last>Hoste</last></author>
-      <author><first>Guy De</first><last>Pauw</last></author>
+      <author><first>Guy</first><last>De Pauw</last></author>
       <title><fixed-case>KNACK</fixed-case>-2002: a Richly Annotated Corpus of <fixed-case>D</fixed-case>utch Written Text</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/342_pdf.pdf</url>
     </paper>
@@ -2547,7 +2547,7 @@
     </paper>
     <paper id="353">
       <author><first>Joris</first><last>Vaneyghen</last></author>
-      <author><first>Guy De</first><last>Pauw</last></author>
+      <author><first>Guy</first><last>De Pauw</last></author>
       <author><first>Dirk</first><last>Van Compernolle</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
       <title>A mixed word / morphological approach for extending <fixed-case>CELEX</fixed-case> for high coverage on contemporary large corpora</title>
@@ -2731,7 +2731,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/618_pdf.pdf</url>
     </paper>
     <paper id="378">
-      <author><first>Ernesto William De</first><last>Luca</last></author>
+      <author><first>Ernesto William</first><last>De Luca</last></author>
       <author><first>Andreas</first><last>Nürnberger</last></author>
       <title>Rebuilding Lexical Resources for Information Retrieval using Sense Folder Detection and Merging Methods</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/620_pdf.pdf</url>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -532,7 +532,7 @@
     <paper id="69">
       <author><first>Carol</first><last>Peters</last></author>
       <author><first>Martin</first><last>Braschler</last></author>
-      <author><first>Giorgio Di</first><last>Nunzio</last></author>
+      <author><first>Giorgio</first><last>Di Nunzio</last></author>
       <author><first>Nicola</first><last>Ferro</last></author>
       <author><first>Julio</first><last>Gonzalo</last></author>
       <author><first>Mark</first><last>Sanderson</last></author>
@@ -2144,7 +2144,7 @@
     <paper id="285">
       <author><first>Thomas</first><last>Mandl</last></author>
       <author><first>Fredric</first><last>Gey</last></author>
-      <author><first>Giorgio Di</first><last>Nunzio</last></author>
+      <author><first>Giorgio</first><last>Di Nunzio</last></author>
       <author><first>Nicola</first><last>Ferro</last></author>
       <author><first>Mark</first><last>Sanderson</last></author>
       <author><first>Diana</first><last>Santos</last></author>
@@ -4507,7 +4507,7 @@
     </paper>
     <paper id="601">
       <author><first>Bento Carlos</first><last>Dias-da-Silva</last></author>
-      <author><first>Ariani Di</first><last>Felippo</last></author>
+      <author><first>Ariani</first><last>Di Felippo</last></author>
       <author><first>Maria</first><last>das Graças Volpe Nunes</last></author>
       <title>The Automatic Mapping of <fixed-case>P</fixed-case>rinceton <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Lexical-Conceptual Relations onto the <fixed-case>B</fixed-case>razilian <fixed-case>P</fixed-case>ortuguese <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Database</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/391_paper.pdf</url>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -3286,7 +3286,7 @@
       <author><first>Jan Pieter</first><last>Kunst</last></author>
       <author><first>Louis ten</first><last>Bosch</last></author>
       <author><first>Charlotte</first><last>Giesbers</last></author>
-      <author><first>Roeland van</first><last>Hout</last></author>
+      <author><first>Roeland</first><last>van Hout</last></author>
       <title>Evaluating the Relationship between Linguistic and Geographic Distances using a 3<fixed-case>D</fixed-case> Visualization</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/559_paper.pdf</url>
     </paper>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -532,7 +532,7 @@
     <paper id="69">
       <author><first>Carol</first><last>Peters</last></author>
       <author><first>Martin</first><last>Braschler</last></author>
-      <author><first>Giorgio</first><last> Nunzio</last></author>
+      <author><first>Giorgio Di</first><last>Nunzio</last></author>
       <author><first>Nicola</first><last>Ferro</last></author>
       <author><first>Julio</first><last>Gonzalo</last></author>
       <author><first>Mark</first><last>Sanderson</last></author>
@@ -2144,7 +2144,7 @@
     <paper id="285">
       <author><first>Thomas</first><last>Mandl</last></author>
       <author><first>Fredric</first><last>Gey</last></author>
-      <author><first>Giorgio</first><last> Nunzio</last></author>
+      <author><first>Giorgio Di</first><last>Nunzio</last></author>
       <author><first>Nicola</first><last>Ferro</last></author>
       <author><first>Mark</first><last>Sanderson</last></author>
       <author><first>Diana</first><last>Santos</last></author>
@@ -4507,7 +4507,7 @@
     </paper>
     <paper id="601">
       <author><first>Bento Carlos</first><last>Dias-da-Silva</last></author>
-      <author><first>Ariani</first><last> Felippo</last></author>
+      <author><first>Ariani Di</first><last>Felippo</last></author>
       <author><first>Maria</first><last>das Graças Volpe Nunes</last></author>
       <title>The Automatic Mapping of <fixed-case>P</fixed-case>rinceton <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Lexical-Conceptual Relations onto the <fixed-case>B</fixed-case>razilian <fixed-case>P</fixed-case>ortuguese <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Database</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/391_paper.pdf</url>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -3282,7 +3282,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/519_paper.pdf</url>
     </paper>
     <paper id="439">
-      <author><first>Folkert de</first><last>Vriend</last></author>
+      <author><first>Folkert</first><last>de Vriend</last></author>
       <author><first>Jan Pieter</first><last>Kunst</last></author>
       <author><first>Louis ten</first><last>Bosch</last></author>
       <author><first>Charlotte</first><last>Giesbers</last></author>
@@ -3683,7 +3683,7 @@
       <author><first>Frédéric</first><last>Duvert</last></author>
       <author><first>Frédéric</first><last>Béchet</last></author>
       <author><first>Fabrice</first><last>Lefèvre</last></author>
-      <author><first>Renato de</first><last>Mori</last></author>
+      <author><first>Renato</first><last>de Mori</last></author>
       <title>Semantic Frame Annotation on the <fixed-case>F</fixed-case>rench <fixed-case>MEDIA</fixed-case> corpus</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/256_paper.pdf</url>
     </paper>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -725,7 +725,7 @@
       <author><first>Veronique</first><last>Hoste</last></author>
       <author><first>Geert</first><last>Kloosterman</last></author>
       <author><first>Anne-Marie</first><last>Mineur</last></author>
-      <author><first>Joeri Van Der</first><last>Vloet</last></author>
+      <author><first>Joeri</first><last>Van Der Vloet</last></author>
       <author><first>Jean-Luc</first><last>Verschelde</last></author>
       <title>A Coreference Corpus and Resolution System for <fixed-case>D</fixed-case>utch</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/49_paper.pdf</url>
@@ -1693,7 +1693,7 @@
       <author><first>Nelleke</first><last>Oostdijk</last></author>
       <author><first>Martin</first><last>Reynaert</last></author>
       <author><first>Paola</first><last>Monachesi</last></author>
-      <author><first>Gertjan Van</first><last>Noord</last></author>
+      <author><first>Gertjan</first><last>Van Noord</last></author>
       <author><first>Roeland</first><last>Ordelman</last></author>
       <author><first>Ineke</first><last>Schuurman</last></author>
       <author><first>Vincent</first><last>Vandeghinste</last></author>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -903,7 +903,7 @@
     </paper>
     <paper id="118">
       <author><first>Lena</first><last>Grothe</last></author>
-      <author><first>Ernesto William De</first><last>Luca</last></author>
+      <author><first>Ernesto William</first><last>De Luca</last></author>
       <author><first>Andreas</first><last>Nürnberger</last></author>
       <title>A Comparative Study on Language Identification Methods</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/249_paper.pdf</url>
@@ -1256,7 +1256,7 @@
     </paper>
     <paper id="168">
       <author><first>Yves</first><last>Peirsman</last></author>
-      <author><first>Simon De</first><last>Deyne</last></author>
+      <author><first>Simon</first><last>De Deyne</last></author>
       <author><first>Kris</first><last>Heylen</last></author>
       <author><first>Dirk</first><last>Geeraerts</last></author>
       <title>The Construction and Evaluation of Word Space Models</title>
@@ -1512,7 +1512,7 @@
     </paper>
     <paper id="202">
       <author><first>Marco</first><last>Pennacchiotti</last></author>
-      <author><first>Diego De</first><last>Cao</last></author>
+      <author><first>Diego</first><last>De Cao</last></author>
       <author><first>Paolo</first><last>Marocco</last></author>
       <author><first>Roberto</first><last>Basili</last></author>
       <title>Towards a Vector Space Model for <fixed-case>F</fixed-case>rame<fixed-case>N</fixed-case>et-like Resources</title>
@@ -1767,7 +1767,7 @@
     <paper id="234">
       <author><first>Valeria</first><last>Quochi</last></author>
       <author><first>Monica</first><last>Monachini</last></author>
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Nicoletta</first><last>Calzolari</last></author>
       <title>A lexicon for biology and bioinformatics: the <fixed-case>BOOTS</fixed-case>trep experience.</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/576_paper.pdf</url>
@@ -3130,7 +3130,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/564_paper.pdf</url>
     </paper>
     <paper id="418">
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Roberto</first><last>Bartolini</last></author>
       <author><first>Tommaso</first><last>Caselli</last></author>
       <author><first>Monica</first><last>Monachini</last></author>
@@ -4193,7 +4193,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/903_paper.pdf</url>
     </paper>
     <paper id="557">
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Nilda</first><last>Ruimy</last></author>
       <author><first>Antonio</first><last>Toral</last></author>
       <title>Simple-Clips ongoing research: more information with less data by implementing inheritance</title>
@@ -4470,7 +4470,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/77_paper.pdf</url>
     </paper>
     <paper id="595">
-      <author><first>Ernesto William De</first><last>Luca</last></author>
+      <author><first>Ernesto William</first><last>De Luca</last></author>
       <author><first>Birte</first><last>Lönneker-Rodman</last></author>
       <title>Integrating Metaphor Information into <fixed-case>RDF</fixed-case>/<fixed-case>OWL</fixed-case> <fixed-case>E</fixed-case>uro<fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/108_paper.pdf</url>

--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -532,7 +532,7 @@
     <paper id="69">
       <author><first>Carol</first><last>Peters</last></author>
       <author><first>Martin</first><last>Braschler</last></author>
-      <author><first>Giorgio Di</first><last>Nunzio</last></author>
+      <author><first>Giorgio</first><last> Nunzio</last></author>
       <author><first>Nicola</first><last>Ferro</last></author>
       <author><first>Julio</first><last>Gonzalo</last></author>
       <author><first>Mark</first><last>Sanderson</last></author>
@@ -2144,7 +2144,7 @@
     <paper id="285">
       <author><first>Thomas</first><last>Mandl</last></author>
       <author><first>Fredric</first><last>Gey</last></author>
-      <author><first>Giorgio Di</first><last>Nunzio</last></author>
+      <author><first>Giorgio</first><last> Nunzio</last></author>
       <author><first>Nicola</first><last>Ferro</last></author>
       <author><first>Mark</first><last>Sanderson</last></author>
       <author><first>Diana</first><last>Santos</last></author>
@@ -4507,7 +4507,7 @@
     </paper>
     <paper id="601">
       <author><first>Bento Carlos</first><last>Dias-da-Silva</last></author>
-      <author><first>Ariani Di</first><last>Felippo</last></author>
+      <author><first>Ariani</first><last> Felippo</last></author>
       <author><first>Maria</first><last>das Graças Volpe Nunes</last></author>
       <title>The Automatic Mapping of <fixed-case>P</fixed-case>rinceton <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Lexical-Conceptual Relations onto the <fixed-case>B</fixed-case>razilian <fixed-case>P</fixed-case>ortuguese <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Database</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/391_paper.pdf</url>

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -77,7 +77,7 @@
     </paper>
     <paper id="10">
       <author><first>Antoinette</first><last>Hawayek</last></author>
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Giuseppe</first><last>Cappelli</last></author>
       <title>A Bilingual Dictionary <fixed-case>M</fixed-case>exican Sign Language-<fixed-case>S</fixed-case>panish/<fixed-case>S</fixed-case>panish-<fixed-case>M</fixed-case>exican Sign Language</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/27_Paper.pdf</url>
@@ -990,7 +990,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/203_Paper.pdf</url>
     </paper>
     <paper id="137">
-      <author><first>Orphée De</first><last>Clercq</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
       <author><first>Maribel Montero</first><last>Perez</last></author>
       <title>Data Collection and <fixed-case>IPR</fixed-case> in Multilingual Parallel Corpora. <fixed-case>D</fixed-case>utch Parallel Corpus</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/204_Paper.pdf</url>
@@ -1870,7 +1870,7 @@
     <paper id="253">
       <author><first>Nicoletta</first><last>Calzolari</last></author>
       <author><first>Claudia</first><last>Soria</last></author>
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Sara</first><last>Goggi</last></author>
       <author><first>Valeria</first><last>Quochi</last></author>
       <author><first>Irene</first><last>Russo</last></author>
@@ -2804,7 +2804,7 @@
     <paper id="376">
       <author><first>Martin</first><last>Reynaert</last></author>
       <author><first>Nelleke</first><last>Oostdijk</last></author>
-      <author><first>Orphée De</first><last>Clercq</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
       <author><first>Henk</first><last>van den Heuvel</last></author>
       <author><first>Franciska</first><last>de Jong</last></author>
       <title>Balancing <fixed-case>S</fixed-case>o<fixed-case>N</fixed-case>a<fixed-case>R</fixed-case>: <fixed-case>IPR</fixed-case> versus Processing Issues in a 500-Million-Word Written <fixed-case>D</fixed-case>utch Reference Corpus</title>
@@ -4007,7 +4007,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/772_Paper.pdf</url>
     </paper>
     <paper id="533">
-      <author><first>Diego De</first><last>Cao</last></author>
+      <author><first>Diego</first><last>De Cao</last></author>
       <author><first>Danilo</first><last>Croce</last></author>
       <author><first>Roberto</first><last>Basili</last></author>
       <title>Extensive Evaluation of a <fixed-case>F</fixed-case>rame<fixed-case>N</fixed-case>et-<fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et mapping resource</title>
@@ -4222,7 +4222,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/815_Paper.pdf</url>
     </paper>
     <paper id="562">
-      <author><first>Ernesto William De</first><last>Luca</last></author>
+      <author><first>Ernesto William</first><last>De Luca</last></author>
       <title>A Corpus for Evaluating Semantic Multilingual Web Retrieval Systems: The Sense Folder Corpus</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/816_Paper.pdf</url>
     </paper>

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -1063,7 +1063,7 @@
     <paper id="148">
       <author><first>Giuseppe</first><last>Attardi</last></author>
       <author><first>Stefano Dei</first><last>Rossi</last></author>
-      <author><first>Giulia</first><last> Pietro</last></author>
+      <author><first>Giulia Di</first><last>Pietro</last></author>
       <author><first>Alessandro</first><last>Lenci</last></author>
       <author><first>Simonetta</first><last>Montemagni</last></author>
       <author><first>Maria</first><last>Simi</last></author>

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -1063,7 +1063,7 @@
     <paper id="148">
       <author><first>Giuseppe</first><last>Attardi</last></author>
       <author><first>Stefano Dei</first><last>Rossi</last></author>
-      <author><first>Giulia Di</first><last>Pietro</last></author>
+      <author><first>Giulia</first><last>Di Pietro</last></author>
       <author><first>Alessandro</first><last>Lenci</last></author>
       <author><first>Simonetta</first><last>Montemagni</last></author>
       <author><first>Maria</first><last>Simi</last></author>

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -1063,7 +1063,7 @@
     <paper id="148">
       <author><first>Giuseppe</first><last>Attardi</last></author>
       <author><first>Stefano Dei</first><last>Rossi</last></author>
-      <author><first>Giulia Di</first><last>Pietro</last></author>
+      <author><first>Giulia</first><last> Pietro</last></author>
       <author><first>Alessandro</first><last>Lenci</last></author>
       <author><first>Simonetta</first><last>Montemagni</last></author>
       <author><first>Maria</first><last>Simi</last></author>

--- a/data/xml/L10.xml
+++ b/data/xml/L10.xml
@@ -749,7 +749,7 @@
     <paper id="105">
       <author><first>Daan</first><last>Broeder</last></author>
       <author><first>Marc</first><last>Kemps-Snijders</last></author>
-      <author><first>Dieter Van</first><last>Uytvanck</last></author>
+      <author><first>Dieter</first><last>Van Uytvanck</last></author>
       <author><first>Menzo</first><last>Windhouwer</last></author>
       <author><first>Peter</first><last>Withers</last></author>
       <author><first>Peter</first><last>Wittenburg</last></author>
@@ -1365,7 +1365,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/272_Paper.pdf</url>
     </paper>
     <paper id="187">
-      <author><first>Dieter Van</first><last>Uytvanck</last></author>
+      <author><first>Dieter</first><last>Van Uytvanck</last></author>
       <author><first>Claus</first><last>Zinn</last></author>
       <author><first>Daan</first><last>Broeder</last></author>
       <author><first>Peter</first><last>Wittenburg</last></author>
@@ -4366,7 +4366,7 @@
     </paper>
     <paper id="584">
       <author><first>Parisa</first><last>Kordjamshidi</last></author>
-      <author><first>Martijn Van</first><last>Otterlo</last></author>
+      <author><first>Martijn</first><last>Van Otterlo</last></author>
       <author><first>Marie-Francine</first><last>Moens</last></author>
       <title>Spatial Role Labeling: Task Definition and Annotation Scheme</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2010/pdf/846_Paper.pdf</url>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -1004,7 +1004,7 @@
     <paper id="125">
       <author><first>Maristella</first><last>Agosti</last></author>
       <author><first>Birgit</first><last>Alber</last></author>
-      <author><first>Giorgio Maria</first><last> Nunzio</last></author>
+      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
       <author><first>Marco</first><last>Dussin</last></author>
       <author><first>Stefan</first><last>Rabanus</last></author>
       <author><first>Alessandra</first><last>Tomaselli</last></author>
@@ -3468,7 +3468,7 @@
       <author><first>Alistair</first><last>Conkie</last></author>
       <author><first>Thomas</first><last>Okken</last></author>
       <author><first>Yeon-Jun</first><last>Kim</last></author>
-      <author><first>Giuseppe</first><last> Fabbrizio</last></author>
+      <author><first>Giuseppe Di</first><last>Fabbrizio</last></author>
       <title>Building Text-To-Speech Voices in the Cloud</title>
       <pages>3317–3321</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/716_Paper.pdf</url>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -630,7 +630,7 @@
       <author><first>Danuta</first><last>Ploch</last></author>
       <author><first>Leonhard</first><last>Hennig</last></author>
       <author><first>Angelina</first><last>Duka</last></author>
-      <author><first>Ernesto William De</first><last>Luca</last></author>
+      <author><first>Ernesto William</first><last>De Luca</last></author>
       <author><first>Sahin</first><last>Albayrak</last></author>
       <title><fixed-case>G</fixed-case>er<fixed-case>NED</fixed-case>: A <fixed-case>G</fixed-case>erman Corpus for Named Entity Disambiguation</title>
       <pages>3886–3893</pages>
@@ -1175,7 +1175,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/311_Paper.pdf</url>
     </paper>
     <paper id="145">
-      <author><first>Tom De</first><last>Smedt</last></author>
+      <author><first>Tom</first><last>De Smedt</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
       <title>“Vreselijk mooi!” (terribly beautiful): A Subjectivity Lexicon for <fixed-case>D</fixed-case>utch Adjectives.</title>
       <pages>3568–3572</pages>
@@ -1242,7 +1242,7 @@
       <author><first>Ville</first><last>Viitaniemi</last></author>
       <author><first>Jorma</first><last>Laaksonen</last></author>
       <author><first>Birgitta</first><last>Burger</last></author>
-      <author><first>Danny De</first><last>Weerdt</last></author>
+      <author><first>Danny</first><last>De Weerdt</last></author>
       <title>Comparing computer vision analysis of signed language video with motion capture recordings</title>
       <pages>2421–2425</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/321_Paper.pdf</url>
@@ -1651,7 +1651,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/394_Paper.pdf</url>
     </paper>
     <paper id="202">
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Francesca</first><last>Frontini</last></author>
       <author><first>Francesco</first><last>Rubino</last></author>
       <author><first>Irene</first><last>Russo</last></author>
@@ -1725,7 +1725,7 @@
       <author><first>Fabrizio</first><last>Borgia</last></author>
       <author><first>Claudia S.</first><last>Bianchini</last></author>
       <author><first>Patrice</first><last>Dalle</last></author>
-      <author><first>Maria De</first><last>Marsico</last></author>
+      <author><first>Maria</first><last>De Marsico</last></author>
       <title>Resource production of written forms of Sign Languages by a user-centered editor, <fixed-case>SW</fixed-case>ift (<fixed-case>S</fixed-case>ign<fixed-case>W</fixed-case>riting improved fast transcriber)</title>
       <pages>3779–3784</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/404_Paper.pdf</url>
@@ -2234,7 +2234,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/496_Paper.pdf</url>
     </paper>
     <paper id="272">
-      <author><first>Ernesto William De</first><last>Luca</last></author>
+      <author><first>Ernesto William</first><last>De Luca</last></author>
       <title>Is it Useful to Support Users with Lexical Resources? A User Study.</title>
       <pages>3184–3189</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/502_Paper.pdf</url>
@@ -2289,7 +2289,7 @@
     <paper id="278">
       <author><first>Els</first><last>Lefever</last></author>
       <author><first>Véronique</first><last>Hoste</last></author>
-      <author><first>Martine De</first><last>Cock</last></author>
+      <author><first>Martine</first><last>De Cock</last></author>
       <title>Discovering Missing <fixed-case>W</fixed-case>ikipedia Inter-language Links by means of Cross-lingual Word Sense Disambiguation</title>
       <pages>841–846</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/508_Paper.pdf</url>
@@ -2520,7 +2520,7 @@
     </paper>
     <paper id="302">
       <author><first>Maaske</first><last>Treurniet</last></author>
-      <author><first>Orphée De</first><last>Clercq</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
       <author><first>Henk</first><last>van den Heuvel</last></author>
       <author><first>Nelleke</first><last>Oostdijk</last></author>
       <title>Collection of a corpus of <fixed-case>D</fixed-case>utch <fixed-case>SMS</fixed-case></title>
@@ -3288,7 +3288,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/679_Paper.pdf</url>
     </paper>
     <paper id="396">
-      <author><first>Orphée De</first><last>Clercq</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
       <author><first>Veronique</first><last>Hoste</last></author>
       <author><first>Paola</first><last>Monachesi</last></author>
       <title>Evaluating automatic cross-domain <fixed-case>D</fixed-case>utch semantic role annotation</title>
@@ -3319,7 +3319,7 @@
       <author><first>Nicolas</first><last>Bigouroux</last></author>
       <author><first>Thierry</first><last>Bazillon</last></author>
       <author><first>Marc</first><last>El-Bèze</last></author>
-      <author><first>Renato De</first><last>Mori</last></author>
+      <author><first>Renato</first><last>De Mori</last></author>
       <author><first>Eric</first><last>Arbillot</last></author>
       <title><fixed-case>DECODA</fixed-case>: a call-centre human-human spoken conversation corpus</title>
       <pages>1343–1347</pages>
@@ -3631,7 +3631,7 @@
       <author><first>Bolette</first><last>Pedersen</last></author>
       <author><first>Eiríkur</first><last>Rögnvaldsson</last></author>
       <author><first>Inguna</first><last>Skadiņa</last></author>
-      <author><first>Koenraad De</first><last>Smedt</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <author><first>Ville</first><last>Oksanen</last></author>
       <author><first>Roberts</first><last>Rozis</last></author>
       <title>Creation of an Open Shared Language Resource Repository in the Nordic and Baltic Countries</title>
@@ -3767,7 +3767,7 @@
     </paper>
     <paper id="450">
       <author><first>Nicoletta</first><last>Calzolari</last></author>
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Gil</first><last>Francopoulo</last></author>
       <author><first>Joseph</first><last>Mariani</last></author>
       <author><first>Francesco</first><last>Rubino</last></author>
@@ -4731,8 +4731,8 @@
     <paper id="558">
       <author><first>Mike</first><last>Kestemont</last></author>
       <author><first>Claudia</first><last>Peersman</last></author>
-      <author><first>Benny De</first><last>Decker</last></author>
-      <author><first>Guy De</first><last>Pauw</last></author>
+      <author><first>Benny</first><last>De Decker</last></author>
+      <author><first>Guy</first><last>De Pauw</last></author>
       <author><first>Kim</first><last>Luyckx</last></author>
       <author><first>Roser</first><last>Morante</last></author>
       <author><first>Frederik</first><last>Vaassen</last></author>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -1004,7 +1004,7 @@
     <paper id="125">
       <author><first>Maristella</first><last>Agosti</last></author>
       <author><first>Birgit</first><last>Alber</last></author>
-      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
+      <author><first>Giorgio Maria</first><last> Nunzio</last></author>
       <author><first>Marco</first><last>Dussin</last></author>
       <author><first>Stefan</first><last>Rabanus</last></author>
       <author><first>Alessandra</first><last>Tomaselli</last></author>
@@ -3468,7 +3468,7 @@
       <author><first>Alistair</first><last>Conkie</last></author>
       <author><first>Thomas</first><last>Okken</last></author>
       <author><first>Yeon-Jun</first><last>Kim</last></author>
-      <author><first>Giuseppe Di</first><last>Fabbrizio</last></author>
+      <author><first>Giuseppe</first><last> Fabbrizio</last></author>
       <title>Building Text-To-Speech Voices in the Cloud</title>
       <pages>3317–3321</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/716_Paper.pdf</url>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -253,7 +253,7 @@
       <author><first>Lieve</first><last>Macken</last></author>
       <author><first>Veronique</first><last>Hoste</last></author>
       <author><first>Mariëlle</first><last>Leijten</last></author>
-      <author><first>Luuk Van</first><last>Waes</last></author>
+      <author><first>Luuk</first><last>Van Waes</last></author>
       <title>From keystrokes to annotated process data: Enriching the output of Inputlog with linguistic information</title>
       <pages>2224–2229</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/161_Paper.pdf</url>
@@ -654,7 +654,7 @@
     <paper id="81">
       <author><first>Aditi Sharma</first><last>Grover</last></author>
       <author><first>Annamart</first><last>Nieman</last></author>
-      <author><first>Gerhard Van</first><last>Huyssteen</last></author>
+      <author><first>Gerhard</first><last>Van Huyssteen</last></author>
       <author><first>Justus</first><last>Roux</last></author>
       <title>Aspects of a Legal Framework for Language Resource Management</title>
       <pages>1035–1039</pages>
@@ -3704,7 +3704,7 @@
     <paper id="442">
       <author><first>Liesbeth</first><last>Augustinus</last></author>
       <author><first>Vincent</first><last>Vandeghinste</last></author>
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <title>Example-Based Treebank Querying</title>
       <pages>3161–3167</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/756_Paper.pdf</url>

--- a/data/xml/L12.xml
+++ b/data/xml/L12.xml
@@ -1004,7 +1004,7 @@
     <paper id="125">
       <author><first>Maristella</first><last>Agosti</last></author>
       <author><first>Birgit</first><last>Alber</last></author>
-      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
+      <author><first>Giorgio Maria</first><last>Di Nunzio</last></author>
       <author><first>Marco</first><last>Dussin</last></author>
       <author><first>Stefan</first><last>Rabanus</last></author>
       <author><first>Alessandra</first><last>Tomaselli</last></author>
@@ -3468,7 +3468,7 @@
       <author><first>Alistair</first><last>Conkie</last></author>
       <author><first>Thomas</first><last>Okken</last></author>
       <author><first>Yeon-Jun</first><last>Kim</last></author>
-      <author><first>Giuseppe Di</first><last>Fabbrizio</last></author>
+      <author><first>Giuseppe</first><last>Di Fabbrizio</last></author>
       <title>Building Text-To-Speech Voices in the Cloud</title>
       <pages>3317–3321</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2012/pdf/716_Paper.pdf</url>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -1551,7 +1551,7 @@
       <author><first>Catia</first><last>Cucchiarini</last></author>
       <author><first>Steve</first><last>Bodnar</last></author>
       <author><first>Bart Penning</first><last>de Vries</last></author>
-      <author><first>Roeland van</first><last>Hout</last></author>
+      <author><first>Roeland</first><last>van Hout</last></author>
       <author><first>Helmer</first><last>Strik</last></author>
       <title><fixed-case>ASR</fixed-case>-based <fixed-case>CALL</fixed-case> systems and learner speech data: new resources and opportunities for research and development in second language learning</title>
       <pages>2708–2714</pages>
@@ -4535,7 +4535,7 @@
     </paper>
     <paper id="521">
       <author><first>Menno</first><last>van Zaanen</last></author>
-      <author><first>Gerhard van</first><last>Huyssteen</last></author>
+      <author><first>Gerhard</first><last>van Huyssteen</last></author>
       <author><first>Suzanne</first><last>Aussems</last></author>
       <author><first>Chris</first><last>Emmery</last></author>
       <author><first>Roald</first><last>Eiselen</last></author>
@@ -5923,7 +5923,7 @@
     </paper>
     <paper id="682">
       <author><first>Jetske</first><last>Klatter</last></author>
-      <author><first>Roeland van</first><last>Hout</last></author>
+      <author><first>Roeland</first><last>van Hout</last></author>
       <author><first>Henk</first><last>van den Heuvel</last></author>
       <author><first>Paula</first><last>Fikkert</last></author>
       <author><first>Anne</first><last>Baker</last></author>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -1290,7 +1290,7 @@
       <author><first>Jennifer</first><last>Drexler</last></author>
       <author><first>Pushpendre</first><last>Rastogi</last></author>
       <author><first>Jacqueline</first><last>Aguilar</last></author>
-      <author><first>Benjamin Van</first><last>Durme</last></author>
+      <author><first>Benjamin</first><last>Van Durme</last></author>
       <author><first>Matt</first><last>Post</last></author>
       <title>A <fixed-case>W</fixed-case>ikipedia-based Corpus for Contextualized Machine Translation</title>
       <pages>3593–3596</pages>
@@ -3190,7 +3190,7 @@
     </paper>
     <paper id="365">
       <author><first>Els</first><last>Lefever</last></author>
-      <author><first>Marjan Van</first><last>de Kauter</last></author>
+      <author><first>Marjan</first><last>Van de Kauter</last></author>
       <author><first>Véronique</first><last>Hoste</last></author>
       <title>Evaluation of Automatic Hypernym Extraction from Technical Corpora in <fixed-case>E</fixed-case>nglish and <fixed-case>D</fixed-case>utch</title>
       <pages>490–497</pages>
@@ -3264,7 +3264,7 @@
       <author><first>Luciano</first><last>Serafini</last></author>
       <author><first>Pim</first><last>Stouten</last></author>
       <author><first>Francis</first><last>Irving</last></author>
-      <author><first>Willem Van</first><last>Hage</last></author>
+      <author><first>Willem</first><last>Van Hage</last></author>
       <title><fixed-case>N</fixed-case>ews<fixed-case>R</fixed-case>eader: recording history from daily news streams</title>
       <pages>2000–2007</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/436_Paper.pdf</url>
@@ -3345,7 +3345,7 @@
     </paper>
     <paper id="383">
       <author><first>Maarten</first><last>Truyens</last></author>
-      <author><first>Patrick Van</first><last>Eecke</last></author>
+      <author><first>Patrick</first><last>Van Eecke</last></author>
       <title>Legal aspects of text mining</title>
       <pages>2182–2186</pages>
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/452_Paper.pdf</url>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -1273,8 +1273,8 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/1213_Paper.pdf</url>
     </paper>
     <paper id="148">
-      <author><first>Emanuele</first><last> Buccio</last></author>
-      <author><first>Giorgio Maria</first><last> Nunzio</last></author>
+      <author><first>Emanuele Di</first><last>Buccio</last></author>
+      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
       <author><first>Gianmaria</first><last>Silvello</last></author>
       <title>A Vector Space Model for Syntactic Distances Between Dialects</title>
       <pages>2486–2489</pages>
@@ -6217,7 +6217,7 @@
     <paper id="719">
       <author><first>Livio</first><last>Robaldo</last></author>
       <author><first>Guido</first><last>Boella</last></author>
-      <author><first>Luigi</first><last> Caro</last></author>
+      <author><first>Luigi Di</first><last>Caro</last></author>
       <author><first>Andrea</first><last>Violato</last></author>
       <title>Exploiting networks in Law</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/95_Paper.pdf</url>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -1273,8 +1273,8 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/1213_Paper.pdf</url>
     </paper>
     <paper id="148">
-      <author><first>Emanuele Di</first><last>Buccio</last></author>
-      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
+      <author><first>Emanuele</first><last> Buccio</last></author>
+      <author><first>Giorgio Maria</first><last> Nunzio</last></author>
       <author><first>Gianmaria</first><last>Silvello</last></author>
       <title>A Vector Space Model for Syntactic Distances Between Dialects</title>
       <pages>2486–2489</pages>
@@ -6217,7 +6217,7 @@
     <paper id="719">
       <author><first>Livio</first><last>Robaldo</last></author>
       <author><first>Guido</first><last>Boella</last></author>
-      <author><first>Luigi Di</first><last>Caro</last></author>
+      <author><first>Luigi</first><last> Caro</last></author>
       <author><first>Andrea</first><last>Violato</last></author>
       <title>Exploiting networks in Law</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/95_Paper.pdf</url>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -5320,7 +5320,7 @@
       <author><first>Khalid</first><last>Choukri</last></author>
       <author><first>Olivier</first><last>Hamon</last></author>
       <author><first>Nicoletta</first><last>Calzolari</last></author>
-      <author><first>Riccardo del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>del Gratta</last></author>
       <author><first>Bernardo</first><last>Magnini</last></author>
       <author><first>Christian</first><last>Girardi</last></author>
       <title><fixed-case>META</fixed-case>-<fixed-case>SHARE</fixed-case>: One year after</title>
@@ -5927,7 +5927,7 @@
       <author><first>Henk</first><last>van den Heuvel</last></author>
       <author><first>Paula</first><last>Fikkert</last></author>
       <author><first>Anne</first><last>Baker</last></author>
-      <author><first>Jan de</first><last>Jong</last></author>
+      <author><first>Jan</first><last>de Jong</last></author>
       <author><first>Frank</first><last>Wijnen</last></author>
       <author><first>Eric</first><last>Sanders</last></author>
       <author><first>Paul</first><last>Trilsbeek</last></author>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -471,7 +471,7 @@
       <author><first>Yuri</first><last>Bizzoni</last></author>
       <author><first>Federico</first><last>Boschetti</last></author>
       <author><first>Harry</first><last>Diakoff</last></author>
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Monica</first><last>Monachini</last></author>
       <author><first>Gregory</first><last>Crane</last></author>
       <title>The Making of Ancient <fixed-case>G</fixed-case>reek <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et</title>
@@ -2714,7 +2714,7 @@
     </paper>
     <paper id="317">
       <author><first>Matteo</first><last>Abrate</last></author>
-      <author><first>Angelo Mario Del</first><last>Grosso</last></author>
+      <author><first>Angelo Mario</first><last>Del Grosso</last></author>
       <author><first>Emiliano</first><last>Giovannetti</last></author>
       <author><first>Angelica Lo</first><last>Duca</last></author>
       <author><first>Damiana</first><last>Luzzi</last></author>
@@ -3042,7 +3042,7 @@
       <author><first>Michael</first><last>Rosner</last></author>
       <author><first>Bolette</first><last>Pedersen</last></author>
       <author><first>Inguna</first><last>Skadiņa</last></author>
-      <author><first>Koenraad De</first><last>Smedt</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <author><first>Marko</first><last>Tadić</last></author>
       <author><first>Paul</first><last>Thompson</last></author>
       <author><first>Dan</first><last>Tufiş</last></author>
@@ -3069,7 +3069,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/41_Paper.pdf</url>
     </paper>
     <paper id="353">
-      <author><first>Koenraad De</first><last>Smedt</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <author><first>Erhard</first><last>Hinrichs</last></author>
       <author><first>Detmar</first><last>Meurers</last></author>
       <author><first>Inguna</first><last>Skadiņa</last></author>
@@ -3328,7 +3328,7 @@
       <author><first>Ralf</first><last>Steinberger</last></author>
       <author><first>Maud</first><last>Ehrmann</last></author>
       <author><first>Mohamed</first><last>Ebrahim</last></author>
-      <author><first>Leonida Della</first><last>Rocca</last></author>
+      <author><first>Leonida</first><last>Della Rocca</last></author>
       <author><first>Stefano</first><last>Bucci</last></author>
       <author><first>Eszter</first><last>Simon</last></author>
       <author><first>Tamás</first><last>Váradi</last></author>
@@ -4857,7 +4857,7 @@
     <paper id="559">
       <author><first>Roberto</first><last>Bartolini</last></author>
       <author><first>Valeria</first><last>Quochi</last></author>
-      <author><first>Irene De</first><last>Felice</last></author>
+      <author><first>Irene</first><last>De Felice</last></author>
       <author><first>Irene</first><last>Russo</last></author>
       <author><first>Monica</first><last>Monachini</last></author>
       <title>From Synsets to Videos: Enriching <fixed-case>I</fixed-case>tal<fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et Multimodally</title>
@@ -4979,7 +4979,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/732_Paper.pdf</url>
     </paper>
     <paper id="574">
-      <author><first>Orphée De</first><last>Clercq</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
       <author><first>Sarah</first><last>Schulz</last></author>
       <author><first>Bart</first><last>Desmet</last></author>
       <author><first>Véronique</first><last>Hoste</last></author>
@@ -5049,7 +5049,7 @@
       <author><first>Pamela</first><last>Carreno</last></author>
       <author><first>Brice</first><last>Isableu</last></author>
       <author><first>Sylvie</first><last>Gibet</last></author>
-      <author><first>Pierre De</first><last>Loor</last></author>
+      <author><first>Pierre</first><last>De Loor</last></author>
       <author><first>Jean-Claude</first><last>Martin</last></author>
       <title>A Database of Full Body Virtual Interactions Annotated with Expressivity Scores</title>
       <pages>3505–3510</pages>
@@ -5336,7 +5336,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/787_Paper.pdf</url>
     </paper>
     <paper id="612">
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Gabriella</first><last>Pardelli</last></author>
       <author><first>Sara</first><last>Goggi</last></author>
       <title>The <fixed-case>LRE</fixed-case> Map disclosed</title>
@@ -6016,7 +6016,7 @@
     <paper id="693">
       <author><first>Iolanda</first><last>Alfano</last></author>
       <author><first>Francesco</first><last>Cutugno</last></author>
-      <author><first>Aurelio De</first><last>Rosa</last></author>
+      <author><first>Aurelio</first><last>De Rosa</last></author>
       <author><first>Claudio</first><last>Iacobini</last></author>
       <author><first>Renata</first><last>Savy</last></author>
       <author><first>Miriam</first><last>Voghera</last></author>
@@ -6185,7 +6185,7 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/940_Paper.pdf</url>
     </paper>
     <paper id="715">
-      <author><first>Marco Del</first><last>Tredici</last></author>
+      <author><first>Marco</first><last>Del Tredici</last></author>
       <author><first>Malvina</first><last>Nissim</last></author>
       <title>A Modular System for Rule-based Text Categorisation</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/941_Paper.pdf</url>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -1273,8 +1273,8 @@
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/1213_Paper.pdf</url>
     </paper>
     <paper id="148">
-      <author><first>Emanuele Di</first><last>Buccio</last></author>
-      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
+      <author><first>Emanuele</first><last>Di Buccio</last></author>
+      <author><first>Giorgio Maria</first><last>Di Nunzio</last></author>
       <author><first>Gianmaria</first><last>Silvello</last></author>
       <title>A Vector Space Model for Syntactic Distances Between Dialects</title>
       <pages>2486–2489</pages>
@@ -6217,7 +6217,7 @@
     <paper id="719">
       <author><first>Livio</first><last>Robaldo</last></author>
       <author><first>Guido</first><last>Boella</last></author>
-      <author><first>Luigi Di</first><last>Caro</last></author>
+      <author><first>Luigi</first><last>Di Caro</last></author>
       <author><first>Andrea</first><last>Violato</last></author>
       <title>Exploiting networks in Law</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/95_Paper.pdf</url>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -1280,7 +1280,7 @@
     </paper>
     <paper id="132">
       <title>Automatic Enrichment of <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et with Common-Sense Knowledge</title>
-      <author><first>Luigi Di</first><last>Caro</last></author>
+      <author><first>Luigi</first><last>Di Caro</last></author>
       <author><first>Guido</first><last>Boella</last></author>
       <pages>819–822</pages>
       <abstract>WordNet represents a cornerstone in the Computational Linguistics field, linking words to meanings (or senses) through a taxonomical representation of synsets, i.e., clusters of words with an equivalent meaning in a specific context often described by few definitions (or glosses) and examples. Most of the approaches to the Word Sense Disambiguation task fully rely on these short texts as a source of contextual information to match with the input text to disambiguate. This paper presents the first attempt to enrich synsets data with common-sense definitions, automatically retrieved from ConceptNet 5, and disambiguated accordingly to WordNet. The aim was to exploit the shared- and immediate-thinking nature of common-sense knowledge to extend the short but incredibly useful contextual information of the synsets. A manual evaluation on a subset of the entire result (which counts a total of almost 600K synset enrichments) shows a very high precision with an estimated good recall.</abstract>
@@ -6845,8 +6845,8 @@
     <paper id="709">
       <title>Designing A Long Lasting Linguistic Project: The Case Study of <fixed-case>ASI</fixed-case>t</title>
       <author><first>Maristella</first><last>Agosti</last></author>
-      <author><first>Emanuele Di</first><last>Buccio</last></author>
-      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
+      <author><first>Emanuele</first><last>Di Buccio</last></author>
+      <author><first>Giorgio Maria</first><last>Di Nunzio</last></author>
       <author><first>Cecilia</first><last>Poletto</last></author>
       <author><first>Esther</first><last>Rinke</last></author>
       <pages>4479–4483</pages>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -1046,11 +1046,11 @@
       <title><fixed-case>A</fixed-case>fri<fixed-case>B</fixed-case>ooms: An Online Treebank for <fixed-case>A</fixed-case>frikaans</title>
       <author><first>Liesbeth</first><last>Augustinus</last></author>
       <author><first>Peter</first><last>Dirix</last></author>
-      <author><first>Daniel van</first><last>Niekerk</last></author>
+      <author><first>Daniel</first><last>van Niekerk</last></author>
       <author><first>Ineke</first><last>Schuurman</last></author>
       <author><first>Vincent</first><last>Vandeghinste</last></author>
       <author><first>Frank Van</first><last>Eynde</last></author>
-      <author><first>Gerhard van</first><last>Huyssteen</last></author>
+      <author><first>Gerhard</first><last>van Huyssteen</last></author>
       <pages>677–682</pages>
       <abstract>Compared to well-resourced languages such as English and Dutch, natural language processing (NLP) tools for Afrikaans are still not abundant. In the context of the AfriBooms project, KU Leuven and the North-West University collaborated to develop a first, small treebank, a dependency parser, and an easy to use online linguistic search engine for Afrikaans for use by researchers and students in the humanities and social sciences. The search tool is based on a similar development for Dutch, i.e. GrETEL, a user-friendly search engine which allows users to query a treebank by means of a natural language example instead of a formal search instruction.</abstract>
       <url>L16-1107</url>
@@ -3808,7 +3808,7 @@
       <author><first>Marc</first><last>Kemps-Snijders</last></author>
       <author><first>Paul</first><last>Trilsbeek</last></author>
       <author><first>André</first><last>Moreira</last></author>
-      <author><first>Bas van</first><last>der Veen</last></author>
+      <author><first>Bas</first><last>van der Veen</last></author>
       <author><first>Guilherme</first><last>Silva</last></author>
       <author><first>Daniel von</first><last>Reihn</last></author>
       <pages>2478–2483</pages>
@@ -7138,7 +7138,7 @@
       <author><first>Maaike</first><last>Andringa</last></author>
       <author><first>Sigrid</first><last>Kingma</last></author>
       <author><first>Jelske</first><last>Dijkstra</last></author>
-      <author><first>Frits van</first><last>der Kuip</last></author>
+      <author><first>Frits</first><last>van der Kuip</last></author>
       <author><first>Hans Van</first><last>de Velde</last></author>
       <author><first>Frederik</first><last>Kampstra</last></author>
       <author><first>Jouke</first><last>Algra</last></author>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -3810,7 +3810,7 @@
       <author><first>André</first><last>Moreira</last></author>
       <author><first>Bas</first><last>van der Veen</last></author>
       <author><first>Guilherme</first><last>Silva</last></author>
-      <author><first>Daniel von</first><last>Reihn</last></author>
+      <author><first>Daniel</first><last>von Reihn</last></author>
       <pages>2478–2483</pages>
       <abstract>Language resources are valuable assets, both for institutions and researchers. To safeguard these resources requirements for repository systems and data management have been specified by various branch organizations, e.g., CLARIN and the Data Seal of Approval. This paper describes these and some additional ones posed by the authors’ home institutions. And it shows how they are met by FLAT, to provide a new home for language resources. The basis of FLAT is formed by the Fedora Commons repository system. This repository system can meet many of the requirements out-of-the box, but still additional configuration and some development work is needed to meet the remaining ones, e.g., to add support for Handles and Component Metadata. This paper describes design decisions taken in the construction of FLAT’s system architecture via a mix-and-match strategy, with a preference for the reuse of existing solutions. FLAT is developed and used by the Meertens Institute and The Language Archive, but is also freely available for anyone in need of a CLARIN-compliant repository for their language resources.</abstract>
       <url>L16-1393</url>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -1280,7 +1280,7 @@
     </paper>
     <paper id="132">
       <title>Automatic Enrichment of <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et with Common-Sense Knowledge</title>
-      <author><first>Luigi Di</first><last>Caro</last></author>
+      <author><first>Luigi</first><last> Caro</last></author>
       <author><first>Guido</first><last>Boella</last></author>
       <pages>819–822</pages>
       <abstract>WordNet represents a cornerstone in the Computational Linguistics field, linking words to meanings (or senses) through a taxonomical representation of synsets, i.e., clusters of words with an equivalent meaning in a specific context often described by few definitions (or glosses) and examples. Most of the approaches to the Word Sense Disambiguation task fully rely on these short texts as a source of contextual information to match with the input text to disambiguate. This paper presents the first attempt to enrich synsets data with common-sense definitions, automatically retrieved from ConceptNet 5, and disambiguated accordingly to WordNet. The aim was to exploit the shared- and immediate-thinking nature of common-sense knowledge to extend the short but incredibly useful contextual information of the synsets. A manual evaluation on a subset of the entire result (which counts a total of almost 600K synset enrichments) shows a very high precision with an estimated good recall.</abstract>
@@ -6845,8 +6845,8 @@
     <paper id="709">
       <title>Designing A Long Lasting Linguistic Project: The Case Study of <fixed-case>ASI</fixed-case>t</title>
       <author><first>Maristella</first><last>Agosti</last></author>
-      <author><first>Emanuele Di</first><last>Buccio</last></author>
-      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
+      <author><first>Emanuele</first><last> Buccio</last></author>
+      <author><first>Giorgio Maria</first><last> Nunzio</last></author>
       <author><first>Cecilia</first><last>Poletto</last></author>
       <author><first>Esther</first><last>Rinke</last></author>
       <pages>4479–4483</pages>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -1049,7 +1049,7 @@
       <author><first>Daniel</first><last>van Niekerk</last></author>
       <author><first>Ineke</first><last>Schuurman</last></author>
       <author><first>Vincent</first><last>Vandeghinste</last></author>
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <author><first>Gerhard</first><last>van Huyssteen</last></author>
       <pages>677–682</pages>
       <abstract>Compared to well-resourced languages such as English and Dutch, natural language processing (NLP) tools for Afrikaans are still not abundant. In the context of the AfriBooms project, KU Leuven and the North-West University collaborated to develop a first, small treebank, a dependency parser, and an easy to use online linguistic search engine for Afrikaans for use by researchers and students in the humanities and social sciences. The search tool is based on a similar development for Dutch, i.e. GrETEL, a user-friendly search engine which allows users to query a treebank by means of a natural language example instead of a formal search instruction.</abstract>
@@ -2736,7 +2736,7 @@
     </paper>
     <paper id="283">
       <title>Exploring the Realization of Irony in Twitter Data</title>
-      <author><first>Cynthia Van</first><last>Hee</last></author>
+      <author><first>Cynthia</first><last>Van Hee</last></author>
       <author><first>Els</first><last>Lefever</last></author>
       <author><first>Véronique</first><last>Hoste</last></author>
       <pages>1794–1799</pages>
@@ -7139,7 +7139,7 @@
       <author><first>Sigrid</first><last>Kingma</last></author>
       <author><first>Jelske</first><last>Dijkstra</last></author>
       <author><first>Frits</first><last>van der Kuip</last></author>
-      <author><first>Hans Van</first><last>de Velde</last></author>
+      <author><first>Hans</first><last>Van de Velde</last></author>
       <author><first>Frederik</first><last>Kampstra</last></author>
       <author><first>Jouke</first><last>Algra</last></author>
       <author><first>Henk</first><last>van den Heuvel</last></author>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -1280,7 +1280,7 @@
     </paper>
     <paper id="132">
       <title>Automatic Enrichment of <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et with Common-Sense Knowledge</title>
-      <author><first>Luigi</first><last> Caro</last></author>
+      <author><first>Luigi Di</first><last>Caro</last></author>
       <author><first>Guido</first><last>Boella</last></author>
       <pages>819–822</pages>
       <abstract>WordNet represents a cornerstone in the Computational Linguistics field, linking words to meanings (or senses) through a taxonomical representation of synsets, i.e., clusters of words with an equivalent meaning in a specific context often described by few definitions (or glosses) and examples. Most of the approaches to the Word Sense Disambiguation task fully rely on these short texts as a source of contextual information to match with the input text to disambiguate. This paper presents the first attempt to enrich synsets data with common-sense definitions, automatically retrieved from ConceptNet 5, and disambiguated accordingly to WordNet. The aim was to exploit the shared- and immediate-thinking nature of common-sense knowledge to extend the short but incredibly useful contextual information of the synsets. A manual evaluation on a subset of the entire result (which counts a total of almost 600K synset enrichments) shows a very high precision with an estimated good recall.</abstract>
@@ -6845,8 +6845,8 @@
     <paper id="709">
       <title>Designing A Long Lasting Linguistic Project: The Case Study of <fixed-case>ASI</fixed-case>t</title>
       <author><first>Maristella</first><last>Agosti</last></author>
-      <author><first>Emanuele</first><last> Buccio</last></author>
-      <author><first>Giorgio Maria</first><last> Nunzio</last></author>
+      <author><first>Emanuele Di</first><last>Buccio</last></author>
+      <author><first>Giorgio Maria Di</first><last>Nunzio</last></author>
       <author><first>Cecilia</first><last>Poletto</last></author>
       <author><first>Esther</first><last>Rinke</last></author>
       <pages>4479–4483</pages>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -2609,7 +2609,7 @@
     <paper id="269">
       <title>A Large-Scale Multilingual Disambiguation of Glosses</title>
       <author><first>José</first><last>Camacho-Collados</last></author>
-      <author><first>Claudio Delli</first><last>Bovi</last></author>
+      <author><first>Claudio</first><last>Delli Bovi</last></author>
       <author><first>Alessandro</first><last>Raganato</last></author>
       <author><first>Roberto</first><last>Navigli</last></author>
       <pages>1701–1708</pages>
@@ -3569,7 +3569,7 @@
     <paper id="368">
       <title><fixed-case>MWE</fixed-case>s in Treebanks: From Survey to Guidelines</title>
       <author><first>Victoria</first><last>Rosén</last></author>
-      <author><first>Koenraad De</first><last>Smedt</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <author><first>Gyri Smørdal</first><last>Losnegaard</last></author>
       <author><first>Eduard</first><last>Bejček</last></author>
       <author><first>Agata</first><last>Savary</last></author>
@@ -3893,7 +3893,7 @@
     </paper>
     <paper id="401">
       <title><fixed-case>LREC</fixed-case> as a Graph: People and Resources in a Network</title>
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Francesca</first><last>Frontini</last></author>
       <author><first>Monica</first><last>Monachini</last></author>
       <author><first>Gabriella</first><last>Pardelli</last></author>
@@ -4478,7 +4478,7 @@
     </paper>
     <paper id="465">
       <title>Rude waiter but mouthwatering pastries! An exploratory study into <fixed-case>D</fixed-case>utch Aspect-Based Sentiment Analysis</title>
-      <author><first>Orphée De</first><last>Clercq</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
       <author><first>Véronique</first><last>Hoste</last></author>
       <pages>2910–2917</pages>
       <abstract>The fine-grained task of automatically detecting all sentiment expressions within a given document and the aspects to which they refer is known as aspect-based sentiment analysis. In this paper we present the first full aspect-based sentiment analysis pipeline for Dutch and apply it to customer reviews. To this purpose, we collected reviews from two different domains, i.e. restaurant and smartphone reviews. Both corpora have been manually annotated using newly developed guidelines that comply to standard practices in the field. For our experimental pipeline we perceive aspect-based sentiment analysis as a task consisting of three main subtasks which have to be tackled incrementally: aspect term extraction, aspect category classification and polarity classification. First experiments on our Dutch restaurant corpus reveal that this is indeed a feasible approach that yields promising results.</abstract>
@@ -5469,7 +5469,7 @@
       <author><first>Helge</first><last>Dyvik</last></author>
       <author><first>Paul</first><last>Meurer</last></author>
       <author><first>Victoria</first><last>Rosén</last></author>
-      <author><first>Koenraad De</first><last>Smedt</last></author>
+      <author><first>Koenraad</first><last>De Smedt</last></author>
       <author><first>Petter</first><last>Haugereid</last></author>
       <author><first>Gyri Smørdal</first><last>Losnegaard</last></author>
       <author><first>Gunn Inger</first><last>Lyse</last></author>
@@ -6016,7 +6016,7 @@
     </paper>
     <paper id="621">
       <title>Focus Annotation of Task-based Data: A Comparison of Expert and Crowd-Sourced Annotation in a Reading Comprehension Corpus</title>
-      <author><first>Kordula De</first><last>Kuthy</last></author>
+      <author><first>Kordula</first><last>De Kuthy</last></author>
       <author><first>Ramon</first><last>Ziai</last></author>
       <author><first>Detmar</first><last>Meurers</last></author>
       <pages>3928–3935</pages>
@@ -6912,7 +6912,7 @@
       <title>New Developments in the <fixed-case>LRE</fixed-case> Map</title>
       <author><first>Vladimir</first><last>Popescu</last></author>
       <author><first>Lin</first><last>Liu</last></author>
-      <author><first>Riccardo Del</first><last>Gratta</last></author>
+      <author><first>Riccardo</first><last>Del Gratta</last></author>
       <author><first>Khalid</first><last>Choukri</last></author>
       <author><first>Nicoletta</first><last>Calzolari</last></author>
       <pages>4526–4530</pages>
@@ -6992,7 +6992,7 @@
     </paper>
     <paper id="724">
       <title>Assessing the Potential of Metaphoricity of verbs using corpus data</title>
-      <author><first>Marco Del</first><last>Tredici</last></author>
+      <author><first>Marco</first><last>Del Tredici</last></author>
       <author><first>Núria</first><last>Bel</last></author>
       <pages>4573–4577</pages>
       <abstract>The paper investigates the relation between metaphoricity and distributional characteristics of verbs, introducing POM, a corpus-derived index that can be used to define the upper bound of metaphoricity of any expression in which a given verb occurs. The work moves from the observation that while some verbs can be used to create highly metaphoric expressions, others can not. We conjecture that this fact is related to the number of contexts in which a verb occurs and to the frequency of each context. This intuition is modelled by introducing a method in which each context of a verb in a corpus is assigned a vector representation, and a clustering algorithm is employed to identify similar contexts. Eventually, the Standard Deviation of the relative frequency values of the clusters is computed and taken as the POM of the target verb. We tested POM in two experimental settings obtaining values of accuracy of 84% and 92%. Since we are convinced, along with (Shutoff, 2015), that metaphor detection systems should be concerned only with the identification of highly metaphoric expressions, we believe that POM could be profitably employed by these systems to a priori exclude expressions that, due to the verb they include, can only have low degrees of metaphoricity</abstract>

--- a/data/xml/L18.xml
+++ b/data/xml/L18.xml
@@ -2596,7 +2596,7 @@
     <paper id="334">
       <title>The Effects of Unimodal Representation Choices on Multimodal Learning</title>
       <author><first>Fernando Tadao</first> <last>Ito</last></author>
-      <author><first>Helena de Medeiros</first> <last>Caseli</last></author>
+      <author><first>Helena</first><last>de Medeiros Caseli</last></author>
       <author><first>Jander</first> <last>Moreira</last></author>
       <url>L18-1334</url>
     </paper>

--- a/data/xml/N01.xml
+++ b/data/xml/N01.xml
@@ -170,9 +170,9 @@
     </paper>
     <paper id="29">
       <title>A Structured Language Model Based on Context-Sensitive Probabilistic Left-Corner Parsing</title>
-      <author><first>Dong Hoon Van</first><last>Uytsel</last></author>
-      <author><first>Filip Van</first><last>Aelten</last></author>
-      <author><first>Dirk Van</first><last>Compernolle</last></author>
+      <author><first>Dong Hoon</first><last>Van Uytsel</last></author>
+      <author><first>Filip</first><last>Van Aelten</last></author>
+      <author><first>Dirk</first><last>Van Compernolle</last></author>
       <url>N01-1029</url>
     </paper>
     <paper id="30">

--- a/data/xml/N03.xml
+++ b/data/xml/N03.xml
@@ -54,7 +54,7 @@
     </paper>
     <paper id="7">
       <title>An Analysis of Clarification Dialogue for Question Answering</title>
-      <author><first>Marco De</first><last>Boni</last></author>
+      <author><first>Marco</first><last>De Boni</last></author>
       <author><first>Suresh</first><last>Manandhar</last></author>
       <pages>48–55</pages>
       <url>N03-1007</url>

--- a/data/xml/N13.xml
+++ b/data/xml/N13.xml
@@ -75,7 +75,7 @@
       <author><first>Kentaro</first><last>Torisawa</last></author>
       <author><first>Takao</first><last>Kawai</last></author>
       <author><first>Jun’ichi</first><last>Kazama</last></author>
-      <author><first>Stijn De</first><last>Saeger</last></author>
+      <author><first>Stijn</first><last>De Saeger</last></author>
       <pages>63–73</pages>
       <url>N13-1007</url>
       <video href="http://techtalks.tv/talks/minimally-supervised-method-for-multilingual-paraphrase-extraction/58434/" tag="video"/>

--- a/data/xml/P00.xml
+++ b/data/xml/P00.xml
@@ -204,7 +204,7 @@
     </paper>
     <paper id="26">
       <title>A Morphologically Sensitive Clustering Algorithm for Identifying <fixed-case>A</fixed-case>rabic Roots</title>
-      <author><first>Anne N. De</first><last>Roeck</last></author>
+      <author><first>Anne N.</first><last>De Roeck</last></author>
       <author><first>Waleed</first><last>Al-Fares</last></author>
       <doi>10.3115/1075218.1075244</doi>
       <pages>199–206</pages>

--- a/data/xml/P01.xml
+++ b/data/xml/P01.xml
@@ -561,7 +561,7 @@
     </paper>
     <paper id="65">
       <title>A Generic Approach to Parallel Chart Parsing with an Application to <fixed-case>L</fixed-case>in<fixed-case>GO</fixed-case></title>
-      <author><first>Marcel P. Van</first><last>Lohuizen</last></author>
+      <author><first>Marcel P.</first><last>Van Lohuizen</last></author>
       <doi>10.3115/1073012.1073077</doi>
       <pages>507–514</pages>
       <url>P01-1065</url>

--- a/data/xml/P10.xml
+++ b/data/xml/P10.xml
@@ -2095,7 +2095,7 @@
       <title>Wide-Coverage <fixed-case>NLP</fixed-case> with Linguistically Expressive Grammars</title>
       <author><first>Julia</first><last>Hockenmaier</last></author>
       <author><first>Yusuke</first><last>Miyao</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>1</pages>
       <url>P10-5001</url>
     </paper>

--- a/data/xml/P19.xml
+++ b/data/xml/P19.xml
@@ -4807,7 +4807,7 @@
     <paper id="411">
       <title>Employing the Correspondence of Relations and Connectives to Identify Implicit Discourse Relations via Label Embeddings</title>
       <author><first>Linh The</first><last>Nguyen</last></author>
-      <author><first>Linh Van</first><last>Ngo</last></author>
+      <author><first>Linh</first><last>Van Ngo</last></author>
       <author><first>Khoat</first><last>Than</last></author>
       <author><first>Thien Huu</first><last>Nguyen</last></author>
       <pages>4201–4207</pages>

--- a/data/xml/P84.xml
+++ b/data/xml/P84.xml
@@ -803,7 +803,7 @@
     <paper id="106">
       <title>NAtural Language driven Image Generation</title>
       <author><first>Giovanni</first><last>Adorni</last></author>
-      <author><first>Mauro Di</first><last>Manzo</last></author>
+      <author><first>Mauro</first><last> Manzo</last></author>
       <author><first>Fausto</first><last>Giunchiglia</last></author>
       <doi>10.3115/980491.980597</doi>
       <pages>495–500</pages>

--- a/data/xml/P84.xml
+++ b/data/xml/P84.xml
@@ -803,7 +803,7 @@
     <paper id="106">
       <title>NAtural Language driven Image Generation</title>
       <author><first>Giovanni</first><last>Adorni</last></author>
-      <author><first>Mauro</first><last> Manzo</last></author>
+      <author><first>Mauro Di</first><last>Manzo</last></author>
       <author><first>Fausto</first><last>Giunchiglia</last></author>
       <doi>10.3115/980491.980597</doi>
       <pages>495–500</pages>

--- a/data/xml/P84.xml
+++ b/data/xml/P84.xml
@@ -803,7 +803,7 @@
     <paper id="106">
       <title>NAtural Language driven Image Generation</title>
       <author><first>Giovanni</first><last>Adorni</last></author>
-      <author><first>Mauro Di</first><last>Manzo</last></author>
+      <author><first>Mauro</first><last>Di Manzo</last></author>
       <author><first>Fausto</first><last>Giunchiglia</last></author>
       <doi>10.3115/980491.980597</doi>
       <pages>495–500</pages>

--- a/data/xml/P90.xml
+++ b/data/xml/P90.xml
@@ -239,7 +239,7 @@
     </paper>
     <paper id="31">
       <title>Parsing the <fixed-case>LOB</fixed-case> Corpus</title>
-      <author><first>Carl G. de</first><last>Marcken</last></author>
+      <author><first>Carl G.</first><last>de Marcken</last></author>
       <doi>10.3115/981823.981854</doi>
       <pages>243–251</pages>
       <url>P90-1031</url>

--- a/data/xml/P98.xml
+++ b/data/xml/P98.xml
@@ -445,7 +445,7 @@
     <paper id="51">
       <title>Error Driven Word Sense Disambiguation</title>
       <author><first>Luca</first><last>Dini</last></author>
-      <author><first>Vittorio Di</first><last>Tomaso</last></author>
+      <author><first>Vittorio</first><last>Di Tomaso</last></author>
       <author><first>Frederique</first><last>Segond</last></author>
       <doi>10.3115/980845.980898</doi>
       <pages>320–324</pages>

--- a/data/xml/P98.xml
+++ b/data/xml/P98.xml
@@ -445,7 +445,7 @@
     <paper id="51">
       <title>Error Driven Word Sense Disambiguation</title>
       <author><first>Luca</first><last>Dini</last></author>
-      <author><first>Vittorio</first><last> Tomaso</last></author>
+      <author><first>Vittorio Di</first><last>Tomaso</last></author>
       <author><first>Frederique</first><last>Segond</last></author>
       <doi>10.3115/980845.980898</doi>
       <pages>320–324</pages>

--- a/data/xml/P98.xml
+++ b/data/xml/P98.xml
@@ -445,7 +445,7 @@
     <paper id="51">
       <title>Error Driven Word Sense Disambiguation</title>
       <author><first>Luca</first><last>Dini</last></author>
-      <author><first>Vittorio Di</first><last>Tomaso</last></author>
+      <author><first>Vittorio</first><last> Tomaso</last></author>
       <author><first>Frederique</first><last>Segond</last></author>
       <doi>10.3115/980845.980898</doi>
       <pages>320–324</pages>

--- a/data/xml/R09.xml
+++ b/data/xml/R09.xml
@@ -311,7 +311,7 @@
     </paper>
     <paper id="42">
       <title>The Design of an Experiment in Anaphora Resolution for Referring Expressions Generation</title>
-      <author><first>Diego Jesus de</first><last>Lucena</last></author>
+      <author><first>Diego Jesus</first><last>de Lucena</last></author>
       <author><first>Ivandré</first><last>Paraboni</last></author>
       <pages>225–229</pages>
       <url>R09-1042</url>
@@ -393,7 +393,7 @@
       <title>Unsupervised Word Sense Induction from Multiple Semantic Spaces with Locality Sensitive Hashing</title>
       <author><first>Claire</first><last>Mouton</last></author>
       <author><first>Guillaume</first><last>Pitel</last></author>
-      <author><first>Gaël de</first><last>Chalendar</last></author>
+      <author><first>Gaël</first><last>de Chalendar</last></author>
       <author><first>Anne</first><last>Vilnat</last></author>
       <pages>287–291</pages>
       <url>R09-1053</url>

--- a/data/xml/R09.xml
+++ b/data/xml/R09.xml
@@ -95,7 +95,7 @@
     <paper id="12">
       <title>Combining Finite State and Corpus-based Techniques for Unknown Word Prediction</title>
       <author><first>Kostadin</first><last>Cholakov</last></author>
-      <author><first>Gertjan van</first><last>Noord</last></author>
+      <author><first>Gertjan</first><last>van Noord</last></author>
       <pages>60–64</pages>
       <url>R09-1012</url>
     </paper>
@@ -103,7 +103,7 @@
       <title>Prototype-based Active Learning for Lemmatization</title>
       <author><first>Walter</first><last>Daelemans</last></author>
       <author><first>Hendrik J.</first><last>Groenewald</last></author>
-      <author><first>Gerhard B. van</first><last>Huyssteen</last></author>
+      <author><first>Gerhard B.</first><last>van Huyssteen</last></author>
       <pages>65–70</pages>
       <url>R09-1013</url>
     </paper>

--- a/data/xml/S15.xml
+++ b/data/xml/S15.xml
@@ -1745,7 +1745,7 @@
       <author><first>Genevieve</first> <last>Gorrell</last></author>
       <author><first>Angus</first> <last>Roberts</last></author>
       <author><first>Leon</first> <last>Derczynski</last></author>
-      <author><first>Marcos Didonet Del</first> <last>Fabro</last></author>
+      <author><first>Marcos Didonet</first><last>Del Fabro</last></author>
       <pages>835–839</pages>
       <url>S15-2141</url>
       <doi>10.18653/v1/S15-2141</doi>

--- a/data/xml/U16.xml
+++ b/data/xml/U16.xml
@@ -31,7 +31,7 @@
     <paper id="3">
       <title>The Benefits of Word Embeddings Features for Active Learning in Clinical Information Extraction</title>
       <author><first>Mahnoosh</first><last>Kholghi</last></author>
-      <author><first>Lance De</first><last>Vine</last></author>
+      <author><first>Lance</first><last>De Vine</last></author>
       <author><first>Laurianne</first><last>Sitbon</last></author>
       <author><first>Guido</first><last>Zuccon</last></author>
       <author><first>Anthony</first><last>Nguyen</last></author>

--- a/data/xml/U18.xml
+++ b/data/xml/U18.xml
@@ -41,7 +41,7 @@
     </paper>
     <paper id="4">
       <title>Unsupervised Mining of Analogical Frames by Constraint Satisfaction</title>
-      <author><first>Lance De</first><last>Vine</last></author>
+      <author><first>Lance</first><last>De Vine</last></author>
       <author><first>Shlomo</first><last>Geva</last></author>
       <author><first>Peter</first><last>Bruza</last></author>
       <pages>34–43</pages>

--- a/data/xml/W00.xml
+++ b/data/xml/W00.xml
@@ -104,7 +104,7 @@
       <title>Telicity as a Cue to Temporaland Discourse Structure in <fixed-case>C</fixed-case>hinese-<fixed-case>E</fixed-case>nglish Machine Translation</title>
       <author><first>Mari</first><last>Olsen</last></author>
       <author><first>David</first><last>Traum</last></author>
-      <author><first>Carol Van</first><last>Ess-Dykema</last></author>
+      <author><first>Carol</first><last>Van Ess-Dykema</last></author>
       <author><first>Amy</first><last>Weinberg</last></author>
       <author><first>Ron</first><last>Dolan</last></author>
       <url>W00-0205</url>
@@ -292,7 +292,7 @@
       <title>Using Summarization for Automatic Briefing Generation</title>
       <author><first>Inderjeet</first><last>Mani</last></author>
       <author><first>Kristian</first><last>Concepcion</last></author>
-      <author><first>Linda Van</first><last>Guilder</last></author>
+      <author><first>Linda</first><last>Van Guilder</last></author>
       <url>W00-0410</url>
     </paper>
   </volume>
@@ -306,7 +306,7 @@
     <paper id="1">
       <title>When is an Embedded <fixed-case>MT</fixed-case> System “Good Enough” for Filtering?</title>
       <author><first>Clare R.</first><last>Voss</last></author>
-      <author><first>Carol Van</first><last>Ess-Dykema</last></author>
+      <author><first>Carol</first><last>Van Ess-Dykema</last></author>
       <url>W00-0501</url>
     </paper>
     <paper id="2">

--- a/data/xml/W00.xml
+++ b/data/xml/W00.xml
@@ -445,7 +445,7 @@
     </paper>
     <paper id="4">
       <title>The Role of Algorithm Bias vs Information Source in Learning Algorithms for Morphosyntactic Disambiguation</title>
-      <author><first>Guy De</first><last>Pauw</last></author>
+      <author><first>Guy</first><last>De Pauw</last></author>
       <author><first>Walter</first><last>Daelemans</last></author>
       <url>W00-0704</url>
     </paper>

--- a/data/xml/W04.xml
+++ b/data/xml/W04.xml
@@ -3187,7 +3187,7 @@
     </paper>
     <paper id="14">
       <title>Bootstrapping Spoken Dialog Systems with Data Reuse</title>
-      <author><first>Guiseppe Di</first><last>Fabbrizio</last></author>
+      <author><first>Guiseppe</first><last>Di Fabbrizio</last></author>
       <author><first>Gokhan</first><last>Tur</last></author>
       <author><first>Dilek</first><last>Hakkani-Tür</last></author>
       <pages>72–80</pages>

--- a/data/xml/W04.xml
+++ b/data/xml/W04.xml
@@ -3187,7 +3187,7 @@
     </paper>
     <paper id="14">
       <title>Bootstrapping Spoken Dialog Systems with Data Reuse</title>
-      <author><first>Guiseppe Di</first><last>Fabbrizio</last></author>
+      <author><first>Guiseppe</first><last> Fabbrizio</last></author>
       <author><first>Gokhan</first><last>Tur</last></author>
       <author><first>Dilek</first><last>Hakkani-Tür</last></author>
       <pages>72–80</pages>

--- a/data/xml/W04.xml
+++ b/data/xml/W04.xml
@@ -3187,7 +3187,7 @@
     </paper>
     <paper id="14">
       <title>Bootstrapping Spoken Dialog Systems with Data Reuse</title>
-      <author><first>Guiseppe</first><last> Fabbrizio</last></author>
+      <author><first>Guiseppe Di</first><last>Fabbrizio</last></author>
       <author><first>Gokhan</first><last>Tur</last></author>
       <author><first>Dilek</first><last>Hakkani-Tür</last></author>
       <pages>72–80</pages>

--- a/data/xml/W04.xml
+++ b/data/xml/W04.xml
@@ -4459,7 +4459,7 @@
       <title>Identifying Broken Plurals in Unvowelised <fixed-case>A</fixed-case>rabic Tex</title>
       <author><first>Abduelbaset</first><last>Goweder</last></author>
       <author><first>Massimo</first><last>Poesio</last></author>
-      <author><first>Anne De</first><last>Roeck</last></author>
+      <author><first>Anne</first><last>De Roeck</last></author>
       <author><first>Jeff</first><last>Reynolds</last></author>
       <pages>246–253</pages>
       <url>W04-3232</url>

--- a/data/xml/W06.xml
+++ b/data/xml/W06.xml
@@ -4769,7 +4769,7 @@
       <title>Supporting temporal question answering: strategies for offline data collection</title>
       <author><first>David</first><last>Ahn</last></author>
       <author><first>Steven</first><last>Schockaert</last></author>
-      <author><first>Martine De</first><last>Cock</last></author>
+      <author><first>Martine</first><last>De Cock</last></author>
       <author><first>Etienne</first><last>Kerre</last></author>
       <url>W06-3913</url>
     </paper>

--- a/data/xml/W06.xml
+++ b/data/xml/W06.xml
@@ -2715,7 +2715,7 @@
     </paper>
     <paper id="11">
       <title>On the Prepositions which Introduce an Adjunct of Duration</title>
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <url>W06-2111</url>
     </paper>
     <paper id="12">

--- a/data/xml/W08.xml
+++ b/data/xml/W08.xml
@@ -1295,7 +1295,7 @@
       <booktitle>Proceedings of the Third Workshop on Innovative Use of <fixed-case>NLP</fixed-case> for Building Educational Applications</booktitle>
       <editor><first>Joel</first><last>Tetreault</last></editor>
       <editor><first>Jill</first><last>Burstein</last></editor>
-      <editor><first>Rachele De</first><last>Felice</last></editor>
+      <editor><first>Rachele</first><last>De Felice</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Columbus, Ohio</address>
       <month>June</month>

--- a/data/xml/W08.xml
+++ b/data/xml/W08.xml
@@ -2023,7 +2023,7 @@
     <paper id="6">
       <title>Mixed-Source Multi-Document Speech-to-Text Summarization</title>
       <author><first>Ricardo</first><last>Ribeiro</last></author>
-      <author><first>David Martins de</first><last>Matos</last></author>
+      <author><first>David Martins</first><last>de Matos</last></author>
       <pages>33–40</pages>
       <url>W08-1406</url>
     </paper>

--- a/data/xml/W09.xml
+++ b/data/xml/W09.xml
@@ -1030,7 +1030,7 @@
       <editor><first>Lori</first><last>Levin</last></editor>
       <editor><first>John</first><last>Kiango</last></editor>
       <editor><first>Judith</first><last>Klavans</last></editor>
-      <editor><first>Guy De</first><last>Pauw</last></editor>
+      <editor><first>Guy</first><last>De Pauw</last></editor>
       <editor><first>Gilles-Maurice</first><last>de Schryver</last></editor>
       <editor><first>Peter Waiganjo</first><last>Wagacha</last></editor>
       <publisher>Association for Computational Linguistics</publisher>

--- a/data/xml/W09.xml
+++ b/data/xml/W09.xml
@@ -6380,7 +6380,7 @@
     </paper>
     <paper id="7">
       <title>Extracting Sense-Disambiguated Example Sentences From Parallel Corpora</title>
-      <author><first>Gerard de</first><last>Melo</last></author>
+      <author><first>Gerard</first><last>de Melo</last></author>
       <author><first>Gerhard</first><last>Weikum</last></author>
       <pages>40–46</pages>
       <url>W09-4407</url>

--- a/data/xml/W10.xml
+++ b/data/xml/W10.xml
@@ -1721,7 +1721,7 @@
       <title>Computational Linguistics in Brazil: An Overview</title>
       <author><first>Thiago</first><last>Pardo</last></author>
       <author><first>Caroline</first><last>Gasperin</last></author>
-      <author><first>Helena de Medeiros</first><last>Caseli</last></author>
+      <author><first>Helena</first><last>de Medeiros Caseli</last></author>
       <author><first>Maria das Graças</first><last>Nunes</last></author>
       <pages>1–7</pages>
       <url>W10-1601</url>
@@ -1742,7 +1742,7 @@
     </paper>
     <paper id="4">
       <title>Using Common Sense to generate culturally contextualized Machine Translation</title>
-      <author><first>Helena de Medeiros</first><last>Caseli</last></author>
+      <author><first>Helena</first><last>de Medeiros Caseli</last></author>
       <author><first>Bruno Akio</first><last>Sugiyama</last></author>
       <author><first>Junia Coutinho</first><last>Anacleto</last></author>
       <pages>24–31</pages>
@@ -2709,7 +2709,7 @@
     </paper>
     <paper id="35">
       <title>An Integrated Tool for Annotating Historical Corpora</title>
-      <author><first>Pablo Picasso Feliciano de</first><last>Faria</last></author>
+      <author><first>Pablo Picasso Feliciano</first><last>de Faria</last></author>
       <author><first>Fabio Natanael</first><last>Kepler</last></author>
       <author><first>Maria Clara</first><last>Paixão de Sousa</last></author>
       <pages>217–221</pages>

--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -227,7 +227,7 @@
       <title><fixed-case>DISCUSS</fixed-case>: A dialogue move taxonomy layered over semantic representations</title>
       <author><first>Lee</first><last>Becker</last></author>
       <author><first>Wayne</first><last>Ward</last></author>
-      <author><first>Sarel van</first><last>Vuuren</last></author>
+      <author><first>Sarel</first><last>van Vuuren</last></author>
       <author><first>Martha</first><last>Palmer</last></author>
       <url>W11-0133</url>
     </paper>

--- a/data/xml/W12.xml
+++ b/data/xml/W12.xml
@@ -7100,7 +7100,7 @@
       <title>System Combination with Extra Alignment Information</title>
       <author><first>Xiaofeng</first><last>Wu</last></author>
       <author><first>Tsuyoshi</first><last>Okita</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <author><first>Qun</first><last>Liu</last></author>
       <pages>37–44</pages>
       <url>W12-5704</url>
@@ -7109,7 +7109,7 @@
       <title>Topic Modeling-based Domain Adaptation for System Combination</title>
       <author><first>Tsuyoshi</first><last>Okita</last></author>
       <author><first>Antonio</first><last>Toral</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>45–54</pages>
       <url>W12-5705</url>
     </paper>
@@ -7117,7 +7117,7 @@
       <title>Sentence-Level Quality Estimation for <fixed-case>MT</fixed-case> System Combination</title>
       <author><first>Tsuyoshi</first><last>Okita</last></author>
       <author><first>Raphaël</first><last>Rubino</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>55–64</pages>
       <url>W12-5706</url>
     </paper>
@@ -7140,7 +7140,7 @@
       <author><first>Maite</first><last>Melero</last></author>
       <author><first>Marta R.</first><last>Costa-Jussa</last></author>
       <author><first>Toni</first><last>Badia</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>85–90</pages>
       <url>W12-5709</url>
     </paper>

--- a/data/xml/W12.xml
+++ b/data/xml/W12.xml
@@ -5522,7 +5522,7 @@
     <meta>
       <booktitle>Proceedings of the Workshop on Detecting Structure in Scholarly Discourse</booktitle>
       <url>W12-43</url>
-      <editor><first>Antal Van Den</first><last>Bosch</last></editor>
+      <editor><first>Antal</first><last>Van Den Bosch</last></editor>
       <editor><first>Hagit</first><last>Shatkay</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Jeju Island, Korea</address>

--- a/data/xml/W13.xml
+++ b/data/xml/W13.xml
@@ -1890,7 +1890,7 @@
     </frontmatter>
     <paper id="1">
       <title>Computing the Most Probable String with a Probabilistic Finite State Machine</title>
-      <author><first>Colin de la</first><last>Higuera</last></author>
+      <author><first>Colin</first><last>de la Higuera</last></author>
       <author><first>Jose</first><last>Oncina</last></author>
       <pages>1–8</pages>
       <url>W13-1801</url>
@@ -5404,7 +5404,7 @@
     </paper>
     <paper id="21">
       <title>More Constructions, More Genres: Extending <fixed-case>S</fixed-case>tanford Dependencies</title>
-      <author><first>Marie-Catherine de</first><last>Marneffe</last></author>
+      <author><first>Marie-Catherine</first><last>de Marneffe</last></author>
       <author><first>Miriam</first><last>Connor</last></author>
       <author><first>Natalia</first><last>Silveira</last></author>
       <author><first>Samuel R.</first><last>Bowman</last></author>

--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -8278,7 +8278,7 @@
       <author><first>Dipankar</first><last>Das</last></author>
       <author><first>Sudip Kumar</first><last>Naskar</last></author>
       <author><first>Sivaji</first><last>Bandyopadhyay</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>89–94</pages>
       <url>W14-5114</url>
     </paper>

--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -420,7 +420,7 @@
     <paper id="52">
       <title>Embedding <fixed-case>N</fixed-case>om<fixed-case>L</fixed-case>ex-<fixed-case>BR</fixed-case> nominalizations into <fixed-case>O</fixed-case>pen<fixed-case>W</fixed-case>ordnet-<fixed-case>PT</fixed-case></title>
       <author><first>Alexandre</first><last>Rademaker</last></author>
-      <author><first>Valeria de</first><last>Paiva</last></author>
+      <author><first>Valeria</first><last>de Paiva</last></author>
       <author><first>Gerard</first><last>de Melo</last></author>
       <author><first>Livy Maria Real</first><last>Coelho</last></author>
       <pages>378-382</pages>
@@ -429,7 +429,7 @@
     <paper id="53">
       <title><fixed-case>O</fixed-case>pen<fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et-<fixed-case>PT</fixed-case>: A Project Report</title>
       <author><first>Alexandre</first><last>Rademaker</last></author>
-      <author><first>Valeria de</first><last>Paiva</last></author>
+      <author><first>Valeria</first><last>de Paiva</last></author>
       <author><first>Gerard</first><last>de Melo</last></author>
       <author><first>Livy</first><last>Real</last></author>
       <author><first>Maira</first><last>Gatti</last></author>
@@ -4273,7 +4273,7 @@
       <booktitle>Proceedings of Frame Semantics in <fixed-case>NLP</fixed-case>: A Workshop in Honor of Chuck <fixed-case>F</fixed-case>illmore (1929-2014)</booktitle>
       <url>W14-30</url>
       <editor><first>Miriam R. L.</first> <last>Petruck</last></editor>
-      <editor><first>Gerard de</first> <last>Melo</last></editor>
+      <editor><first>Gerard</first><last>de Melo</last></editor>
       <doi>10.3115/v1/W14-30</doi>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Baltimore, MD, USA</address>
@@ -10718,7 +10718,7 @@
     </paper>
     <paper id="2">
       <title>Bilingual Sentence Alignment of a Parallel Corpus by Using <fixed-case>E</fixed-case>nglish as a Pivot Language</title>
-      <author><first>Josafá de Jesus Aguiar</first> <last>Pontes</last></author>
+      <author><first>Josafá</first><last>de Jesus Aguiar Pontes</last></author>
       <pages>13-20</pages>
       <url>W14-6902</url>
       <doi>10.3115/v1/W14-6902</doi>

--- a/data/xml/W15.xml
+++ b/data/xml/W15.xml
@@ -9837,7 +9837,7 @@
     <paper id="18">
       <title>On Strategies of Human Multi-Document Summarization</title>
       <author><first>Renata Tironi</first><last>de Camargo</last></author>
-      <author><first>Ariani</first><last> Felippo</last></author>
+      <author><first>Ariani Di</first><last>Felippo</last></author>
       <author><first>Thiago A. S.</first><last>Pardo</last></author>
       <pages>141-150</pages>
       <url>W15-5618</url>

--- a/data/xml/W15.xml
+++ b/data/xml/W15.xml
@@ -8857,12 +8857,12 @@
       <title>Smart Computer Aided Translation Environment - <fixed-case>SCATE</fixed-case></title>
       <author><first>Vincent</first><last>Vandeghinste</last></author>
       <author><first>Tom</first><last>Vanallemeersch</last></author>
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <author><first>Geert</first><last>Heyman</last></author>
       <author><first>Sien</first><last>Moens</last></author>
       <author><first>Joris</first><last>Pelemans</last></author>
       <author><first>Patrick</first><last>Wambacq</last></author>
-      <author><first>Iulianna Van</first><last>der Lek - Ciudin</last></author>
+      <author><first>Iulianna</first><last>Van der Lek - Ciudin</last></author>
       <author><first>Arda</first><last>Tezcan</last></author>
       <author><first>Lieve</first><last>Macken</last></author>
       <author><first>Véronique</first><last>Hoste</last></author>
@@ -9227,7 +9227,7 @@
       <author><first>Leen</first><last>Sevens</last></author>
       <author><first>Vincent</first><last>Vandeghinste</last></author>
       <author><first>Ineke</first><last>Schuurman</last></author>
-      <author><first>Frank Van</first><last>Eynde</last></author>
+      <author><first>Frank</first><last>Van Eynde</last></author>
       <pages>110–117</pages>
       <url>W15-5119</url>
       <doi>10.18653/v1/W15-5119</doi>

--- a/data/xml/W15.xml
+++ b/data/xml/W15.xml
@@ -9837,7 +9837,7 @@
     <paper id="18">
       <title>On Strategies of Human Multi-Document Summarization</title>
       <author><first>Renata Tironi</first><last>de Camargo</last></author>
-      <author><first>Ariani Di</first><last>Felippo</last></author>
+      <author><first>Ariani</first><last>Di Felippo</last></author>
       <author><first>Thiago A. S.</first><last>Pardo</last></author>
       <pages>141-150</pages>
       <url>W15-5618</url>

--- a/data/xml/W15.xml
+++ b/data/xml/W15.xml
@@ -9837,7 +9837,7 @@
     <paper id="18">
       <title>On Strategies of Human Multi-Document Summarization</title>
       <author><first>Renata Tironi</first><last>de Camargo</last></author>
-      <author><first>Ariani Di</first><last>Felippo</last></author>
+      <author><first>Ariani</first><last> Felippo</last></author>
       <author><first>Thiago A. S.</first><last>Pardo</last></author>
       <pages>141-150</pages>
       <url>W15-5618</url>

--- a/data/xml/W15.xml
+++ b/data/xml/W15.xml
@@ -9941,7 +9941,7 @@
     </paper>
     <paper id="5">
       <title>Evaluating a Machine Translation System in a Technical Support Scenario</title>
-      <author><first>Rosa Del</first><last>Gaudio</last></author>
+      <author><first>Rosa</first><last>Del Gaudio</last></author>
       <author><first>Aljoscha</first><last>Burchardt</last></author>
       <author><first>Arle</first><last>Lommel</last></author>
       <pages>39–47</pages>

--- a/data/xml/W16.xml
+++ b/data/xml/W16.xml
@@ -5199,7 +5199,7 @@
       <author><first>José</first> <last>Castaño</last></author>
       <author><first>María Laura</first> <last>Gambarte</last></author>
       <author><first>Hee Joon</first> <last>Park</last></author>
-      <author><first>Maria del Pilar</first> <last>Avila Williams</last></author>
+      <author><first>Maria</first><last>del Pilar Avila Williams</last></author>
       <author><first>David</first> <last>Pérez</last></author>
       <author><first>Fernando</first> <last>Campos</last></author>
       <author><first>Daniel</first> <last>Luna</last></author>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -12145,7 +12145,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Graph Databases for Designing High-Performance Speech Recognition Grammars</title>
-      <author><first>Maria</first><last> Maro</last></author>
+      <author><first>Maria Di</first><last>Maro</last></author>
       <author><first>Marco</first><last>Valentino</last></author>
       <author><first>Anna</first><last>Riccio</last></author>
       <author><first>Antonio</first><last>Origlia</last></author>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -12145,7 +12145,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Graph Databases for Designing High-Performance Speech Recognition Grammars</title>
-      <author><first>Maria Di</first><last>Maro</last></author>
+      <author><first>Maria</first><last>Di Maro</last></author>
       <author><first>Marco</first><last>Valentino</last></author>
       <author><first>Anna</first><last>Riccio</last></author>
       <author><first>Antonio</first><last>Origlia</last></author>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -12145,7 +12145,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="7">
       <title>Graph Databases for Designing High-Performance Speech Recognition Grammars</title>
-      <author><first>Maria Di</first><last>Maro</last></author>
+      <author><first>Maria</first><last> Maro</last></author>
       <author><first>Marco</first><last>Valentino</last></author>
       <author><first>Anna</first><last>Riccio</last></author>
       <author><first>Antonio</first><last>Origlia</last></author>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -12007,7 +12007,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
     </paper>
     <paper id="4">
       <title>Semantic Variation in Online Communities of Practice</title>
-      <author><first>Marco Del</first><last>Tredici</last></author>
+      <author><first>Marco</first><last>Del Tredici</last></author>
       <author><first>Raquel</first><last>Fernández</last></author>
       <url>W17-6804</url>
     </paper>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -12343,7 +12343,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
       <title>Skip-Prop: Representing Sentences with One Vector Per Proposition</title>
       <author><first>Rachel</first><last>Rudinger</last></author>
       <author><first>Kevin</first><last>Duh</last></author>
-      <author><first>Benjamin Van</first><last>Durme</last></author>
+      <author><first>Benjamin</first><last>Van Durme</last></author>
       <url>W17-6936</url>
     </paper>
     <paper id="37">
@@ -12410,7 +12410,7 @@ with emotion annotation. We (a) analyse annotation reliability and annotation me
       <title>An Evaluation of <fixed-case>P</fixed-case>red<fixed-case>P</fixed-case>att and Open <fixed-case>IE</fixed-case> via Stage 1 Semantic Role Labeling</title>
       <author><first>Sheng</first><last>Zhang</last></author>
       <author><first>Rachel</first><last>Rudinger</last></author>
-      <author><first>Benjamin Van</first><last>Durme</last></author>
+      <author><first>Benjamin</first><last>Van Durme</last></author>
       <url>W17-6944</url>
     </paper>
   </volume>

--- a/data/xml/W18.xml
+++ b/data/xml/W18.xml
@@ -4501,7 +4501,7 @@
       <author><first>Khyathi</first><last>Chandu</last></author>
       <author><first>Ekaterina</first><last>Loginova</last></author>
       <author><first>Vishal</first><last>Gupta</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <author><first>Günter</first><last>Neumann</last></author>
       <author><first>Manoj</first><last>Chinnakotla</last></author>
       <author><first>Eric</first><last>Nyberg</last></author>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -13709,11 +13709,11 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     </paper>
     <paper id="17">
       <title>APE-QUEST</title>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <author><first>Heidi</first><last>Depraetere</last></author>
       <author><first>Sara</first><last>Szoc</last></author>
       <author><first>Tom</first><last>Vanallemeersch</last></author>
-      <author><first>Koen Van</first><last>Winckel</last></author>
+      <author><first>Koen</first><last>Van Winckel</last></author>
       <author><first>Frederic</first><last>Everaert</last></author>
       <author><first>Lucia</first><last>Specia</last></author>
       <author><first>Julia</first><last>Ive</last></author>
@@ -13743,11 +13743,11 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     </paper>
     <paper id="20">
       <title>MICE</title>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <author><first>Heidi</first><last>Depraetere</last></author>
       <author><first>Tom</first><last>Vanallemeersch</last></author>
       <author><first>Frederic</first><last>Everaert</last></author>
-      <author><first>Koen Van</first><last>Winckel</last></author>
+      <author><first>Koen</first><last>Van Winckel</last></author>
       <author><first>Katri</first><last>Tammsaar</last></author>
       <author><first>Ingmar</first><last>Vali</last></author>
       <author><first>Tambet</first><last>Artma</last></author>
@@ -13883,10 +13883,10 @@ One of the references was wrong therefore it is corrected to cite the appropriat
       <author><first>Tom</first><last>Vanallemeersch</last></author>
       <author><first>Sara</first><last>Szoc</last></author>
       <author><first>Frederic</first><last>Everaert</last></author>
-      <author><first>Koen Van</first><last>Winckel</last></author>
+      <author><first>Koen</first><last>Van Winckel</last></author>
       <author><first>Kim</first><last>Scholte</last></author>
       <author><first>Joris</first><last>Brabers</last></author>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <pages>186–195</pages>
       <url>W19-6733</url>
     </paper>
@@ -14002,8 +14002,8 @@ One of the references was wrong therefore it is corrected to cite the appropriat
       <author><first>Joris</first><last>Brabers</last></author>
       <author><first>Frederic</first><last>Everaert</last></author>
       <author><first>Kim</first><last>Scholte</last></author>
-      <author><first>Koen Van</first><last>Winckel</last></author>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Koen</first><last>Van Winckel</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <pages>32–38</pages>
       <url>W19-6806</url>
     </paper>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -1100,7 +1100,7 @@
       <editor><first>Roman</first><last>Klinger</last></editor>
       <editor><first>Veronique</first><last>Hoste</last></editor>
       <editor><first>Carlo</first><last>Strapparava</last></editor>
-      <editor><first>Orphee De</first><last>Clercq</last></editor>
+      <editor><first>Orphee</first><last>De Clercq</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Minneapolis, USA</address>
       <month>June</month>
@@ -11705,7 +11705,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     <paper id="2">
       <title><fixed-case>S</fixed-case>ensing Tree Automata as a Model of Syntactic Dependencies</title>
       <author><first>Thomas</first><last>Graf</last></author>
-      <author><first>Aniello De</first><last>Santo</last></author>
+      <author><first>Aniello</first><last>De Santo</last></author>
       <pages>12–26</pages>
       <url>W19-5702</url>
       <doi>10.18653/v1/W19-5702</doi>
@@ -13174,7 +13174,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
       <title>The Impact of Spelling Correction and Task Context on Short Answer Assessment for Intelligent Tutoring Systems</title>
       <author><first>Ramon</first><last>Ziai</last></author>
       <author><first>Florian</first><last>Nuxoll</last></author>
-      <author><first>Kordula De</first><last>Kuthy</last></author>
+      <author><first>Kordula</first><last>De Kuthy</last></author>
       <author><first>Björn</first><last>Rudzewitz</last></author>
       <author><first>Detmar</first><last>Meurers</last></author>
       <pages>93–99</pages>
@@ -14185,7 +14185,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     <paper id="2">
       <title>Modelling word translation entropy and syntactic equivalence with machine learning</title>
       <author><first>Bram</first><last>Vanroy</last></author>
-      <author><first>Orphée De</first><last>Clercq</last></author>
+      <author><first>Orphée</first><last>De Clercq</last></author>
       <author><first>Lieve</first><last>Macken</last></author>
       <pages>3–4</pages>
       <url>W19-7002</url>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -13361,7 +13361,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     </paper>
     <paper id="3">
       <title>Enhancing Transformer for End-to-end Speech-to-Text Translation</title>
-      <author><first>Mattia Antonino Di</first><last>Gangi</last></author>
+      <author><first>Mattia Antonino</first><last>Di Gangi</last></author>
       <author><first>Matteo</first><last>Negri</last></author>
       <author><first>Roldano</first><last>Cattoni</last></author>
       <author><first>Roberto</first><last>Dessi</last></author>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -13361,7 +13361,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     </paper>
     <paper id="3">
       <title>Enhancing Transformer for End-to-end Speech-to-Text Translation</title>
-      <author><first>Mattia Antonino Di</first><last>Gangi</last></author>
+      <author><first>Mattia Antonino</first><last> Gangi</last></author>
       <author><first>Matteo</first><last>Negri</last></author>
       <author><first>Roldano</first><last>Cattoni</last></author>
       <author><first>Roberto</first><last>Dessi</last></author>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -13361,7 +13361,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     </paper>
     <paper id="3">
       <title>Enhancing Transformer for End-to-end Speech-to-Text Translation</title>
-      <author><first>Mattia Antonino</first><last> Gangi</last></author>
+      <author><first>Mattia Antonino Di</first><last>Gangi</last></author>
       <author><first>Matteo</first><last>Negri</last></author>
       <author><first>Roldano</first><last>Cattoni</last></author>
       <author><first>Roberto</first><last>Dessi</last></author>

--- a/data/xml/W97.xml
+++ b/data/xml/W97.xml
@@ -670,8 +670,8 @@
       <title>A practical Message-to-Speech strategy for dialogue systems</title>
       <author id="peter-spyns"><first>P.</first><last>Spyns</last></author>
       <author><first>F.</first><last>Deprez</last></author>
-      <author><first>L. Van</first><last>Tichelen</last></author>
-      <author><first>B. Van</first><last>Coile</last></author>
+      <author><first>L.</first><last>Van Tichelen</last></author>
+      <author><first>B.</first><last>Van Coile</last></author>
       <url>W97-0608</url>
     </paper>
     <paper id="9">
@@ -1201,8 +1201,8 @@
       <title>Message-to-Speech: high quality speech generation for messaging and dialogue systems</title>
       <author id="peter-spyns"><first>P.</first><last>Spyns</last></author>
       <author><first>F.</first><last>Deprez</last></author>
-      <author><first>L. Van</first><last>Tichelen</last></author>
-      <author><first>B. Van</first><last>Coile</last></author>
+      <author><first>L.</first><last>Van Tichelen</last></author>
+      <author><first>B.</first><last>Van Coile</last></author>
       <url>W97-1202</url>
     </paper>
     <paper id="3">

--- a/data/xml/W97.xml
+++ b/data/xml/W97.xml
@@ -228,7 +228,7 @@
     <paper id="11">
       <title>Towards a Bootstrapping Framework for Corpus Semantic Tagging</title>
       <author><first>Roberto</first><last>Basili</last></author>
-      <author><first>Michelangelo Della</first><last>Rocca</last></author>
+      <author><first>Michelangelo</first><last>Della Rocca</last></author>
       <author><first>Maria Teresa</first><last>Pazienza</last></author>
       <url>W97-0211</url>
     </paper>
@@ -364,7 +364,7 @@
     <paper id="14">
       <title>Inducing Terminology for Lexical Acquisition</title>
       <author><first>Roberto</first><last>Basili</last></author>
-      <author><first>Gianluca De</first><last>Rossi</last></author>
+      <author><first>Gianluca</first><last>De Rossi</last></author>
       <author><first>Maria Teresa</first><last>Pazienza</last></author>
       <url>W97-0314</url>
     </paper>
@@ -1349,7 +1349,7 @@
     <paper id="2">
       <title>Referring in Multimodal Systems: The Importance of User Expertise and System Features</title>
       <author><first>Daniela</first><last>Petrelli</last></author>
-      <author><first>Antonella De</first><last>Angeli</last></author>
+      <author><first>Antonella</first><last>De Angeli</last></author>
       <author><first>Walter</first><last>Gerbino</last></author>
       <author><first>Giulia</first><last>Cassano</last></author>
       <url>W97-1402</url>

--- a/data/xml/Y04.xml
+++ b/data/xml/Y04.xml
@@ -142,7 +142,7 @@
       <author><first>Rowena</first><last>Chan</last></author>
       <author><first>Ruth</first><last>O’Donovan</last></author>
       <author><first>Adams</first><last>Bodomo</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <author><first>Andy</first><last>Way</last></author>
       <pages>161–172</pages>
       <url>Y04-1016</url>

--- a/data/xml/Y07.xml
+++ b/data/xml/Y07.xml
@@ -313,7 +313,7 @@
     <paper id="39">
       <title>Automatic Acquisition of <fixed-case>L</fixed-case>exical-<fixed-case>F</fixed-case>unctional <fixed-case>G</fixed-case>rammar Resources from a <fixed-case>J</fixed-case>apanese Dependency Corpus</title>
       <author><first>Masanori</first><last>Oya</last></author>
-      <author><first>Josef van</first><last>Genabith</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
       <pages>375–384</pages>
       <url>Y07-1039</url>
       <doi>http://hdl.handle.net/2065/29140</doi>

--- a/data/xml/Y10.xml
+++ b/data/xml/Y10.xml
@@ -588,7 +588,7 @@
       <author><first>Kazuki</first><last>Takigawa</last></author>
       <author><first>Masaki</first><last>Murata</last></author>
       <author><first>Masaaki</first><last>Tsuchida</last></author>
-      <author><first>Stijn De</first><last>Saeger</last></author>
+      <author><first>Stijn</first><last>De Saeger</last></author>
       <author><first>Kazuhide</first><last>Yamamoto</last></author>
       <author><first>Kentaro</first><last>Torisawa</last></author>
       <pages>693–700</pages>

--- a/data/xml/Y12.xml
+++ b/data/xml/Y12.xml
@@ -218,7 +218,7 @@
     <paper id="29">
       <title>Nominative-marked Phrases in <fixed-case>J</fixed-case>apanese Tough Constructions</title>
       <author><first>Akira</first><last>Ohtani</last></author>
-      <author><first>Maria del Pilar Valverde</first><last>Ibanez</last></author>
+      <author><first>Maria</first><last>del Pilar Valverde Ibanez</last></author>
       <pages>272–279</pages>
       <url>Y12-1029</url>
     </paper>
@@ -239,7 +239,7 @@
     </paper>
     <paper id="32">
       <title>Automatic Detection of Gender and Number Agreement Errors in <fixed-case>S</fixed-case>panish Texts Written by <fixed-case>J</fixed-case>apanese Learners</title>
-      <author><first>Maria del Pilar Valverde</first><last>Ibanez</last></author>
+      <author><first>Maria</first><last>del Pilar Valverde Ibanez</last></author>
       <author><first>Akira</first><last>Ohtani</last></author>
       <pages>299–307</pages>
       <url>Y12-1032</url>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -915,7 +915,6 @@
   id: philippe-boula-de-mareuil
   variants:
   - {first: Philippe Boula, last: de Mareüil}
-  - {first: Philippe Boula de, last: Mareüil}
 - canonical: {first: Gilles, last: Boulianne}
   id: gilles-boulianne
 - canonical: {first: Paolo, last: Bouquet}
@@ -2057,44 +2056,21 @@
 - canonical: {first: Vitor, last: De Araujo}
   variants:
   - {first: Vítor, last: Araújo}
-- canonical: {first: Marco, last: De Boni}
-  variants:
-  - {first: Marco De, last: Boni}
-- canonical: {first: Diego, last: De Cao}
-  variants:
-  - {first: Diego De, last: Cao}
 - canonical: {first: Orphee, last: De Clercq}
   variants:
   - {first: Orphée, last: De Clercq}
-  - {first: Orphée De, last: Clercq}
-  - {first: Orphee De, last: Clercq}
-- canonical: {first: Simon, last: De Deyne}
-  variants:
-  - {first: Simon De, last: Deyne}
-- canonical: {first: Rachele, last: De Felice}
-  variants:
-  - {first: Rachele De, last: Felice}
 - canonical: {first: Georges, last: De Moor}
   id: georges-de-moor
 - canonical: {first: Renato, last: De Mori}
   variants:
   - {first: Renato, last: de Mori}
-  - {first: Renato De, last: Mori}
-  - {first: Renato de, last: Mori}
 - canonical: {first: Anne, last: De Roeck}
   variants:
   - {first: Anne, last: DeRoeck}
-  - {first: Anne De, last: Roeck}
   - {first: Anne, last: de Roeck}
   - {first: Anne, last: deRoeck}
-  - {first: A.N. De, last: Roeck}
-  - {first: Anne N. De, last: Roeck}
-- canonical: {first: Stijn, last: De Saeger}
-  variants:
-  - {first: Stijn De, last: Saeger}
-- canonical: {first: Lance, last: De Vine}
-  variants:
-  - {first: Lance De, last: Vine}
+  - {first: A.N., last: De Roeck}
+  - {first: Anne N., last: De Roeck}
 - canonical: {first: Ángel, last: De la Torre}
   id: angel-de-la-torre
 - canonical: {first: Jonathan, last: DeCristofaro}
@@ -2105,16 +2081,12 @@
   - {first: Aina Garí, last: Soler}
 - canonical: {first: Rosa, last: Del Gaudio}
   variants:
-  - {first: Rosa Del, last: Gaudio}
   - {first: Rosa, last: Gaudio}
 - canonical: {first: Iria, last: Del Río Gayo}
   variants:
   - {first: Iria, last: del Río Gayo}
   - {first: Iria, last: del Río}
   - {first: Iria, last: del Rio}
-- canonical: {first: Marco, last: Del Tredici}
-  variants:
-  - {first: Marco Del, last: Tredici}
 - canonical: {first: Elisabeth, last: Delais-Roussarie}
   variants:
   - {first: Élisabeth, last: Delais-Roussarie}
@@ -2191,15 +2163,11 @@
 - canonical: {first: Luigi, last: Di Caro}
   variants:
   - {first: Luigi, last: di Caro}
-  - {first: Luigi Di, last: Caro}
 - canonical: {first: Giuseppe, last: Di Fabbrizio}
   variants:
   - {first: Giuseppe, last: Fabbrizio}
-  - {first: Giuseppe Di, last: Fabbrizio}
 - canonical: {first: Vittorio, last: Di Tomaso}
   id: vittorio-di-tomaso
-  variants:
-  - {first: Vittorio Di, last: Tomaso}
 - canonical: {first: Chrysanne, last: DiMarco}
   variants:
   - {first: Chrysanne, last: Di Marco}
@@ -2529,11 +2497,10 @@
 - canonical: {first: Miquel, last: Esplà-Gomis}
   variants:
   - {first: Miquel, last: Esplà}
-- canonical: {first: Carol Van, last: Ess-Dykema}
+- canonical: {first: Carol, last: Van Ess-Dykema}
   variants:
-  - {first: Carol J. Van, last: Ess-Dykema}
+  - {first: Carol J., last: Van Ess-Dykema}
   - {first: Carol, last: VanEss-Dykema}
-  - {first: Carol, last: Van Ess-Dykema}
 - canonical: {first: Dominique, last: Estival}
   id: dominique-estival
 - canonical: {first: David A., last: Evans}
@@ -3314,10 +3281,9 @@
 - canonical: {first: Robert, last: Granville}
   variants:
   - {first: Robert Alan, last: Granville}
-- canonical: {first: Riccardo Del, last: Gratta}
+- canonical: {first: Riccardo, last: Del Gratta}
   variants:
-  - {first: Riccardo, last: Del Gratta}
-  - {first: Riccardo del, last: Gratta}
+  - {first: Riccardo, last: del Gratta}
 - canonical: {first: Agustin, last: Gravano}
   variants:
   - {first: Agustín, last: Gravano}
@@ -5528,7 +5494,7 @@
   - {first: Roque, last: López}
 - canonical: {first: Oier, last: Lopez de Lacalle}
   variants:
-  - {first: Oier López de, last: Lacalle}
+  - {first: Oier López, last: de Lacalle}
   - {first: Oier Lopez, last: de Lacalle}
   - {first: Oier, last: López de Lacalle}
 - canonical: {first: Alina Beatrice, last: Lorent}
@@ -5918,7 +5884,6 @@
 - canonical: {first: David, last: Martins de Matos}
   variants:
   - {first: David Martins, last: de Matos}
-  - {first: David Martins de, last: Matos}
   - {first: David M., last: de Matos}
 - canonical: {first: M. Antònia, last: Martí}
   id: m-antonia-marti
@@ -6851,10 +6816,9 @@
 - canonical: {first: Rita, last: Nuebel}
   variants:
   - {first: Rita, last: Nüebel}
-- canonical: {first: Giorgio Maria Di, last: Nunzio}
+- canonical: {first: Giorgio Maria, last: Di Nunzio}
   variants:
-  - {first: Giorgio Di, last: Nunzio}
-  - {first: Giorgio Maria, last: Di Nunzio}
+  - {first: Giorgio, last: Di Nunzio}
 - canonical: {first: Minghua, last: Nuo}
   variants:
   - {first: Ming Hua, last: Nuo}
@@ -9377,29 +9341,19 @@
 - canonical: {first: M. Pilar, last: Valverde Ibáñez}
   variants:
   - {first: M. Pilar, last: Valverde Ibañez}
-- canonical: {first: Benjamin, last: Van Durme}
-  variants:
-  - {first: Benjamin Van, last: Durme}
-- canonical: {first: Cynthia, last: Van Hee}
-  variants:
-  - {first: Cynthia Van, last: Hee}
 - canonical: {first: Marjo, last: Van Koppen}
   variants:
   - {first: Marjo, last: van Koppen}
 - canonical: {first: Tim, last: Van de Cruys}
   variants:
-  - {first: Tim Van de, last: Cruys}
   - {first: Tim, last: Van De Cruys}
-- canonical: {first: Marjan, last: Van de Kauter}
-  variants:
-  - {first: Marjan Van, last: de Kauter}
 - canonical: {first: Aline A., last: Vanin}
   variants:
   - {first: Aline, last: Vanin}
 - canonical: {first: Tristan, last: Vanrullen}
   variants:
   - {first: Tristan, last: van Rullen}
-  - {first: Tristan Van, last: Rullen}
+  - {first: Tristan, last: Van Rullen}
 - canonical: {first: Jerome, last: Vapillon}
   id: jerome-vapillon
 - canonical: {first: Dániel, last: Varga}
@@ -10233,23 +10187,16 @@
   variants:
   - {first: Guadalupe, last: Aguado de Cea}
   - {first: Guadalupe, last: Aguado-de-Cea}
-- canonical: {first: Gaël, last: de Chalendar}
-  variants:
-  - {first: Gaël de, last: Chalendar}
 - canonical: {first: Ricardo, last: de Córdoba}
   variants:
   - {first: Ricardo, last: de Cordoba}
 - canonical: {first: Adrià, last: de Gispert}
   variants:
-  - {first: Adrià de, last: Gispert}
   - {first: Adrià, last: Gispert}
   - {first: Adrià, last: De Gispert}
 - canonical: {first: Clément, last: de Groc}
   variants:
-  - {first: Clément De, last: Groc}
-- canonical: {first: Josafá, last: de Jesus Aguiar Pontes}
-  variants:
-  - {first: Josafá de Jesus Aguiar, last: Pontes}
+  - {first: Clément, last: De Groc}
 - canonical: {first: Maddalen Lopez, last: de Lacalle}
   variants:
   - {first: Maddalen López, last: de Lacalle}
@@ -10263,39 +10210,25 @@
   - {first: Celine, last: De Looze}
 - canonical: {first: Claude, last: de Loupy}
   variants:
-  - {first: Claude De, last: Loupy}
-- canonical: {first: Diego Jesus, last: de Lucena}
-  variants:
-  - {first: Diego Jesus de, last: Lucena}
+  - {first: Claude, last: De Loupy}
 - canonical: {first: Carl, last: de Marcken}
   variants:
-  - {first: Carl G. de, last: Marcken}
+  - {first: Carl G., last: de Marcken}
 - canonical: {first: Marie-Catherine, last: de Marneffe}
   variants:
-  - {first: Marie-Catherine de, last: Marneffe}
   - {first: Marie Catherine, last: de Marneffe}
-- canonical: {first: Gerard, last: de Melo}
-  variants:
-  - {first: Gerard de, last: Melo}
 - canonical: {first: Paulo C F, last: de Oliveira}
   variants:
   - {first: Paulo C. F., last: de Oliveira}
 - canonical: {first: Valeria, last: de Paiva}
   id: valeria-de-paiva
   variants:
-  - {first: Valeria de, last: Paiva}
   - {first: Valeria, last: dePaiva}
 - canonical: {first: Maarten, last: de Rijke}
   variants:
-  - {first: Maarten de, last: Rijke}
   - {first: Maarten, last: De Rijke}
 - canonical: {first: Folkert, last: de Vriend}
   id: folkert-de-vriend
-  variants:
-  - {first: Folkert de, last: Vriend}
-- canonical: {first: Colin, last: de la Higuera}
-  variants:
-  - {first: Colin de la, last: Higuera}
 - canonical: {first: Peter V., last: deSouza}
   id: peter-v-desouza
 - canonical: {first: Louis, last: des Tombe}
@@ -10317,70 +10250,47 @@
 - canonical: {first: Kees, last: van Deemter}
   variants:
   - {first: Kees, last: Van Deemter}
-- canonical: {first: Marieke, last: van Erp}
-  variants:
-  - {first: Marieke van, last: Erp}
 - canonical: {first: Josef, last: van Genabith}
   id: josef-van-genabith
   variants:
   - {first: Josef, last: Van Genabith}
-  - {first: Josef van, last: Genabith}
 - canonical: {first: Willem Robert, last: van Hage}
   variants:
-  - {first: Willem Van, last: Hage}
+  - {first: Willem, last: Van Hage}
   - {first: Willem, last: van Hage}
 - canonical: {first: Hans, last: van Halteren}
   variants:
-  - {first: Hans Van, last: Halteren}
-- canonical: {first: Olga, last: van Herwijnen}
-  variants:
-  - {first: Olga van, last: Herwijnen}
-- canonical: {first: Roeland, last: van Hout}
-  variants:
-  - {first: Roeland van, last: Hout}
+  - {first: Hans, last: Van Halteren}
 - canonical: {first: Gerhard B., last: van Huyssteen}
   variants:
-  - {first: Gerhard B. van, last: Huyssteen}
-  - {first: Gerhard Van, last: Huyssteen}
+  - {first: Gerhard, last: Van Huyssteen}
   - {first: Gerhard, last: van Huyssteen}
-  - {first: Gerhard van, last: Huyssteen}
   - {first: Gerhard B, last: van Huyssteen}
 - canonical: {first: Marcel P., last: van Lohuizen}
   variants:
-  - {first: Marcel P. Van, last: Lohuizen}
+  - {first: Marcel P., last: Van Lohuizen}
 - canonical: {first: Erik, last: van Mulligen}
   variants:
   - {first: Erik M., last: van Mulligen}
 - canonical: {first: Gertjan, last: van Noord}
   variants:
-  - {first: Gertjan van, last: Noord}
-  - {first: Gertjan Van, last: Noord}
+  - {first: Gertjan, last: Van Noord}
 - canonical: {first: Marten, last: van Schijndel}
   variants:
   - {first: Marten, last: Van Schijndel}
   - {first: Martin, last: van Schijndel}
 - canonical: {first: Dieter, last: van Uytvanck}
   variants:
-  - {first: Dieter Van, last: Uytvanck}
   - {first: Dieter, last: Van Uytvanck}
-- canonical: {first: Remco, last: van Veenendaal}
-  variants:
-  - {first: Remco van, last: Veenendaal}
-- canonical: {first: Sarel, last: van Vuuren}
-  variants:
-  - {first: Sarel van, last: Vuuren}
 - canonical: {first: Menno, last: van Zaanen}
   variants:
   - {first: Menno, last: van Zannen}
 - canonical: {first: Antal, last: van den Bosch}
   variants:
-  - {first: Antal van den, last: Bosch}
   - {first: Antal, last: Van den Bosch}
-  - {first: Antal Van Den, last: Bosch}
+  - {first: Antal, last: Van Den Bosch}
 - canonical: {first: Henk, last: van den Heuvel}
   id: henk-van-den-heuvel
-  variants:
-  - {first: Henk van den, last: Heuvel}
 - canonical: {first: Erik, last: van der Goot}
   variants:
   - {first: Erik, last: Van der Goot}
@@ -10389,7 +10299,6 @@
   - {first: P.H.J., last: van der Kamp}
 - canonical: {first: Lonneke, last: van der Plas}
   variants:
-  - {first: Lonneke van der, last: Plas}
   - {first: Lonneke, last: Van Der Plas}
 - canonical: {first: Hennie, last: van der Vliet}
   variants:


### PR DESCRIPTION
Moves many "von" particles into last name where they were part of the first name.

Now there are many warnings about unused name variants - what it the best way to fix that?