### PR TITLE
Correction to Anthology ID 2020.acl-main.140

### DIFF
--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -1615,7 +1615,7 @@
       <doi>10.18653/v1/2020.acl-main.139</doi>
     </paper>
     <paper id="140">
-      <title>Probing Linguistic Features of Sentence-Level Representations in Relation Extraction</title>
+      <title>Probing Linguistic Features of Sentence-Level Representations in Neural Relation Extraction</title>
       <author><first>Christoph</first><last>Alt</last></author>
       <author><first>Aleksandra</first><last>Gabryszak</last></author>
       <author><first>Leonhard</first><last>Hennig</last></author>


### PR DESCRIPTION
Fixed title to match the PDF -> "Probing Linguistic Features of Sentence-Level Representations in **Neural** Relation Extraction"
