### PR TITLE
Ingest TACL 2020

### DIFF
--- a/bin/tacl_cl_parser.py
+++ b/bin/tacl_cl_parser.py
@@ -67,7 +67,10 @@ def parse_args():
     )
     pdfs_path = os.path.join(os.environ["HOME"], "anthology-files")
     parser.add_argument(
-        "--pdfs-dir", "-p", default=pdfs_path, help="Root path for placement of PDF files"
+        "--pdfs-dir",
+        "-p",
+        default=pdfs_path,
+        help="Root path for placement of PDF files",
     )
 
     verbosity = parser.add_mutually_exclusive_group()
@@ -403,7 +406,9 @@ if __name__ == "__main__":
         return startpage
 
     paper_id = 1  # Stupid non-enumerate counter because of "Erratum: " papers interleaved with real ones.
-    for papernode, pdf_path, issue_info, issue in sorted(papers, key=sort_papers_by_page):
+    for papernode, pdf_path, issue_info, issue in sorted(
+        papers, key=sort_papers_by_page
+    ):
         issue = issue or "1"
         if issue_info != previous_issue_info:
             # Emit the new volume info before the paper.

--- a/bin/tacl_cl_parser.py
+++ b/bin/tacl_cl_parser.py
@@ -407,9 +407,13 @@ if __name__ == "__main__":
             volume = collection.find(f'./volume[@id="{issue}"]')
             if volume is None:
                 # xml volume = journal issue
-                volume = make_simple_element("volume", attrib={"id": issue}, parent=collection)
+                volume = make_simple_element(
+                    "volume", attrib={"id": issue}, parent=collection
+                )
                 volume.append(
-                    issue_info_to_node(issue_info, year, collection_id, issue_count, is_tacl)
+                    issue_info_to_node(
+                        issue_info, year, collection_id, issue_count, is_tacl
+                    )
                 )
             else:
                 for paper in volume.findall(".//paper"):

--- a/bin/tacl_cl_parser.py
+++ b/bin/tacl_cl_parser.py
@@ -396,7 +396,6 @@ if __name__ == "__main__":
 
         anth_id = f"{volume_id}-{issue_count}.{paper_id}"
 
-
         if not pdf_path.is_file():
             logging.error("Missing pdf for " + pdf_path)
         elif args.pdf_save_destination:

--- a/data/xml/2020.tacl.xml
+++ b/data/xml/2020.tacl.xml
@@ -5,7 +5,6 @@
       <booktitle>Transactions of the Association for Computational Linguistics, Volume 8</booktitle>
       <year>2020</year>
     </meta>
-    <frontmatter />
     <paper id="1">
       <title>Phonotactic Complexity and Its Trade-offs</title>
       <author><first>Tiago</first><last>Pimentel</last></author>
@@ -14,7 +13,7 @@
       <doi>10.1162/tacl_a_00296</doi>
       <abstract>We present methods for calculating a measure of phonotactic complexity—bits per phoneme— that permits a straightforward cross-linguistic comparison. When given a word, represented as a sequence of phonemic segments such as symbols in the international phonetic alphabet, and a statistical model trained on a sample of word types from the language, we can approximately measure bits per phoneme using the negative log-probability of that word under the model. This simple measure allows us to compare the entropy across languages, giving insight into how complex a language’s phonotactics is. Using a collection of 1016 basic concept words across 106 languages, we demonstrate a very strong negative correlation of − 0.74 between bits per phoneme and the average length of words.</abstract>
       <pages>1–18</pages>
-      <url hash="c153b336">2020.tacl-1.1</url>
+      <url hash="580da940">2020.tacl-1.1</url>
     </paper>
     <paper id="2">
       <title><fixed-case>AMR</fixed-case>-To-Text Generation with Graph Transformer</title>
@@ -24,7 +23,7 @@
       <doi>10.1162/tacl_a_00297</doi>
       <abstract>Abstract meaning representation (AMR)-to-text generation is the challenging task of generating natural language texts from AMR graphs, where nodes represent concepts and edges denote relations. The current state-of-the-art methods use graph-to-sequence models; however, they still cannot significantly outperform the previous sequence-to-sequence models or statistical approaches. In this paper, we propose a novel graph-to-sequence model (Graph Transformer) to address this task. The model directly encodes the AMR graphs and learns the node representations. A pairwise interaction function is used for computing the semantic relations between the concepts. Moreover, attention mechanisms are used for aggregating the information from the incoming and outgoing neighbors, which help the model to capture the semantic information effectively. Our model outperforms the state-of-the-art neural approach by 1.5 BLEU points on LDC2015E86 and 4.8 BLEU points on LDC2017T10 and achieves new state-of-the-art performances.</abstract>
       <pages>19–33</pages>
-      <url hash="9dce31b7">2020.tacl-1.2</url>
+      <url hash="580da940">2020.tacl-1.2</url>
     </paper>
     <paper id="3">
       <title>What <fixed-case>BERT</fixed-case> Is Not: Lessons from a New Suite of Psycholinguistic Diagnostics for Language Models</title>
@@ -32,17 +31,17 @@
       <doi>10.1162/tacl_a_00298</doi>
       <abstract>Pre-training by language modeling has become a popular and successful approach to NLP tasks, but we have yet to understand exactly what linguistic capacities these pre-training processes confer upon models. In this paper we introduce a suite of diagnostics drawn from human language experiments, which allow us to ask targeted questions about information used by language models for generating predictions in context. As a case study, we apply these diagnostics to the popular BERT model, finding that it can generally distinguish good from bad completions involving shared category or role reversal, albeit with less sensitivity than humans, and it robustly retrieves noun hypernyms, but it struggles with challenging inference and role-based event prediction— and, in particular, it shows clear insensitivity to the contextual impacts of negation.</abstract>
       <pages>34–48</pages>
-      <url hash="50cfa1c2">2020.tacl-1.3</url>
+      <url hash="580da940">2020.tacl-1.3</url>
     </paper>
     <paper id="4">
-      <title>Membership Inference Attacks on Sequence-to-Sequence Models: <fixed-case>I</fixed-case>s My Data In Your Machine Translation System?</title>
+      <title>Membership Inference Attacks on Sequence-to-Sequence Models: Is My Data In Your Machine Translation System?</title>
       <author><first>Sorami</first><last>Hisamoto</last></author>
       <author><first>Matt</first><last>Post</last></author>
       <author><first>Kevin</first><last>Duh</last></author>
       <doi>10.1162/tacl_a_00299</doi>
       <abstract>Data privacy is an important issue for “machine learning as a service” providers. We focus on the problem of membership inference attacks: Given a data sample and black-box access to a model’s API, determine whether the sample existed in the model’s training data. Our contribution is an investigation of this problem in the context of sequence-to-sequence models, which are important in applications such as machine translation and video captioning. We define the membership inference problem for sequence generation, provide an open dataset based on state-of-the-art machine translation models, and report initial results on whether these models leak private information against several kinds of membership inference attacks.</abstract>
       <pages>49–63</pages>
-      <url hash="dd95e987">2020.tacl-1.4</url>
+      <url hash="580da940">2020.tacl-1.4</url>
     </paper>
     <paper id="5">
       <title><fixed-case>S</fixed-case>pan<fixed-case>BERT</fixed-case>: Improving Pre-training by Representing and Predicting Spans</title>
@@ -55,17 +54,17 @@
       <doi>10.1162/tacl_a_00300</doi>
       <abstract>We present SpanBERT, a pre-training method that is designed to better represent and predict spans of text. Our approach extends BERT by (1) masking contiguous random spans, rather than random tokens, and (2) training the span boundary representations to predict the entire content of the masked span, without relying on the individual token representations within it. SpanBERT consistently outperforms BERT and our better-tuned baselines, with substantial gains on span selection tasks such as question answering and coreference resolution. In particular, with the same training data and model size as BERTlarge, our single model obtains 94.6% and 88.7% F1 on SQuAD 1.1 and 2.0 respectively. We also achieve a new state of the art on the OntoNotes coreference resolution task (79.6% F1), strong performance on the TACRED relation extraction benchmark, and even gains on GLUE.1</abstract>
       <pages>64–77</pages>
-      <url hash="27aaf55c">2020.tacl-1.5</url>
+      <url hash="580da940">2020.tacl-1.5</url>
     </paper>
     <paper id="6">
-      <title>A Graph-based Model for Joint Chinese Word Segmentation and Dependency Parsing</title>
+      <title>A Graph-based Model for Joint <fixed-case>C</fixed-case>hinese Word Segmentation and Dependency Parsing</title>
       <author><first>Hang</first><last>Yan</last></author>
       <author><first>Xipeng</first><last>Qiu</last></author>
       <author><first>Xuanjing</first><last>Huang</last></author>
       <doi>10.1162/tacl_a_00301</doi>
       <abstract>Chinese word segmentation and dependency parsing are two fundamental tasks for Chinese natural language processing. The dependency parsing is defined at the word-level. Therefore word segmentation is the precondition of dependency parsing, which makes dependency parsing suffer from error propagation and unable to directly make use of character-level pre-trained language models (such as BERT). In this paper, we propose a graph-based model to integrate Chinese word segmentation and dependency parsing. Different from previous transition-based joint models, our proposed model is more concise, which results in fewer efforts of feature engineering. Our graph-based joint model achieves better performance than previous joint models and state-of-the-art results in both Chinese word segmentation and dependency parsing. Additionally, when BERT is combined, our model can substantially reduce the performance gap of dependency parsing between joint models and gold-segmented word-based models. Our code is publicly available at https://github.com/fastnlp/JointCwsParser</abstract>
       <pages>78–92</pages>
-      <url hash="8c82b722">2020.tacl-1.6</url>
+      <url hash="580da940">2020.tacl-1.6</url>
     </paper>
     <paper id="7">
       <title>A Knowledge-Enhanced Pretraining Model for Commonsense Story Generation</title>
@@ -77,7 +76,7 @@
       <doi>10.1162/tacl_a_00302</doi>
       <abstract>Story generation, namely, generating a reasonable story from a leading context, is an important but challenging task. In spite of the success in modeling fluency and local coherence, existing neural language generation models (e.g., GPT-2) still suffer from repetition, logic conflicts, and lack of long-range coherence in generated stories. We conjecture that this is because of the difficulty of associating relevant commonsense knowledge, understanding the causal relationships, and planning entities and events with proper temporal order. In this paper, we devise a knowledge-enhanced pretraining model for commonsense story generation. We propose to utilize commonsense knowledge from external knowledge bases to generate reasonable stories. To further capture the causal and temporal dependencies between the sentences in a reasonable story, we use multi-task learning, which combines a discriminative objective to distinguish true and fake stories during fine-tuning. Automatic and manual evaluation shows that our model can generate more reasonable stories than state-of-the-art baselines, particularly in terms of logic and global coherence.</abstract>
       <pages>93–108</pages>
-      <url hash="c075234a">2020.tacl-1.7</url>
+      <url hash="580da940">2020.tacl-1.7</url>
     </paper>
     <paper id="8">
       <title>Improving Candidate Generation for Low-resource Cross-lingual Entity Linking</title>
@@ -89,7 +88,7 @@
       <doi>10.1162/tacl_a_00303</doi>
       <abstract>Cross-lingual entity linking (XEL) is the task of finding referents in a target-language knowledge base (KB) for mentions extracted from source-language texts. The first step of (X)EL is candidate generation, which retrieves a list of plausible candidate entities from the target-language KB for each mention. Approaches based on resources from Wikipedia have proven successful in the realm of relatively high-resource languages, but these do not extend well to low-resource languages with few, if any, Wikipedia pages. Recently, transfer learning methods have been shown to reduce the demand for resources in the low-resource languages by utilizing resources in closely related languages, but the performance still lags far behind their high-resource counterparts. In this paper, we first assess the problems faced by current entity candidate generation methods for low-resource XEL, then propose three improvements that (1) reduce the disconnect between entity mentions and KB entries, and (2) improve the robustness of the model to low-resource scenarios. The methods are simple, but effective: We experiment with our approach on seven XEL datasets and find that they yield an average gain of 16.9% in Top-30 gold candidate recall, compared with state-of-the-art baselines. Our improved model also yields an average gain of 7.9% in in-KB accuracy of end-to-end XEL.1</abstract>
       <pages>109–124</pages>
-      <url hash="74d04e8d">2020.tacl-1.8</url>
+      <url hash="580da940">2020.tacl-1.8</url>
     </paper>
     <paper id="9">
       <title>Does Syntax Need to Grow on Trees? Sources of Hierarchical Inductive Bias in Sequence-to-Sequence Networks</title>
@@ -99,7 +98,7 @@
       <doi>10.1162/tacl_a_00304</doi>
       <abstract>Learners that are exposed to the same training data might generalize differently due to differing inductive biases. In neural network models, inductive biases could in theory arise from any aspect of the model architecture. We investigate which architectural factors affect the generalization behavior of neural sequence-to-sequence models trained on two syntactic tasks, English question formation and English tense reinflection. For both tasks, the training set is consistent with a generalization based on hierarchical structure and a generalization based on linear order. All architectural factors that we investigated qualitatively affected how models generalized, including factors with no clear connection to hierarchical structure. For example, LSTMs and GRUs displayed qualitatively different inductive biases. However, the only factor that consistently contributed a hierarchical bias across tasks was the use of a tree-structured model rather than a model with sequential recurrence, suggesting that human-like syntactic generalization requires architectural syntactic structure.</abstract>
       <pages>125–140</pages>
-      <url hash="2d0d4357">2020.tacl-1.9</url>
+      <url hash="580da940">2020.tacl-1.9</url>
     </paper>
     <paper id="10">
       <title>Investigating Prior Knowledge for Challenging <fixed-case>C</fixed-case>hinese Machine Reading Comprehension</title>
@@ -110,7 +109,7 @@
       <doi>10.1162/tacl_a_00305</doi>
       <abstract>Machine reading comprehension tasks require a machine reader to answer questions relevant to the given document. In this paper, we present the first free-form multiple-Choice Chinese machine reading Comprehension dataset (C3), containing 13,369 documents (dialogues or more formally written mixed-genre texts) and their associated 19,577 multiple-choice free-form questions collected from Chinese-as-a-second-language examinations. We present a comprehensive analysis of the prior knowledge (i.e., linguistic, domain-specific, and general world knowledge) needed for these real-world problems. We implement rule-based and popular neural methods and find that there is still a significant performance gap between the best performing model (68.5%) and human readers (96.0%), especiallyon problems that require prior knowledge. We further study the effects of distractor plausibility and data augmentation based on translated relevant datasets for English on model performance. We expect C3 to present great challenges to existing systems as answering 86.8% of questions requires both knowledge within and beyond the accompanying document, and we hope that C3 can serve as a platform to study how to leverage various kinds of prior knowledge to better understand a given written or orally oriented text. C3 is available at https://dataset.org/c3/.</abstract>
       <pages>141–155</pages>
-      <url hash="2e13d3fe">2020.tacl-1.10</url>
+      <url hash="580da940">2020.tacl-1.10</url>
     </paper>
     <paper id="11">
       <title>Theoretical Limitations of Self-Attention in Neural Sequence Models</title>
@@ -118,9 +117,20 @@
       <doi>10.1162/tacl_a_00306</doi>
       <abstract>Transformers are emerging as the new workhorse of NLP, showing great success across tasks. Unlike LSTMs, transformers process input sequences entirely through self-attention. Previous work has suggested that the computational capabilities of self-attention to process hierarchical structures are limited. In this work, we mathematically investigate the computational power of self-attention to model formal languages. Across both soft and hard attention, we show strong theoretical limitations of the computational abilities of self-attention, finding that it cannot model periodic finite-state languages, nor hierarchical structure, unless the number of layers or heads increases with input length. These limitations seem surprising given the practical success of self-attention and the prominent role assigned to hierarchical structure in linguistics, suggesting that natural language can be approximated well with models that are too weak for the formal languages typically assumed in theoretical linguistics.</abstract>
       <pages>156–171</pages>
-      <url hash="7be349b5">2020.tacl-1.11</url>
+      <url hash="580da940">2020.tacl-1.11</url>
     </paper>
     <paper id="12">
+      <title>Decoding Brain Activity Associated with Literal and Metaphoric Sentence Comprehension Using Distributional Semantic Models</title>
+      <author><first>Vesna G.</first><last>Djokic</last></author>
+      <author><first>Jean</first><last>Maillard</last></author>
+      <author><first>Luana</first><last>Bulat</last></author>
+      <author><first>Ekaterina</first><last>Shutova</last></author>
+      <doi>10.1162/tacl_a_00307</doi>
+      <abstract>Recent years have seen a growing interest within the natural language processing (NLP) community in evaluating the ability of semantic models to capture human meaning representation in the brain. Existing research has mainly focused on applying semantic models to decode brain activity patterns associated with the meaning of individual words, and, more recently, this approach has been extended to sentences and larger text fragments. Our work is the first to investigate metaphor processing in the brain in this context. We evaluate a range of semantic models (word embeddings, compositional, and visual models) in their ability to decode brain activity associated with reading of both literal and metaphoric sentences. Our results suggest that compositional models and word embeddings are able to capture differences in the processing of literal and metaphoric sentences, providing support for the idea that the literal meaning is not fully accessible during familiar metaphor comprehension.</abstract>
+      <pages>231–246</pages>
+      <url hash="580da940">2020.tacl-1.12</url>
+    </paper>
+    <paper id="13">
       <title>Target-Guided Structured Attention Network for Target-Dependent Sentiment Analysis</title>
       <author><first>Ji</first><last>Zhang</last></author>
       <author><first>Chengyao</first><last>Chen</last></author>
@@ -130,9 +140,9 @@
       <doi>10.1162/tacl_a_00308</doi>
       <abstract>Target-dependent sentiment analysis (TDSA) aims to classify the sentiment of a text towards a given target. The major challenge of this task lies in modeling the semantic relatedness between a target and its context sentence. This paper proposes a novel Target-Guided Structured Attention Network (TG-SAN), which captures target-related contexts for TDSA in a fine-to-coarse manner. Given a target and its context sentence, the proposed TG-SAN first identifies multiple semantic segments from the sentence using a target-guided structured attention mechanism. It then fuses the extracted segments based on their relatedness with the target for sentiment classification. We present comprehensive comparative experiments on three benchmarks with three major findings. First, TG-SAN outperforms the state-of-the-art by up to 1.61% and 3.58% in terms of accuracy and Marco-F1, respectively. Second, it shows a strong advantage in determining the sentiment of a target when the context sentence contains multiple semantic segments. Lastly, visualization results show that the attention scores produced by TG-SAN are highly interpretable</abstract>
       <pages>172–182</pages>
-      <url hash="1e1d55c3">2020.tacl-1.12</url>
+      <url hash="580da940">2020.tacl-1.13</url>
     </paper>
-    <paper id="13">
+    <paper id="14">
       <title>Break It Down: A Question Understanding Benchmark</title>
       <author><first>Tomer</first><last>Wolfson</last></author>
       <author><first>Mor</first><last>Geva</last></author>
@@ -144,28 +154,183 @@
       <doi>10.1162/tacl_a_00309</doi>
       <abstract>Understanding natural language questions entails the ability to break down a question into the requisite steps for computing its answer. In this work, we introduce a Question Decomposition Meaning Representation (QDMR) for questions. QDMR constitutes the ordered list of steps, expressed through natural language, that are necessary for answering a question. We develop a crowdsourcing pipeline, showing that quality QDMRs can be annotated at scale, and release the Break dataset, containing over 83K pairs of questions and their QDMRs. We demonstrate the utility of QDMR by showing that (a) it can be used to improve open-domain question answering on the HotpotQA dataset, (b) it can be deterministically converted to a pseudo-SQL formal language, which can alleviate annotation in semantic parsing applications. Last, we use Break to train a sequence-to-sequence model with copying that parses questions into QDMR structures, and show that it substantially outperforms several natural baselines.</abstract>
       <pages>183–198</pages>
-      <url hash="08ba3326">2020.tacl-1.13</url>
+      <url hash="580da940">2020.tacl-1.14</url>
     </paper>
-    <paper id="14">
+    <paper id="15">
+      <title>Machine Learning–Driven Language Assessment</title>
+      <author><first>Burr</first><last>Settles</last></author>
+      <author><first>Geoffrey</first><last>T. LaFlair</last></author>
+      <author><first>Masato</first><last>Hagiwara</last></author>
+      <doi>10.1162/tacl_a_00310</doi>
+      <abstract>We describe a method for rapidly creating language proficiency assessments, and provide experimental evidence that such tests can be valid, reliable, and secure. Our approach is the first to use machine learning and natural language processing to induce proficiency scales based on a given standard, and then use linguistic models to estimate item difficulty directly for computer-adaptive testing. This alleviates the need for expensive pilot testing with human subjects. We used these methods to develop an online proficiency exam called the Duolingo English Test, and demonstrate that its scores align significantly with other high-stakes English assessments. Furthermore, our approach produces test scores that are highly reliable, while generating item banks large enough to satisfy security requirements.</abstract>
+      <pages>247–263</pages>
+      <url hash="580da940">2020.tacl-1.15</url>
+    </paper>
+    <paper id="16">
       <title>Acoustic-Prosodic and Lexical Cues to Deception and Trust: Deciphering How People Detect Lies</title>
       <author><first>Xi (Leslie)</first><last>Chen</last></author>
-      <author><first>Sarah Ita</first><last>Levitan</last></author>
+      <author><first>Sarah</first><last>Ita Levitan</last></author>
       <author><first>Michelle</first><last>Levine</last></author>
       <author><first>Marko</first><last>Mandic</last></author>
       <author><first>Julia</first><last>Hirschberg</last></author>
       <doi>10.1162/tacl_a_00311</doi>
       <abstract>Humans rarely perform better than chance at lie detection. To better understand human perception of deception, we created a game framework, LieCatcher, to collect ratings of perceived deception using a large corpus of deceptive and truthful interviews. We analyzed the acoustic-prosodic and linguistic characteristics of language trusted and mistrusted by raters and compared these to characteristics of actual truthful and deceptive language to understand how perception aligns with reality. With this data we built classifiers to automatically distinguish trusted from mistrusted speech, achieving an F1 of 66.1%. We next evaluated whether the strategies raters said they used to discriminate between truthful and deceptive responses were in fact useful. Our results show that, although several prosodic and lexical features were consistently perceived as trustworthy, they were not reliable cues. Also, the strategies that judges reported using in deception detection were not helpful for the task. Our work sheds light on the nature of trusted language and provides insight into the challenging problem of human deception detection.</abstract>
       <pages>199–214</pages>
-      <url hash="d0dfd22b">2020.tacl-1.14</url>
+      <url hash="580da940">2020.tacl-1.16</url>
     </paper>
-    <paper id="15">
-      <title>Unsupervised Discourse Constituency Parsing Using Viterbi <fixed-case>EM</fixed-case></title>
+    <paper id="17">
+      <title>Unsupervised Discourse Constituency Parsing Using <fixed-case>V</fixed-case>iterbi <fixed-case>EM</fixed-case></title>
       <author><first>Noriki</first><last>Nishida</last></author>
       <author><first>Hideki</first><last>Nakayama</last></author>
       <doi>10.1162/tacl_a_00312</doi>
       <abstract>In this paper, we introduce an unsupervised discourse constituency parsing algorithm. We use Viterbi EM with a margin-based criterion to train a span-based discourse parser in an unsupervised manner. We also propose initialization methods for Viterbi training of discourse constituents based on our prior knowledge of text structures. Experimental results demonstrate that our unsupervised parser achieves comparable or even superior performance to fully supervised parsers. We also investigate discourse constituents that are learned by our method.</abstract>
       <pages>215–230</pages>
-      <url hash="9b0c0560">2020.tacl-1.15</url>
+      <url hash="580da940">2020.tacl-1.17</url>
+    </paper>
+    <paper id="18">
+      <title>Leveraging Pre-trained Checkpoints for Sequence Generation Tasks</title>
+      <author><first>Sascha</first><last>Rothe</last></author>
+      <author><first>Shashi</first><last>Narayan</last></author>
+      <author><first>Aliaksei</first><last>Severyn</last></author>
+      <doi>10.1162/tacl_a_00313</doi>
+      <abstract>Unsupervised pre-training of large neural models has recently revolutionized Natural Language Processing. By warm-starting from the publicly released checkpoints, NLP practitioners have pushed the state-of-the-art on multiple benchmarks while saving significant amounts of compute time. So far the focus has been mainly on the Natural Language Understanding tasks. In this paper, we demonstrate the efficacy of pre-trained checkpoints for Sequence Generation. We developed a Transformer-based sequence-to-sequence model that is compatible with publicly available pre-trained BERT, GPT-2, and RoBERTa checkpoints and conducted an extensive empirical study on the utility of initializing our model, both encoder and decoder, with these checkpoints. Our models result in new state-of-the-art results on Machine Translation, Text Summarization, Sentence Splitting, and Sentence Fusion.</abstract>
+      <pages>264–280</pages>
+      <url hash="580da940">2020.tacl-1.18</url>
+    </paper>
+    <paper id="19">
+      <title><fixed-case>C</fixed-case>ross<fixed-case>WOZ</fixed-case>: A Large-Scale <fixed-case>C</fixed-case>hinese Cross-Domain Task-Oriented Dialogue Dataset</title>
+      <author><first>Qi</first><last>Zhu</last></author>
+      <author><first>Kaili</first><last>Huang</last></author>
+      <author><first>Zheng</first><last>Zhang</last></author>
+      <author><first>Xiaoyan</first><last>Zhu</last></author>
+      <author><first>Minlie</first><last>Huang</last></author>
+      <doi>10.1162/tacl_a_00314</doi>
+      <abstract>To advance multi-domain (cross-domain) dialogue modeling as well as alleviate the shortage of Chinese task-oriented datasets, we propose CrossWOZ, the first large-scale Chinese Cross-Domain Wizard-of-Oz task-oriented dataset. It contains 6K dialogue sessions and 102K utterances for 5 domains, including hotel, restaurant, attraction, metro, and taxi. Moreover, the corpus contains rich annotation of dialogue states and dialogue acts on both user and system sides. About 60% of the dialogues have cross-domain user goals that favor inter-domain dependency and encourage natural transition across domains in conversation. We also provide a user simulator and several benchmark models for pipelined task-oriented dialogue systems, which will facilitate researchers to compare and evaluate their models on this corpus. The large size and rich annotation of CrossWOZ make it suitable to investigate a variety of tasks in cross-domain dialogue modeling, such as dialogue state tracking, policy learning, user simulation, etc.</abstract>
+      <pages>281–295</pages>
+      <url hash="580da940">2020.tacl-1.19</url>
+    </paper>
+    <paper id="20">
+      <title>How Furiously Can Colorless Green Ideas Sleep? Sentence Acceptability in Context</title>
+      <author><first>Jey Han</first><last>Lau</last></author>
+      <author><first>Carlos</first><last>Armendariz</last></author>
+      <author><first>Shalom</first><last>Lappin</last></author>
+      <author><first>Matthew</first><last>Purver</last></author>
+      <author><first>Chang</first><last>Shu</last></author>
+      <doi>10.1162/tacl_a_00315</doi>
+      <abstract>We study the influence of context on sentence acceptability. First we compare the acceptability ratings of sentences judged in isolation, with a relevant context, and with an irrelevant context. Our results show that context induces a cognitive load for humans, which compresses the distribution of ratings. Moreover, in relevant contexts we observe a discourse coherence effect that uniformly raises acceptability. Next, we test unidirectional and bidirectional language models in their ability to predict acceptability ratings. The bidirectional models show very promising results, with the best model achieving a new state-of-the-art for unsupervised acceptability prediction. The two sets of experiments provide insights into the cognitive aspects of sentence processing and central issues in the computational modeling of text and discourse.</abstract>
+      <pages>296–310</pages>
+      <url hash="580da940">2020.tacl-1.20</url>
+    </paper>
+    <paper id="21">
+      <title>Learning Lexical Subspaces in a Distributional Vector Space</title>
+      <author><first>Kushal</first><last>Arora</last></author>
+      <author><first>Aishik</first><last>Chakraborty</last></author>
+      <author><first>Jackie C. K.</first><last>Cheung</last></author>
+      <doi>10.1162/tacl_a_00316</doi>
+      <abstract>In this paper, we propose LexSub, a novel approach towards unifying lexical and distributional semantics. We inject knowledge about lexical-semantic relations into distributional word embeddings by defining subspaces of the distributional vector space in which a lexical relation should hold. Our framework can handle symmetric attract and repel relations (e.g., synonymy and antonymy, respectively), as well as asymmetric relations (e.g., hypernymy and meronomy). In a suite of intrinsic benchmarks, we show that our model outperforms previous approaches on relatedness tasks and on hypernymy classification and detection, while being competitive on word similarity tasks. It also outperforms previous systems on extrinsic classification tasks that benefit from exploiting lexical relational cues. We perform a series of analyses to understand the behaviors of our model.1Code available at https://github.com/aishikchakraborty/LexSub.</abstract>
+      <pages>311–329</pages>
+      <url hash="580da940">2020.tacl-1.21</url>
+    </paper>
+    <paper id="22">
+      <title><fixed-case>T</fixed-case>y<fixed-case>D</fixed-case>i <fixed-case>QA</fixed-case>: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages</title>
+      <author><first>Jonathan H.</first><last>Clark</last></author>
+      <author><first>Eunsol</first><last>Choi</last></author>
+      <author><first>Michael</first><last>Collins</last></author>
+      <author><first>Dan</first><last>Garrette</last></author>
+      <author><first>Tom</first><last>Kwiatkowski</last></author>
+      <author><first>Vitaly</first><last>Nikolaev</last></author>
+      <author><first>Jennimaria</first><last>Palomaki</last></author>
+      <doi>10.1162/tacl_a_00317</doi>
+      <abstract>Confidently making progress on multilingual modeling requires challenging, trustworthy evaluations. We present TyDi QA—a question answering dataset covering 11 typologically diverse languages with 204K question-answer pairs. The languages of TyDi QA are diverse with regard to their typology—the set of linguistic features each language expresses—such that we expect models performing well on this set to generalize across a large number of the world’s languages. We present a quantitative analysis of the data quality and example-level qualitative linguistic analyses of observed language phenomena that would not be found in English-only corpora. To provide a realistic information-seeking task and avoid priming effects, questions are written by people who want to know the answer, but don’t know the answer yet, and the data is collected directly in each language without the use of translation.</abstract>
+      <pages>454–470</pages>
+      <url hash="580da940">2020.tacl-1.22</url>
+    </paper>
+    <paper id="23">
+      <title>Syntax-Guided Controlled Generation of Paraphrases</title>
+      <author><first>Ashutosh</first><last>Kumar</last></author>
+      <author><first>Kabir</first><last>Ahuja</last></author>
+      <author><first>Raghuram</first><last>Vadapalli</last></author>
+      <author><first>Partha</first><last>Talukdar</last></author>
+      <doi>10.1162/tacl_a_00318</doi>
+      <abstract>Given a sentence (e.g., “I like mangoes”) and a constraint (e.g., sentiment flip), the goal of controlled text generation is to produce a sentence that adapts the input sentence to meet the requirements of the constraint (e.g., “I hate mangoes”). Going beyond such simple constraints, recent work has started exploring the incorporation of complex syntactic-guidance as constraints in the task of controlled paraphrase generation. In these methods, syntactic-guidance is sourced from a separate exemplar sentence. However, this prior work has only utilized limited syntactic information available in the parse tree of the exemplar sentence. We address this limitation in the paper and propose Syntax Guided Controlled Paraphraser (SGCP), an end-to-end framework for syntactic paraphrase generation. We find that Sgcp can generate syntax-conforming sentences while not compromising on relevance. We perform extensive automated and human evaluations over multiple real-world English language datasets to demonstrate the efficacy of Sgcp over state-of-the-art baselines. To drive future research, we have made Sgcp’s source code available.1</abstract>
+      <pages>329–345</pages>
+      <url hash="580da940">2020.tacl-1.23</url>
+    </paper>
+    <paper id="24">
+      <title>Better Document-Level Machine Translation with <fixed-case>B</fixed-case>ayes’ Rule</title>
+      <author><first>Lei</first><last>Yu</last></author>
+      <author><first>Laurent</first><last>Sartran</last></author>
+      <author><first>Wojciech</first><last>Stokowiec</last></author>
+      <author><first>Wang</first><last>Ling</last></author>
+      <author><first>Lingpeng</first><last>Kong</last></author>
+      <author><first>Phil</first><last>Blunsom</last></author>
+      <author><first>Chris</first><last>Dyer</last></author>
+      <doi>10.1162/tacl_a_00319</doi>
+      <abstract>We show that Bayes’ rule provides an effective mechanism for creating document translation models that can be learned from only parallel sentences and monolingual documents a compelling benefit because parallel documents are not always available. In our formulation, the posterior probability of a candidate translation is the product of the unconditional (prior) probability of the candidate output document and the “reverse translation probability” of translating the candidate output back into the source language. Our proposed model uses a powerful autoregressive language model as the prior on target language documents, but it assumes that each sentence is translated independently from the target to the source language. Crucially, at test time, when a source document is observed, the document language model prior induces dependencies between the translations of the source sentences in the posterior. The model’s independence assumption not only enables efficient use of available data, but it additionally admits a practical left-to-right beam-search algorithm for carrying out inference. Experiments show that our model benefits from using cross-sentence context in the language model, and it outperforms existing document translation approaches.</abstract>
+      <pages>346–360</pages>
+      <url hash="580da940">2020.tacl-1.24</url>
+    </paper>
+    <paper id="25">
+      <title>Hierarchical Mapping for Crosslingual Word Embedding Alignment</title>
+      <author><first>Ion Madrazo</first><last>Azpiazu</last></author>
+      <author><first>Maria Soledad</first><last>Pera</last></author>
+      <doi>10.1162/tacl_a_00320</doi>
+      <abstract>The alignment of word embedding spaces in different languages into a common crosslingual space has recently been in vogue. Strategies that do so compute pairwise alignments and then map multiple languages to a single pivot language (most often English). These strategies, however, are biased towards the choice of the pivot language, given that language proximity and the linguistic characteristics of the target language can strongly impact the resultant crosslingual space in detriment of topologically distant languages. We present a strategy that eliminates the need for a pivot language by learning the mappings across languages in a hierarchical way. Experiments demonstrate that our strategy significantly improves vocabulary induction scores in all existing benchmarks, as well as in a new non-English–centered benchmark we built, which we make publicly available.</abstract>
+      <pages>361–376</pages>
+      <url hash="580da940">2020.tacl-1.25</url>
+    </paper>
+    <paper id="26">
+      <title><fixed-case>BL</fixed-case>i<fixed-case>MP</fixed-case>: The Benchmark of Linguistic Minimal Pairs for <fixed-case>E</fixed-case>nglish</title>
+      <author><first>Alex</first><last>Warstadt</last></author>
+      <author><first>Alicia</first><last>Parrish</last></author>
+      <author><first>Haokun</first><last>Liu</last></author>
+      <author><first>Anhad</first><last>Mohananey</last></author>
+      <author><first>Wei</first><last>Peng</last></author>
+      <author><first>Sheng-Fu</first><last>Wang</last></author>
+      <author><first>Samuel R.</first><last>Bowman</last></author>
+      <doi>10.1162/tacl_a_00321</doi>
+      <abstract>We introduce The Benchmark of Linguistic Minimal Pairs (BLiMP),1 a challenge set for evaluating the linguistic knowledge of language models (LMs) on major grammatical phenomena in English. BLiMP consists of 67 individual datasets, each containing 1,000 minimal pairs—that is, pairs of minimally different sentences that contrast in grammatical acceptability and isolate specific phenomenon in syntax, morphology, or semantics. We generate the data according to linguist-crafted grammar templates, and human aggregate agreement with the labels is 96.4%. We evaluate n-gram, LSTM, and Transformer (GPT-2 and Transformer-XL) LMs by observing whether they assign a higher probability to the acceptable sentence in each minimal pair. We find that state-of-the-art models identify morphological contrasts related to agreement reliably, but they struggle with some subtle semantic and syntactic phenomena, such as negative polarity items and extraction islands.</abstract>
+      <pages>377–392</pages>
+      <url hash="580da940">2020.tacl-1.26</url>
+    </paper>
+    <paper id="27">
+      <title>Reproducible and Efficient Benchmarks for Hyperparameter Optimization of Neural Machine Translation Systems</title>
+      <author><first>Xuan</first><last>Zhang</last></author>
+      <author><first>Kevin</first><last>Duh</last></author>
+      <doi>10.1162/tacl_a_00322</doi>
+      <abstract>Hyperparameter selection is a crucial part of building neural machine translation (NMT) systems across both academia and industry. Fine-grained adjustments to a model’s architecture or training recipe can mean the difference between a positive and negative research result or between a state-of-the-art and underperforming system. While recent literature has proposed methods for automatic hyperparameter optimization (HPO), there has been limited work on applying these methods to neural machine translation (NMT), due in part to the high costs associated with experiments that train large numbers of model variants. To facilitate research in this space, we introduce a lookup-based approach that uses a library of pre-trained models for fast, low cost HPO experimentation. Our contributions include (1) the release of a large collection of trained NMT models covering a wide range of hyperparameters, (2) the proposal of targeted metrics for evaluating HPO methods on NMT, and (3) a reproducible benchmark of several HPO methods against our model library, including novel graph-based and multiobjective methods.</abstract>
+      <pages>393–408</pages>
+      <url hash="580da940">2020.tacl-1.27</url>
+    </paper>
+    <paper id="28">
+      <title>Consistent Unsupervised Estimators for Anchored <fixed-case>PCFG</fixed-case>s</title>
+      <author><first>Alexander</first><last>Clark</last></author>
+      <author><first>Nathanaël</first><last>Fijalkow</last></author>
+      <doi>10.1162/tacl_a_00323</doi>
+      <abstract>Learning probabilistic context-free grammars (PCFGs) from strings is a classic problem in computational linguistics since Horning (1969). Here we present an algorithm based on distributional learning that is a consistent estimator for a large class of PCFGs that satisfy certain natural conditions including being anchored (Stratos et al., 2016). We proceed via a reparameterization of (top--down) PCFGs that we call a bottom–up weighted context-free grammar. We show that if the grammar is anchored and satisfies additional restrictions on its ambiguity, then the parameters can be directly related to distributional properties of the anchoring strings; we show the asymptotic correctness of a naive estimator and present some simulations using synthetic data that show that algorithms based on this approach have good finite sample behavior.</abstract>
+      <pages>409–422</pages>
+      <url hash="580da940">2020.tacl-1.28</url>
+    </paper>
+    <paper id="29">
+      <title>How Can We Know What Language Models Know?</title>
+      <author><first>Zhengbao</first><last>Jiang</last></author>
+      <author><first>Frank F.</first><last>Xu</last></author>
+      <author><first>Jun</first><last>Araki</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <doi>10.1162/tacl_a_00324</doi>
+      <abstract>Recent work has presented intriguing results examining the knowledge contained in language models (LMs) by having the LM fill in the blanks of prompts such as “Obama is a __ by profession”. These prompts are usually manually created, and quite possibly sub-optimal; another prompt such as “Obama worked as a __ ” may result in more accurately predicting the correct profession. Because of this, given an inappropriate prompt, we might fail to retrieve facts that the LM does know, and thus any given prompt only provides a lower bound estimate of the knowledge contained in an LM. In this paper, we attempt to more accurately estimate the knowledge contained in LMs by automatically discovering better prompts to use in this querying process. Specifically, we propose mining-based and paraphrasing-based methods to automatically generate high-quality and diverse prompts, as well as ensemble methods to combine answers from different prompts. Extensive experiments on the LAMA benchmark for extracting relational knowledge from LMs demonstrate that our methods can improve accuracy from 31.1% to 39.6%, providing a tighter lower bound on what LMs know. We have released the code and the resulting LM Prompt And Query Archive (LPAQA) at https://github.com/jzbjyb/LPAQA.</abstract>
+      <pages>423–438</pages>
+      <url hash="580da940">2020.tacl-1.29</url>
+    </paper>
+    <paper id="30">
+      <title>Topic Modeling in Embedding Spaces</title>
+      <author><first>Adji B.</first><last>Dieng</last></author>
+      <author><first>Francisco J. R.</first><last>Ruiz</last></author>
+      <author><first>David M.</first><last>Blei</last></author>
+      <doi>10.1162/tacl_a_00325</doi>
+      <abstract>Topic modeling analyzes documents to learn meaningful patterns of words. However, existing topic models fail to learn interpretable topics when working with large and heavy-tailed vocabularies. To this end, we develop the embedded topic model (etm), a generative model of documents that marries traditional topic models with word embeddings. More specifically, the etm models each word with a categorical distribution whose natural parameter is the inner product between the word’s embedding and an embedding of its assigned topic. To fit the etm, we develop an efficient amortized variational inference algorithm. The etm discovers interpretable topics even with large vocabularies that include rare words and stop words. It outperforms existing document models, such as latent Dirichlet allocation, in terms of both topic quality and predictive performance.</abstract>
+      <pages>439–453</pages>
+      <url hash="580da940">2020.tacl-1.30</url>
     </paper>
   </volume>
 </collection>

--- a/data/xml/2020.tacl.xml
+++ b/data/xml/2020.tacl.xml
@@ -5,7 +5,7 @@
       <booktitle>Transactions of the Association for Computational Linguistics, Volume 8</booktitle>
       <year>2020</year>
     </meta>
-    <frontmatter />
+    <frontmatter/>
     <paper id="1">
       <title>Phonotactic Complexity and Its Trade-offs</title>
       <author><first>Tiago</first><last>Pimentel</last></author>
@@ -166,6 +166,172 @@
       <abstract>In this paper, we introduce an unsupervised discourse constituency parsing algorithm. We use Viterbi EM with a margin-based criterion to train a span-based discourse parser in an unsupervised manner. We also propose initialization methods for Viterbi training of discourse constituents based on our prior knowledge of text structures. Experimental results demonstrate that our unsupervised parser achieves comparable or even superior performance to fully supervised parsers. We also investigate discourse constituents that are learned by our method.</abstract>
       <pages>215–230</pages>
       <url hash="9b0c0560">2020.tacl-1.15</url>
+    </paper>
+    <paper id="16">
+      <title>Decoding Brain Activity Associated with Literal and Metaphoric Sentence Comprehension Using Distributional Semantic Models</title>
+      <author><first>Vesna G.</first><last>Djokic</last></author>
+      <author><first>Jean</first><last>Maillard</last></author>
+      <author><first>Luana</first><last>Bulat</last></author>
+      <author><first>Ekaterina</first><last>Shutova</last></author>
+      <doi>10.1162/tacl_a_00307</doi>
+      <abstract>Recent years have seen a growing interest within the natural language processing (NLP) community in evaluating the ability of semantic models to capture human meaning representation in the brain. Existing research has mainly focused on applying semantic models to decode brain activity patterns associated with the meaning of individual words, and, more recently, this approach has been extended to sentences and larger text fragments. Our work is the first to investigate metaphor processing in the brain in this context. We evaluate a range of semantic models (word embeddings, compositional, and visual models) in their ability to decode brain activity associated with reading of both literal and metaphoric sentences. Our results suggest that compositional models and word embeddings are able to capture differences in the processing of literal and metaphoric sentences, providing support for the idea that the literal meaning is not fully accessible during familiar metaphor comprehension.</abstract>
+      <pages>231–246</pages>
+      <url hash="467f82a0">2020.tacl-1.16</url>
+    </paper>
+    <paper id="17">
+      <title>Machine Learning–Driven Language Assessment</title>
+      <author><first>Burr</first><last>Settles</last></author>
+      <author><first>Geoffrey</first><last>T. LaFlair</last></author>
+      <author><first>Masato</first><last>Hagiwara</last></author>
+      <doi>10.1162/tacl_a_00310</doi>
+      <abstract>We describe a method for rapidly creating language proficiency assessments, and provide experimental evidence that such tests can be valid, reliable, and secure. Our approach is the first to use machine learning and natural language processing to induce proficiency scales based on a given standard, and then use linguistic models to estimate item difficulty directly for computer-adaptive testing. This alleviates the need for expensive pilot testing with human subjects. We used these methods to develop an online proficiency exam called the Duolingo English Test, and demonstrate that its scores align significantly with other high-stakes English assessments. Furthermore, our approach produces test scores that are highly reliable, while generating item banks large enough to satisfy security requirements.</abstract>
+      <pages>247–263</pages>
+      <url hash="d2c076d9">2020.tacl-1.17</url>
+    </paper>
+    <paper id="18">
+      <title>Leveraging Pre-trained Checkpoints for Sequence Generation Tasks</title>
+      <author><first>Sascha</first><last>Rothe</last></author>
+      <author><first>Shashi</first><last>Narayan</last></author>
+      <author><first>Aliaksei</first><last>Severyn</last></author>
+      <doi>10.1162/tacl_a_00313</doi>
+      <abstract>Unsupervised pre-training of large neural models has recently revolutionized Natural Language Processing. By warm-starting from the publicly released checkpoints, NLP practitioners have pushed the state-of-the-art on multiple benchmarks while saving significant amounts of compute time. So far the focus has been mainly on the Natural Language Understanding tasks. In this paper, we demonstrate the efficacy of pre-trained checkpoints for Sequence Generation. We developed a Transformer-based sequence-to-sequence model that is compatible with publicly available pre-trained BERT, GPT-2, and RoBERTa checkpoints and conducted an extensive empirical study on the utility of initializing our model, both encoder and decoder, with these checkpoints. Our models result in new state-of-the-art results on Machine Translation, Text Summarization, Sentence Splitting, and Sentence Fusion.</abstract>
+      <pages>264–280</pages>
+      <url hash="c925bfbe">2020.tacl-1.18</url>
+    </paper>
+    <paper id="19">
+      <title><fixed-case>C</fixed-case>ross<fixed-case>WOZ</fixed-case>: A Large-Scale <fixed-case>C</fixed-case>hinese Cross-Domain Task-Oriented Dialogue Dataset</title>
+      <author><first>Qi</first><last>Zhu</last></author>
+      <author><first>Kaili</first><last>Huang</last></author>
+      <author><first>Zheng</first><last>Zhang</last></author>
+      <author><first>Xiaoyan</first><last>Zhu</last></author>
+      <author><first>Minlie</first><last>Huang</last></author>
+      <doi>10.1162/tacl_a_00314</doi>
+      <abstract>To advance multi-domain (cross-domain) dialogue modeling as well as alleviate the shortage of Chinese task-oriented datasets, we propose CrossWOZ, the first large-scale Chinese Cross-Domain Wizard-of-Oz task-oriented dataset. It contains 6K dialogue sessions and 102K utterances for 5 domains, including hotel, restaurant, attraction, metro, and taxi. Moreover, the corpus contains rich annotation of dialogue states and dialogue acts on both user and system sides. About 60% of the dialogues have cross-domain user goals that favor inter-domain dependency and encourage natural transition across domains in conversation. We also provide a user simulator and several benchmark models for pipelined task-oriented dialogue systems, which will facilitate researchers to compare and evaluate their models on this corpus. The large size and rich annotation of CrossWOZ make it suitable to investigate a variety of tasks in cross-domain dialogue modeling, such as dialogue state tracking, policy learning, user simulation, etc.</abstract>
+      <pages>281–295</pages>
+      <url hash="818f0418">2020.tacl-1.19</url>
+    </paper>
+    <paper id="20">
+      <title>How Furiously Can Colorless Green Ideas Sleep? Sentence Acceptability in Context</title>
+      <author><first>Jey Han</first><last>Lau</last></author>
+      <author><first>Carlos</first><last>Armendariz</last></author>
+      <author><first>Shalom</first><last>Lappin</last></author>
+      <author><first>Matthew</first><last>Purver</last></author>
+      <author><first>Chang</first><last>Shu</last></author>
+      <doi>10.1162/tacl_a_00315</doi>
+      <abstract>We study the influence of context on sentence acceptability. First we compare the acceptability ratings of sentences judged in isolation, with a relevant context, and with an irrelevant context. Our results show that context induces a cognitive load for humans, which compresses the distribution of ratings. Moreover, in relevant contexts we observe a discourse coherence effect that uniformly raises acceptability. Next, we test unidirectional and bidirectional language models in their ability to predict acceptability ratings. The bidirectional models show very promising results, with the best model achieving a new state-of-the-art for unsupervised acceptability prediction. The two sets of experiments provide insights into the cognitive aspects of sentence processing and central issues in the computational modeling of text and discourse.</abstract>
+      <pages>296–310</pages>
+      <url hash="3d5936e2">2020.tacl-1.20</url>
+    </paper>
+    <paper id="21">
+      <title>Learning Lexical Subspaces in a Distributional Vector Space</title>
+      <author><first>Kushal</first><last>Arora</last></author>
+      <author><first>Aishik</first><last>Chakraborty</last></author>
+      <author><first>Jackie C. K.</first><last>Cheung</last></author>
+      <doi>10.1162/tacl_a_00316</doi>
+      <abstract>In this paper, we propose LexSub, a novel approach towards unifying lexical and distributional semantics. We inject knowledge about lexical-semantic relations into distributional word embeddings by defining subspaces of the distributional vector space in which a lexical relation should hold. Our framework can handle symmetric attract and repel relations (e.g., synonymy and antonymy, respectively), as well as asymmetric relations (e.g., hypernymy and meronomy). In a suite of intrinsic benchmarks, we show that our model outperforms previous approaches on relatedness tasks and on hypernymy classification and detection, while being competitive on word similarity tasks. It also outperforms previous systems on extrinsic classification tasks that benefit from exploiting lexical relational cues. We perform a series of analyses to understand the behaviors of our model.1Code available at https://github.com/aishikchakraborty/LexSub.</abstract>
+      <pages>311–329</pages>
+      <url hash="347f167b">2020.tacl-1.21</url>
+    </paper>
+    <paper id="22">
+      <title>Syntax-Guided Controlled Generation of Paraphrases</title>
+      <author><first>Ashutosh</first><last>Kumar</last></author>
+      <author><first>Kabir</first><last>Ahuja</last></author>
+      <author><first>Raghuram</first><last>Vadapalli</last></author>
+      <author><first>Partha</first><last>Talukdar</last></author>
+      <doi>10.1162/tacl_a_00318</doi>
+      <abstract>Given a sentence (e.g., “I like mangoes”) and a constraint (e.g., sentiment flip), the goal of controlled text generation is to produce a sentence that adapts the input sentence to meet the requirements of the constraint (e.g., “I hate mangoes”). Going beyond such simple constraints, recent work has started exploring the incorporation of complex syntactic-guidance as constraints in the task of controlled paraphrase generation. In these methods, syntactic-guidance is sourced from a separate exemplar sentence. However, this prior work has only utilized limited syntactic information available in the parse tree of the exemplar sentence. We address this limitation in the paper and propose Syntax Guided Controlled Paraphraser (SGCP), an end-to-end framework for syntactic paraphrase generation. We find that Sgcp can generate syntax-conforming sentences while not compromising on relevance. We perform extensive automated and human evaluations over multiple real-world English language datasets to demonstrate the efficacy of Sgcp over state-of-the-art baselines. To drive future research, we have made Sgcp’s source code available.1</abstract>
+      <pages>329–345</pages>
+      <url hash="206976b9">2020.tacl-1.22</url>
+    </paper>
+    <paper id="23">
+      <title>Better Document-Level Machine Translation with <fixed-case>B</fixed-case>ayes’ Rule</title>
+      <author><first>Lei</first><last>Yu</last></author>
+      <author><first>Laurent</first><last>Sartran</last></author>
+      <author><first>Wojciech</first><last>Stokowiec</last></author>
+      <author><first>Wang</first><last>Ling</last></author>
+      <author><first>Lingpeng</first><last>Kong</last></author>
+      <author><first>Phil</first><last>Blunsom</last></author>
+      <author><first>Chris</first><last>Dyer</last></author>
+      <doi>10.1162/tacl_a_00319</doi>
+      <abstract>We show that Bayes’ rule provides an effective mechanism for creating document translation models that can be learned from only parallel sentences and monolingual documents a compelling benefit because parallel documents are not always available. In our formulation, the posterior probability of a candidate translation is the product of the unconditional (prior) probability of the candidate output document and the “reverse translation probability” of translating the candidate output back into the source language. Our proposed model uses a powerful autoregressive language model as the prior on target language documents, but it assumes that each sentence is translated independently from the target to the source language. Crucially, at test time, when a source document is observed, the document language model prior induces dependencies between the translations of the source sentences in the posterior. The model’s independence assumption not only enables efficient use of available data, but it additionally admits a practical left-to-right beam-search algorithm for carrying out inference. Experiments show that our model benefits from using cross-sentence context in the language model, and it outperforms existing document translation approaches.</abstract>
+      <pages>346–360</pages>
+      <url hash="0d9b8922">2020.tacl-1.23</url>
+    </paper>
+    <paper id="24">
+      <title>Hierarchical Mapping for Crosslingual Word Embedding Alignment</title>
+      <author><first>Ion Madrazo</first><last>Azpiazu</last></author>
+      <author><first>Maria Soledad</first><last>Pera</last></author>
+      <doi>10.1162/tacl_a_00320</doi>
+      <abstract>The alignment of word embedding spaces in different languages into a common crosslingual space has recently been in vogue. Strategies that do so compute pairwise alignments and then map multiple languages to a single pivot language (most often English). These strategies, however, are biased towards the choice of the pivot language, given that language proximity and the linguistic characteristics of the target language can strongly impact the resultant crosslingual space in detriment of topologically distant languages. We present a strategy that eliminates the need for a pivot language by learning the mappings across languages in a hierarchical way. Experiments demonstrate that our strategy significantly improves vocabulary induction scores in all existing benchmarks, as well as in a new non-English–centered benchmark we built, which we make publicly available.</abstract>
+      <pages>361–376</pages>
+      <url hash="cb4e07ef">2020.tacl-1.24</url>
+    </paper>
+    <paper id="25">
+      <title><fixed-case>BL</fixed-case>i<fixed-case>MP</fixed-case>: The Benchmark of Linguistic Minimal Pairs for <fixed-case>E</fixed-case>nglish</title>
+      <author><first>Alex</first><last>Warstadt</last></author>
+      <author><first>Alicia</first><last>Parrish</last></author>
+      <author><first>Haokun</first><last>Liu</last></author>
+      <author><first>Anhad</first><last>Mohananey</last></author>
+      <author><first>Wei</first><last>Peng</last></author>
+      <author><first>Sheng-Fu</first><last>Wang</last></author>
+      <author><first>Samuel R.</first><last>Bowman</last></author>
+      <doi>10.1162/tacl_a_00321</doi>
+      <abstract>We introduce The Benchmark of Linguistic Minimal Pairs (BLiMP),1 a challenge set for evaluating the linguistic knowledge of language models (LMs) on major grammatical phenomena in English. BLiMP consists of 67 individual datasets, each containing 1,000 minimal pairs—that is, pairs of minimally different sentences that contrast in grammatical acceptability and isolate specific phenomenon in syntax, morphology, or semantics. We generate the data according to linguist-crafted grammar templates, and human aggregate agreement with the labels is 96.4%. We evaluate n-gram, LSTM, and Transformer (GPT-2 and Transformer-XL) LMs by observing whether they assign a higher probability to the acceptable sentence in each minimal pair. We find that state-of-the-art models identify morphological contrasts related to agreement reliably, but they struggle with some subtle semantic and syntactic phenomena, such as negative polarity items and extraction islands.</abstract>
+      <pages>377–392</pages>
+      <url hash="b43362e8">2020.tacl-1.25</url>
+    </paper>
+    <paper id="26">
+      <title>Reproducible and Efficient Benchmarks for Hyperparameter Optimization of Neural Machine Translation Systems</title>
+      <author><first>Xuan</first><last>Zhang</last></author>
+      <author><first>Kevin</first><last>Duh</last></author>
+      <doi>10.1162/tacl_a_00322</doi>
+      <abstract>Hyperparameter selection is a crucial part of building neural machine translation (NMT) systems across both academia and industry. Fine-grained adjustments to a model’s architecture or training recipe can mean the difference between a positive and negative research result or between a state-of-the-art and underperforming system. While recent literature has proposed methods for automatic hyperparameter optimization (HPO), there has been limited work on applying these methods to neural machine translation (NMT), due in part to the high costs associated with experiments that train large numbers of model variants. To facilitate research in this space, we introduce a lookup-based approach that uses a library of pre-trained models for fast, low cost HPO experimentation. Our contributions include (1) the release of a large collection of trained NMT models covering a wide range of hyperparameters, (2) the proposal of targeted metrics for evaluating HPO methods on NMT, and (3) a reproducible benchmark of several HPO methods against our model library, including novel graph-based and multiobjective methods.</abstract>
+      <pages>393–408</pages>
+      <url hash="1c10a562">2020.tacl-1.26</url>
+    </paper>
+    <paper id="27">
+      <title>Consistent Unsupervised Estimators for Anchored <fixed-case>PCFG</fixed-case>s</title>
+      <author><first>Alexander</first><last>Clark</last></author>
+      <author><first>Nathanaël</first><last>Fijalkow</last></author>
+      <doi>10.1162/tacl_a_00323</doi>
+      <abstract>Learning probabilistic context-free grammars (PCFGs) from strings is a classic problem in computational linguistics since Horning (1969). Here we present an algorithm based on distributional learning that is a consistent estimator for a large class of PCFGs that satisfy certain natural conditions including being anchored (Stratos et al., 2016). We proceed via a reparameterization of (top--down) PCFGs that we call a bottom–up weighted context-free grammar. We show that if the grammar is anchored and satisfies additional restrictions on its ambiguity, then the parameters can be directly related to distributional properties of the anchoring strings; we show the asymptotic correctness of a naive estimator and present some simulations using synthetic data that show that algorithms based on this approach have good finite sample behavior.</abstract>
+      <pages>409–422</pages>
+      <url hash="412a6877">2020.tacl-1.27</url>
+    </paper>
+    <paper id="28">
+      <title>How Can We Know What Language Models Know?</title>
+      <author><first>Zhengbao</first><last>Jiang</last></author>
+      <author><first>Frank F.</first><last>Xu</last></author>
+      <author><first>Jun</first><last>Araki</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <doi>10.1162/tacl_a_00324</doi>
+      <abstract>Recent work has presented intriguing results examining the knowledge contained in language models (LMs) by having the LM fill in the blanks of prompts such as “Obama is a __ by profession”. These prompts are usually manually created, and quite possibly sub-optimal; another prompt such as “Obama worked as a __ ” may result in more accurately predicting the correct profession. Because of this, given an inappropriate prompt, we might fail to retrieve facts that the LM does know, and thus any given prompt only provides a lower bound estimate of the knowledge contained in an LM. In this paper, we attempt to more accurately estimate the knowledge contained in LMs by automatically discovering better prompts to use in this querying process. Specifically, we propose mining-based and paraphrasing-based methods to automatically generate high-quality and diverse prompts, as well as ensemble methods to combine answers from different prompts. Extensive experiments on the LAMA benchmark for extracting relational knowledge from LMs demonstrate that our methods can improve accuracy from 31.1% to 39.6%, providing a tighter lower bound on what LMs know. We have released the code and the resulting LM Prompt And Query Archive (LPAQA) at https://github.com/jzbjyb/LPAQA.</abstract>
+      <pages>423–438</pages>
+      <url hash="687667e2">2020.tacl-1.28</url>
+    </paper>
+    <paper id="29">
+      <title>Topic Modeling in Embedding Spaces</title>
+      <author><first>Adji B.</first><last>Dieng</last></author>
+      <author><first>Francisco J. R.</first><last>Ruiz</last></author>
+      <author><first>David M.</first><last>Blei</last></author>
+      <doi>10.1162/tacl_a_00325</doi>
+      <abstract>Topic modeling analyzes documents to learn meaningful patterns of words. However, existing topic models fail to learn interpretable topics when working with large and heavy-tailed vocabularies. To this end, we develop the embedded topic model (etm), a generative model of documents that marries traditional topic models with word embeddings. More specifically, the etm models each word with a categorical distribution whose natural parameter is the inner product between the word’s embedding and an embedding of its assigned topic. To fit the etm, we develop an efficient amortized variational inference algorithm. The etm discovers interpretable topics even with large vocabularies that include rare words and stop words. It outperforms existing document models, such as latent Dirichlet allocation, in terms of both topic quality and predictive performance.</abstract>
+      <pages>439–453</pages>
+      <url hash="580da940">2020.tacl-1.29</url>
+    </paper>
+    <paper id="30">
+      <title><fixed-case>T</fixed-case>y<fixed-case>D</fixed-case>i <fixed-case>QA</fixed-case>: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages</title>
+      <author><first>Jonathan H.</first><last>Clark</last></author>
+      <author><first>Eunsol</first><last>Choi</last></author>
+      <author><first>Michael</first><last>Collins</last></author>
+      <author><first>Dan</first><last>Garrette</last></author>
+      <author><first>Tom</first><last>Kwiatkowski</last></author>
+      <author><first>Vitaly</first><last>Nikolaev</last></author>
+      <author><first>Jennimaria</first><last>Palomaki</last></author>
+      <doi>10.1162/tacl_a_00317</doi>
+      <abstract>Confidently making progress on multilingual modeling requires challenging, trustworthy evaluations. We present TyDi QA—a question answering dataset covering 11 typologically diverse languages with 204K question-answer pairs. The languages of TyDi QA are diverse with regard to their typology—the set of linguistic features each language expresses—such that we expect models performing well on this set to generalize across a large number of the world’s languages. We present a quantitative analysis of the data quality and example-level qualitative linguistic analyses of observed language phenomena that would not be found in English-only corpora. To provide a realistic information-seeking task and avoid priming effects, questions are written by people who want to know the answer, but don’t know the answer yet, and the data is collected directly in each language without the use of translation.</abstract>
+      <pages>454–470</pages>
+      <url hash="6fabbd2b">2020.tacl-1.30</url>
     </paper>
   </volume>
 </collection>

--- a/data/xml/2020.tacl.xml
+++ b/data/xml/2020.tacl.xml
@@ -5,6 +5,7 @@
       <booktitle>Transactions of the Association for Computational Linguistics, Volume 8</booktitle>
       <year>2020</year>
     </meta>
+    <frontmatter />
     <paper id="1">
       <title>Phonotactic Complexity and Its Trade-offs</title>
       <author><first>Tiago</first><last>Pimentel</last></author>
@@ -34,7 +35,7 @@
       <url hash="50cfa1c2">2020.tacl-1.3</url>
     </paper>
     <paper id="4">
-      <title>Membership Inference Attacks on Sequence-to-Sequence Models: Is My Data In Your Machine Translation System?</title>
+      <title>Membership Inference Attacks on Sequence-to-Sequence Models: <fixed-case>I</fixed-case>s My Data In Your Machine Translation System?</title>
       <author><first>Sorami</first><last>Hisamoto</last></author>
       <author><first>Matt</first><last>Post</last></author>
       <author><first>Kevin</first><last>Duh</last></author>
@@ -57,7 +58,7 @@
       <url hash="27aaf55c">2020.tacl-1.5</url>
     </paper>
     <paper id="6">
-      <title>A Graph-based Model for Joint <fixed-case>C</fixed-case>hinese Word Segmentation and Dependency Parsing</title>
+      <title>A Graph-based Model for Joint Chinese Word Segmentation and Dependency Parsing</title>
       <author><first>Hang</first><last>Yan</last></author>
       <author><first>Xipeng</first><last>Qiu</last></author>
       <author><first>Xuanjing</first><last>Huang</last></author>
@@ -120,17 +121,6 @@
       <url hash="7be349b5">2020.tacl-1.11</url>
     </paper>
     <paper id="12">
-      <title>Decoding Brain Activity Associated with Literal and Metaphoric Sentence Comprehension Using Distributional Semantic Models</title>
-      <author><first>Vesna G.</first><last>Djokic</last></author>
-      <author><first>Jean</first><last>Maillard</last></author>
-      <author><first>Luana</first><last>Bulat</last></author>
-      <author><first>Ekaterina</first><last>Shutova</last></author>
-      <doi>10.1162/tacl_a_00307</doi>
-      <abstract>Recent years have seen a growing interest within the natural language processing (NLP) community in evaluating the ability of semantic models to capture human meaning representation in the brain. Existing research has mainly focused on applying semantic models to decode brain activity patterns associated with the meaning of individual words, and, more recently, this approach has been extended to sentences and larger text fragments. Our work is the first to investigate metaphor processing in the brain in this context. We evaluate a range of semantic models (word embeddings, compositional, and visual models) in their ability to decode brain activity associated with reading of both literal and metaphoric sentences. Our results suggest that compositional models and word embeddings are able to capture differences in the processing of literal and metaphoric sentences, providing support for the idea that the literal meaning is not fully accessible during familiar metaphor comprehension.</abstract>
-      <pages>231–246</pages>
-      <url hash="467f82a0">2020.tacl-1.12</url>
-    </paper>
-    <paper id="13">
       <title>Target-Guided Structured Attention Network for Target-Dependent Sentiment Analysis</title>
       <author><first>Ji</first><last>Zhang</last></author>
       <author><first>Chengyao</first><last>Chen</last></author>
@@ -140,9 +130,9 @@
       <doi>10.1162/tacl_a_00308</doi>
       <abstract>Target-dependent sentiment analysis (TDSA) aims to classify the sentiment of a text towards a given target. The major challenge of this task lies in modeling the semantic relatedness between a target and its context sentence. This paper proposes a novel Target-Guided Structured Attention Network (TG-SAN), which captures target-related contexts for TDSA in a fine-to-coarse manner. Given a target and its context sentence, the proposed TG-SAN first identifies multiple semantic segments from the sentence using a target-guided structured attention mechanism. It then fuses the extracted segments based on their relatedness with the target for sentiment classification. We present comprehensive comparative experiments on three benchmarks with three major findings. First, TG-SAN outperforms the state-of-the-art by up to 1.61% and 3.58% in terms of accuracy and Marco-F1, respectively. Second, it shows a strong advantage in determining the sentiment of a target when the context sentence contains multiple semantic segments. Lastly, visualization results show that the attention scores produced by TG-SAN are highly interpretable</abstract>
       <pages>172–182</pages>
-      <url hash="1e1d55c3">2020.tacl-1.13</url>
+      <url hash="1e1d55c3">2020.tacl-1.12</url>
     </paper>
-    <paper id="14">
+    <paper id="13">
       <title>Break It Down: A Question Understanding Benchmark</title>
       <author><first>Tomer</first><last>Wolfson</last></author>
       <author><first>Mor</first><last>Geva</last></author>
@@ -154,183 +144,28 @@
       <doi>10.1162/tacl_a_00309</doi>
       <abstract>Understanding natural language questions entails the ability to break down a question into the requisite steps for computing its answer. In this work, we introduce a Question Decomposition Meaning Representation (QDMR) for questions. QDMR constitutes the ordered list of steps, expressed through natural language, that are necessary for answering a question. We develop a crowdsourcing pipeline, showing that quality QDMRs can be annotated at scale, and release the Break dataset, containing over 83K pairs of questions and their QDMRs. We demonstrate the utility of QDMR by showing that (a) it can be used to improve open-domain question answering on the HotpotQA dataset, (b) it can be deterministically converted to a pseudo-SQL formal language, which can alleviate annotation in semantic parsing applications. Last, we use Break to train a sequence-to-sequence model with copying that parses questions into QDMR structures, and show that it substantially outperforms several natural baselines.</abstract>
       <pages>183–198</pages>
-      <url hash="08ba3326">2020.tacl-1.14</url>
+      <url hash="08ba3326">2020.tacl-1.13</url>
     </paper>
-    <paper id="15">
-      <title>Machine Learning–Driven Language Assessment</title>
-      <author><first>Burr</first><last>Settles</last></author>
-      <author><first>Geoffrey</first><last>T. LaFlair</last></author>
-      <author><first>Masato</first><last>Hagiwara</last></author>
-      <doi>10.1162/tacl_a_00310</doi>
-      <abstract>We describe a method for rapidly creating language proficiency assessments, and provide experimental evidence that such tests can be valid, reliable, and secure. Our approach is the first to use machine learning and natural language processing to induce proficiency scales based on a given standard, and then use linguistic models to estimate item difficulty directly for computer-adaptive testing. This alleviates the need for expensive pilot testing with human subjects. We used these methods to develop an online proficiency exam called the Duolingo English Test, and demonstrate that its scores align significantly with other high-stakes English assessments. Furthermore, our approach produces test scores that are highly reliable, while generating item banks large enough to satisfy security requirements.</abstract>
-      <pages>247–263</pages>
-      <url hash="d2c076d9">2020.tacl-1.15</url>
-    </paper>
-    <paper id="16">
+    <paper id="14">
       <title>Acoustic-Prosodic and Lexical Cues to Deception and Trust: Deciphering How People Detect Lies</title>
       <author><first>Xi (Leslie)</first><last>Chen</last></author>
-      <author><first>Sarah</first><last>Ita Levitan</last></author>
+      <author><first>Sarah Ita</first><last>Levitan</last></author>
       <author><first>Michelle</first><last>Levine</last></author>
       <author><first>Marko</first><last>Mandic</last></author>
       <author><first>Julia</first><last>Hirschberg</last></author>
       <doi>10.1162/tacl_a_00311</doi>
       <abstract>Humans rarely perform better than chance at lie detection. To better understand human perception of deception, we created a game framework, LieCatcher, to collect ratings of perceived deception using a large corpus of deceptive and truthful interviews. We analyzed the acoustic-prosodic and linguistic characteristics of language trusted and mistrusted by raters and compared these to characteristics of actual truthful and deceptive language to understand how perception aligns with reality. With this data we built classifiers to automatically distinguish trusted from mistrusted speech, achieving an F1 of 66.1%. We next evaluated whether the strategies raters said they used to discriminate between truthful and deceptive responses were in fact useful. Our results show that, although several prosodic and lexical features were consistently perceived as trustworthy, they were not reliable cues. Also, the strategies that judges reported using in deception detection were not helpful for the task. Our work sheds light on the nature of trusted language and provides insight into the challenging problem of human deception detection.</abstract>
       <pages>199–214</pages>
-      <url hash="d0dfd22b">2020.tacl-1.16</url>
+      <url hash="d0dfd22b">2020.tacl-1.14</url>
     </paper>
-    <paper id="17">
-      <title>Unsupervised Discourse Constituency Parsing Using <fixed-case>V</fixed-case>iterbi <fixed-case>EM</fixed-case></title>
+    <paper id="15">
+      <title>Unsupervised Discourse Constituency Parsing Using Viterbi <fixed-case>EM</fixed-case></title>
       <author><first>Noriki</first><last>Nishida</last></author>
       <author><first>Hideki</first><last>Nakayama</last></author>
       <doi>10.1162/tacl_a_00312</doi>
       <abstract>In this paper, we introduce an unsupervised discourse constituency parsing algorithm. We use Viterbi EM with a margin-based criterion to train a span-based discourse parser in an unsupervised manner. We also propose initialization methods for Viterbi training of discourse constituents based on our prior knowledge of text structures. Experimental results demonstrate that our unsupervised parser achieves comparable or even superior performance to fully supervised parsers. We also investigate discourse constituents that are learned by our method.</abstract>
       <pages>215–230</pages>
-      <url hash="9b0c0560">2020.tacl-1.17</url>
-    </paper>
-    <paper id="18">
-      <title>Leveraging Pre-trained Checkpoints for Sequence Generation Tasks</title>
-      <author><first>Sascha</first><last>Rothe</last></author>
-      <author><first>Shashi</first><last>Narayan</last></author>
-      <author><first>Aliaksei</first><last>Severyn</last></author>
-      <doi>10.1162/tacl_a_00313</doi>
-      <abstract>Unsupervised pre-training of large neural models has recently revolutionized Natural Language Processing. By warm-starting from the publicly released checkpoints, NLP practitioners have pushed the state-of-the-art on multiple benchmarks while saving significant amounts of compute time. So far the focus has been mainly on the Natural Language Understanding tasks. In this paper, we demonstrate the efficacy of pre-trained checkpoints for Sequence Generation. We developed a Transformer-based sequence-to-sequence model that is compatible with publicly available pre-trained BERT, GPT-2, and RoBERTa checkpoints and conducted an extensive empirical study on the utility of initializing our model, both encoder and decoder, with these checkpoints. Our models result in new state-of-the-art results on Machine Translation, Text Summarization, Sentence Splitting, and Sentence Fusion.</abstract>
-      <pages>264–280</pages>
-      <url hash="c925bfbe">2020.tacl-1.18</url>
-    </paper>
-    <paper id="19">
-      <title><fixed-case>C</fixed-case>ross<fixed-case>WOZ</fixed-case>: A Large-Scale <fixed-case>C</fixed-case>hinese Cross-Domain Task-Oriented Dialogue Dataset</title>
-      <author><first>Qi</first><last>Zhu</last></author>
-      <author><first>Kaili</first><last>Huang</last></author>
-      <author><first>Zheng</first><last>Zhang</last></author>
-      <author><first>Xiaoyan</first><last>Zhu</last></author>
-      <author><first>Minlie</first><last>Huang</last></author>
-      <doi>10.1162/tacl_a_00314</doi>
-      <abstract>To advance multi-domain (cross-domain) dialogue modeling as well as alleviate the shortage of Chinese task-oriented datasets, we propose CrossWOZ, the first large-scale Chinese Cross-Domain Wizard-of-Oz task-oriented dataset. It contains 6K dialogue sessions and 102K utterances for 5 domains, including hotel, restaurant, attraction, metro, and taxi. Moreover, the corpus contains rich annotation of dialogue states and dialogue acts on both user and system sides. About 60% of the dialogues have cross-domain user goals that favor inter-domain dependency and encourage natural transition across domains in conversation. We also provide a user simulator and several benchmark models for pipelined task-oriented dialogue systems, which will facilitate researchers to compare and evaluate their models on this corpus. The large size and rich annotation of CrossWOZ make it suitable to investigate a variety of tasks in cross-domain dialogue modeling, such as dialogue state tracking, policy learning, user simulation, etc.</abstract>
-      <pages>281–295</pages>
-      <url hash="818f0418">2020.tacl-1.19</url>
-    </paper>
-    <paper id="20">
-      <title>How Furiously Can Colorless Green Ideas Sleep? Sentence Acceptability in Context</title>
-      <author><first>Jey Han</first><last>Lau</last></author>
-      <author><first>Carlos</first><last>Armendariz</last></author>
-      <author><first>Shalom</first><last>Lappin</last></author>
-      <author><first>Matthew</first><last>Purver</last></author>
-      <author><first>Chang</first><last>Shu</last></author>
-      <doi>10.1162/tacl_a_00315</doi>
-      <abstract>We study the influence of context on sentence acceptability. First we compare the acceptability ratings of sentences judged in isolation, with a relevant context, and with an irrelevant context. Our results show that context induces a cognitive load for humans, which compresses the distribution of ratings. Moreover, in relevant contexts we observe a discourse coherence effect that uniformly raises acceptability. Next, we test unidirectional and bidirectional language models in their ability to predict acceptability ratings. The bidirectional models show very promising results, with the best model achieving a new state-of-the-art for unsupervised acceptability prediction. The two sets of experiments provide insights into the cognitive aspects of sentence processing and central issues in the computational modeling of text and discourse.</abstract>
-      <pages>296–310</pages>
-      <url hash="3d5936e2">2020.tacl-1.20</url>
-    </paper>
-    <paper id="21">
-      <title>Learning Lexical Subspaces in a Distributional Vector Space</title>
-      <author><first>Kushal</first><last>Arora</last></author>
-      <author><first>Aishik</first><last>Chakraborty</last></author>
-      <author><first>Jackie C. K.</first><last>Cheung</last></author>
-      <doi>10.1162/tacl_a_00316</doi>
-      <abstract>In this paper, we propose LexSub, a novel approach towards unifying lexical and distributional semantics. We inject knowledge about lexical-semantic relations into distributional word embeddings by defining subspaces of the distributional vector space in which a lexical relation should hold. Our framework can handle symmetric attract and repel relations (e.g., synonymy and antonymy, respectively), as well as asymmetric relations (e.g., hypernymy and meronomy). In a suite of intrinsic benchmarks, we show that our model outperforms previous approaches on relatedness tasks and on hypernymy classification and detection, while being competitive on word similarity tasks. It also outperforms previous systems on extrinsic classification tasks that benefit from exploiting lexical relational cues. We perform a series of analyses to understand the behaviors of our model.1Code available at https://github.com/aishikchakraborty/LexSub.</abstract>
-      <pages>311–329</pages>
-      <url hash="347f167b">2020.tacl-1.21</url>
-    </paper>
-    <paper id="22">
-      <title><fixed-case>T</fixed-case>y<fixed-case>D</fixed-case>i <fixed-case>QA</fixed-case>: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages</title>
-      <author><first>Jonathan H.</first><last>Clark</last></author>
-      <author><first>Eunsol</first><last>Choi</last></author>
-      <author><first>Michael</first><last>Collins</last></author>
-      <author><first>Dan</first><last>Garrette</last></author>
-      <author><first>Tom</first><last>Kwiatkowski</last></author>
-      <author><first>Vitaly</first><last>Nikolaev</last></author>
-      <author><first>Jennimaria</first><last>Palomaki</last></author>
-      <doi>10.1162/tacl_a_00317</doi>
-      <abstract>Confidently making progress on multilingual modeling requires challenging, trustworthy evaluations. We present TyDi QA—a question answering dataset covering 11 typologically diverse languages with 204K question-answer pairs. The languages of TyDi QA are diverse with regard to their typology—the set of linguistic features each language expresses—such that we expect models performing well on this set to generalize across a large number of the world’s languages. We present a quantitative analysis of the data quality and example-level qualitative linguistic analyses of observed language phenomena that would not be found in English-only corpora. To provide a realistic information-seeking task and avoid priming effects, questions are written by people who want to know the answer, but don’t know the answer yet, and the data is collected directly in each language without the use of translation.</abstract>
-      <pages>454–470</pages>
-      <url hash="6fabbd2b">2020.tacl-1.22</url>
-    </paper>
-    <paper id="23">
-      <title>Syntax-Guided Controlled Generation of Paraphrases</title>
-      <author><first>Ashutosh</first><last>Kumar</last></author>
-      <author><first>Kabir</first><last>Ahuja</last></author>
-      <author><first>Raghuram</first><last>Vadapalli</last></author>
-      <author><first>Partha</first><last>Talukdar</last></author>
-      <doi>10.1162/tacl_a_00318</doi>
-      <abstract>Given a sentence (e.g., “I like mangoes”) and a constraint (e.g., sentiment flip), the goal of controlled text generation is to produce a sentence that adapts the input sentence to meet the requirements of the constraint (e.g., “I hate mangoes”). Going beyond such simple constraints, recent work has started exploring the incorporation of complex syntactic-guidance as constraints in the task of controlled paraphrase generation. In these methods, syntactic-guidance is sourced from a separate exemplar sentence. However, this prior work has only utilized limited syntactic information available in the parse tree of the exemplar sentence. We address this limitation in the paper and propose Syntax Guided Controlled Paraphraser (SGCP), an end-to-end framework for syntactic paraphrase generation. We find that Sgcp can generate syntax-conforming sentences while not compromising on relevance. We perform extensive automated and human evaluations over multiple real-world English language datasets to demonstrate the efficacy of Sgcp over state-of-the-art baselines. To drive future research, we have made Sgcp’s source code available.1</abstract>
-      <pages>329–345</pages>
-      <url hash="206976b9">2020.tacl-1.23</url>
-    </paper>
-    <paper id="24">
-      <title>Better Document-Level Machine Translation with <fixed-case>B</fixed-case>ayes’ Rule</title>
-      <author><first>Lei</first><last>Yu</last></author>
-      <author><first>Laurent</first><last>Sartran</last></author>
-      <author><first>Wojciech</first><last>Stokowiec</last></author>
-      <author><first>Wang</first><last>Ling</last></author>
-      <author><first>Lingpeng</first><last>Kong</last></author>
-      <author><first>Phil</first><last>Blunsom</last></author>
-      <author><first>Chris</first><last>Dyer</last></author>
-      <doi>10.1162/tacl_a_00319</doi>
-      <abstract>We show that Bayes’ rule provides an effective mechanism for creating document translation models that can be learned from only parallel sentences and monolingual documents a compelling benefit because parallel documents are not always available. In our formulation, the posterior probability of a candidate translation is the product of the unconditional (prior) probability of the candidate output document and the “reverse translation probability” of translating the candidate output back into the source language. Our proposed model uses a powerful autoregressive language model as the prior on target language documents, but it assumes that each sentence is translated independently from the target to the source language. Crucially, at test time, when a source document is observed, the document language model prior induces dependencies between the translations of the source sentences in the posterior. The model’s independence assumption not only enables efficient use of available data, but it additionally admits a practical left-to-right beam-search algorithm for carrying out inference. Experiments show that our model benefits from using cross-sentence context in the language model, and it outperforms existing document translation approaches.</abstract>
-      <pages>346–360</pages>
-      <url hash="0d9b8922">2020.tacl-1.24</url>
-    </paper>
-    <paper id="25">
-      <title>Hierarchical Mapping for Crosslingual Word Embedding Alignment</title>
-      <author><first>Ion Madrazo</first><last>Azpiazu</last></author>
-      <author><first>Maria Soledad</first><last>Pera</last></author>
-      <doi>10.1162/tacl_a_00320</doi>
-      <abstract>The alignment of word embedding spaces in different languages into a common crosslingual space has recently been in vogue. Strategies that do so compute pairwise alignments and then map multiple languages to a single pivot language (most often English). These strategies, however, are biased towards the choice of the pivot language, given that language proximity and the linguistic characteristics of the target language can strongly impact the resultant crosslingual space in detriment of topologically distant languages. We present a strategy that eliminates the need for a pivot language by learning the mappings across languages in a hierarchical way. Experiments demonstrate that our strategy significantly improves vocabulary induction scores in all existing benchmarks, as well as in a new non-English–centered benchmark we built, which we make publicly available.</abstract>
-      <pages>361–376</pages>
-      <url hash="cb4e07ef">2020.tacl-1.25</url>
-    </paper>
-    <paper id="26">
-      <title><fixed-case>BL</fixed-case>i<fixed-case>MP</fixed-case>: The Benchmark of Linguistic Minimal Pairs for <fixed-case>E</fixed-case>nglish</title>
-      <author><first>Alex</first><last>Warstadt</last></author>
-      <author><first>Alicia</first><last>Parrish</last></author>
-      <author><first>Haokun</first><last>Liu</last></author>
-      <author><first>Anhad</first><last>Mohananey</last></author>
-      <author><first>Wei</first><last>Peng</last></author>
-      <author><first>Sheng-Fu</first><last>Wang</last></author>
-      <author><first>Samuel R.</first><last>Bowman</last></author>
-      <doi>10.1162/tacl_a_00321</doi>
-      <abstract>We introduce The Benchmark of Linguistic Minimal Pairs (BLiMP),1 a challenge set for evaluating the linguistic knowledge of language models (LMs) on major grammatical phenomena in English. BLiMP consists of 67 individual datasets, each containing 1,000 minimal pairs—that is, pairs of minimally different sentences that contrast in grammatical acceptability and isolate specific phenomenon in syntax, morphology, or semantics. We generate the data according to linguist-crafted grammar templates, and human aggregate agreement with the labels is 96.4%. We evaluate n-gram, LSTM, and Transformer (GPT-2 and Transformer-XL) LMs by observing whether they assign a higher probability to the acceptable sentence in each minimal pair. We find that state-of-the-art models identify morphological contrasts related to agreement reliably, but they struggle with some subtle semantic and syntactic phenomena, such as negative polarity items and extraction islands.</abstract>
-      <pages>377–392</pages>
-      <url hash="b43362e8">2020.tacl-1.26</url>
-    </paper>
-    <paper id="27">
-      <title>Reproducible and Efficient Benchmarks for Hyperparameter Optimization of Neural Machine Translation Systems</title>
-      <author><first>Xuan</first><last>Zhang</last></author>
-      <author><first>Kevin</first><last>Duh</last></author>
-      <doi>10.1162/tacl_a_00322</doi>
-      <abstract>Hyperparameter selection is a crucial part of building neural machine translation (NMT) systems across both academia and industry. Fine-grained adjustments to a model’s architecture or training recipe can mean the difference between a positive and negative research result or between a state-of-the-art and underperforming system. While recent literature has proposed methods for automatic hyperparameter optimization (HPO), there has been limited work on applying these methods to neural machine translation (NMT), due in part to the high costs associated with experiments that train large numbers of model variants. To facilitate research in this space, we introduce a lookup-based approach that uses a library of pre-trained models for fast, low cost HPO experimentation. Our contributions include (1) the release of a large collection of trained NMT models covering a wide range of hyperparameters, (2) the proposal of targeted metrics for evaluating HPO methods on NMT, and (3) a reproducible benchmark of several HPO methods against our model library, including novel graph-based and multiobjective methods.</abstract>
-      <pages>393–408</pages>
-      <url hash="1c10a562">2020.tacl-1.27</url>
-    </paper>
-    <paper id="28">
-      <title>Consistent Unsupervised Estimators for Anchored <fixed-case>PCFG</fixed-case>s</title>
-      <author><first>Alexander</first><last>Clark</last></author>
-      <author><first>Nathanaël</first><last>Fijalkow</last></author>
-      <doi>10.1162/tacl_a_00323</doi>
-      <abstract>Learning probabilistic context-free grammars (PCFGs) from strings is a classic problem in computational linguistics since Horning (1969). Here we present an algorithm based on distributional learning that is a consistent estimator for a large class of PCFGs that satisfy certain natural conditions including being anchored (Stratos et al., 2016). We proceed via a reparameterization of (top--down) PCFGs that we call a bottom–up weighted context-free grammar. We show that if the grammar is anchored and satisfies additional restrictions on its ambiguity, then the parameters can be directly related to distributional properties of the anchoring strings; we show the asymptotic correctness of a naive estimator and present some simulations using synthetic data that show that algorithms based on this approach have good finite sample behavior.</abstract>
-      <pages>409–422</pages>
-      <url hash="412a6877">2020.tacl-1.28</url>
-    </paper>
-    <paper id="29">
-      <title>How Can We Know What Language Models Know?</title>
-      <author><first>Zhengbao</first><last>Jiang</last></author>
-      <author><first>Frank F.</first><last>Xu</last></author>
-      <author><first>Jun</first><last>Araki</last></author>
-      <author><first>Graham</first><last>Neubig</last></author>
-      <doi>10.1162/tacl_a_00324</doi>
-      <abstract>Recent work has presented intriguing results examining the knowledge contained in language models (LMs) by having the LM fill in the blanks of prompts such as “Obama is a __ by profession”. These prompts are usually manually created, and quite possibly sub-optimal; another prompt such as “Obama worked as a __ ” may result in more accurately predicting the correct profession. Because of this, given an inappropriate prompt, we might fail to retrieve facts that the LM does know, and thus any given prompt only provides a lower bound estimate of the knowledge contained in an LM. In this paper, we attempt to more accurately estimate the knowledge contained in LMs by automatically discovering better prompts to use in this querying process. Specifically, we propose mining-based and paraphrasing-based methods to automatically generate high-quality and diverse prompts, as well as ensemble methods to combine answers from different prompts. Extensive experiments on the LAMA benchmark for extracting relational knowledge from LMs demonstrate that our methods can improve accuracy from 31.1% to 39.6%, providing a tighter lower bound on what LMs know. We have released the code and the resulting LM Prompt And Query Archive (LPAQA) at https://github.com/jzbjyb/LPAQA.</abstract>
-      <pages>423–438</pages>
-      <url hash="687667e2">2020.tacl-1.29</url>
-    </paper>
-    <paper id="30">
-      <title>Topic Modeling in Embedding Spaces</title>
-      <author><first>Adji B.</first><last>Dieng</last></author>
-      <author><first>Francisco J. R.</first><last>Ruiz</last></author>
-      <author><first>David M.</first><last>Blei</last></author>
-      <doi>10.1162/tacl_a_00325</doi>
-      <abstract>Topic modeling analyzes documents to learn meaningful patterns of words. However, existing topic models fail to learn interpretable topics when working with large and heavy-tailed vocabularies. To this end, we develop the embedded topic model (etm), a generative model of documents that marries traditional topic models with word embeddings. More specifically, the etm models each word with a categorical distribution whose natural parameter is the inner product between the word’s embedding and an embedding of its assigned topic. To fit the etm, we develop an efficient amortized variational inference algorithm. The etm discovers interpretable topics even with large vocabularies that include rare words and stop words. It outperforms existing document models, such as latent Dirichlet allocation, in terms of both topic quality and predictive performance.</abstract>
-      <pages>439–453</pages>
-      <url hash="580da940">2020.tacl-1.30</url>
+      <url hash="9b0c0560">2020.tacl-1.15</url>
     </paper>
   </volume>
 </collection>

--- a/data/xml/2020.tacl.xml
+++ b/data/xml/2020.tacl.xml
@@ -13,7 +13,7 @@
       <doi>10.1162/tacl_a_00296</doi>
       <abstract>We present methods for calculating a measure of phonotactic complexity—bits per phoneme— that permits a straightforward cross-linguistic comparison. When given a word, represented as a sequence of phonemic segments such as symbols in the international phonetic alphabet, and a statistical model trained on a sample of word types from the language, we can approximately measure bits per phoneme using the negative log-probability of that word under the model. This simple measure allows us to compare the entropy across languages, giving insight into how complex a language’s phonotactics is. Using a collection of 1016 basic concept words across 106 languages, we demonstrate a very strong negative correlation of − 0.74 between bits per phoneme and the average length of words.</abstract>
       <pages>1–18</pages>
-      <url hash="580da940">2020.tacl-1.1</url>
+      <url hash="c153b336">2020.tacl-1.1</url>
     </paper>
     <paper id="2">
       <title><fixed-case>AMR</fixed-case>-To-Text Generation with Graph Transformer</title>
@@ -23,7 +23,7 @@
       <doi>10.1162/tacl_a_00297</doi>
       <abstract>Abstract meaning representation (AMR)-to-text generation is the challenging task of generating natural language texts from AMR graphs, where nodes represent concepts and edges denote relations. The current state-of-the-art methods use graph-to-sequence models; however, they still cannot significantly outperform the previous sequence-to-sequence models or statistical approaches. In this paper, we propose a novel graph-to-sequence model (Graph Transformer) to address this task. The model directly encodes the AMR graphs and learns the node representations. A pairwise interaction function is used for computing the semantic relations between the concepts. Moreover, attention mechanisms are used for aggregating the information from the incoming and outgoing neighbors, which help the model to capture the semantic information effectively. Our model outperforms the state-of-the-art neural approach by 1.5 BLEU points on LDC2015E86 and 4.8 BLEU points on LDC2017T10 and achieves new state-of-the-art performances.</abstract>
       <pages>19–33</pages>
-      <url hash="580da940">2020.tacl-1.2</url>
+      <url hash="9dce31b7">2020.tacl-1.2</url>
     </paper>
     <paper id="3">
       <title>What <fixed-case>BERT</fixed-case> Is Not: Lessons from a New Suite of Psycholinguistic Diagnostics for Language Models</title>
@@ -31,7 +31,7 @@
       <doi>10.1162/tacl_a_00298</doi>
       <abstract>Pre-training by language modeling has become a popular and successful approach to NLP tasks, but we have yet to understand exactly what linguistic capacities these pre-training processes confer upon models. In this paper we introduce a suite of diagnostics drawn from human language experiments, which allow us to ask targeted questions about information used by language models for generating predictions in context. As a case study, we apply these diagnostics to the popular BERT model, finding that it can generally distinguish good from bad completions involving shared category or role reversal, albeit with less sensitivity than humans, and it robustly retrieves noun hypernyms, but it struggles with challenging inference and role-based event prediction— and, in particular, it shows clear insensitivity to the contextual impacts of negation.</abstract>
       <pages>34–48</pages>
-      <url hash="580da940">2020.tacl-1.3</url>
+      <url hash="50cfa1c2">2020.tacl-1.3</url>
     </paper>
     <paper id="4">
       <title>Membership Inference Attacks on Sequence-to-Sequence Models: Is My Data In Your Machine Translation System?</title>
@@ -41,7 +41,7 @@
       <doi>10.1162/tacl_a_00299</doi>
       <abstract>Data privacy is an important issue for “machine learning as a service” providers. We focus on the problem of membership inference attacks: Given a data sample and black-box access to a model’s API, determine whether the sample existed in the model’s training data. Our contribution is an investigation of this problem in the context of sequence-to-sequence models, which are important in applications such as machine translation and video captioning. We define the membership inference problem for sequence generation, provide an open dataset based on state-of-the-art machine translation models, and report initial results on whether these models leak private information against several kinds of membership inference attacks.</abstract>
       <pages>49–63</pages>
-      <url hash="580da940">2020.tacl-1.4</url>
+      <url hash="dd95e987">2020.tacl-1.4</url>
     </paper>
     <paper id="5">
       <title><fixed-case>S</fixed-case>pan<fixed-case>BERT</fixed-case>: Improving Pre-training by Representing and Predicting Spans</title>
@@ -54,7 +54,7 @@
       <doi>10.1162/tacl_a_00300</doi>
       <abstract>We present SpanBERT, a pre-training method that is designed to better represent and predict spans of text. Our approach extends BERT by (1) masking contiguous random spans, rather than random tokens, and (2) training the span boundary representations to predict the entire content of the masked span, without relying on the individual token representations within it. SpanBERT consistently outperforms BERT and our better-tuned baselines, with substantial gains on span selection tasks such as question answering and coreference resolution. In particular, with the same training data and model size as BERTlarge, our single model obtains 94.6% and 88.7% F1 on SQuAD 1.1 and 2.0 respectively. We also achieve a new state of the art on the OntoNotes coreference resolution task (79.6% F1), strong performance on the TACRED relation extraction benchmark, and even gains on GLUE.1</abstract>
       <pages>64–77</pages>
-      <url hash="580da940">2020.tacl-1.5</url>
+      <url hash="27aaf55c">2020.tacl-1.5</url>
     </paper>
     <paper id="6">
       <title>A Graph-based Model for Joint <fixed-case>C</fixed-case>hinese Word Segmentation and Dependency Parsing</title>
@@ -64,7 +64,7 @@
       <doi>10.1162/tacl_a_00301</doi>
       <abstract>Chinese word segmentation and dependency parsing are two fundamental tasks for Chinese natural language processing. The dependency parsing is defined at the word-level. Therefore word segmentation is the precondition of dependency parsing, which makes dependency parsing suffer from error propagation and unable to directly make use of character-level pre-trained language models (such as BERT). In this paper, we propose a graph-based model to integrate Chinese word segmentation and dependency parsing. Different from previous transition-based joint models, our proposed model is more concise, which results in fewer efforts of feature engineering. Our graph-based joint model achieves better performance than previous joint models and state-of-the-art results in both Chinese word segmentation and dependency parsing. Additionally, when BERT is combined, our model can substantially reduce the performance gap of dependency parsing between joint models and gold-segmented word-based models. Our code is publicly available at https://github.com/fastnlp/JointCwsParser</abstract>
       <pages>78–92</pages>
-      <url hash="580da940">2020.tacl-1.6</url>
+      <url hash="8c82b722">2020.tacl-1.6</url>
     </paper>
     <paper id="7">
       <title>A Knowledge-Enhanced Pretraining Model for Commonsense Story Generation</title>
@@ -76,7 +76,7 @@
       <doi>10.1162/tacl_a_00302</doi>
       <abstract>Story generation, namely, generating a reasonable story from a leading context, is an important but challenging task. In spite of the success in modeling fluency and local coherence, existing neural language generation models (e.g., GPT-2) still suffer from repetition, logic conflicts, and lack of long-range coherence in generated stories. We conjecture that this is because of the difficulty of associating relevant commonsense knowledge, understanding the causal relationships, and planning entities and events with proper temporal order. In this paper, we devise a knowledge-enhanced pretraining model for commonsense story generation. We propose to utilize commonsense knowledge from external knowledge bases to generate reasonable stories. To further capture the causal and temporal dependencies between the sentences in a reasonable story, we use multi-task learning, which combines a discriminative objective to distinguish true and fake stories during fine-tuning. Automatic and manual evaluation shows that our model can generate more reasonable stories than state-of-the-art baselines, particularly in terms of logic and global coherence.</abstract>
       <pages>93–108</pages>
-      <url hash="580da940">2020.tacl-1.7</url>
+      <url hash="c075234a">2020.tacl-1.7</url>
     </paper>
     <paper id="8">
       <title>Improving Candidate Generation for Low-resource Cross-lingual Entity Linking</title>
@@ -88,7 +88,7 @@
       <doi>10.1162/tacl_a_00303</doi>
       <abstract>Cross-lingual entity linking (XEL) is the task of finding referents in a target-language knowledge base (KB) for mentions extracted from source-language texts. The first step of (X)EL is candidate generation, which retrieves a list of plausible candidate entities from the target-language KB for each mention. Approaches based on resources from Wikipedia have proven successful in the realm of relatively high-resource languages, but these do not extend well to low-resource languages with few, if any, Wikipedia pages. Recently, transfer learning methods have been shown to reduce the demand for resources in the low-resource languages by utilizing resources in closely related languages, but the performance still lags far behind their high-resource counterparts. In this paper, we first assess the problems faced by current entity candidate generation methods for low-resource XEL, then propose three improvements that (1) reduce the disconnect between entity mentions and KB entries, and (2) improve the robustness of the model to low-resource scenarios. The methods are simple, but effective: We experiment with our approach on seven XEL datasets and find that they yield an average gain of 16.9% in Top-30 gold candidate recall, compared with state-of-the-art baselines. Our improved model also yields an average gain of 7.9% in in-KB accuracy of end-to-end XEL.1</abstract>
       <pages>109–124</pages>
-      <url hash="580da940">2020.tacl-1.8</url>
+      <url hash="74d04e8d">2020.tacl-1.8</url>
     </paper>
     <paper id="9">
       <title>Does Syntax Need to Grow on Trees? Sources of Hierarchical Inductive Bias in Sequence-to-Sequence Networks</title>
@@ -98,7 +98,7 @@
       <doi>10.1162/tacl_a_00304</doi>
       <abstract>Learners that are exposed to the same training data might generalize differently due to differing inductive biases. In neural network models, inductive biases could in theory arise from any aspect of the model architecture. We investigate which architectural factors affect the generalization behavior of neural sequence-to-sequence models trained on two syntactic tasks, English question formation and English tense reinflection. For both tasks, the training set is consistent with a generalization based on hierarchical structure and a generalization based on linear order. All architectural factors that we investigated qualitatively affected how models generalized, including factors with no clear connection to hierarchical structure. For example, LSTMs and GRUs displayed qualitatively different inductive biases. However, the only factor that consistently contributed a hierarchical bias across tasks was the use of a tree-structured model rather than a model with sequential recurrence, suggesting that human-like syntactic generalization requires architectural syntactic structure.</abstract>
       <pages>125–140</pages>
-      <url hash="580da940">2020.tacl-1.9</url>
+      <url hash="2d0d4357">2020.tacl-1.9</url>
     </paper>
     <paper id="10">
       <title>Investigating Prior Knowledge for Challenging <fixed-case>C</fixed-case>hinese Machine Reading Comprehension</title>
@@ -109,7 +109,7 @@
       <doi>10.1162/tacl_a_00305</doi>
       <abstract>Machine reading comprehension tasks require a machine reader to answer questions relevant to the given document. In this paper, we present the first free-form multiple-Choice Chinese machine reading Comprehension dataset (C3), containing 13,369 documents (dialogues or more formally written mixed-genre texts) and their associated 19,577 multiple-choice free-form questions collected from Chinese-as-a-second-language examinations. We present a comprehensive analysis of the prior knowledge (i.e., linguistic, domain-specific, and general world knowledge) needed for these real-world problems. We implement rule-based and popular neural methods and find that there is still a significant performance gap between the best performing model (68.5%) and human readers (96.0%), especiallyon problems that require prior knowledge. We further study the effects of distractor plausibility and data augmentation based on translated relevant datasets for English on model performance. We expect C3 to present great challenges to existing systems as answering 86.8% of questions requires both knowledge within and beyond the accompanying document, and we hope that C3 can serve as a platform to study how to leverage various kinds of prior knowledge to better understand a given written or orally oriented text. C3 is available at https://dataset.org/c3/.</abstract>
       <pages>141–155</pages>
-      <url hash="580da940">2020.tacl-1.10</url>
+      <url hash="2e13d3fe">2020.tacl-1.10</url>
     </paper>
     <paper id="11">
       <title>Theoretical Limitations of Self-Attention in Neural Sequence Models</title>
@@ -117,7 +117,7 @@
       <doi>10.1162/tacl_a_00306</doi>
       <abstract>Transformers are emerging as the new workhorse of NLP, showing great success across tasks. Unlike LSTMs, transformers process input sequences entirely through self-attention. Previous work has suggested that the computational capabilities of self-attention to process hierarchical structures are limited. In this work, we mathematically investigate the computational power of self-attention to model formal languages. Across both soft and hard attention, we show strong theoretical limitations of the computational abilities of self-attention, finding that it cannot model periodic finite-state languages, nor hierarchical structure, unless the number of layers or heads increases with input length. These limitations seem surprising given the practical success of self-attention and the prominent role assigned to hierarchical structure in linguistics, suggesting that natural language can be approximated well with models that are too weak for the formal languages typically assumed in theoretical linguistics.</abstract>
       <pages>156–171</pages>
-      <url hash="580da940">2020.tacl-1.11</url>
+      <url hash="7be349b5">2020.tacl-1.11</url>
     </paper>
     <paper id="12">
       <title>Decoding Brain Activity Associated with Literal and Metaphoric Sentence Comprehension Using Distributional Semantic Models</title>
@@ -128,7 +128,7 @@
       <doi>10.1162/tacl_a_00307</doi>
       <abstract>Recent years have seen a growing interest within the natural language processing (NLP) community in evaluating the ability of semantic models to capture human meaning representation in the brain. Existing research has mainly focused on applying semantic models to decode brain activity patterns associated with the meaning of individual words, and, more recently, this approach has been extended to sentences and larger text fragments. Our work is the first to investigate metaphor processing in the brain in this context. We evaluate a range of semantic models (word embeddings, compositional, and visual models) in their ability to decode brain activity associated with reading of both literal and metaphoric sentences. Our results suggest that compositional models and word embeddings are able to capture differences in the processing of literal and metaphoric sentences, providing support for the idea that the literal meaning is not fully accessible during familiar metaphor comprehension.</abstract>
       <pages>231–246</pages>
-      <url hash="580da940">2020.tacl-1.12</url>
+      <url hash="467f82a0">2020.tacl-1.12</url>
     </paper>
     <paper id="13">
       <title>Target-Guided Structured Attention Network for Target-Dependent Sentiment Analysis</title>
@@ -140,7 +140,7 @@
       <doi>10.1162/tacl_a_00308</doi>
       <abstract>Target-dependent sentiment analysis (TDSA) aims to classify the sentiment of a text towards a given target. The major challenge of this task lies in modeling the semantic relatedness between a target and its context sentence. This paper proposes a novel Target-Guided Structured Attention Network (TG-SAN), which captures target-related contexts for TDSA in a fine-to-coarse manner. Given a target and its context sentence, the proposed TG-SAN first identifies multiple semantic segments from the sentence using a target-guided structured attention mechanism. It then fuses the extracted segments based on their relatedness with the target for sentiment classification. We present comprehensive comparative experiments on three benchmarks with three major findings. First, TG-SAN outperforms the state-of-the-art by up to 1.61% and 3.58% in terms of accuracy and Marco-F1, respectively. Second, it shows a strong advantage in determining the sentiment of a target when the context sentence contains multiple semantic segments. Lastly, visualization results show that the attention scores produced by TG-SAN are highly interpretable</abstract>
       <pages>172–182</pages>
-      <url hash="580da940">2020.tacl-1.13</url>
+      <url hash="1e1d55c3">2020.tacl-1.13</url>
     </paper>
     <paper id="14">
       <title>Break It Down: A Question Understanding Benchmark</title>
@@ -154,7 +154,7 @@
       <doi>10.1162/tacl_a_00309</doi>
       <abstract>Understanding natural language questions entails the ability to break down a question into the requisite steps for computing its answer. In this work, we introduce a Question Decomposition Meaning Representation (QDMR) for questions. QDMR constitutes the ordered list of steps, expressed through natural language, that are necessary for answering a question. We develop a crowdsourcing pipeline, showing that quality QDMRs can be annotated at scale, and release the Break dataset, containing over 83K pairs of questions and their QDMRs. We demonstrate the utility of QDMR by showing that (a) it can be used to improve open-domain question answering on the HotpotQA dataset, (b) it can be deterministically converted to a pseudo-SQL formal language, which can alleviate annotation in semantic parsing applications. Last, we use Break to train a sequence-to-sequence model with copying that parses questions into QDMR structures, and show that it substantially outperforms several natural baselines.</abstract>
       <pages>183–198</pages>
-      <url hash="580da940">2020.tacl-1.14</url>
+      <url hash="08ba3326">2020.tacl-1.14</url>
     </paper>
     <paper id="15">
       <title>Machine Learning–Driven Language Assessment</title>
@@ -164,7 +164,7 @@
       <doi>10.1162/tacl_a_00310</doi>
       <abstract>We describe a method for rapidly creating language proficiency assessments, and provide experimental evidence that such tests can be valid, reliable, and secure. Our approach is the first to use machine learning and natural language processing to induce proficiency scales based on a given standard, and then use linguistic models to estimate item difficulty directly for computer-adaptive testing. This alleviates the need for expensive pilot testing with human subjects. We used these methods to develop an online proficiency exam called the Duolingo English Test, and demonstrate that its scores align significantly with other high-stakes English assessments. Furthermore, our approach produces test scores that are highly reliable, while generating item banks large enough to satisfy security requirements.</abstract>
       <pages>247–263</pages>
-      <url hash="580da940">2020.tacl-1.15</url>
+      <url hash="d2c076d9">2020.tacl-1.15</url>
     </paper>
     <paper id="16">
       <title>Acoustic-Prosodic and Lexical Cues to Deception and Trust: Deciphering How People Detect Lies</title>
@@ -176,7 +176,7 @@
       <doi>10.1162/tacl_a_00311</doi>
       <abstract>Humans rarely perform better than chance at lie detection. To better understand human perception of deception, we created a game framework, LieCatcher, to collect ratings of perceived deception using a large corpus of deceptive and truthful interviews. We analyzed the acoustic-prosodic and linguistic characteristics of language trusted and mistrusted by raters and compared these to characteristics of actual truthful and deceptive language to understand how perception aligns with reality. With this data we built classifiers to automatically distinguish trusted from mistrusted speech, achieving an F1 of 66.1%. We next evaluated whether the strategies raters said they used to discriminate between truthful and deceptive responses were in fact useful. Our results show that, although several prosodic and lexical features were consistently perceived as trustworthy, they were not reliable cues. Also, the strategies that judges reported using in deception detection were not helpful for the task. Our work sheds light on the nature of trusted language and provides insight into the challenging problem of human deception detection.</abstract>
       <pages>199–214</pages>
-      <url hash="580da940">2020.tacl-1.16</url>
+      <url hash="d0dfd22b">2020.tacl-1.16</url>
     </paper>
     <paper id="17">
       <title>Unsupervised Discourse Constituency Parsing Using <fixed-case>V</fixed-case>iterbi <fixed-case>EM</fixed-case></title>
@@ -185,7 +185,7 @@
       <doi>10.1162/tacl_a_00312</doi>
       <abstract>In this paper, we introduce an unsupervised discourse constituency parsing algorithm. We use Viterbi EM with a margin-based criterion to train a span-based discourse parser in an unsupervised manner. We also propose initialization methods for Viterbi training of discourse constituents based on our prior knowledge of text structures. Experimental results demonstrate that our unsupervised parser achieves comparable or even superior performance to fully supervised parsers. We also investigate discourse constituents that are learned by our method.</abstract>
       <pages>215–230</pages>
-      <url hash="580da940">2020.tacl-1.17</url>
+      <url hash="9b0c0560">2020.tacl-1.17</url>
     </paper>
     <paper id="18">
       <title>Leveraging Pre-trained Checkpoints for Sequence Generation Tasks</title>
@@ -195,7 +195,7 @@
       <doi>10.1162/tacl_a_00313</doi>
       <abstract>Unsupervised pre-training of large neural models has recently revolutionized Natural Language Processing. By warm-starting from the publicly released checkpoints, NLP practitioners have pushed the state-of-the-art on multiple benchmarks while saving significant amounts of compute time. So far the focus has been mainly on the Natural Language Understanding tasks. In this paper, we demonstrate the efficacy of pre-trained checkpoints for Sequence Generation. We developed a Transformer-based sequence-to-sequence model that is compatible with publicly available pre-trained BERT, GPT-2, and RoBERTa checkpoints and conducted an extensive empirical study on the utility of initializing our model, both encoder and decoder, with these checkpoints. Our models result in new state-of-the-art results on Machine Translation, Text Summarization, Sentence Splitting, and Sentence Fusion.</abstract>
       <pages>264–280</pages>
-      <url hash="580da940">2020.tacl-1.18</url>
+      <url hash="c925bfbe">2020.tacl-1.18</url>
     </paper>
     <paper id="19">
       <title><fixed-case>C</fixed-case>ross<fixed-case>WOZ</fixed-case>: A Large-Scale <fixed-case>C</fixed-case>hinese Cross-Domain Task-Oriented Dialogue Dataset</title>
@@ -207,7 +207,7 @@
       <doi>10.1162/tacl_a_00314</doi>
       <abstract>To advance multi-domain (cross-domain) dialogue modeling as well as alleviate the shortage of Chinese task-oriented datasets, we propose CrossWOZ, the first large-scale Chinese Cross-Domain Wizard-of-Oz task-oriented dataset. It contains 6K dialogue sessions and 102K utterances for 5 domains, including hotel, restaurant, attraction, metro, and taxi. Moreover, the corpus contains rich annotation of dialogue states and dialogue acts on both user and system sides. About 60% of the dialogues have cross-domain user goals that favor inter-domain dependency and encourage natural transition across domains in conversation. We also provide a user simulator and several benchmark models for pipelined task-oriented dialogue systems, which will facilitate researchers to compare and evaluate their models on this corpus. The large size and rich annotation of CrossWOZ make it suitable to investigate a variety of tasks in cross-domain dialogue modeling, such as dialogue state tracking, policy learning, user simulation, etc.</abstract>
       <pages>281–295</pages>
-      <url hash="580da940">2020.tacl-1.19</url>
+      <url hash="818f0418">2020.tacl-1.19</url>
     </paper>
     <paper id="20">
       <title>How Furiously Can Colorless Green Ideas Sleep? Sentence Acceptability in Context</title>
@@ -219,7 +219,7 @@
       <doi>10.1162/tacl_a_00315</doi>
       <abstract>We study the influence of context on sentence acceptability. First we compare the acceptability ratings of sentences judged in isolation, with a relevant context, and with an irrelevant context. Our results show that context induces a cognitive load for humans, which compresses the distribution of ratings. Moreover, in relevant contexts we observe a discourse coherence effect that uniformly raises acceptability. Next, we test unidirectional and bidirectional language models in their ability to predict acceptability ratings. The bidirectional models show very promising results, with the best model achieving a new state-of-the-art for unsupervised acceptability prediction. The two sets of experiments provide insights into the cognitive aspects of sentence processing and central issues in the computational modeling of text and discourse.</abstract>
       <pages>296–310</pages>
-      <url hash="580da940">2020.tacl-1.20</url>
+      <url hash="3d5936e2">2020.tacl-1.20</url>
     </paper>
     <paper id="21">
       <title>Learning Lexical Subspaces in a Distributional Vector Space</title>
@@ -229,7 +229,7 @@
       <doi>10.1162/tacl_a_00316</doi>
       <abstract>In this paper, we propose LexSub, a novel approach towards unifying lexical and distributional semantics. We inject knowledge about lexical-semantic relations into distributional word embeddings by defining subspaces of the distributional vector space in which a lexical relation should hold. Our framework can handle symmetric attract and repel relations (e.g., synonymy and antonymy, respectively), as well as asymmetric relations (e.g., hypernymy and meronomy). In a suite of intrinsic benchmarks, we show that our model outperforms previous approaches on relatedness tasks and on hypernymy classification and detection, while being competitive on word similarity tasks. It also outperforms previous systems on extrinsic classification tasks that benefit from exploiting lexical relational cues. We perform a series of analyses to understand the behaviors of our model.1Code available at https://github.com/aishikchakraborty/LexSub.</abstract>
       <pages>311–329</pages>
-      <url hash="580da940">2020.tacl-1.21</url>
+      <url hash="347f167b">2020.tacl-1.21</url>
     </paper>
     <paper id="22">
       <title><fixed-case>T</fixed-case>y<fixed-case>D</fixed-case>i <fixed-case>QA</fixed-case>: A Benchmark for Information-Seeking Question Answering in Typologically Diverse Languages</title>
@@ -243,7 +243,7 @@
       <doi>10.1162/tacl_a_00317</doi>
       <abstract>Confidently making progress on multilingual modeling requires challenging, trustworthy evaluations. We present TyDi QA—a question answering dataset covering 11 typologically diverse languages with 204K question-answer pairs. The languages of TyDi QA are diverse with regard to their typology—the set of linguistic features each language expresses—such that we expect models performing well on this set to generalize across a large number of the world’s languages. We present a quantitative analysis of the data quality and example-level qualitative linguistic analyses of observed language phenomena that would not be found in English-only corpora. To provide a realistic information-seeking task and avoid priming effects, questions are written by people who want to know the answer, but don’t know the answer yet, and the data is collected directly in each language without the use of translation.</abstract>
       <pages>454–470</pages>
-      <url hash="580da940">2020.tacl-1.22</url>
+      <url hash="6fabbd2b">2020.tacl-1.22</url>
     </paper>
     <paper id="23">
       <title>Syntax-Guided Controlled Generation of Paraphrases</title>
@@ -254,7 +254,7 @@
       <doi>10.1162/tacl_a_00318</doi>
       <abstract>Given a sentence (e.g., “I like mangoes”) and a constraint (e.g., sentiment flip), the goal of controlled text generation is to produce a sentence that adapts the input sentence to meet the requirements of the constraint (e.g., “I hate mangoes”). Going beyond such simple constraints, recent work has started exploring the incorporation of complex syntactic-guidance as constraints in the task of controlled paraphrase generation. In these methods, syntactic-guidance is sourced from a separate exemplar sentence. However, this prior work has only utilized limited syntactic information available in the parse tree of the exemplar sentence. We address this limitation in the paper and propose Syntax Guided Controlled Paraphraser (SGCP), an end-to-end framework for syntactic paraphrase generation. We find that Sgcp can generate syntax-conforming sentences while not compromising on relevance. We perform extensive automated and human evaluations over multiple real-world English language datasets to demonstrate the efficacy of Sgcp over state-of-the-art baselines. To drive future research, we have made Sgcp’s source code available.1</abstract>
       <pages>329–345</pages>
-      <url hash="580da940">2020.tacl-1.23</url>
+      <url hash="206976b9">2020.tacl-1.23</url>
     </paper>
     <paper id="24">
       <title>Better Document-Level Machine Translation with <fixed-case>B</fixed-case>ayes’ Rule</title>
@@ -268,7 +268,7 @@
       <doi>10.1162/tacl_a_00319</doi>
       <abstract>We show that Bayes’ rule provides an effective mechanism for creating document translation models that can be learned from only parallel sentences and monolingual documents a compelling benefit because parallel documents are not always available. In our formulation, the posterior probability of a candidate translation is the product of the unconditional (prior) probability of the candidate output document and the “reverse translation probability” of translating the candidate output back into the source language. Our proposed model uses a powerful autoregressive language model as the prior on target language documents, but it assumes that each sentence is translated independently from the target to the source language. Crucially, at test time, when a source document is observed, the document language model prior induces dependencies between the translations of the source sentences in the posterior. The model’s independence assumption not only enables efficient use of available data, but it additionally admits a practical left-to-right beam-search algorithm for carrying out inference. Experiments show that our model benefits from using cross-sentence context in the language model, and it outperforms existing document translation approaches.</abstract>
       <pages>346–360</pages>
-      <url hash="580da940">2020.tacl-1.24</url>
+      <url hash="0d9b8922">2020.tacl-1.24</url>
     </paper>
     <paper id="25">
       <title>Hierarchical Mapping for Crosslingual Word Embedding Alignment</title>
@@ -277,7 +277,7 @@
       <doi>10.1162/tacl_a_00320</doi>
       <abstract>The alignment of word embedding spaces in different languages into a common crosslingual space has recently been in vogue. Strategies that do so compute pairwise alignments and then map multiple languages to a single pivot language (most often English). These strategies, however, are biased towards the choice of the pivot language, given that language proximity and the linguistic characteristics of the target language can strongly impact the resultant crosslingual space in detriment of topologically distant languages. We present a strategy that eliminates the need for a pivot language by learning the mappings across languages in a hierarchical way. Experiments demonstrate that our strategy significantly improves vocabulary induction scores in all existing benchmarks, as well as in a new non-English–centered benchmark we built, which we make publicly available.</abstract>
       <pages>361–376</pages>
-      <url hash="580da940">2020.tacl-1.25</url>
+      <url hash="cb4e07ef">2020.tacl-1.25</url>
     </paper>
     <paper id="26">
       <title><fixed-case>BL</fixed-case>i<fixed-case>MP</fixed-case>: The Benchmark of Linguistic Minimal Pairs for <fixed-case>E</fixed-case>nglish</title>
@@ -291,7 +291,7 @@
       <doi>10.1162/tacl_a_00321</doi>
       <abstract>We introduce The Benchmark of Linguistic Minimal Pairs (BLiMP),1 a challenge set for evaluating the linguistic knowledge of language models (LMs) on major grammatical phenomena in English. BLiMP consists of 67 individual datasets, each containing 1,000 minimal pairs—that is, pairs of minimally different sentences that contrast in grammatical acceptability and isolate specific phenomenon in syntax, morphology, or semantics. We generate the data according to linguist-crafted grammar templates, and human aggregate agreement with the labels is 96.4%. We evaluate n-gram, LSTM, and Transformer (GPT-2 and Transformer-XL) LMs by observing whether they assign a higher probability to the acceptable sentence in each minimal pair. We find that state-of-the-art models identify morphological contrasts related to agreement reliably, but they struggle with some subtle semantic and syntactic phenomena, such as negative polarity items and extraction islands.</abstract>
       <pages>377–392</pages>
-      <url hash="580da940">2020.tacl-1.26</url>
+      <url hash="b43362e8">2020.tacl-1.26</url>
     </paper>
     <paper id="27">
       <title>Reproducible and Efficient Benchmarks for Hyperparameter Optimization of Neural Machine Translation Systems</title>
@@ -300,7 +300,7 @@
       <doi>10.1162/tacl_a_00322</doi>
       <abstract>Hyperparameter selection is a crucial part of building neural machine translation (NMT) systems across both academia and industry. Fine-grained adjustments to a model’s architecture or training recipe can mean the difference between a positive and negative research result or between a state-of-the-art and underperforming system. While recent literature has proposed methods for automatic hyperparameter optimization (HPO), there has been limited work on applying these methods to neural machine translation (NMT), due in part to the high costs associated with experiments that train large numbers of model variants. To facilitate research in this space, we introduce a lookup-based approach that uses a library of pre-trained models for fast, low cost HPO experimentation. Our contributions include (1) the release of a large collection of trained NMT models covering a wide range of hyperparameters, (2) the proposal of targeted metrics for evaluating HPO methods on NMT, and (3) a reproducible benchmark of several HPO methods against our model library, including novel graph-based and multiobjective methods.</abstract>
       <pages>393–408</pages>
-      <url hash="580da940">2020.tacl-1.27</url>
+      <url hash="1c10a562">2020.tacl-1.27</url>
     </paper>
     <paper id="28">
       <title>Consistent Unsupervised Estimators for Anchored <fixed-case>PCFG</fixed-case>s</title>
@@ -309,7 +309,7 @@
       <doi>10.1162/tacl_a_00323</doi>
       <abstract>Learning probabilistic context-free grammars (PCFGs) from strings is a classic problem in computational linguistics since Horning (1969). Here we present an algorithm based on distributional learning that is a consistent estimator for a large class of PCFGs that satisfy certain natural conditions including being anchored (Stratos et al., 2016). We proceed via a reparameterization of (top--down) PCFGs that we call a bottom–up weighted context-free grammar. We show that if the grammar is anchored and satisfies additional restrictions on its ambiguity, then the parameters can be directly related to distributional properties of the anchoring strings; we show the asymptotic correctness of a naive estimator and present some simulations using synthetic data that show that algorithms based on this approach have good finite sample behavior.</abstract>
       <pages>409–422</pages>
-      <url hash="580da940">2020.tacl-1.28</url>
+      <url hash="412a6877">2020.tacl-1.28</url>
     </paper>
     <paper id="29">
       <title>How Can We Know What Language Models Know?</title>
@@ -320,7 +320,7 @@
       <doi>10.1162/tacl_a_00324</doi>
       <abstract>Recent work has presented intriguing results examining the knowledge contained in language models (LMs) by having the LM fill in the blanks of prompts such as “Obama is a __ by profession”. These prompts are usually manually created, and quite possibly sub-optimal; another prompt such as “Obama worked as a __ ” may result in more accurately predicting the correct profession. Because of this, given an inappropriate prompt, we might fail to retrieve facts that the LM does know, and thus any given prompt only provides a lower bound estimate of the knowledge contained in an LM. In this paper, we attempt to more accurately estimate the knowledge contained in LMs by automatically discovering better prompts to use in this querying process. Specifically, we propose mining-based and paraphrasing-based methods to automatically generate high-quality and diverse prompts, as well as ensemble methods to combine answers from different prompts. Extensive experiments on the LAMA benchmark for extracting relational knowledge from LMs demonstrate that our methods can improve accuracy from 31.1% to 39.6%, providing a tighter lower bound on what LMs know. We have released the code and the resulting LM Prompt And Query Archive (LPAQA) at https://github.com/jzbjyb/LPAQA.</abstract>
       <pages>423–438</pages>
-      <url hash="580da940">2020.tacl-1.29</url>
+      <url hash="687667e2">2020.tacl-1.29</url>
     </paper>
     <paper id="30">
       <title>Topic Modeling in Embedding Spaces</title>


### PR DESCRIPTION
This brings TACL 2020 up to date.

Note that I found and fixed a bug in the ingestion: MIT Press does not provide files in page order so I had to change `bin/tacl_cl_parser.py` to explicitly sort incoming papers by page numbers. <strike>**This invalidates two assigned IDs**. I am thinking of just fixing the problem, but we may want to stick to the invariant that assigned IDs cannot be changed. In this case, I will keep the IDs, and change the order in the file.</strike>

**Update**: I'm not sure why I thought IDs were invalidated, but I've fixed that.

I also simplified the ingestion script. It now takes only the directory containing the MIT press unzipped archives, as documented. It infers the XML file path and updates it, skipping already-ingesting files (identified by DOI).