### PR TITLE
Ingest SIGDIAL 2007

### DIFF
--- a/bin/anthology/bibtex.py
+++ b/bin/anthology/bibtex.py
@@ -41,15 +41,5 @@ def read_bibtex(bibfilename):
 
     # for parser in [lambda s: pybtex.database.parse_string(s, 'bibtex'),
     #                fake_parse]:
-    parser = pybtex.database.parse_string(s, 'bibtex')
-    try:
-        bibdata = parser(bibstring)
-    except KeyboardInterrupt:
-        raise
-    except Exception as e:
-        logging.warning(
-            "BibTeX parser raised exception '{}'; trying alternate parser".format(e)
-        )
-        bibdata = pybtex.database.BibliographyData(dict())
-
+    bibdata = pybtex.database.parse_string(bibstring, "bibtex")
     return bibdata

--- a/bin/anthology/utils.py
+++ b/bin/anthology/utils.py
@@ -413,3 +413,8 @@ def make_simple_element(tag, text=None, attrib=None, parent=None, namespaces=Non
 def compute_hash(value: bytes) -> str:
     checksum = crc32(value) & 0xFFFFFFFF
     return f"{checksum:08x}"
+
+
+def compute_hash_from_file(path: str) -> str:
+    with open(path, "rb") as f:
+        return compute_hash(f.read())

--- a/data/xml/2007.sigdial.xml
+++ b/data/xml/2007.sigdial.xml
@@ -1,0 +1,417 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection id="2007.sigdial">
+  <volume id="1">
+    <meta>
+      <booktitle>Proceedings of the 8th SIGdialWorkshop on Discourse and Dialogue</booktitle>
+      <editor><first>Harry</first><last>Bunt</last></editor>
+      <editor><first>Simon</first><last>Keizer</last></editor>
+      <editor><first>Tim</first><last>Paek</last></editor>
+      <publisher>Association for Computational Linguistics</publisher>
+      <address>Antwerp, Belgium</address>
+      <month>September</month>
+      <year>2007</year>
+      <url hash="e098d110">2007.sigdial-1</url>
+    </meta>
+    <frontmatter>
+      <url hash="0bff8bb0">2007.sigdial-1.0</url>
+    </frontmatter>
+    <paper id="1">
+      <title>Rationality and Conversation</title>
+      <author><first>Herbert H.</first><last>Clark</last></author>
+      <pages>1</pages>
+      <url hash="8a69c7da">2007.sigdial-1.1</url>
+    </paper>
+    <paper id="2">
+      <title>Collective States of Understanding</title>
+      <author><first>Arash</first><last>Eshghi</last></author>
+      <author><first>Patrick G.T.</first><last>Healey</last></author>
+      <pages>2–9</pages>
+      <url hash="bd96db25">2007.sigdial-1.2</url>
+    </paper>
+    <paper id="3">
+      <title>Contrasting the Automatic Identification of Two Discourse Markers in Multiparty Dialogues</title>
+      <author><first>Andrei</first><last>Popescu-Belis</last></author>
+      <author><first>Sandrine</first><last>Zufferey</last></author>
+      <pages>10–17</pages>
+      <url hash="b59dd33d">2007.sigdial-1.3</url>
+    </paper>
+    <paper id="4">
+      <title>Detecting and Summarizing Action Items in Multi-Party Dialogue</title>
+      <author><first>Matthew</first><last>Purver</last></author>
+      <author><first>John</first><last>Dowding</last></author>
+      <author><first>John</first><last>Niekrasz</last></author>
+      <author><first>Patrick</first><last>Ehlen</last></author>
+      <author><first>Sharareh</first><last>Noorbaloochi</last></author>
+      <author><first>Stanley</first><last>Peters</last></author>
+      <pages>18–25</pages>
+      <url hash="0557a8be">2007.sigdial-1.4</url>
+    </paper>
+    <paper id="5">
+      <title>Detecting Arguing and Sentiment in Meetings</title>
+      <author><first>Swapna</first><last>Somasundaran</last></author>
+      <author><first>Josef</first><last>Ruppenhofer</last></author>
+      <author><first>Janyce</first><last>Wiebe</last></author>
+      <pages>26–34</pages>
+      <url hash="305c0e67">2007.sigdial-1.5</url>
+    </paper>
+    <paper id="6">
+      <title>A Model of Compliance and Emotion for Potentially Adversarial Dialogue Agents</title>
+      <author><first>Antonio</first><last>Roque</last></author>
+      <author><first>David</first><last>Traum</last></author>
+      <pages>35–38</pages>
+      <url hash="bb631e91">2007.sigdial-1.6</url>
+    </paper>
+    <paper id="7">
+      <title>Acquiring and Evaluating a Dialog Corpus through a Dialog Simulation Technique</title>
+      <author><first>David</first><last>Griol</last></author>
+      <author><first>Lluis F.</first><last>Hurtado</last></author>
+      <author><first>Emilio</first><last>Sanchis</last></author>
+      <author><first>Encarna</first><last>Segarra</last></author>
+      <pages>39–42</pages>
+      <url hash="2b334f71">2007.sigdial-1.7</url>
+    </paper>
+    <paper id="8">
+      <title>An Empirical View on <fixed-case>IQA</fixed-case> Follow-up Questions</title>
+      <author><first>Manuel</first><last>Kirschner</last></author>
+      <author><first>Raffaella</first><last>Bernardi</last></author>
+      <pages>43–46</pages>
+      <url hash="0ea699de">2007.sigdial-1.8</url>
+    </paper>
+    <paper id="9">
+      <title>An Implemented Method for Distributed Collection and Assessment of Speech Data</title>
+      <author><first>Alexander</first><last>Siebert</last></author>
+      <author><first>David</first><last>Schlangen</last></author>
+      <author><first>Raquel</first><last>Fernández</last></author>
+      <pages>47–50</pages>
+      <url hash="d17f55e2">2007.sigdial-1.9</url>
+    </paper>
+    <paper id="10">
+      <url hash="96d357c0">2007.sigdial-1.10</url>
+    </paper>
+    <paper id="11">
+      <title>Dialogue Policy Learning for Combinations of Noise and User Simulation: Transfer Results</title>
+      <author><first>Oliver</first><last>Lemon</last></author>
+      <author><first>Xingkun</first><last>Liu</last></author>
+      <pages>55–58</pages>
+      <url hash="d95df505">2007.sigdial-1.11</url>
+    </paper>
+    <paper id="12">
+      <title>Dynamic n-best Selection and Its Application in Dialog Act Detection</title>
+      <author><first>Junling</first><last>Hu</last></author>
+      <author><first>Fabrizio</first><last>Morbini</last></author>
+      <author><first>Fuliang</first><last>Weng</last></author>
+      <author><first>Xue</first><last>Liu</last></author>
+      <pages>59–62</pages>
+      <url hash="5b8bd4d4">2007.sigdial-1.12</url>
+    </paper>
+    <paper id="13">
+      <title>Emergent Conversational Recommendations: A Dialogue Behavior Approach</title>
+      <author><first>Pontus</first><last>Wärnestal</last></author>
+      <author><first>Lars</first><last>Degerstedt</last></author>
+      <author><first>Arne</first><last>Jönsson</last></author>
+      <pages>63–66</pages>
+      <url hash="419fe00d">2007.sigdial-1.13</url>
+    </paper>
+    <paper id="14">
+      <title>Exploiting Semantic and Pragmatic Information for the Automatic Resolution of Spatial Linguistic Expressions</title>
+      <author><first>Andrea</first><last>Corradini</last></author>
+      <pages>67–70</pages>
+      <url hash="740bdfdb">2007.sigdial-1.14</url>
+    </paper>
+    <paper id="15">
+      <title><fixed-case>H</fixed-case>assan: A Virtual Human for Tactical Questioning</title>
+      <author><first>David</first><last>Traum</last></author>
+      <author><first>Antonio</first><last>Roque</last></author>
+      <author><first>Anton</first><last>Leuski</last></author>
+      <author><first>Panayiotis</first><last>Georgiou</last></author>
+      <author><first>Jillian</first><last>Gerten</last></author>
+      <author><first>Bilyana</first><last>Martinovski</last></author>
+      <author><first>Shrikanth</first><last>Narayanan</last></author>
+      <author><first>Susan</first><last>Robinson</last></author>
+      <author><first>Ashish</first><last>Vaswani</last></author>
+      <pages>71–74</pages>
+      <url hash="d237f6c0">2007.sigdial-1.15</url>
+    </paper>
+    <paper id="16">
+      <title>Identifying Formal and Functional Zones in Film Reviews</title>
+      <author><first>Heike</first><last>Bieler</last></author>
+      <author><first>Stefanie</first><last>Dipper</last></author>
+      <author><first>Manfred</first><last>Stede</last></author>
+      <pages>75–78</pages>
+      <url hash="78a2e843">2007.sigdial-1.16</url>
+    </paper>
+    <paper id="17">
+      <title><fixed-case>CHAT</fixed-case> to Your Destination</title>
+      <author><first>Fuliang</first><last>Weng</last></author>
+      <author><first>Baoshi</first><last>Yan</last></author>
+      <author><first>Zhe</first><last>Feng</last></author>
+      <author><first>Florin</first><last>Ratiu</last></author>
+      <author><first>Madhuri</first><last>Raya</last></author>
+      <author><first>Brian</first><last>Lathrop</last></author>
+      <author><first>Annie</first><last>Lien</last></author>
+      <author><first>Sebastian</first><last>Varges</last></author>
+      <author><first>Rohit</first><last>Mishra</last></author>
+      <author><first>Feng</first><last>Lin</last></author>
+      <author><first>Matthew</first><last>Purver</last></author>
+      <author><first>Harry</first><last>Bratt</last></author>
+      <author><first>Yao</first><last>Meng</last></author>
+      <author><first>Stanley</first><last>Peters</last></author>
+      <author><first>Tobias</first><last>Scheideck</last></author>
+      <author><first>Badri</first><last>Raghunathan</last></author>
+      <author><first>Zhaoxia</first><last>Zhang</last></author>
+      <pages>79–86</pages>
+      <url hash="6e596a7a">2007.sigdial-1.17</url>
+    </paper>
+    <paper id="18">
+      <title>Commute <fixed-case>UX</fixed-case>: Telephone Dialog System for Location-based Services</title>
+      <author><first>Ivan</first><last>Tashev</last></author>
+      <author><first>Michael</first><last>Seltzer</last></author>
+      <author><first>Yun-Cheng</first><last>Ju</last></author>
+      <author><first>Dong</first><last>Yu</last></author>
+      <author><first>Alex</first><last>Acero</last></author>
+      <pages>87–94</pages>
+      <url hash="f9be08f8">2007.sigdial-1.18</url>
+    </paper>
+    <paper id="19">
+      <title>Corpus-Based Training of Action-Specific Language Models</title>
+      <author><first>Lars</first><last>Schillingmann</last></author>
+      <author><first>Sven</first><last>Wachsmuth</last></author>
+      <author><first>Britta</first><last>Wrede</last></author>
+      <pages>95–102</pages>
+      <url hash="0a5470df">2007.sigdial-1.19</url>
+    </paper>
+    <paper id="20">
+      <title>Negotiating Spatial Goals with a Wheelchair</title>
+      <author><first>Thora</first><last>Tenbrink</last></author>
+      <author><first>Hui</first><last>Shi</last></author>
+      <pages>103–110</pages>
+      <url hash="19966868">2007.sigdial-1.20</url>
+    </paper>
+    <paper id="21">
+      <title>Releasing a Multimodal Dialogue System into the Wild: User Support Mechanisms</title>
+      <author><first>Alexander</first><last>Gruenstein</last></author>
+      <author><first>Stephanie</first><last>Seneff</last></author>
+      <pages>111–119</pages>
+      <url hash="336d53b0">2007.sigdial-1.21</url>
+    </paper>
+    <paper id="22">
+      <title>Analysis of User Reactions to Turn-Taking Failures in Spoken Dialogue Systems</title>
+      <author><first>Mikio</first><last>Nakano</last></author>
+      <author><first>Yuka</first><last>Nagano</last></author>
+      <author><first>Kotaro</first><last>Funakoshi</last></author>
+      <author><first>Toshihiko</first><last>Ito</last></author>
+      <author><first>Kenji</first><last>Araki</last></author>
+      <author><first>Yuji</first><last>Hasegawa</last></author>
+      <author><first>Hiroshi</first><last>Tsujino</last></author>
+      <pages>120–123</pages>
+      <url hash="3320c365">2007.sigdial-1.22</url>
+    </paper>
+    <paper id="23">
+      <title>Comparing Spoken Dialog Corpora Collected with Recruited Subjects versus Real Users</title>
+      <author><first>Hua</first><last>Ai</last></author>
+      <author><first>Antoine</first><last>Raux</last></author>
+      <author><first>Dan</first><last>Bohus</last></author>
+      <author><first>Maxine</first><last>Eskenazi</last></author>
+      <author><first>Diane</first><last>Litman</last></author>
+      <pages>124–131</pages>
+      <url hash="935c4391">2007.sigdial-1.23</url>
+    </paper>
+    <paper id="24">
+      <title>Dealing with <fixed-case>DEAL</fixed-case>: A Dialogue System for Conversation Training</title>
+      <author><first>Anna</first><last>Hjalmarsson</last></author>
+      <author><first>Preben</first><last>Wik</last></author>
+      <author><first>Jenny</first><last>Brusk</last></author>
+      <pages>132–135</pages>
+      <url hash="0941f510">2007.sigdial-1.24</url>
+    </paper>
+    <paper id="25">
+      <url hash="97da76ed">2007.sigdial-1.25</url>
+    </paper>
+    <paper id="26">
+      <title>A Multidimensional Approach to Utterance Segmentation and Dialogue Act Classification</title>
+      <author><first>Jeroen</first><last>Geertzen</last></author>
+      <author><first>Volha</first><last>Petukhova</last></author>
+      <author><first>Harry</first><last>Bunt</last></author>
+      <pages>140–149</pages>
+      <url hash="ac0082fa">2007.sigdial-1.26</url>
+    </paper>
+    <paper id="27">
+      <title>Accented Pronouns and Unusual Antecedents: A Corpus Study</title>
+      <author><first>Anubha</first><last>Kothari</last></author>
+      <pages>150–157</pages>
+      <url hash="8d2e80d0">2007.sigdial-1.27</url>
+    </paper>
+    <paper id="28">
+      <title>Evaluating Combinations of Dialogue Acts for Generation</title>
+      <author><first>Simon</first><last>Keizer</last></author>
+      <author><first>Harry</first><last>Bunt</last></author>
+      <pages>158–165</pages>
+      <url hash="5dc88e30">2007.sigdial-1.28</url>
+    </paper>
+    <paper id="29">
+      <title>Measuring Adaptation Between Dialogs</title>
+      <author><first>Svetlana</first><last>Stenchikova</last></author>
+      <author><first>Amanda</first><last>Stent</last></author>
+      <pages>166–173</pages>
+      <url hash="50c4009b">2007.sigdial-1.29</url>
+    </paper>
+    <paper id="30">
+      <title>Token-based Chunking of Turn-internal Dialogue Act Sequences</title>
+      <author><first>Piroska</first><last>Lendvai</last></author>
+      <author><first>Jeroen</first><last>Geertzen</last></author>
+      <pages>174–181</pages>
+      <url hash="e89461a1">2007.sigdial-1.30</url>
+    </paper>
+    <paper id="31">
+      <title>A Comprehensive Disfluency Model for Multi-Party Interaction</title>
+      <author><first>Jana</first><last>Besser</last></author>
+      <author><first>Jan</first><last>Alexandersson</last></author>
+      <pages>182–189</pages>
+      <url hash="96b6d608">2007.sigdial-1.31</url>
+    </paper>
+    <paper id="32">
+      <title>Experimental Modeling of Human-human Multi-threaded Dialogues in the Presence of a Manual-visual Task</title>
+      <author><first>Alexander</first><last>Shyrokov</last></author>
+      <author><first>Andrew</first><last>Kun</last></author>
+      <author><first>Peter</first><last>Heeman</last></author>
+      <pages>190–193</pages>
+      <url hash="d08a010d">2007.sigdial-1.32</url>
+    </paper>
+    <paper id="33">
+      <title>Modeling Vocal Interaction for Text-Independent Classification of Conversation Type</title>
+      <author><first>Kornel</first><last>Laskowski</last></author>
+      <author><first>Mari</first><last>Ostendorf</last></author>
+      <author><first>Tanja</first><last>Schultz</last></author>
+      <pages>194–201</pages>
+      <url hash="608f3f35">2007.sigdial-1.33</url>
+    </paper>
+    <paper id="34">
+      <title>Introducing Utterance Verification in Spoken Dialogue System to Improve Dynamic Help Generation for Novice Users</title>
+      <author><first>Kazunori</first><last>Komatani</last></author>
+      <author><first>Yuichiro</first><last>Fukubayashi</last></author>
+      <author><first>Tetsuya</first><last>Ogata</last></author>
+      <author><first>Hiroshi G.</first><last>Okuno</last></author>
+      <pages>202–205</pages>
+      <url hash="f7ceaaf1">2007.sigdial-1.34</url>
+    </paper>
+    <paper id="35">
+      <title>Making Grounding Decisions: Data-driven Estimation of Dialogue Costs and Confidence Thresholds</title>
+      <author><first>Gabriel</first><last>Skantze</last></author>
+      <pages>206–210</pages>
+      <url hash="046828fa">2007.sigdial-1.35</url>
+    </paper>
+    <paper id="36">
+      <title>On the Training Data Requirements for an Automatic Dialogue Annotation Technique</title>
+      <author><first>Carlos D.</first><last>Martínez-Hinarejos</last></author>
+      <pages>211–214</pages>
+      <url hash="5a5d7dde">2007.sigdial-1.36</url>
+    </paper>
+    <paper id="37">
+      <title>Practical Dialogue Manager Development using <fixed-case>POMDP</fixed-case>s</title>
+      <author><first>Trung H.</first><last>Bui</last></author>
+      <author><first>Boris van</first><last>Schooten</last></author>
+      <author><first>Dennis</first><last>Hofs</last></author>
+      <pages>215–218</pages>
+      <url hash="3030e646">2007.sigdial-1.37</url>
+    </paper>
+    <paper id="38">
+      <title>Problem-Sensitive Response Generation in Human-Robot Dialogs</title>
+      <author><first>Petra</first><last>Gieselmann</last></author>
+      <author><first>Mari</first><last>Ostendorf</last></author>
+      <pages>219–222</pages>
+      <url hash="11c6dd61">2007.sigdial-1.38</url>
+    </paper>
+    <paper id="39">
+      <title>Rapid Development of Dialogue Systems by Grammar Compilation</title>
+      <author><first>Björn</first><last>Bringert</last></author>
+      <pages>223–226</pages>
+      <url hash="e5fc7e20">2007.sigdial-1.39</url>
+    </paper>
+    <paper id="40">
+      <title>Resolving “You” in Multi-Party Dialog</title>
+      <author><first>Surabhi</first><last>Gupta</last></author>
+      <author><first>John</first><last>Niekrasz</last></author>
+      <author><first>Matthew</first><last>Purver</last></author>
+      <author><first>Dan</first><last>Jurafsky</last></author>
+      <pages>227–230</pages>
+      <url hash="8518753d">2007.sigdial-1.40</url>
+    </paper>
+    <paper id="41">
+      <title><fixed-case>SIDGRID</fixed-case>: A Framework for Distributed and Integrated Multimodal Annotation and Archiving and and Analysis</title>
+      <author><first>Gina-Anne</first><last>Levow</last></author>
+      <author><first>Bennett</first><last>Bertenthal</last></author>
+      <author><first>Mark</first><last>Hereld</last></author>
+      <author><first>Sarah</first><last>Kenny</last></author>
+      <author><first>David</first><last>McNeill</last></author>
+      <author><first>Michael</first><last>Papka</last></author>
+      <author><first>Sonjia</first><last>Waxmonsky</last></author>
+      <pages>231–234</pages>
+      <url hash="e01f1f71">2007.sigdial-1.41</url>
+    </paper>
+    <paper id="42">
+      <title><fixed-case>S</fixed-case>c<fixed-case>IML</fixed-case>: Model-based Design of Voice User Interfaces</title>
+      <author><first>Jörn</first><last>Kreutel</last></author>
+      <pages>235–238</pages>
+      <url hash="89cb7aeb">2007.sigdial-1.42</url>
+    </paper>
+    <paper id="43">
+      <title>Tutoring in a Spoken Language Dialogue System</title>
+      <author><first>Jaakko</first><last>Hakulinen</last></author>
+      <author><first>Markku</first><last>Turunen</last></author>
+      <author><first>Kari-Jouko</first><last>Räihä</last></author>
+      <pages>239–242</pages>
+      <url hash="f6c916f9">2007.sigdial-1.43</url>
+    </paper>
+    <paper id="44">
+      <title>Using Speech Acts in Logic-Based Rhetorical Structuring for Natural Language Generation in Human-Computer Dialogue</title>
+      <author><first>Vladimir</first><last>Popescu</last></author>
+      <author><first>Jean</first><last>Caelen</last></author>
+      <author><first>Corneliu</first><last>Burileanu</last></author>
+      <pages>243–246</pages>
+      <url hash="bb7f5b03">2007.sigdial-1.44</url>
+    </paper>
+    <paper id="45">
+      <title>Dialogue Management for Automatic Troubleshooting and other Problem-solving Applications</title>
+      <author><first>Johan</first><last>Boye</last></author>
+      <pages>247–255</pages>
+      <url hash="396f4880">2007.sigdial-1.45</url>
+    </paper>
+    <paper id="46">
+      <title>Implicitly-supervised Learning in Spoken Language Interfaces: an Application to the Confidence Annotation Problem</title>
+      <author><first>Dan</first><last>Bohus</last></author>
+      <author><first>Alexander</first><last>Rudnicky</last></author>
+      <pages>256–264</pages>
+      <url hash="2014a1dc">2007.sigdial-1.46</url>
+    </paper>
+    <paper id="47">
+      <title>Planning Dialog Actions</title>
+      <author><first>Mark</first><last>Steedman</last></author>
+      <author><first>Ronald</first><last>Petrick</last></author>
+      <pages>265–272</pages>
+      <url hash="0db7fbef">2007.sigdial-1.47</url>
+    </paper>
+    <paper id="48">
+      <title>Statistical User Simulation with a Hidden Agenda</title>
+      <author><first>Jost</first><last>Schatzmann</last></author>
+      <author><first>Blaise</first><last>Thomson</last></author>
+      <author><first>Steve</first><last>Young</last></author>
+      <pages>273–282</pages>
+      <url hash="8c39d12b">2007.sigdial-1.48</url>
+    </paper>
+    <paper id="49">
+      <title>An Empirically Based Computational Model of Grounding in Dialogue</title>
+      <author><first>Harry</first><last>Bunt</last></author>
+      <author><first>Roser</first><last>Morante</last></author>
+      <author><first>Simon</first><last>Keizer</last></author>
+      <pages>283–290</pages>
+      <url hash="f7b2b31f">2007.sigdial-1.49</url>
+    </paper>
+    <paper id="50">
+      <title>Pragmatic Usage of Linear Regression Models for the Prediction of User Judgments</title>
+      <author><first>Klaus-Peter</first><last>Engelbrecht</last></author>
+      <author><first>Sebastian</first><last>Möller</last></author>
+      <pages>291–294</pages>
+      <url hash="4953bf3e">2007.sigdial-1.50</url>
+    </paper>
+  </volume>
+</collection>

--- a/data/xml/2007.sigdial.xml
+++ b/data/xml/2007.sigdial.xml
@@ -86,6 +86,10 @@
       <url hash="d17f55e2">2007.sigdial-1.9</url>
     </paper>
     <paper id="10">
+      <title>Beyond Repair – Testing the Limits of the Conversational Repair System</title>
+      <author><first>David</first><last>Schlangen</last></author>
+      <author><first>Raquel</first><last>Fernández</last></author>
+      <pages>51–54</pages>
       <url hash="96d357c0">2007.sigdial-1.10</url>
     </paper>
     <paper id="11">
@@ -225,6 +229,11 @@
       <url hash="0941f510">2007.sigdial-1.24</url>
     </paper>
     <paper id="25">
+      <title>Referring under Restricted Interactivity Conditions</title>
+      <author><first>Raquel</first><last>Fernández</last></author>
+      <author><first>Tatjana</first><last>Lucht</last></author>
+      <author><first>David</first><last>Schlangen</last></author>
+      <pages>136–139</pages>
       <url hash="97da76ed">2007.sigdial-1.25</url>
     </paper>
     <paper id="26">


### PR DESCRIPTION
Adds a missing volume, contributed by Mikio Nakano. Includes a few changes to the scripts:

- Adds hashes to `ingest.py` (#819)
- Adjusts field names read in from ACLPUB "meta" file
- `compute_hash_from_file` convenience function