### PR TITLE
Modeling presentations and other data types

### DIFF
--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -22,7 +22,26 @@ attachment = element attachment {
     checksum,
     local-filename
 }
+video = element video {
+    attribute href { xsd:anyURI },
+    attribute tag { text },
+    attribute permission { xsd:boolean }?
+}
 
+Presentation = element presentation {
+  attribute id { xsd:positiveInteger },
+  attribute ingest-date { xsd:date }?,
+  (element abstract { MarkupText }?
+   & attachment*
+   & element title { MarkupText }
+   & element author { Person }*
+   & element doi { xsd:anyURI }?
+   & element note { text }?
+   & url-with-checksum?
+   & video*
+   & element language { xsd:language }?
+   )
+}
 Paper = element paper {
   attribute id { xsd:positiveInteger },
   attribute ingest-date { xsd:date }?,
@@ -54,11 +73,7 @@ Paper = element paper {
    & element pages { text }?
    & element title { MarkupText }
    & url-with-checksum?
-   & element video {
-       attribute href { xsd:anyURI },
-       attribute tag { text },
-       attribute permission { xsd:boolean }?
-     }*
+   & video*
    & element volume { xsd:positiveInteger }?
    & element language { xsd:language }?
    )
@@ -95,7 +110,8 @@ Volume = element volume {
   attribute ingest-date { xsd:date }?,
   Meta,
   Frontmatter?,
-  Paper*
+  Paper*,
+  Presentation*
 }
 Collection = element collection {
   attribute id { xsd:string },


### PR DESCRIPTION
With the ACL 2020 ingestion looming, it's a good time to revisit #298 proposing that we include other data types. There have been many requests to include keynotes, in particular, and so we need a way to represent them. I am hoping we can use this draft to discuss this.

I've added a Presentation type, which includes relevant tags. One thing we might consider doing here is using this as a chance to remodel the `<video>` tag. We currently have this:
```
<video href="https://vimeo.com/385493447" tag="video" permission="false"/>
```
(Does anyone know what the purpose the "tag" here is? )

I suggest we use this instead:
```
<video permission="false">https://vimeo.com/385493447"</video>
```
This more closely mirrors the `<url>` tag.

We could also add other attributes, such as language.