### PR TITLE
IWPT corrections

### DIFF
--- a/data/xml/1995.iwpt.xml
+++ b/data/xml/1995.iwpt.xml
@@ -71,11 +71,11 @@
       <abstract>We present a new technique for parsing grammar formalisms that express non-immediate dominance relations by ‘dominance-links’. Dominance links have been introduced in various formalisms such as extensions to CFG and TAG in order to capture long-distance dependencies in free-word order languages (Becker et al., 1991; Rambow, 1994). We show how the addition of ‘link counters’ to standard parsing algorithms such as CKY- and Earley-based methods for TAG results in a polynomial time complexity algorithm for parsing lexicalized V-TAG, a multi-component version of TAGs defined in (Rambow, 1994). A variant of this method has previously been applied to context-free grammar based formalisms such as UVG-DL.</abstract>
     </paper>
     <paper id="7">
-      <title>Yet Another <tex-math>\mathcal{0}(n^6)</tex-math> Recognition Algorithm for Mildly Context-Sensitive Languages</title>
-      <author><first>Pierre</first><last>BOULLIER</last></author>
+      <title>Yet Another <tex-math>0(n^6)</tex-math> Recognition Algorithm for Mildly Context-Sensitive Languages</title>
+      <author><first>Pierre</first><last>Boullier</last></author>
       <pages>34-47</pages>
       <url>1995.iwpt-1.7</url>
-      <abstract>Vijay-Shanker and Weir have shown in [17] that Tree Adjoining Grammars and Combinatory Categorial Grammars can be transformed into equivalent Linear Indexed Grammars (LIGs) which can be recognized in <tex-math>\mathcal{0}(n^6)</tex-math> time using a Cocke-Kasami-Younger style algorithm. This paper exhibits another recognition algorithm for LIGs, with the same upper-bound complexity, but whose average case behaves much better. This algorithm works in two steps: first a general context-free parsing algorithm (using the underlying context-free grammar) builds a shared parse forest, and second, the LIG properties are checked on this forest. This check is based upon the composition of simple relations and does not require any computation of symbol stacks.</abstract>
+      <abstract>Vijay-Shanker and Weir have shown in [17] that Tree Adjoining Grammars and Combinatory Categorial Grammars can be transformed into equivalent Linear Indexed Grammars (LIGs) which can be recognized in <tex-math>0(n^6)</tex-math> time using a Cocke-Kasami-Younger style algorithm. This paper exhibits another recognition algorithm for LIGs, with the same upper-bound complexity, but whose average case behaves much better. This algorithm works in two steps: first a general context-free parsing algorithm (using the underlying context-free grammar) builds a shared parse forest, and second, the LIG properties are checked on this forest. This check is based upon the composition of simple relations and does not require any computation of symbol stacks.</abstract>
     </paper>
     <paper id="8">
       <title>Developing and Evaluating a Probabilistic <fixed-case>LR</fixed-case> Parser of Part-of-Speech and Punctuation Labels</title>


### PR DESCRIPTION
Corrected capitalization of `Boullier`. Removed `\mathcal`, which is currently not supported by `tex-math` environments.
