### PR TITLE
Handling retractions

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -130,6 +130,9 @@ class Paper:
                 [x[0].full for x in paper.attrib["author"]]
             )
 
+        if "retracted" in paper.attrib:
+            paper.attrib["retracted"] = True
+
         paper.attrib["thumbnail"] = data.ANTHOLOGY_THUMBNAIL.format(paper.full_id)
 
         return paper
@@ -203,6 +206,10 @@ class Paper:
     @property
     def has_abstract(self):
         return "xml_abstract" in self.attrib
+
+    @property
+    def is_retracted(self) -> bool:
+        return "retracted" in self.attrib
 
     @property
     def isbn(self):

--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -6432,8 +6432,11 @@
       <author><first>Jie</first><last>Zhou</last></author>
       <pages>6322–6333</pages>
       <abstract>Recent studies in dialogue state tracking (DST) leverage historical information to determine states which are generally represented as slot-value pairs. However, most of them have limitations to efficiently exploit relevant context due to the lack of a powerful mechanism for modeling interactions between the slot and the dialogue history. Besides, existing methods usually ignore the slot imbalance problem and treat all slots indiscriminately, which limits the learning of hard slots and eventually hurts overall performance. In this paper, we propose to enhance the DST through employing a contextual hierarchical attention network to not only discern relevant information at both word level and turn level but also learn contextual representations. We further propose an adaptive objective to alleviate the slot imbalance problem by dynamically adjust weights of different slots during training. Experimental results show that our approach reaches 52.68% and 58.55% joint accuracy on MultiWOZ 2.0 and MultiWOZ 2.1 datasets respectively and achieves new state-of-the-art performance with considerable improvements (+1.24% and +5.98%).</abstract>
-      <url hash="7db54ea8">2020.acl-main.563</url>
+      <url hash="1d1908ca">2020.acl-main.563</url>
+      <retracted date="2020-09-01"/>
       <doi>10.18653/v1/2020.acl-main.563</doi>
+      <revision id="1" href="2020.acl-main.563v1" hash="7db54ea8"/>
+      <revision id="2" href="2020.acl-main.563v2" hash="1d1908ca" date="2020-09-01">Paper retracted.</revision>
     </paper>
     <paper id="564">
       <title>Data Manipulation: Towards Effective Instance Learning for Neural Dialogue Generation via Learning to Augment and Reweight</title>

--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -44,6 +44,9 @@ Paper = element paper {
        checksum,
        local-filename
      }*
+   & element retracted {
+       attribute date { xsd:date }
+     }?
    & element issue { xsd:nonNegativeInteger }?
    & element journal { text }?
    & element mrf {

--- a/hugo/layouts/papers/list-entry.html
+++ b/hugo/layouts/papers/list-entry.html
@@ -20,7 +20,7 @@
         <a class="badge badge-attachment align-middle mr-1" href="{{ .url }}" data-toggle="tooltip" data-placement="top" title="{{ .type | humanize }}">{{ partial "attachment_repr.html" . }}</a>
       {{- end -}}
   </span>
-  <span class="d-block">
+  <span class="d-block" {{ with $paper.retracted }} style="text-decoration: line-through" {{ end }}>
     {{ if eq hugo.Environment "development" }}
       <span class="badge badge-light align-middle">{{ .Params.anthology_id }}</span>
     {{ end }}

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -52,7 +52,7 @@
 {{ $volume_id := index (split .Params.anthology_id "-") 0 }}
 {{ $paper := index (index .Site.Data.papers $volume_id) .Params.anthology_id }}
 <section id="main">
-  <h2 id="title">
+  <h2 id="title" {{ with $paper.retracted }} style="text-decoration: line-through" {{ end }}>
     {{ with $paper.pdf }}
     <a href="{{ . }}">{{ $paper.title_html | safeHTML }}</a>
     {{ else }}
@@ -70,6 +70,12 @@
 
   <div class="row acl-paper-details">
     <div class="col col-lg-10 order-2">
+      {{ with $paper.retracted }}
+      <div class="alert alert-danger" role="alert">
+        This paper has been retracted. The original version remains available. More information can be found <a href="{{ $paper.pdf }}">here</a>.
+      </div>
+      {{ end }}
+
       {{ with $paper.abstract_html }}
       <div class="card bg-light mb-2 mb-lg-3">
         <div class="card-body acl-abstract">


### PR DESCRIPTION
Following up on [the discussion here](https://github.com/acl-org/acl-anthology/issues/760), this PR implements retractions. It:

* Adds a `<retracted/>` tag to mark the paper status
* Processes the PDF explanation as a revision, so that it gets returned by default when accessing the PDF
* Strikes the paper in the volume and event listings, and suppresses it entirely from the author listing

Comments welcome!