### PR TITLE
documentation updates for new ID format (plus bug fix)

### DIFF
--- a/hugo/content/faq/linking.md
+++ b/hugo/content/faq/linking.md
@@ -4,8 +4,9 @@ weight: 1
 ---
 
 Every paper in the Anthology is assigned an [Anthology ID]({{< relref "/info/ids.md" >}}).
+After 2020, identifiers are of the form `{year}.{venue}-{volume}.{#}`, where `{year}` is the four-digit year, `{venue}` a lowercased venue code comprising ASCII letters and digits, `{volume}` is a volume name or number, and `{#}` is the paper number.
 Prior to 2020, this identifier took the form `CYY-VPPP` or `CYY-VVPP`, where `C` is a collection, `YY` a two-digit year, `V` a volume, and `P` a paper ID.
-The **canonical URL** of an Anthology paper is given by appending this identifier to the Anthology's base URL <https://www.aclweb.org/anthology/>; e.g., <https://www.aclweb.org/anthology/E91-1001>.
+The **canonical URL** of an Anthology paper is given by appending this identifier to the Anthology's base URL <https://www.aclweb.org/anthology/>; e.g., <https://www.aclweb.org/anthology/2020.iwclul-1.4> (new style) or <https://www.aclweb.org/anthology/E91-1001> (old style).
 This is the paper's landing page, which includes (among other things) a link to the PDF.
 
 Many papers in the Anthology also have Digital Object Identifiers (DOIs).
@@ -14,8 +15,8 @@ When available, DOI URLs will redirect to the Anthology canonical URL, and will 
 
 Variations of the canonical URL can be used to access the PDF and citation format files directly:
 
-- Append `.pdf` to get the PDF, e.g., <https://www.aclweb.org/anthology/E91-1001.pdf>
-- Append `.bib` to retrieve the BibTeX file, e.g., <https://www.aclweb.org/anthology/E91-1001.bib>
-- Append `.xml` to get the [MODS-formatted](http://www.loc.gov/standards/mods/) XML file, e.g., <https://www.aclweb.org/anthology/E91-1001.xml>
+- Append `.pdf` to get the PDF, e.g., <https://www.aclweb.org/anthology/2020.iwclul-1.4.pdf>
+- Append `.bib` to retrieve the BibTeX file, e.g., <https://www.aclweb.org/anthology/2020.iwclul-1.4.bib>
+- Append `.xml` to get the [MODS-formatted](http://www.loc.gov/standards/mods/) XML file, e.g., <https://www.aclweb.org/anthology/2020.iwclul-1.4.xml>
 
 and so on.

--- a/hugo/content/info/contrib.md
+++ b/hugo/content/info/contrib.md
@@ -86,26 +86,16 @@ The remaining steps are handled by Anthology staff and use [Anthology tools](htt
 
 ### Copyright
 
-For copyright transfers, you can use the default form at:
+If you are using the START system (softconf.com), this process is handled as part of the camera-ready submission process.
+
+Otherwise, for copyright transfers, please use the form at:
 
 + https://github.com/acl-org/ACLPUB/blob/master/doc/authors/ACL-copyright-form.pdf
 
-Ask authors to sign the form, scan a B/W copy at 150 to 200 DPI for you as a
-`.pdf` (or `.jpg` or `.png` if otherwise not possible). Name the forms using
-the ACL Anthology identifiers, and send me a separate `.zip` or `.tgz`
-archive as you would for the proceedings of your event (e.g., a file in the
-archive might be `copyright-transfers/P11-1001.pdf`).
-These copyrights should be delivered in bulk to the Anthology Editor when submitting the proceedings.
+Forms should be signed by authors and saved using the ACL Anthology identifiers.
+Please these into a folder (e.g., `copyright-transfers/P11-1001.pdf`) and then deliver them in bulk to the Anthology Editor when submitting the proceedings.
 
-Note that if you are using the START system (softconf.com), there is a
-digital form of this copyright transfer form, so you may not have to ask the
-authors to print, sign and submit to you. You may be able to simply download
-the `.zip` or `.tgz` version of the archived forms and submit them to
-me. Please note this when submitting.
-
-For both current and legacy events, it is good practice for the organizers
-to attempt to obtain copyright transfers for their materials, but we will
-ingest materials even if no copyright transfers are on file.
+For both current and legacy events, it is good practice for the organizers to attempt to obtain copyright transfers for their materials, but we will ingest materials even if no copyright transfers are on file.
 
 ### ISBN Numbers
 

--- a/hugo/content/info/contrib.md
+++ b/hugo/content/info/contrib.md
@@ -5,7 +5,8 @@ subtitle: General information on submitting proceedings to the ACL Anthology (fo
 date: "2020-03-25"
 ---
 
-This page contains general information about how to submit proceedings to the ACL Anthology.
+This page contains general information about how to send your proceedings to the ACL Anthology.
+(For information about the complete conference management process, particularly for ACL publications chairs, [see this document](https://github.com/acl-org/acl-pub).)
 If you are a workshop or publication chair whose job it is to submit your conference proceedings, this page should be helpful to you.
 Please read through it so that you have an understanding of the ingestion process.
 
@@ -70,11 +71,12 @@ If you prefer to have it published on a different date, please inform us when yo
 
 ### Submit your data
 
-After your conference management software has collected all the camera-ready papers and associated attachments, you will prepare data for the Anthology as described here.
-(For information about the complete conference management process, particularly for ACL publications chairs, [see this document](https://github.com/acl-org/acl-pub).)
-If you used [Softconf](https://www.softconf.com)'s [STARTv2 conference management system](https://www.softconf.com/about/start-v2-mainmenu-26), this data preparation is handled by the [ACLPUB](https://github.com/acl-org/ACLPUB/) package.
+After your conference management software has collected all the camera-ready papers and associated attachments, you will arrange all the volumes of your proceedings into [ACLPUB](https://github.com/acl-org/ACLPUB) format, as described in the [ACLPUB → Anthology documentation](https://github.com/acl-org/ACLPUB/tree/master/anthology).
+
+If you used [Softconf](https://www.softconf.com)'s [STARTv2 conference management system](https://www.softconf.com/about/start-v2-mainmenu-26), the situation is easy for you, since ACLPUB is integrated.
 For meetings using EasyChair, you will need to first convert to ACLPUB format using [our easy2acl scripts](https://github.com/acl-org/easy2acl).
-The end result in either case is a tarball, a link to which should be sent to the Anthology Director **two weeks prior to your desired publication date** (which was negotiated when you first contacted us).
+The end result in either case is a `data` directory containing ACLPUB proceedings, one for each conference (again, see [the ACLPUB -> Anthology instructions](https://github.com/acl-org/ACLPUB/tree/master/anthology)).
+A link to this directory (preferably via a file sharing service, such as Dropbox or Google Drive) should be sent to the Anthology Director **two weeks prior to your desired publication date** (which was negotiated when you first contacted us).
 
 The remaining steps are handled by Anthology staff and use [Anthology tools](https://github.com/acl-org/acl-anthology/tree/master/bin/):
 

--- a/hugo/content/info/contrib.md
+++ b/hugo/content/info/contrib.md
@@ -86,14 +86,14 @@ The remaining steps are handled by Anthology staff and use [Anthology tools](htt
 
 ### Copyright
 
-If you are using the START system (softconf.com), this process is handled as part of the camera-ready submission process.
+If you are using the START system, this process is handled as part of the camera-ready submission process.
 
 Otherwise, for copyright transfers, please use the form at:
 
 + https://github.com/acl-org/ACLPUB/blob/master/doc/authors/ACL-copyright-form.pdf
 
-Forms should be signed by authors and saved using the ACL Anthology identifiers.
-Please these into a folder (e.g., `copyright-transfers/P11-1001.pdf`) and then deliver them in bulk to the Anthology Editor when submitting the proceedings.
+Forms should be signed by authors and saved using the ACL Anthology identifiers as names.
+Please place these into a folder (e.g., `copyright-transfers/P11-1001.pdf`) and then deliver them in bulk to the Anthology Editor when submitting the proceedings.
 
 For both current and legacy events, it is good practice for the organizers to attempt to obtain copyright transfers for their materials, but we will ingest materials even if no copyright transfers are on file.
 
@@ -103,5 +103,5 @@ If you need to assign ISBN numbers, please provide the exact titles of each volu
 
 ### Errata and Corrections
 
-If you get requests from authors needing to post errata or revised versions of the papers, or supplemental attachments after the publication of the proceedings, please ask them to submit revisions to the current ACL Anthology editor directly (see [Corrections]({{< relref "corrections.md" >}})).
+If you get requests from authors needing to post errata or revised versions of the papers, or supplemental attachments after the publication of the proceedings, please refer them to [our documentation on the matter]({{< relref "corrections.md" >}}).
 Note that after the publiation date, corrections can only be applied to individual papers; the full proceedings volumes will not be replaced or revised.

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -63,7 +63,7 @@ RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+\.\d+)\.pdf$ /anthology-files/p
 
 # Attachments (e.g., P17-1069.Poster.pdf loads /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)
 RewriteRule ^attachments/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]
-RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+\.\d+)\.(.*)$ /anthology-files/attachments/$2/$1.$2-$3.$4 [L,NC]
+RewriteRule ^attachments/(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+\.\d+)\.(.*)$ /anthology-files/attachments/$2/$1.$2-$3.$4 [L,NC]
 
 # Thumbnails (e.g., /thumb/P17-1069.jpg loads /anthology-files/thumb/P17-1069.jpg)
 RewriteRule ^thumb/(.*)$ /anthology-files/thumb/$1 [L,NC]


### PR DESCRIPTION
Updated FAQ and other documentation with info on new ID format.

Also fixes bug that prevents *.bib, *.xml, etc being served for new IDs (e.g., https://www.aclweb.org/anthology/2020.iwclul-1.4.xml).