### PR TITLE
ACL 2020 fixes (closes #893)

### DIFF
--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -8573,7 +8573,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
-      <url hash="b98801a0">2020.acl-srw</url>
+      <url hash="2159c735">2020.acl-srw</url>
     </meta>
     <frontmatter>
       <url hash="76c5423d">2020.acl-srw.0</url>

--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -8750,17 +8750,6 @@
       <abstract>The prevailing approach for training and evaluating paraphrase identification models is constructed as a binary classification problem: the model is given a pair of sentences, and is judged by how accurately it classifies pairs as either paraphrases or non-paraphrases. This pointwise-based evaluation method does not match well the objective of most real world applications, so the goal of our work is to understand how models which perform well under pointwise evaluation may fail in practice and find better methods for evaluating paraphrase identification models. As a first step towards that goal, we show that although the standard way of fine-tuning BERT for paraphrase identification by pairing two sentences as one sequence results in a model with state-of-the-art performance, that model may perform poorly on simple tasks like identifying pairs with two identical sentences. Moreover, we show that these models may even predict a pair of randomly-selected sentences with higher paraphrase score than a pair of identical ones.</abstract>
       <url hash="a7826a9e">2020.acl-srw.20</url>
     </paper>
-    <paper id="21">
-      <title>Let’s be Humorous: Knowledge Enhanced Humor Generation</title>
-      <author><first>Hang</first><last>Zhang</last></author>
-      <author><first>Dayiheng</first><last>Liu</last></author>
-      <author><first>Jiancheng</first><last>Lv</last></author>
-      <author><first>Luo</first><last>Cheng</last></author>
-      <pages>156–161</pages>
-      <abstract>The generation of humor is an under-explored and challenging problem. Previous works mainly utilize templates or replace phrases to generate humor. However, few works focus on freer forms and the background knowledge of humor. The linguistic theory of humor defines the structure of a humor sentence as set-up and punchline. In this paper, we explore how to generate a punchline given the set-up with the relevant knowledge. We propose a framework that can fuse the knowledge to end-to-end models. To our knowledge, this is the first attempt to generate punchlines with knowledge enhanced model. Furthermore, we create the first humor-knowledge dataset. The experimental results demonstrate that our method can make use of knowledge to generate fluent, funny punchlines, which outperforms several baselines.</abstract>
-      <url hash="5303c790">2020.acl-srw.21</url>
-      <attachment type="Software" hash="f1acf675">2020.acl-srw.21.Software.zip</attachment>
-    </paper>
     <paper id="22">
       <title>Efficient Neural Machine Translation for Low-Resource Languages via Exploiting Related Languages</title>
       <author><first>Vikrant</first><last>Goyal</last></author>

--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -11,6 +11,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="bdf5095c">2020.acl-main</url>
     </meta>
     <frontmatter>
       <url hash="5ccfe647">2020.acl-main.0</url>
@@ -8044,6 +8045,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="1568b2a0">2020.acl-demos</url>
     </meta>
     <frontmatter>
       <url hash="730f78b5">2020.acl-demos.0</url>
@@ -8571,6 +8573,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="b98801a0">2020.acl-srw</url>
     </meta>
     <frontmatter>
       <url hash="76c5423d">2020.acl-srw.0</url>
@@ -8981,6 +8984,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="aec3bf11">2020.acl-tutorials</url>
     </meta>
     <frontmatter>
       <url hash="486c2a84">2020.acl-tutorials.0</url>

--- a/data/xml/2020.alvr.xml
+++ b/data/xml/2020.alvr.xml
@@ -16,6 +16,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="7f4feb1f">2020.alvr-1</url>
     </meta>
     <frontmatter>
       <url hash="30a10a5a">2020.alvr-1.0</url>

--- a/data/xml/2020.autosimtrans.xml
+++ b/data/xml/2020.autosimtrans.xml
@@ -14,6 +14,7 @@
       <address>Seattle, Washington</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="acf5340f">2020.autosimtrans-1</url>
     </meta>
     <frontmatter>
       <url hash="fdc9613d">2020.autosimtrans-1.0</url>

--- a/data/xml/2020.bea.xml
+++ b/data/xml/2020.bea.xml
@@ -14,6 +14,7 @@
       <address>Seattle, WA, USA → Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="24dd231d">2020.bea-1</url>
     </meta>
     <frontmatter>
       <url hash="d9b0a62a">2020.bea-1.0</url>

--- a/data/xml/2020.bionlp.xml
+++ b/data/xml/2020.bionlp.xml
@@ -11,6 +11,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="bea3611e">2020.bionlp-1</url>
     </meta>
     <frontmatter>
       <url hash="be6d2b3b">2020.bionlp-1.0</url>

--- a/data/xml/2020.challengehml.xml
+++ b/data/xml/2020.challengehml.xml
@@ -11,6 +11,7 @@
       <address>Seattle, USA</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="ce85a8c6">2020.challengehml-1</url>
     </meta>
     <frontmatter>
       <url hash="1197a09f">2020.challengehml-1.0</url>

--- a/data/xml/2020.ecnlp.xml
+++ b/data/xml/2020.ecnlp.xml
@@ -13,6 +13,7 @@
       <address>Seattle, WA, USA</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="e2c30d8c">2020.ecnlp-1</url>
     </meta>
     <frontmatter>
       <url hash="11960fe3">2020.ecnlp-1.0</url>

--- a/data/xml/2020.fever.xml
+++ b/data/xml/2020.fever.xml
@@ -12,6 +12,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="ee435e98">2020.fever-1</url>
     </meta>
     <frontmatter>
       <url hash="c5f632b1">2020.fever-1.0</url>

--- a/data/xml/2020.figlang.xml
+++ b/data/xml/2020.figlang.xml
@@ -14,6 +14,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="5a671364">2020.figlang-1</url>
     </meta>
     <frontmatter>
       <url hash="567b9601">2020.figlang-1.0</url>

--- a/data/xml/2020.iwpt.xml
+++ b/data/xml/2020.iwpt.xml
@@ -16,6 +16,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="fe3f84b1">2020.iwpt-1</url>
     </meta>
     <frontmatter>
       <url hash="93260931">2020.iwpt-1.0</url>

--- a/data/xml/2020.iwslt.xml
+++ b/data/xml/2020.iwslt.xml
@@ -17,6 +17,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="4afe5e25">2020.iwslt-1</url>
     </meta>
     <frontmatter>
       <url hash="3be4c876">2020.iwslt-1.0</url>

--- a/data/xml/2020.ngt.xml
+++ b/data/xml/2020.ngt.xml
@@ -16,6 +16,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="35b7d8df">2020.ngt-1</url>
     </meta>
     <frontmatter>
       <url hash="ce0cb7a8">2020.ngt-1.0</url>

--- a/data/xml/2020.nli.xml
+++ b/data/xml/2020.nli.xml
@@ -11,6 +11,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="fed11dde">2020.nli-1</url>
     </meta>
     <frontmatter>
       <url hash="175d8ef8">2020.nli-1.0</url>

--- a/data/xml/2020.nlp4convai.xml
+++ b/data/xml/2020.nlp4convai.xml
@@ -15,6 +15,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="ce634d6f">2020.nlp4convai-1</url>
     </meta>
     <frontmatter>
       <url hash="a9c1804c">2020.nlp4convai-1.0</url>

--- a/data/xml/2020.nlpmc.xml
+++ b/data/xml/2020.nlpmc.xml
@@ -15,6 +15,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="915e7714">2020.nlpmc-1</url>
     </meta>
     <frontmatter>
       <url hash="6f84e28c">2020.nlpmc-1.0</url>

--- a/data/xml/2020.nuse.xml
+++ b/data/xml/2020.nuse.xml
@@ -20,6 +20,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="9075bb72">2020.nuse-1</url>
     </meta>
     <frontmatter>
       <url hash="16e67b2a">2020.nuse-1.0</url>

--- a/data/xml/2020.repl4nlp.xml
+++ b/data/xml/2020.repl4nlp.xml
@@ -15,6 +15,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="67f2d50b">2020.repl4nlp-1</url>
     </meta>
     <frontmatter>
       <url hash="d40b3f5b">2020.repl4nlp-1.0</url>

--- a/data/xml/2020.sigmorphon.xml
+++ b/data/xml/2020.sigmorphon.xml
@@ -10,6 +10,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="52a1928d">2020.sigmorphon-1</url>
     </meta>
     <frontmatter>
       <url hash="348ca84d">2020.sigmorphon-1.0</url>

--- a/data/xml/2020.socialnlp.xml
+++ b/data/xml/2020.socialnlp.xml
@@ -9,6 +9,7 @@
       <address>Online</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="57dbb390">2020.socialnlp-1</url>
     </meta>
     <frontmatter>
       <url hash="0bba0f3b">2020.socialnlp-1.0</url>

--- a/data/xml/2020.winlp.xml
+++ b/data/xml/2020.winlp.xml
@@ -14,6 +14,7 @@
       <address>Seattle, USA</address>
       <month>July</month>
       <year>2020</year>
+      <url hash="d30f3291">2020.winlp-1</url>
     </meta>
     <frontmatter>
       <url hash="ea9c5bdf">2020.winlp-1.0</url>

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -59,7 +59,7 @@ RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})\.pdf$ /anthology-files/pdf/$1/
 # PDF link, revisions, and errata (P17-1069[v2].pdf loads P/P17/P17-1069[v2].pdf --- with "v2" optional)
 # TODO: decide on a new format for revisions and errata
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)?\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
-RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+\.\d+)\.pdf$ /anthology-files/pdf/$2/$1.$2-$3.pdf [L,NC]
+RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+(\.\d+)?)\.pdf$ /anthology-files/pdf/$2/$1.$2-$3.pdf [L,NC]
 
 # Attachments (e.g., P17-1069.Poster.pdf loads /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)
 RewriteRule ^attachments/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]


### PR DESCRIPTION
* Adds full volume PDFs
* Fixes .htaccess redirect to load new-ID full volume PDFs
* Removes a pulled paper
