### PR TITLE
cleanup

### DIFF
--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -260,7 +260,7 @@ class AnthologyIndex:
         ## no longer issuing a warning for unused variants
         ## it is generally a good idea to keep them around in case they pop up again
         ## if you want to prune them, try clean_name_variants.py
-        #for name, ids in self.name_to_ids.items():
+        # for name, ids in self.name_to_ids.items():
         #    for id_ in ids:
         #        cname = self.id_to_canonical[id_]
         #        if name != cname and name not in self.id_to_used[id_]:

--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -257,15 +257,18 @@ class AnthologyIndex:
                         self.coauthors[id_][co_id] += 1
 
     def verify(self):
-        for name, ids in self.name_to_ids.items():
-            for id_ in ids:
-                cname = self.id_to_canonical[id_]
-                if name != cname and name not in self.id_to_used[id_]:
-                    log.warning(
-                        "Variant name '{}' of '{}' is not used".format(
-                            repr(name), repr(cname)
-                        )
-                    )
+        ## no longer issuing a warning for unused variants
+        ## it is generally a good idea to keep them around in case they pop up again
+        ## if you want to prune them, try clean_name_variants.py
+        #for name, ids in self.name_to_ids.items():
+        #    for id_ in ids:
+        #        cname = self.id_to_canonical[id_]
+        #        if name != cname and name not in self.id_to_used[id_]:
+        #            log.warning(
+        #                "Variant name '{}' of '{}' is not used".format(
+        #                    repr(name), repr(cname)
+        #                )
+        #            )
         for name, d in self.name_to_papers.items():
             if len(d[False]) > 0 and len(d[True]) > 0:
                 log.error(

--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -65,7 +65,7 @@
       <author><first>Xinyu</first><last>Dai</last></author>
       <author><first>Yinggong</first><last>Zhao</last></author>
       <author><first>Shujian</first><last>Huang</last></author>
-      <author><first>Jiajun</first><last>CHEN</last></author>
+      <author><first>Jiajun</first><last>Chen</last></author>
       <pages>34–40</pages>
       <abstract>Recent proposed approaches have made promising progress in dialogue state tracking (DST). However, in multi-domain scenarios, ellipsis and reference are frequently adopted by users to express values that have been mentioned by slots from other domains. To handle these phenomena, we propose a Dialogue State Tracking with Slot Connections (DST-SC) model to explicitly consider slot correlations across different domains. Given a target slot, the slot connecting mechanism in DST-SC can infer its source slot and copy the source slot value directly, thus significantly reducing the difficulty of learning and reasoning. Experimental results verify the benefits of explicit slot connection modeling, and our model achieves state-of-the-art performance on MultiWOZ 2.0 and MultiWOZ 2.1 datasets.</abstract>
       <url hash="745c331d">2020.acl-main.5</url>
@@ -90,7 +90,7 @@
       <author><first>Zongsheng</first><last>Wang</last></author>
       <author><first>Yifu</first><last>Chen</last></author>
       <author><first>Derek F.</first><last>Wong</last></author>
-      <author><first>qihang</first><last>feng</last></author>
+      <author><first>Qihang</first><last>Feng</last></author>
       <author><first>Junhong</first><last>Huang</last></author>
       <author><first>Baoxun</first><last>Wang</last></author>
       <pages>53–65</pages>
@@ -185,7 +185,7 @@
       <author><first>Jinglin</first><last>Liu</last></author>
       <author><first>Xu</first><last>Tan</last></author>
       <author><first>Zhou</first><last>Zhao</last></author>
-      <author><first>sheng</first><last>zhao</last></author>
+      <author><first>Sheng</first><last>Zhao</last></author>
       <author><first>Tie-Yan</first><last>Liu</last></author>
       <pages>149–159</pages>
       <abstract>Non-autoregressive (NAR) models generate all the tokens of a sequence in parallel, resulting in faster generation speed compared to their autoregressive (AR) counterparts but at the cost of lower accuracy. Different techniques including knowledge distillation and source-target alignment have been proposed to bridge the gap between AR and NAR models in various tasks such as neural machine translation (NMT), automatic speech recognition (ASR), and text to speech (TTS). With the help of those techniques, NAR models can catch up with the accuracy of AR models in some tasks but not in some others. In this work, we conduct a study to understand the difficulty of NAR sequence generation and try to answer: (1) Why NAR models can catch up with AR models in some tasks but not all? (2) Why techniques like knowledge distillation and source-target alignment can help NAR models. Since the main difference between AR and NAR models is that NAR models do not use dependency among target tokens while AR models do, intuitively the difficulty of NAR sequence generation heavily depends on the strongness of dependency among target tokens. To quantify such dependency, we propose an analysis model called CoMMA to characterize the difficulty of different NAR sequence generation tasks. We have several interesting findings: 1) Among the NMT, ASR and TTS tasks, ASR has the most target-token dependency while TTS has the least. 2) Knowledge distillation reduces the target-token dependency in target sequence and thus improves the accuracy of NAR models. 3) Source-target alignment constraint encourages dependency of a target token on source tokens and thus eases the training of NAR models.</abstract>
@@ -315,7 +315,7 @@
       <author><first>Ruichu</first><last>Cai</last></author>
       <author><first>Zhihao</first><last>Liang</last></author>
       <author><first>Boyan</first><last>Xu</last></author>
-      <author><first>zijian</first><last>li</last></author>
+      <author><first>Zijian</first><last>Li</last></author>
       <author><first>Yuexing</first><last>Hao</last></author>
       <author><first>Yao</first><last>Chen</last></author>
       <pages>291–301</pages>
@@ -671,7 +671,7 @@
       <title>Learning to Tag <fixed-case>OOV</fixed-case> Tokens by Integrating Contextual Representation and Background Knowledge</title>
       <author><first>Keqing</first><last>He</last></author>
       <author><first>Yuanmeng</first><last>Yan</last></author>
-      <author><first>Weiran</first><last>XU</last></author>
+      <author><first>Weiran</first><last>Xu</last></author>
       <pages>619–624</pages>
       <abstract>Neural-based context-aware models for slot tagging have achieved state-of-the-art performance. However, the presence of OOV(out-of-vocab) words significantly degrades the performance of neural-based models, especially in a few-shot scenario. In this paper, we propose a novel knowledge-enhanced slot tagging model to integrate contextual representation of input text and the large-scale lexical background knowledge. Besides, we use multi-level graph attention to explicitly model lexical relations. The experiments show that our proposed knowledge integration mechanism achieves consistent improvements across settings with different sizes of training data on two public benchmark datasets.</abstract>
       <url hash="f61b86ee">2020.acl-main.58</url>
@@ -704,7 +704,7 @@
       <author><first>Wei</first><last>Bi</last></author>
       <author><first>Dongkyu</first><last>Lee</last></author>
       <author><first>Lanqing</first><last>Xue</last></author>
-      <author><first>YIPING</first><last>SONG</last></author>
+      <author><first>Yiping</first><last>Song</last></author>
       <author><first>Xiaojiang</first><last>Liu</last></author>
       <author><first>Nevin L.</first><last>Zhang</last></author>
       <pages>650–659</pages>
@@ -748,7 +748,7 @@
       <author><first>Yu</first><last>Bao</last></author>
       <author><first>Shujian</first><last>Huang</last></author>
       <author><first>Xinyu</first><last>Dai</last></author>
-      <author><first>Jiajun</first><last>CHEN</last></author>
+      <author><first>Jiajun</first><last>Chen</last></author>
       <pages>708–717</pages>
       <abstract>Definition generation, which aims to automatically generate dictionary definitions for words, has recently been proposed to assist the construction of dictionaries and help people understand unfamiliar texts. However, previous works hardly consider explicitly modeling the “components” of definitions, leading to under-specific generation results. In this paper, we propose ESD, namely Explicit Semantic Decomposition for definition Generation, which explicitly decomposes the meaning of words into semantic components, and models them with discrete latent variables for definition generation. Experimental results show that achieves top results on WordNet and Oxford benchmarks, outperforming strong previous baselines.</abstract>
       <url hash="0a961d6b">2020.acl-main.65</url>
@@ -1109,7 +1109,7 @@
       <title><fixed-case>DTCA</fixed-case>: Decision Tree-based Co-Attention Networks for Explainable Claim Verification</title>
       <author><first>Lianwei</first><last>Wu</last></author>
       <author><first>Yuan</first><last>Rao</last></author>
-      <author><first>yongqiang</first><last>zhao</last></author>
+      <author><first>Yongqiang</first><last>Zhao</last></author>
       <author><first>Hao</first><last>Liang</last></author>
       <author><first>Ambreen</first><last>Nazir</last></author>
       <pages>1024–1035</pages>
@@ -1518,7 +1518,7 @@
       <author><first>Qian</first><last>Liu</last></author>
       <author><first>Yihong</first><last>Chen</last></author>
       <author><first>Bei</first><last>Chen</last></author>
-      <author><first>Jian-Guang</first><last>LOU</last></author>
+      <author><first>Jian-Guang</first><last>Lou</last></author>
       <author><first>Zixuan</first><last>Chen</last></author>
       <author><first>Bin</first><last>Zhou</last></author>
       <author><first>Dongmei</first><last>Zhang</last></author>
@@ -1662,7 +1662,7 @@
     </paper>
     <paper id="144">
       <title>Boosting Neural Machine Translation with Similar Translations</title>
-      <author><first>Jitao</first><last>XU</last></author>
+      <author><first>Jitao</first><last>Xu</last></author>
       <author><first>Josep</first><last>Crego</last></author>
       <author><first>Jean</first><last>Senellart</last></author>
       <pages>1580–1590</pages>
@@ -2144,7 +2144,7 @@
     <paper id="188">
       <title>Calibrating Structured Output Predictors for Natural Language Processing</title>
       <author><first>Abhyuday</first><last>Jagannatha</last></author>
-      <author><first>hong</first><last>yu</last></author>
+      <author><first>Hong</first><last>Yu</last></author>
       <pages>2078–2092</pages>
       <abstract>We address the problem of calibrating prediction confidence for output entities of interest in natural language processing (NLP) applications. It is important that NLP applications such as named entity recognition and question answering produce calibrated confidence scores for their predictions, especially if the applications are to be deployed in a safety-critical domain such as healthcare. However the output space of such structured prediction models are often too large to directly adapt binary or multi-class calibration methods. In this study, we propose a general calibration scheme for output entities of interest in neural network based structured prediction models. Our proposed method can be used with any binary class calibration scheme and a neural network model. Additionally, we show that our calibration method can also be used as an uncertainty-aware, entity-specific decoding step to improve the performance of the underlying model at no additional training cost or data requirements. We show that our method outperforms current calibration techniques for Named Entity Recognition, Part-of-speech tagging and Question Answering systems. We also observe an improvement in model performance from our decoding step across several tasks and benchmark datasets. Our method improves the calibration and model performance on out-of-domain test scenarios as well.</abstract>
       <url hash="9d1aa696">2020.acl-main.188</url>
@@ -2522,7 +2522,7 @@
     <paper id="222">
       <title>The Dialogue Dodecathlon: Open-Domain Knowledge and Image Grounded Conversational Agents</title>
       <author><first>Kurt</first><last>Shuster</last></author>
-      <author><first>Da</first><last>JU</last></author>
+      <author><first>Da</first><last>Ju</last></author>
       <author><first>Stephen</first><last>Roller</last></author>
       <author><first>Emily</first><last>Dinan</last></author>
       <author><first>Y-Lan</first><last>Boureau</last></author>
@@ -2912,7 +2912,7 @@
     <paper id="256">
       <title><fixed-case>G</fixed-case>lyph2<fixed-case>V</fixed-case>ec: Learning <fixed-case>C</fixed-case>hinese Out-of-Vocabulary Word Embedding from Glyphs</title>
       <author><first>Hong-You</first><last>Chen</last></author>
-      <author><first>SZ-HAN</first><last>YU</last></author>
+      <author><first>Sz-Han</first><last>Yu</last></author>
       <author><first>Shou-de</first><last>Lin</last></author>
       <pages>2865–2871</pages>
       <abstract>Chinese NLP applications that rely on large text often contain huge amounts of vocabulary which are sparse in corpus. We show that characters’ written form, <i>Glyphs</i>, in ideographic languages could carry rich semantics. We present a multi-modal model, <i>Glyph2Vec</i>, to tackle Chinese out-of-vocabulary word embedding problem. Glyph2Vec extracts visual features from word glyphs to expand current word embedding space for out-of-vocabulary word embedding, without the need of accessing any corpus, which is useful for improving Chinese NLP systems, especially for low-resource scenarios. Experiments across different applications show the significant effectiveness of our model.</abstract>
@@ -2967,7 +2967,7 @@
     </paper>
     <paper id="261">
       <title>Give Me Convenience and Give Her Death: Who Should Decide What Uses of <fixed-case>NLP</fixed-case> are Appropriate, and on What Basis?</title>
-      <author><first>kobi</first><last>leins</last></author>
+      <author><first>Kobi</first><last>Leins</last></author>
       <author><first>Jey Han</first><last>Lau</last></author>
       <author><first>Timothy</first><last>Baldwin</last></author>
       <pages>2908–2913</pages>
@@ -3253,7 +3253,7 @@
       <author><first>Tong</first><last>Xiao</last></author>
       <author><first>Qingyang</first><last>Zhong</last></author>
       <author><first>Yuquan</first><last>Wang</last></author>
-      <author><first>wenzheng</first><last>feng</last></author>
+      <author><first>Wenzheng</first><last>Feng</last></author>
       <author><first>Junyi</first><last>Luo</last></author>
       <author><first>Chenyu</first><last>Wang</last></author>
       <author><first>Lei</first><last>Hou</last></author>
@@ -3357,7 +3357,7 @@
       <title>Parallel Data Augmentation for Formality Style Transfer</title>
       <author><first>Yi</first><last>Zhang</last></author>
       <author><first>Tao</first><last>Ge</last></author>
-      <author><first>Xu</first><last>SUN</last></author>
+      <author><first>Xu</first><last>Sun</last></author>
       <pages>3221–3228</pages>
       <abstract>The main barrier to progress in the task of Formality Style Transfer is the inadequacy of training data. In this paper, we study how to augment parallel data and propose novel and simple data augmentation methods for this task to obtain useful sentence pairs with easily accessible models and systems. Experiments demonstrate that our augmented parallel data largely helps improve formality style transfer when it is used to pre-train the model, leading to the state-of-the-art results in the GYAFC benchmark dataset.</abstract>
       <url hash="d4c0793f">2020.acl-main.294</url>
@@ -3381,7 +3381,7 @@
       <author><first>Longtao</first><last>Huang</last></author>
       <author><first>Rong</first><last>Zhang</last></author>
       <author><first>Quan</first><last>Lu</last></author>
-      <author><first>hui</first><last>xue</last></author>
+      <author><first>Hui</first><last>Xue</last></author>
       <pages>3239–3248</pages>
       <abstract>Aspect terms extraction and opinion terms extraction are two key problems of fine-grained Aspect Based Sentiment Analysis (ABSA). The aspect-opinion pairs can provide a global profile about a product or service for consumers and opinion mining systems. However, traditional methods can not directly output aspect-opinion pairs without given aspect terms or opinion terms. Although some recent co-extraction methods have been proposed to extract both terms jointly, they fail to extract them as pairs. To this end, this paper proposes an end-to-end method to solve the task of Pair-wise Aspect and Opinion Terms Extraction (PAOTE). Furthermore, this paper treats the problem from a perspective of joint term and relation extraction rather than under the sequence tagging formulation performed in most prior works. We propose a multi-task learning framework based on shared spans, where the terms are extracted under the supervision of span boundaries. Meanwhile, the pair-wise relations are jointly identified using the span representations. Extensive experiments show that our model consistently outperforms state-of-the-art methods.</abstract>
       <url hash="6c822869">2020.acl-main.296</url>
@@ -3632,7 +3632,7 @@
       <author><first>Shujian</first><last>Huang</last></author>
       <author><first>Jun</first><last>Xie</last></author>
       <author><first>Xinyu</first><last>Dai</last></author>
-      <author><first>Jiajun</first><last>CHEN</last></author>
+      <author><first>Jiajun</first><last>Chen</last></author>
       <pages>3486–3497</pages>
       <abstract>Neural machine translation systems tend to fail on less decent inputs despite its significant efficacy, which may significantly harm the credibility of these systems—fathoming how and when neural-based systems fail in such cases is critical for industrial maintenance. Instead of collecting and analyzing bad cases using limited handcrafted error features, here we investigate this issue by generating adversarial examples via a new paradigm based on reinforcement learning. Our paradigm could expose pitfalls for a given performance metric, e.g., BLEU, and could target any given neural machine translation architecture. We conduct experiments of adversarial attacks on two mainstream neural machine translation architectures, RNN-search, and Transformer. The results show that our method efficiently produces stable attacks with meaning-preserving adversarial examples. We also present a qualitative and quantitative analysis for the preference pattern of the attack, demonstrating its capability of pitfall exposure.</abstract>
       <url hash="61c3189a">2020.acl-main.319</url>
@@ -3670,7 +3670,7 @@
       <author><first>Tong</first><last>Xiao</last></author>
       <author><first>Jingbo</first><last>Zhu</last></author>
       <author><first>Tongran</first><last>Liu</last></author>
-      <author><first>changliang</first><last>li</last></author>
+      <author><first>changliang</first><last>Li</last></author>
       <pages>3512–3518</pages>
       <abstract>In encoder-decoder neural models, multiple encoders are in general used to represent the contextual information in addition to the individual sentence. In this paper, we investigate multi-encoder approaches in document-level neural machine translation (NMT). Surprisingly, we find that the context encoder does not only encode the surrounding sentences but also behaves as a noise generator. This makes us rethink the real benefits of multi-encoder in context-aware translation - some of the improvements come from robust training. We compare several methods that introduce noise and/or well-tuned dropout setup into the training of these encoders. Experimental results show that noisy training plays an important role in multi-encoder-based NMT, especially when the training data is small. Also, we establish a new state-of-the-art on IWSLT Fr-En task by careful use of noise generation and dropout methods.</abstract>
       <url hash="49515b79">2020.acl-main.322</url>
@@ -3807,7 +3807,7 @@
     <paper id="334">
       <title><fixed-case>B</fixed-case>i<fixed-case>RRE</fixed-case>: Learning Bidirectional Residual Relation Embeddings for Supervised Hypernymy Detection</title>
       <author><first>Chengyu</first><last>Wang</last></author>
-      <author><first>XIAOFENG</first><last>HE</last></author>
+      <author><first>Xiaofeng</first><last>He</last></author>
       <pages>3630–3640</pages>
       <abstract>The hypernymy detection task has been addressed under various frameworks. Previously, the design of unsupervised hypernymy scores has been extensively studied. In contrast, supervised classifiers, especially distributional models, leverage the global contexts of terms to make predictions, but are more likely to suffer from “lexical memorization”. In this work, we revisit supervised distributional models for hypernymy detection. Rather than taking embeddings of two terms as classification inputs, we introduce a representation learning framework named Bidirectional Residual Relation Embeddings (BiRRE). In this model, a term pair is represented by a BiRRE vector as features for hypernymy classification, which models the possibility of a term being mapped to another in the embedding space by hypernymy relations. A Latent Projection Model with Negative Regularization (LPMNR) is proposed to simulate how hypernyms and hyponyms are generated by neural language models, and to generate BiRRE vectors based on bidirectional residuals of projections. Experiments verify BiRRE outperforms strong baselines over various evaluation frameworks.</abstract>
       <url hash="e1956a33">2020.acl-main.334</url>
@@ -3864,7 +3864,7 @@
       <author><first>Yu</first><last>Hong</last></author>
       <author><first>Bowei</first><last>Zou</last></author>
       <author><first>Meng</first><last>Cheng</last></author>
-      <author><first>Jianmin</first><last>YAO</last></author>
+      <author><first>Jianmin</first><last>Yao</last></author>
       <pages>3678–3684</pages>
       <abstract>The current aspect extraction methods suffer from boundary errors. In general, these errors lead to a relatively minor difference between the extracted aspects and the ground-truth. However, they hurt the performance severely. In this paper, we propose to utilize a pointer network for repositioning the boundaries. Recycling mechanism is used, which enables the training data to be collected without manual intervention. We conduct the experiments on the benchmark datasets SE14 of laptop and SE14-16 of restaurant. Experimental results show that our method achieves substantial improvements over the baseline, and outperforms state-of-the-art methods.</abstract>
       <url hash="7ea92669">2020.acl-main.339</url>
@@ -3986,7 +3986,7 @@
       <author><first>Jinglin</first><last>Liu</last></author>
       <author><first>Xu</first><last>Tan</last></author>
       <author><first>Chen</first><last>Zhang</last></author>
-      <author><first>Tao</first><last>QIN</last></author>
+      <author><first>Tao</first><last>Qin</last></author>
       <author><first>Zhou</first><last>Zhao</last></author>
       <author><first>Tie-Yan</first><last>Liu</last></author>
       <pages>3787–3796</pages>
@@ -4115,7 +4115,7 @@
       <author><first>Fangkai</first><last>Jiao</last></author>
       <author><first>Mantong</first><last>Zhou</last></author>
       <author><first>Ting</first><last>Yao</last></author>
-      <author><first>jingfang</first><last>xu</last></author>
+      <author><first>Jingfang</first><last>Xu</last></author>
       <author><first>Minlie</first><last>Huang</last></author>
       <pages>3916–3927</pages>
       <abstract>Neural models have achieved great success on machine reading comprehension (MRC), many of which typically consist of two components: an evidence extractor and an answer predictor. The former seeks the most relevant information from a reference text, while the latter is to locate or generate answers from the extracted evidence. Despite the importance of evidence labels for training the evidence extractor, they are not cheaply accessible, particularly in many non-extractive MRC tasks such as YES/NO question answering and multi-choice MRC. To address this problem, we present a Self-Training method (STM), which supervises the evidence extractor with auto-generated evidence labels in an iterative process. At each iteration, a base MRC model is trained with golden answers and noisy evidence labels. The trained model will predict pseudo evidence labels as extra supervision in the next iteration. We evaluate STM on seven datasets over three MRC tasks. Experimental results demonstrate the improvement on existing MRC models, and we also analyze how and why such a self-training method works in MRC.</abstract>
@@ -4248,7 +4248,7 @@
     <paper id="373">
       <title>He said “who’s gonna take care of your children when you are at <fixed-case>ACL</fixed-case>?”: Reported Sexist Acts are Not Sexist</title>
       <author><first>Patricia</first><last>Chiril</last></author>
-      <author><first>Véronique</first><last>MORICEAU</last></author>
+      <author><first>Véronique</first><last>Moriceau</last></author>
       <author><first>Farah</first><last>Benamara</last></author>
       <author><first>Alda</first><last>Mari</last></author>
       <author><first>Gloria</first><last>Origgi</last></author>
@@ -4267,7 +4267,7 @@
       <author><first>Bolei</first><last>He</last></author>
       <author><first>Hua</first><last>Wu</last></author>
       <author><first>Haifeng</first><last>Wang</last></author>
-      <author><first>feng</first><last>wu</last></author>
+      <author><first>Feng</first><last>Wu</last></author>
       <pages>4067–4076</pages>
       <abstract>Recently, sentiment analysis has seen remarkable advance with the help of pre-training approaches. However, sentiment knowledge, such as sentiment words and aspect-sentiment pairs, is ignored in the process of pre-training, despite the fact that they are widely used in traditional sentiment analysis approaches. In this paper, we introduce Sentiment Knowledge Enhanced Pre-training (SKEP) in order to learn a unified sentiment representation for multiple sentiment analysis tasks. With the help of automatically-mined knowledge, SKEP conducts sentiment masking and constructs three sentiment knowledge prediction objectives, so as to embed sentiment information at the word, polarity and aspect level into pre-trained sentiment representation. In particular, the prediction of aspect-sentiment pairs is converted into multi-label classification, aiming to capture the dependency between words in a pair. Experiments on three kinds of sentiment tasks show that SKEP significantly outperforms strong pre-training baseline, and achieves new state-of-the-art results on most of the test datasets. We release our code at https://github.com/baidu/Senta.</abstract>
       <url hash="a6055126">2020.acl-main.374</url>
@@ -4871,7 +4871,7 @@
       <author><first>Kavya</first><last>Srinet</last></author>
       <author><first>Yacine</first><last>Jernite</last></author>
       <author><first>Jonathan</first><last>Gray</last></author>
-      <author><first>arthur</first><last>szlam</last></author>
+      <author><first>Arthur</first><last>Szlam</last></author>
       <pages>4693–4714</pages>
       <abstract>We propose a semantic parsing dataset focused on instruction-driven communication with an agent in the game Minecraft. The dataset consists of 7K human utterances and their corresponding parses. Given proper world state, the parses can be interpreted and executed in game. We report the performance of baseline models, and analyze their successes and failures.</abstract>
       <url hash="46956cab">2020.acl-main.427</url>
@@ -5856,7 +5856,7 @@
     </paper>
     <paper id="517">
       <title>Learning to Customize Model Structures for Few-shot Dialogue Generation Tasks</title>
-      <author><first>YIPING</first><last>SONG</last></author>
+      <author><first>Yiping</first><last>Song</last></author>
       <author><first>Zequn</first><last>Liu</last></author>
       <author><first>Wei</first><last>Bi</last></author>
       <author><first>Rui</first><last>Yan</last></author>
@@ -5947,7 +5947,7 @@
     </paper>
     <paper id="525">
       <title><fixed-case>P</fixed-case>yramid: A Layered Model for Nested Named Entity Recognition</title>
-      <author><first>Jue</first><last>WANG</last></author>
+      <author><first>Jue</first><last>Wang</last></author>
       <author><first>Lidan</first><last>Shou</last></author>
       <author><first>Ke</first><last>Chen</last></author>
       <author><first>Gang</first><last>Chen</last></author>
@@ -6088,7 +6088,7 @@
       <author><first>Zhiruo</first><last>Wang</last></author>
       <author><first>Zhe</first><last>Zhao</last></author>
       <author><first>Haotang</first><last>Deng</last></author>
-      <author><first>QI</first><last>JU</last></author>
+      <author><first>Qi</first><last>Ju</last></author>
       <pages>6035–6044</pages>
       <abstract>Pre-trained language models like BERT have proven to be highly performant. However, they are often computationally expensive in many practical scenarios, for such heavy models can hardly be readily implemented with limited resources. To improve their efficiency with an assured model performance, we propose a novel speed-tunable FastBERT with adaptive inference time. The speed at inference can be flexibly adjusted under varying demands, while redundant calculation of samples is avoided. Moreover, this model adopts a unique self-distillation mechanism at fine-tuning, further enabling a greater computational efficacy with minimal loss in performance. Our model achieves promising results in twelve English and Chinese datasets. It is able to speed up by a wide range from 1 to 12 times than BERT if given different speedup thresholds to make a speed-performance tradeoff.</abstract>
       <url hash="b85d9d46">2020.acl-main.537</url>
@@ -6189,7 +6189,7 @@
       <title>How to Ask Good Questions? Try to Leverage Paraphrases</title>
       <author><first>Xin</first><last>Jia</last></author>
       <author><first>Wenjie</first><last>Zhou</last></author>
-      <author><first>Xu</first><last>SUN</last></author>
+      <author><first>Xu</first><last>Sun</last></author>
       <author><first>Yunfang</first><last>Wu</last></author>
       <pages>6130–6140</pages>
       <abstract>Given a sentence and its relevant answer, how to ask good questions is a challenging task, which has many real applications. Inspired by human’s paraphrasing capability to ask questions of the same meaning but with diverse expressions, we propose to incorporate paraphrase knowledge into question generation(QG) to generate human-like questions. Specifically, we present a two-hand hybrid model leveraging a self-built paraphrase resource, which is automatically conducted by a simple back-translation method. On the one hand, we conduct multi-task learning with sentence-level paraphrase generation (PG) as an auxiliary task to supplement paraphrase knowledge to the task-share encoder. On the other hand, we adopt a new loss function for diversity training to introduce more question patterns to QG. Extensive experimental results show that our proposed model obtains obvious performance gain over several strong baselines, and further human evaluation validates that our model can ask questions of high quality by leveraging paraphrase knowledge.</abstract>
@@ -6445,7 +6445,7 @@
       <author><first>Jiaying</first><last>Hu</last></author>
       <author><first>Yan</first><last>Yang</last></author>
       <author><first>Chencai</first><last>Chen</last></author>
-      <author><first>liang</first><last>he</last></author>
+      <author><first>Liang</first><last>He</last></author>
       <author><first>Zhou</first><last>Yu</last></author>
       <pages>6366–6375</pages>
       <abstract>Dialogue state tracker is responsible for inferring user intentions through dialogue history. Previous methods have difficulties in handling dialogues with long interaction context, due to the excessive information. We propose a Dialogue State Tracker with Slot Attention and Slot Information Sharing (SAS) to reduce redundant information’s interference and improve long dialogue context tracking. Specially, we first apply a Slot Attention to learn a set of slot-specific features from the original dialogue and then integrate them using a slot information sharing module. Our model yields a significantly improved performance compared to previous state-of the-art models on the MultiWOZ dataset.</abstract>
@@ -6495,10 +6495,10 @@
     <paper id="572">
       <title>Connecting Embeddings for Knowledge Graph Entity Typing</title>
       <author><first>Yu</first><last>Zhao</last></author>
-      <author><first>anxiang</first><last>zhang</last></author>
+      <author><first>Anxiang</first><last>Zhang</last></author>
       <author><first>Ruobing</first><last>Xie</last></author>
       <author><first>Kang</first><last>Liu</last></author>
-      <author><first>Xiaojie</first><last>WANG</last></author>
+      <author><first>Xiaojie</first><last>Wang</last></author>
       <pages>6419–6428</pages>
       <abstract>Knowledge graph (KG) entity typing aims at inferring possible missing entity type instances in KG, which is a very significant but still under-explored subtask of knowledge graph completion. In this paper, we propose a novel approach for KG entity typing which is trained by jointly utilizing local typing knowledge from existing entity type assertions and global triple knowledge in KGs. Specifically, we present two distinct knowledge-driven effective mechanisms of entity type inference. Accordingly, we build two novel embedding models to realize the mechanisms. Afterward, a joint model via connecting them is used to infer missing entity type instances, which favors inferences that agree with both entity type instances and triple knowledge in KGs. Experimental results on two real-world datasets (Freebase and YAGO) demonstrate the effectiveness of our proposed mechanisms and models for improving KG entity typing. The source code and data of this paper can be obtained from: https://github.com/Adam1679/ConnectE .</abstract>
       <url hash="b2b19ed9">2020.acl-main.572</url>
@@ -6610,7 +6610,7 @@
       <author><first>Qianhui</first><last>Wu</last></author>
       <author><first>Zijia</first><last>Lin</last></author>
       <author><first>Börje</first><last>Karlsson</last></author>
-      <author><first>Jian-Guang</first><last>LOU</last></author>
+      <author><first>Jian-Guang</first><last>Lou</last></author>
       <author><first>Biqing</first><last>Huang</last></author>
       <pages>6505–6514</pages>
       <abstract>To better tackle the named entity recognition (NER) problem on languages with little/no labeled data, cross-lingual NER must effectively leverage knowledge learned from source languages with rich labeled data. Previous works on cross-lingual NER are mostly based on label projection with pairwise texts or direct model transfer. However, such methods either are not applicable if the labeled data in the source languages is unavailable, or do not leverage information contained in unlabeled data in the target language. In this paper, we propose a teacher-student learning method to address such limitations, where NER models in the source languages are used as teachers to train a student model on unlabeled data in the target language. The proposed method works for both single-source and multi-source cross-lingual NER. For the latter, we further propose a similarity measuring method to better weight the supervision from different teacher models. Extensive experiments for 3 target languages on benchmark datasets well demonstrate that our method outperforms existing state-of-the-art methods for both single-source and multi-source cross-lingual NER.</abstract>
@@ -6743,7 +6743,7 @@
       <author><first>Tong</first><last>Xiao</last></author>
       <author><first>Jingbo</first><last>Zhu</last></author>
       <author><first>Tongran</first><last>Liu</last></author>
-      <author><first>changliang</first><last>li</last></author>
+      <author><first>Changliang</first><last>Li</last></author>
       <pages>6629–6639</pages>
       <abstract>Neural architecture search (NAS) has advanced significantly in recent years but most NAS systems restrict search to learning architectures of a recurrent or convolutional cell. In this paper, we extend the search space of NAS. In particular, we present a general approach to learn both intra-cell and inter-cell architectures (call it ESS). For a better search result, we design a joint learning method to perform intra-cell and inter-cell NAS simultaneously. We implement our model in a differentiable architecture search system. For recurrent neural language modeling, it outperforms a strong baseline significantly on the PTB and WikiText data, with a new state-of-the-art on PTB. Moreover, the learned architectures show good transferability to other systems. E.g., they improve state-of-the-art systems on the CoNLL and WNUT named entity recognition (NER) tasks and CoNLL chunking task, indicating a promising line of research on large-scale pre-learned architectures.</abstract>
       <url hash="ed3eec78">2020.acl-main.592</url>
@@ -6914,7 +6914,7 @@
       <title>Semantic Parsing for <fixed-case>E</fixed-case>nglish as a Second Language</title>
       <author><first>Yuanyuan</first><last>Zhao</last></author>
       <author><first>Weiwei</first><last>Sun</last></author>
-      <author><first>junjie</first><last>cao</last></author>
+      <author><first>Junjie</first><last>Cao</last></author>
       <author><first>Xiaojun</first><last>Wan</last></author>
       <pages>6783–6794</pages>
       <abstract>This paper is concerned with semantic parsing for English as a second language (ESL). Motivated by the theoretical emphasis on the learning challenges that occur at the syntax-semantics interface during second language acquisition, we formulate the task based on the divergence between literal and intended meanings. We combine the complementary strengths of English Resource Grammar, a linguistically-precise hand-crafted deep grammar, and TLE, an existing manually annotated ESL UD-TreeBank with a novel reranking model. Experiments demonstrate that in comparison to human annotations, our method can obtain a very promising SemBanking quality. By means of the newly created corpus, we evaluate state-of-the-art semantic parsing as well as grammatical error correction models. The evaluation profiles the performance of neural NLP techniques for handling ESL data and suggests some research directions.</abstract>
@@ -7230,7 +7230,7 @@
       <author><first>Sanqiang</first><last>Zhao</last></author>
       <author><first>Zhou</first><last>Xiao</last></author>
       <author><first>Pengwei</first><last>Hu</last></author>
-      <author><first>randy</first><last>zhong</last></author>
+      <author><first>Randy</first><last>Zhong</last></author>
       <author><first>Cheng</first><last>Niu</last></author>
       <author><first>Jie</first><last>Zhou</last></author>
       <pages>7087–7097</pages>
@@ -8685,7 +8685,7 @@
       <author><first>Yutao</first><last>Zhu</last></author>
       <author><first>Ruihua</first><last>Song</last></author>
       <author><first>Zhicheng</first><last>Dou</last></author>
-      <author><first>Jian-Yun</first><last>NIE</last></author>
+      <author><first>Jian-Yun</first><last>Nie</last></author>
       <author><first>Jin</first><last>Zhou</last></author>
       <pages>8647–8657</pages>
       <abstract>It is appealing to have a system that generates a story or scripts automatically from a storyline, even though this is still out of our reach. In dialogue systems, it would also be useful to drive dialogues by a dialogue plan. In this paper, we address a key problem involved in these applications - guiding a dialogue by a narrative. The proposed model ScriptWriter selects the best response among the candidates that fit the context as well as the given narrative. It keeps track of what in the narrative has been said and what is to be said. A narrative plays a different role than the context (i.e., previous utterances), which is generally used in current dialogue systems. Due to the unavailability of data for this new application, we construct a new large-scale data collection GraphMovie from a movie website where end- users can upload their narratives freely when watching a movie. Experimental results on the dataset show that our proposed approach based on narratives significantly outperforms the baselines that simply use the narrative as a kind of context.</abstract>

--- a/data/xml/2020.eamt.xml
+++ b/data/xml/2020.eamt.xml
@@ -240,7 +240,7 @@
       <author><first>M. Amin</first><last>Farajian</last></author>
       <author><first>Rachel</first><last>Bawden</last></author>
       <author><first>Michael</first><last>Zhang</last></author>
-      <author><first>André T.</first><last>Martins</last></author>
+      <author><first>André F. T.</first><last>Martins</last></author>
       <pages>225–234</pages>
       <abstract>In this paper we provide a systematic comparison of existing and new document-level neural machine translation solutions. As part of this comparison, we introduce and evaluate a document-level variant of the recently proposed Star Transformer architecture. In addition to using the traditional metric BLEU, we report the accuracy of the models in handling anaphoric pronoun translation as well as coherence and cohesion using contrastive test sets. Finally, we report the results of human evaluation in terms of Multidimensional Quality Metrics (MQM) and analyse the correlation of the results obtained by the automatic metrics with human judgments.</abstract>
       <url hash="75c56ae1">2020.eamt-1.24</url>
@@ -334,7 +334,7 @@
       <title>A User Study of the Incremental Learning in <fixed-case>NMT</fixed-case></title>
       <author><first>Miguel</first><last>Domingo</last></author>
       <author><first>Mercedes</first><last>García-Martínez</last></author>
-      <author><first></first><last>Álvaro Peris</last></author>
+      <author><first>Álvaro</first><last>Peris</last></author>
       <author><first>Alexandre</first><last>Helle</last></author>
       <author><first>Amando</first><last>Estela</last></author>
       <author><first>Laurent</first><last>Bié</last></author>
@@ -349,7 +349,7 @@
       <author><first>Daniel Marín</first><last>Buj</last></author>
       <author><first>Daniel</first><last>Ibáñez García</last></author>
       <author><first>Zuzanna</first><last>Parcheta</last></author>
-      <author><first>Francisco Casacuberta</first><last>Nolla</last></author>
+      <author><first>Francisco</first><last>Casacuberta</last></author>
       <pages>329–338</pages>
       <abstract>In this paper, we present a machine translation system implemented by the Translation Centre for the Bodies of the European Union (CdT). The main goal of this project is to create domain-specific machine translation engines in order to support machine translation services and applications to the Translation Centre’s clients. In this article, we explain the entire implementation process of NICE: Neural Integrated Custom Engines. We describe the problems identified and the solutions provided, and present the final results for different language pairs. Finally, we describe the work that will be done on this project in the future.</abstract>
       <url hash="adf7f158">2020.eamt-1.35</url>
@@ -534,7 +534,7 @@
       <author><first>Petra</first><last>Bago</last></author>
       <author><first>Jane</first><last>Dunne</last></author>
       <author><first>Federico</first><last>Gaspari</last></author>
-      <author><first>Andre</first><last>K</last></author>
+      <author><first>Andre</first><last>Kåsen</last></author>
       <author><first>Gauti</first><last>Kristmannsson</last></author>
       <author><first>Helen</first><last>McHugh</last></author>
       <author><first>Jon Arild</first><last>Olsen</last></author>
@@ -589,7 +589,7 @@
     <paper id="58">
       <title><fixed-case>APE</fixed-case>-<fixed-case>QUEST</fixed-case>: an <fixed-case>MT</fixed-case> Quality Gate</title>
       <author><first>Heidi</first><last>Depraetere</last></author>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <author><first>Sara</first><last>Szoc</last></author>
       <author><first>Tom</first><last>Vanallemeersch</last></author>
       <pages>473–474</pages>
@@ -598,7 +598,7 @@
     </paper>
     <paper id="59">
       <title><fixed-case>MICE</fixed-case>: a middleware layer for <fixed-case>MT</fixed-case></title>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <author><first>Tom</first><last>Vanallemeersch</last></author>
       <author><first>Heidi</first><last>Depraetere</last></author>
       <pages>475–476</pages>
@@ -615,8 +615,8 @@
       <author><first>Manuel</first><last>Herranz</last></author>
       <author><first>Alejandro</first><last>Kohan</last></author>
       <author><first>Maite</first><last>Melero</last></author>
-      <author><first>Tony</first><last>O’dowd</last></author>
-      <author><first>Sinéad</first><last>O’gorman</last></author>
+      <author><first>Tony</first><last>O’Dowd</last></author>
+      <author><first>Sinéad</first><last>O’Gorman</last></author>
       <author><first>Mārcis</first><last>Pinnis</last></author>
       <author><first>Roberts</first><last>Rozis</last></author>
       <author><first>Riccardo</first><last>Superbo</last></author>
@@ -637,10 +637,10 @@
       <title><fixed-case>OCR</fixed-case>, Classification
 
 &amp; Machine Translation (<fixed-case>OCCAM</fixed-case>)</title>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <author><first>Arne</first><last>Defauw</last></author>
       <author><first>Frederic</first><last>Everaert</last></author>
-      <author><first>Koen Van</first><last>Winckel</last></author>
+      <author><first>Koen</first><last>Van Winckel</last></author>
       <author><first>Alina</first><last>Kramchaninova</last></author>
       <author><first>Anna</first><last>Bardadym</last></author>
       <author><first>Tom</first><last>Vanallemeersch</last></author>
@@ -652,11 +652,11 @@
     </paper>
     <paper id="63">
       <title><fixed-case>CEFAT</fixed-case>4<fixed-case>C</fixed-case>ities, a Natural Language Layer for the <fixed-case>ISA</fixed-case>2 Core Public Service Vocabulary</title>
-      <author><first>Joachim Van</first><last>den Bogaert</last></author>
+      <author><first>Joachim</first><last>Van den Bogaert</last></author>
       <author><first>Arne</first><last>Defauw</last></author>
       <author><first>Sara</first><last>Szoc</last></author>
       <author><first>Frederic</first><last>Everaert</last></author>
-      <author><first>Koen Van</first><last>Winckel</last></author>
+      <author><first>Koen</first><last>Van Winckel</last></author>
       <author><first>Alina</first><last>Kramchaninova</last></author>
       <author><first>Anna</first><last>Bardadym</last></author>
       <author><first>Tom</first><last>Vanallemeersch</last></author>
@@ -692,14 +692,14 @@
     </paper>
     <paper id="67">
       <title><fixed-case>D</fixed-case>eep<fixed-case>SPIN</fixed-case>: Deep Structured Prediction for Natural Language Processing</title>
-      <author><first>Andre Filipe Torres</first><last>Martins</last></author>
+      <author><first>André F. T.</first><last>Martins</last></author>
       <pages>493–494</pages>
       <abstract>DeepSPIN is a research project funded by the European Research Council (ERC) whose goal is to develop new neural structured prediction methods, models, and algorithms for improving the quality, interpretability, and data-efficiency of natural language processing (NLP) systems, with special emphasis on machine translation and quality estimation applications.</abstract>
       <url hash="fcc2fce4">2020.eamt-1.67</url>
     </paper>
     <paper id="68">
       <title>Project <fixed-case>MAIA</fixed-case>: Multilingual <fixed-case>AI</fixed-case> Agent Assistant</title>
-      <author><first>Andre Filipe Torres</first><last>Martins</last></author>
+      <author><first>André F. T.</first><last>Martins</last></author>
       <author><first>Joao</first><last>Graca</last></author>
       <author><first>Paulo</first><last>Dimas</last></author>
       <author><first>Helena</first><last>Moniz</last></author>

--- a/data/xml/P85.xml
+++ b/data/xml/P85.xml
@@ -249,7 +249,7 @@
       <title>Structure-Sharing in Lexical Representation</title>
       <author><first>Daniel</first><last>Flickinger</last></author>
       <author><first>Carl</first><last>Pollard</last></author>
-      <author><first>Thomas</first><last>Wasaw</last></author>
+      <author><first>Thomas</first><last>Wasow</last></author>
       <doi>10.3115/981210.981242</doi>
       <pages>262–267</pages>
       <url hash="5552667e">P85-1032</url>

--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -986,7 +986,7 @@
       <booktitle>Proceedings of the Workshop on Automatic Summarization for Different Genres, Media, and Languages</booktitle>
       <url hash="00b82daf">W11-05</url>
       <editor><first>Ani</first><last>Nenkova</last></editor>
-      <editor><first>Julia</first><last>Hirchberg</last></editor>
+      <editor><first>Julia</first><last>Hirschberg</last></editor>
       <editor id="yang-liu-icsi"><first>Yang</first><last>Liu</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Portland, Oregon</address>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -1039,6 +1039,8 @@
   - {first: Razvan C., last: Bunescu}
 - canonical: {first: Harry, last: Bunt}
   id: harry-bunt
+  variants:
+  - {first: Harry C., last: Bunt}
 - canonical: {first: Laura, last: Burdick}
   variants:
   - {first: Laura, last: Wendlandt}
@@ -1687,6 +1689,8 @@
   variants:
   - {first: Alina, last: Ciobanu}
 - canonical: {first: Manuel R., last: Ciosici}
+  variants:
+  - {first: Manuel, last: Ciosici}
 - canonical: {first: Fabio, last: Ciravegna}
   id: fabio-ciravegna
 - canonical: {first: Montserrat, last: Civit}
@@ -2076,6 +2080,8 @@
   variants:
   - {first: Jonathan D., last: DeCristofaro}
 - canonical: {first: Aina, last: Garí Soler}
+  variants:
+  - {first: Aina Garí, last: Soler}
 - canonical: {first: Rosa, last: Del Gaudio}
   variants:
   - {first: Rosa, last: Gaudio}
@@ -3400,6 +3406,7 @@
 - canonical: {first: E. Dario, last: Gutierrez}
   variants:
   - {first: Elkin, last: Darío Gutiérrez}
+  - {first: E.Dario, last: Gutiérrez}
   - {first: E. Darío, last: Gutiérrez}
 - canonical: {first: Yoan, last: Gutiérrez}
   variants:
@@ -3761,6 +3768,8 @@
   variants:
   - {first: Barbora, last: Hladka}
 - canonical: {first: Milena, last: Hnátková}
+  variants:
+  - {first: Milena, last: Hnatkova}
 - canonical: {first: Bao Quoc, last: Ho}
   variants:
   - {first: Quoc, last: Ho}
@@ -4714,6 +4723,8 @@
   variants:
   - {first: Marek, last: Kozłowski}
 - canonical: {first: Marcus, last: Kracht}
+  variants:
+  - {first: Marcus, last: Kracht II}
 - canonical: {first: Emiel, last: Krahmer}
   variants:
   - {first: Emiel J., last: Krahmer}
@@ -4895,6 +4906,8 @@
   - {first: Jenifer C., last: Lai}
   - {first: Jennifer, last: Lai}
 - canonical: {first: K. Robert, last: Lai}
+  variants:
+  - {first: K.Robert, last: Lai}
 - canonical: {first: Min-Hua, last: Lai}
   variants:
   - {first: Min Hua, last: Lai}
@@ -4921,6 +4934,9 @@
   - {first: Lalitha Devi, last: Sobha}
   - {first: Sobha Lalitha, last: Devi}
 - canonical: {first: John P., last: Lalor}
+  variants:
+  - {first: John, last: Lalor}
+  - {first: John Patrick, last: Lalor}
 - canonical: {first: Lori, last: Lamel}
   id: lori-lamel
   variants:
@@ -5504,6 +5520,9 @@
 - canonical: {first: Juan Manuel, last: Lucas-Cuesta}
   variants:
   - {first: Juan Manuel, last: Lucas}
+- canonical: {first: Li, last: Lucy}
+  variants:
+  - {first: Lucy, last: Li}
 - canonical: {first: Peter J., last: Ludlow}
   variants:
   - {first: Peter, last: Ludlow}
@@ -5570,6 +5589,8 @@
   - {first: Birte, last: Lönneker-Rodman}
   - {first: Birte, last: Loenneker-Rodman}
 - canonical: {first: Jan Tore, last: Lønning}
+  variants:
+  - {first: Jan Tore, last: Lonning}
 - canonical: {first: Jia, last: Lü}
   variants:
   - {first: Jia, last: Lu}
@@ -6168,6 +6189,8 @@
   variants:
   - {first: Lesly, last: Miculicich}
 - canonical: {first: Sebastian J., last: Mielke}
+  variants:
+  - {first: Sebastian, last: Mielke}
 - canonical: {first: Rada, last: Mihalcea}
   variants:
   - {first: Rada F., last: Mihalcea}
@@ -6735,6 +6758,8 @@
   similar: [nikola-i-nikolov]
 - canonical: {first: Nikola I., last: Nikolov}
   id: nikola-i-nikolov
+  variants:
+  - {first: Nikola, last: Nikolov}
   similar: [nicolas-nicolov]
 - canonical: {first: Jian-Yun, last: Nie}
   variants:
@@ -10179,6 +10204,8 @@
   - {first: Paulo C. F., last: de Oliveira}
 - canonical: {first: Valeria, last: de Paiva}
   id: valeria-de-paiva
+  variants:
+  - {first: Valeria, last: dePaiva}
 - canonical: {first: Maarten, last: de Rijke}
   variants:
   - {first: Maarten, last: De Rijke}

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -1039,8 +1039,6 @@
   - {first: Razvan C., last: Bunescu}
 - canonical: {first: Harry, last: Bunt}
   id: harry-bunt
-  variants:
-  - {first: Harry C., last: Bunt}
 - canonical: {first: Laura, last: Burdick}
   variants:
   - {first: Laura, last: Wendlandt}
@@ -1689,8 +1687,6 @@
   variants:
   - {first: Alina, last: Ciobanu}
 - canonical: {first: Manuel R., last: Ciosici}
-  variants:
-  - {first: Manuel, last: Ciosici}
 - canonical: {first: Fabio, last: Ciravegna}
   id: fabio-ciravegna
 - canonical: {first: Montserrat, last: Civit}
@@ -2080,8 +2076,6 @@
   variants:
   - {first: Jonathan D., last: DeCristofaro}
 - canonical: {first: Aina, last: Garí Soler}
-  variants:
-  - {first: Aina Garí, last: Soler}
 - canonical: {first: Rosa, last: Del Gaudio}
   variants:
   - {first: Rosa, last: Gaudio}
@@ -3082,9 +3076,6 @@
   - {first: Helen, last: Gigley}
 - canonical: {first: Luca, last: Gilardoni}
   id: luca-gilardoni
-- canonical: {first: Daniel, last: Gildea.}
-  variants:
-  - {first: Daniel, last: Gildea}
 - canonical: {first: Laurent, last: Gillard}
   id: laurent-gillard
 - canonical: {first: Dan, last: Gillick}
@@ -3409,7 +3400,6 @@
 - canonical: {first: E. Dario, last: Gutierrez}
   variants:
   - {first: Elkin, last: Darío Gutiérrez}
-  - {first: E.Dario, last: Gutiérrez}
   - {first: E. Darío, last: Gutiérrez}
 - canonical: {first: Yoan, last: Gutiérrez}
   variants:
@@ -3757,7 +3747,6 @@
 - canonical: {first: Julia, last: Hirschberg}
   variants:
   - {first: Julia B., last: Hirschberg}
-  - {first: Julia, last: Hirchberg}
 - canonical: {first: Lynette, last: Hirschman}
   id: lynette-hirschman
   variants:
@@ -3772,8 +3761,6 @@
   variants:
   - {first: Barbora, last: Hladka}
 - canonical: {first: Milena, last: Hnátková}
-  variants:
-  - {first: Milena, last: Hnatkova}
 - canonical: {first: Bao Quoc, last: Ho}
   variants:
   - {first: Quoc, last: Ho}
@@ -4727,8 +4714,6 @@
   variants:
   - {first: Marek, last: Kozłowski}
 - canonical: {first: Marcus, last: Kracht}
-  variants:
-  - {first: Marcus, last: Kracht II}
 - canonical: {first: Emiel, last: Krahmer}
   variants:
   - {first: Emiel J., last: Krahmer}
@@ -4910,8 +4895,6 @@
   - {first: Jenifer C., last: Lai}
   - {first: Jennifer, last: Lai}
 - canonical: {first: K. Robert, last: Lai}
-  variants:
-  - {first: K.Robert, last: Lai}
 - canonical: {first: Min-Hua, last: Lai}
   variants:
   - {first: Min Hua, last: Lai}
@@ -4938,9 +4921,6 @@
   - {first: Lalitha Devi, last: Sobha}
   - {first: Sobha Lalitha, last: Devi}
 - canonical: {first: John P., last: Lalor}
-  variants:
-  - {first: John, last: Lalor}
-  - {first: John Patrick, last: Lalor}
 - canonical: {first: Lori, last: Lamel}
   id: lori-lamel
   variants:
@@ -5524,9 +5504,6 @@
 - canonical: {first: Juan Manuel, last: Lucas-Cuesta}
   variants:
   - {first: Juan Manuel, last: Lucas}
-- canonical: {first: Li, last: Lucy}
-  variants:
-  - {first: Lucy, last: Li}
 - canonical: {first: Peter J., last: Ludlow}
   variants:
   - {first: Peter, last: Ludlow}
@@ -5593,8 +5570,6 @@
   - {first: Birte, last: Lönneker-Rodman}
   - {first: Birte, last: Loenneker-Rodman}
 - canonical: {first: Jan Tore, last: Lønning}
-  variants:
-  - {first: Jan Tore, last: Lonning}
 - canonical: {first: Jia, last: Lü}
   variants:
   - {first: Jia, last: Lu}
@@ -5883,7 +5858,6 @@
   id: m-antonia-marti
   variants:
   - {first: M. Antonia, last: Martí}
-  - {first: M.Antònia, last: Martí}
   - {first: M. Antonia, last: Marti}
   - {first: Antonia, last: Martí}
   - {first: Mª Antònia, last: Martí}
@@ -6194,8 +6168,6 @@
   variants:
   - {first: Lesly, last: Miculicich}
 - canonical: {first: Sebastian J., last: Mielke}
-  variants:
-  - {first: Sebastian, last: Mielke}
 - canonical: {first: Rada, last: Mihalcea}
   variants:
   - {first: Rada F., last: Mihalcea}
@@ -6763,8 +6735,6 @@
   similar: [nikola-i-nikolov]
 - canonical: {first: Nikola I., last: Nikolov}
   id: nikola-i-nikolov
-  variants:
-  - {first: Nikola, last: Nikolov}
   similar: [nicolas-nicolov]
 - canonical: {first: Jian-Yun, last: Nie}
   variants:
@@ -9660,7 +9630,7 @@
   - {first: Jonathan N., last: Washington}
 - canonical: {first: Thomas, last: Wasow}
   variants:
-  - {first: Thomas, last: Wasaw}
+  - {first: Tom, last: Wasow}
 - canonical: {first: Jakub, last: Waszczuk}
   variants:
   - {first: Jakub, last: Wasczuk}
@@ -10209,8 +10179,6 @@
   - {first: Paulo C. F., last: de Oliveira}
 - canonical: {first: Valeria, last: de Paiva}
   id: valeria-de-paiva
-  variants:
-  - {first: Valeria, last: dePaiva}
 - canonical: {first: Maarten, last: de Rijke}
   variants:
   - {first: Maarten, last: De Rijke}


### PR DESCRIPTION
- remove unused name variants (fixes compile warnings)
- some name capitalizations (need to do something about this in START)
- other typos
