### PR TITLE
Fix abstract toggling for new-style IDs (fixes #813)

### DIFF
--- a/hugo/layouts/papers/list-entry-author.html
+++ b/hugo/layouts/papers/list-entry-author.html
@@ -13,7 +13,7 @@
     </a>
     {{- end -}}
     {{- with $paper.abstract_html -}}
-    <a class="badge badge-info align-middle mr-1" href="#abstract-{{ $.Params.anthology_id }}" data-toggle="collapse" aria-expanded="false" aria-controls="abstract-{{ $.Params.anthology_id }}" title="Show Abstract">abs</a>
+    <a class="badge badge-info align-middle mr-1" href="#abstract-{{ replace $.Params.anthology_id "." "--" }}" data-toggle="collapse" aria-expanded="false" aria-controls="abstract-{{ $.Params.anthology_id }}" title="Show Abstract">abs</a>
     {{- end -}}
     <br class="d-none d-sm-inline-block" />
       {{- range $paper.attachment -}}
@@ -43,7 +43,7 @@
 </p>
 
 {{ with $paper.abstract_html }}
-<div class="card bg-light mb-2 mb-lg-3 collapse abstract-collapse" id="abstract-{{ $.Params.anthology_id }}">
+<div class="card bg-light mb-2 mb-lg-3 collapse abstract-collapse" id="abstract-{{ replace $.Params.anthology_id "." "--" }}">
   <div class="card-body p-3 small">
     {{ . | safeHTML }}
   </div>

--- a/hugo/layouts/papers/list-entry.html
+++ b/hugo/layouts/papers/list-entry.html
@@ -13,7 +13,7 @@
     </a>
     {{- end -}}
     {{- with $paper.abstract_html -}}
-    <a class="badge badge-info align-middle mr-1" href="#abstract-{{ $.Params.anthology_id }}" data-toggle="collapse" aria-expanded="false" aria-controls="abstract-{{ $.Params.anthology_id }}" title="Show Abstract">abs</a>
+    <a class="badge badge-info align-middle mr-1" href="#abstract-{{ replace $.Params.anthology_id "." "--" }}" data-toggle="collapse" aria-expanded="false" aria-controls="abstract-{{ $.Params.anthology_id }}" title="Show Abstract">abs</a>
     {{- end -}}
     <br class="d-none d-sm-inline-block" />
       {{- range $paper.attachment -}}
@@ -37,7 +37,7 @@
 </p>
 
 {{ with $paper.abstract_html }}
-<div class="card bg-light mb-2 mb-lg-3 collapse abstract-collapse" id="abstract-{{ $.Params.anthology_id }}">
+<div class="card bg-light mb-2 mb-lg-3 collapse abstract-collapse" id="abstract-{{ replace $.Params.anthology_id "." "--" }}">
   <div class="card-body p-3 small">
     {{ . | safeHTML }}
   </div>


### PR DESCRIPTION
I've replaced periods in identifiers with double dashes so they work again with Bootstrap Collapse.