### PR TITLE
Fix N19-1169 video link

### DIFF
--- a/data/xml/N19.xml
+++ b/data/xml/N19.xml
@@ -1963,7 +1963,7 @@
       <abstract>How can we measure whether a natural language generation system produces both high quality and diverse outputs? Human evaluation captures quality but not diversity, as it does not catch models that simply plagiarize from the training set. On the other hand, statistical evaluation (i.e., perplexity) captures diversity but not quality, as models that occasionally emit low quality samples would be insufficiently penalized. In this paper, we propose a unified framework which evaluates both diversity and quality, based on the optimal error rate of predicting whether a sentence is human- or machine-generated. We demonstrate that this error rate can be efficiently estimated by combining human and statistical evaluation, using an evaluation metric which we call HUSE. On summarization and chit-chat dialogue, we show that (i) HUSE detects diversity defects which fool pure human evaluation and that (ii) techniques such as annealing for improving quality actually decrease HUSE due to decreased diversity.</abstract>
       <url>N19-1169</url>
       <doi>10.18653/v1/N19-1169</doi>
-      <video href="https://vimeo.com/359681098" tag="video"/>
+      <video href="https://vimeo.com/359678934" tag="video"/>
     </paper>
     <paper id="170">
       <title>What makes a good conversation? How controllable attributes affect human judgments</title>


### PR DESCRIPTION
Somewhere along the line two versions of the video for [N19-1168](https://www.aclweb.org/anthology/N19-1168/) were uploaded - [one with the correct title](https://vimeo.com/361580764), and [one with 1169's title](https://vimeo.com/359681098). This left [N19-1169](https://www.aclweb.org/anthology/N19-1169/) linking to the wrong video (the latter) - this PR updates the link to the [correct one](https://vimeo.com/359678934).