### PR TITLE
Add missing whitespace to title

### DIFF
--- a/data/xml/2020.signlang.xml
+++ b/data/xml/2020.signlang.xml
@@ -108,7 +108,7 @@
       <language>eng</language>
     </paper>
     <paper id="9">
-      <title>Elicitation and Corpus of <fixed-case>S</fixed-case>pontaneous Sign Language Discourse Representation Diagrams</title>
+      <title>Elicitation and Corpus of Spontaneous Sign Language Discourse Representation Diagrams</title>
       <author><first>Michael</first><last>Filhol</last></author>
       <pages>53–60</pages>
       <abstract>While Sign Languages have no standard written form, many signers do capture their language in some form of spontaneous graphical form. We list a few use cases (discourse preparation, deverbalising for translation, etc.) and give examples of diagrams. After hypothesising that they contain regular patterns of significant value, we propose to build a corpus of such productions. The main contribution of this paper is the specification of the elicitation protocol, explaining the variables that are likely to affect the diagrams collected. We conclude with a report on the current state of a collection following this protocol, and a few observations on the collected contents. A first prospect is the standardisation of a scheme to represent SL discourse in a way that would make them sharable. A subsequent longer-term prospect is for this scheme to be owned by users and with time be shaped into a script for their language.</abstract>

--- a/data/xml/2020.signlang.xml
+++ b/data/xml/2020.signlang.xml
@@ -108,7 +108,7 @@
       <language>eng</language>
     </paper>
     <paper id="9">
-      <title>Elicitation and Corpus of<fixed-case>S</fixed-case>pontaneous Sign Language Discourse Representation Diagrams</title>
+      <title>Elicitation and Corpus of <fixed-case>S</fixed-case>pontaneous Sign Language Discourse Representation Diagrams</title>
       <author><first>Michael</first><last>Filhol</last></author>
       <pages>53–60</pages>
       <abstract>While Sign Languages have no standard written form, many signers do capture their language in some form of spontaneous graphical form. We list a few use cases (discourse preparation, deverbalising for translation, etc.) and give examples of diagrams. After hypothesising that they contain regular patterns of significant value, we propose to build a corpus of such productions. The main contribution of this paper is the specification of the elicitation protocol, explaining the variables that are likely to affect the diagrams collected. We conclude with a report on the current state of a collection following this protocol, and a few observations on the collected contents. A first prospect is the standardisation of a scheme to represent SL discourse in a way that would make them sharable. A subsequent longer-term prospect is for this scheme to be owned by users and with time be shaped into a script for their language.</abstract>


### PR DESCRIPTION
Missing whitespace was resulting in the title containing "ofSpontaneous" instead of "of Spontaneous". Added the missing whitespace. See issue #949 