### PR TITLE
Add missing umlauts to paper title

### DIFF
--- a/data/xml/C80.xml
+++ b/data/xml/C80.xml
@@ -488,7 +488,7 @@
       <url hash="62681236">C80-1083</url>
     </paper>
     <paper id="84">
-      <title>Naturlichsprachige Problembeschreibung Als Ein Verfahren Fur Den Burgernahen Zugang Zu Dokumentationssystemen</title>
+      <title>Natürlichsprachige Problembeschreibung Als Ein Verfahren Fur Den Bürgernahen Zugang Zu Dokumentationssystemen</title>
       <author><first>Harald H.</first><last>Zimmermann</last></author>
       <url hash="db6ad35f">C80-1084</url>
     </paper>


### PR DESCRIPTION
Added missing umlauts to paper title to match PDF.

Issue #961 