### PR TITLE
New id fixes

### DIFF
--- a/bin/ingest.py
+++ b/bin/ingest.py
@@ -174,9 +174,10 @@ def main(args):
     for volume, meta in volumes.items():
         root_path = os.path.join(meta["path"], "cdrom")
         collection_id = meta["collection_id"]
+        venue_name = meta["abbrev"].lower()
         volume_name = meta["volume_name"]
 
-        pdfs_dest_dir = os.path.join(args.pdfs_dir, collection_id)
+        pdfs_dest_dir = os.path.join(args.pdfs_dir, venue_name)
         if not os.path.exists(pdfs_dest_dir):
             os.makedirs(pdfs_dest_dir)
 

--- a/data/yaml/venues_mapping.yaml
+++ b/data/yaml/venues_mapping.yaml
@@ -2,4 +2,4 @@
 iwclul:
   venue: IWCLUL
   joint:
-    2020.iwclul: WS
+    2020.iwclul-1: WS

--- a/data/yaml/venues_mapping.yaml
+++ b/data/yaml/venues_mapping.yaml
@@ -1,3 +1,5 @@
 ---
 iwclul:
   venue: IWCLUL
+  joint:
+    2020.iwclul: WS

--- a/data/yaml/venues_mapping.yaml
+++ b/data/yaml/venues_mapping.yaml
@@ -1,3 +1,3 @@
 ---
 iwclul:
-  venue: WS
+  venue: IWCLUL

--- a/hugo/content/info/contrib.md
+++ b/hugo/content/info/contrib.md
@@ -44,7 +44,7 @@ Please read through it so that you have an understanding of the ingestion proces
 
 ### Register your meeting
 
-All publications chairs need to obtain or verify [the venue identifiers]({{< relref "ids.md" >}} for proceedings submitted to the Anthology.
+All publications chairs need to obtain or verify [the venue identifiers]({{< relref "ids.md" >}}) for proceedings submitted to the Anthology.
 This should be done before the paper submission deadline for your conference.
 If you are chairing a meeting attached as a satellite of a main conference (e.g., ACL or EMNLP), please work with the main conference publication chair to receive your identifiers.
 (If you are an established venue, you can also look yours up [here](https://github.com/acl-org/acl-anthology/blob/new-id-format/data/yaml/venues_mapping.yaml).)

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -59,11 +59,11 @@ RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})\.pdf$ /anthology-files/pdf/$1/
 # PDF link, revisions, and errata (P17-1069[v2].pdf loads P/P17/P17-1069[v2].pdf --- with "v2" optional)
 # TODO: decide on a new format for revisions and errata
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)?\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
-RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-(\d+\.\d+)\.pdf$ /anthology-files/pdf/$2/$1.$2-$3.pdf [L,NC]
+RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+\.\d+)\.pdf$ /anthology-files/pdf/$2/$1.$2-$3.pdf [L,NC]
 
 # Attachments (e.g., P17-1069.Poster.pdf loads /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)
 RewriteRule ^attachments/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]
-RewriteRule ^(\d{4}\.[a-zA-Z0-9]+)(\-\d+\.\d+)\.pdf$ /anthology-files/pdf/$1/$1$2.pdf [L,NC]
+RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+\.\d+)\.(.*)$ /anthology-files/attachments/$2/$1.$2-$3.$4 [L,NC]
 
 # Thumbnails (e.g., /thumb/P17-1069.jpg loads /anthology-files/thumb/P17-1069.jpg)
 RewriteRule ^thumb/(.*)$ /anthology-files/thumb/$1 [L,NC]


### PR DESCRIPTION
I found a few small bugs in testing out the latest ingest under the new ID format: https://www.aclweb.org/anthology/events/ws-2020/

- [x] PDFs copied to wrong place
- [x] Redirection for attachments has wrong rule
- [x] Nothing shows up on venue page (https://www.aclweb.org/anthology/venues/iwclul/)

I expect a few more to show up, so don't merge yet. I will look at this more tonight.