### PR TITLE
Correction to Anthology ID 2020.nuse-1.5

### DIFF
--- a/data/xml/2020.nuse.xml
+++ b/data/xml/2020.nuse.xml
@@ -69,8 +69,8 @@
     <paper id="5">
       <title>Extensively Matching for Few-shot Learning Event Detection</title>
       <author><first>Viet Dac</first><last>Lai</last></author>
-      <author><first>Thien Huu</first><last>Nguyen</last></author>
-      <author><first>Frank</first><last>Dernoncourt</last></author>
+      <author><first>Franck</first><last>Dernoncourt</last></author>
+      <author><first>Thien Huu</first><last>Nguyen</last></author>      
       <pages>38–45</pages>
       <abstract>Current event detection models under supervised learning settings fail to transfer to new event types. Few-shot learning has not been explored in event detection even though it allows a model to perform well with high generalization on new event types. In this work, we formulate event detection as a few-shot learning problem to enable to extend event detection to new event types. We propose two novel loss factors that matching examples in the support set to provide more training signals to the model. Moreover, these training signals can be applied in many metric-based few-shot learning models. Our extensive experiments on the ACE-2005 dataset (under a few-shot learning setting) show that the proposed method can improve the performance of few-shot learning.</abstract>
       <url hash="adf9c622">2020.nuse-1.5</url>

--- a/data/xml/2020.nuse.xml
+++ b/data/xml/2020.nuse.xml
@@ -69,8 +69,8 @@
     <paper id="5">
       <title>Extensively Matching for Few-shot Learning Event Detection</title>
       <author><first>Viet Dac</first><last>Lai</last></author>
-      <author><first>Franck</first><last>Dernoncourt</last></author>
       <author><first>Thien Huu</first><last>Nguyen</last></author>
+      <author><first>Franck</first><last>Dernoncourt</last></author>
       <pages>38–45</pages>
       <abstract>Current event detection models under supervised learning settings fail to transfer to new event types. Few-shot learning has not been explored in event detection even though it allows a model to perform well with high generalization on new event types. In this work, we formulate event detection as a few-shot learning problem to enable to extend event detection to new event types. We propose two novel loss factors that matching examples in the support set to provide more training signals to the model. Moreover, these training signals can be applied in many metric-based few-shot learning models. Our extensive experiments on the ACE-2005 dataset (under a few-shot learning setting) show that the proposed method can improve the performance of few-shot learning.</abstract>
       <url hash="adf9c622">2020.nuse-1.5</url>

--- a/data/xml/2020.nuse.xml
+++ b/data/xml/2020.nuse.xml
@@ -70,7 +70,7 @@
       <title>Extensively Matching for Few-shot Learning Event Detection</title>
       <author><first>Viet Dac</first><last>Lai</last></author>
       <author><first>Franck</first><last>Dernoncourt</last></author>
-      <author><first>Thien Huu</first><last>Nguyen</last></author>      
+      <author><first>Thien Huu</first><last>Nguyen</last></author>
       <pages>38–45</pages>
       <abstract>Current event detection models under supervised learning settings fail to transfer to new event types. Few-shot learning has not been explored in event detection even though it allows a model to perform well with high generalization on new event types. In this work, we formulate event detection as a few-shot learning problem to enable to extend event detection to new event types. We propose two novel loss factors that matching examples in the support set to provide more training signals to the model. Moreover, these training signals can be applied in many metric-based few-shot learning models. Our extensive experiments on the ACE-2005 dataset (under a few-shot learning setting) show that the proposed method can improve the performance of few-shot learning.</abstract>
       <url hash="adf9c622">2020.nuse-1.5</url>


### PR DESCRIPTION
- Fixed typo Frank -> Franck. 
- Fixed author order to match the [PDF](https://www.aclweb.org/anthology/2020.nuse-1.5.pdf).