### PR TITLE
Author initial + period missing space after

### DIFF
--- a/data/xml/L08.xml
+++ b/data/xml/L08.xml
@@ -4484,7 +4484,7 @@
     <paper id="597">
       <author><first>Juan</first><last>Aparicio</last></author>
       <author><first>Mariona</first><last>Taulé</last></author>
-      <author><first>M.Antònia</first><last>Martí</last></author>
+      <author><first>M. Antònia</first><last>Martí</last></author>
       <title><fixed-case>A</fixed-case>n<fixed-case>C</fixed-case>ora-Verb: A Lexical Resource for the Semantic Annotation of Corpora</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2008/pdf/203_paper.pdf</url>
     </paper>

--- a/data/xml/O17.xml
+++ b/data/xml/O17.xml
@@ -191,7 +191,7 @@
       <author><first>Xiang</first><last>Xiao</last></author>
       <author><first>Shao-Zhen</first><last>Ye</last></author>
       <author><first>Liang-Chih</first><last>Yu</last></author>
-      <author><first>K.Robert</first><last>Lai</last></author>
+      <author><first>K. Robert</first><last>Lai</last></author>
       <pages>230–243</pages>
       <url>O17-1022</url>
     </paper>

--- a/data/xml/P16.xml
+++ b/data/xml/P16.xml
@@ -175,7 +175,7 @@
     </paper>
     <paper id="18">
       <title>Literal and Metaphorical Senses in Compositional Distributional Semantic Models</title>
-      <author><first>E.Dario</first> <last>Gutiérrez</last></author>
+      <author><first>E. Dario</first> <last>Gutiérrez</last></author>
       <author><first>Ekaterina</first> <last>Shutova</last></author>
       <author><first>Tyler</first> <last>Marghetis</last></author>
       <author><first>Benjamin</first> <last>Bergen</last></author>
@@ -2178,7 +2178,7 @@
     </paper>
     <paper id="225">
       <title>Finding Non-Arbitrary Form-Meaning Systematicity Using String-Metric Learning for Kernel Regression</title>
-      <author><first>E.Dario</first> <last>Gutiérrez</last></author>
+      <author><first>E. Dario</first> <last>Gutiérrez</last></author>
       <author><first>Roger</first> <last>Levy</last></author>
       <author><first>Benjamin</first> <last>Bergen</last></author>
       <pages>2379–2388</pages>

--- a/data/xml/R17.xml
+++ b/data/xml/R17.xml
@@ -833,7 +833,7 @@
     </paper>
     <paper id="84">
       <title>A Calibration Method for Evaluation of Sentiment Analysis</title>
-      <author><first>F.Sharmila</first><last>Satthar</last></author>
+      <author><first>F. Sharmila</first><last>Satthar</last></author>
       <author><first>Roger</first><last>Evans</last></author>
       <author><first>Gulden</first><last>Uchyigit</last></author>
       <pages>652–660</pages>


### PR DESCRIPTION
These are all metadata errors.

(V.G.Vinod Vydiswaran also fits the pattern, but that appears to be intentional [judging by his homepage](http://www-personal.umich.edu/~vgvinodv/).)