### PR TITLE
have hugo auto-update footer date range

### DIFF
--- a/hugo/layouts/partials/footer.html
+++ b/hugo/layouts/partials/footer.html
@@ -3,7 +3,7 @@
     <p class="text-muted small px-1">
       <span class="float-right mt-2 ml-2"><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a></span>
 
-      ACL materials are Copyright ©&nbsp;1963&ndash;2019 ACL; other materials are copyrighted by their respective copyright holders.  Materials prior to 2016 here are licensed under the <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 International License</a>.  Permission is granted to make copies for the purposes of teaching and research. Materials published in or after 2016 are licensed on a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+      ACL materials are Copyright ©&nbsp;1963&ndash;{{ dateFormat "2006" now }} ACL; other materials are copyrighted by their respective copyright holders.  Materials prior to 2016 here are licensed under the <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 International License</a>.  Permission is granted to make copies for the purposes of teaching and research. Materials published in or after 2016 are licensed on a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
     </p>
 
     <p class="text-muted small px-1">


### PR DESCRIPTION
Footer year was static and out of date; use Huge date format to automate this range to always put copyright up until current year.