### PR TITLE
add "url" attrib

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -19,6 +19,7 @@ import logging as log
 from .utils import (
     build_anthology_id,
     parse_element,
+    infer_url,
     infer_attachment_url,
     remove_extra_whitespace,
     is_journal,

--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -74,9 +74,14 @@ class Paper:
                 del paper.attrib["editor"]
             paper.attrib[key] = value
 
+        # Frontmatter title is the volume 'booktitle'
+        if paper.is_volume:
+            paper.attrib["xml_title"] = paper.attrib["xml_booktitle"]
+            paper.attrib["xml_title"].tag = "title"
+
         # Create URL field if not present. But see https://github.com/acl-org/acl-anthology/issues/997.
         if "url" not in paper.attrib:
-            paper.attrib["url"] = data.ANTHOLOGY_URL.format(paper.full_id)
+            paper.attrib["url"] = infer_url(paper.full_id)
 
         # Remove booktitle for frontmatter and journals
         if paper.is_volume or is_journal(paper.full_id):

--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -74,10 +74,9 @@ class Paper:
                 del paper.attrib["editor"]
             paper.attrib[key] = value
 
-        # Frontmatter title is the volume 'booktitle'
-        if paper.is_volume:
-            paper.attrib["xml_title"] = paper.attrib["xml_booktitle"]
-            paper.attrib["xml_title"].tag = "title"
+        # Create URL field if not present. But see https://github.com/acl-org/acl-anthology/issues/997.
+        if "url" not in paper.attrib:
+            paper.attrib["url"] = data.ANTHOLOGY_URL.format(paper.full_id)
 
         # Remove booktitle for frontmatter and journals
         if paper.is_volume or is_journal(paper.full_id):

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -43,15 +43,16 @@ RewriteRule ^[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9
 # This way there is only one page. Should maintain for backward compatibility for some time after August 2019.
 RewriteRule ^papers/[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])/?$ https://www.aclweb.org/anthology/$1$2-$3 [R=301,L]
 
-# Volume pages (e.g., redirect /W19-75 to /volumes/W19-75)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9])/?$ https://www.aclweb.org/anthology/volumes/$1$2-$3 [R=301,L]
-
 #
 # INTERNAL RETRIEVALS
 #
 # These rules take valid external URLS (which are often virtual targets) and retrieve their target.
 # They are invisible to the outside.
 #
+
+# Volume pages (e.g., redirect /W19-75 to /volumes/W19-75)
+RewriteRule ^([A-Za-z][0-9][0-9]\-[0-9]{1,2})/?$ /anthology/volumes/$1 [L,NC]
+RewriteRule ^(\d{4}\.[a-zA-Z\d]+\-[a-zA-Z\d]+)/?$ /anthology/volumes/$1 [L,NC]
 
 # Volume URLs (e.g., P17-1.pdf loads P/P17/P17-1.pdf, 2020.acl-main loads acl/2020.acl-main.pdf)
 RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -37,11 +37,11 @@ RewriteRule ^(.*)$ https://www.aclweb.org/anthology/$1 [R=301,L]
 # Redirect old nested file paths (e.g., P/P17/P17-1069.pdf -> https://www.aclweb.org/anthology/P17-1069.pdf)
 # Note that since capture patterns can't be reused in the capture portion of the string, this is a leaky match
 # that will also redirect X/Z19/P17-1069.pdf -> /anthology-files/pdf/P/P17/P17-1069.pdf
-RewriteRule ^[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(/|\.[a-z]+)?$ https://www.aclweb.org/anthology/$1$2-$3$4 [R=301,L]
+RewriteRule ^[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})(/|\.[a-z]+)?$ https://www.aclweb.org/anthology/$1$2-$3$4 [R=301,L]
 
 # Redirect nested paper pages to the canonical location (e.g., papers/P/P19/P19-1001/ -> P19-1001)
 # This way there is only one page. Should maintain for backward compatibility for some time after August 2019.
-RewriteRule ^papers/[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])/?$ https://www.aclweb.org/anthology/$1$2-$3 [R=301,L]
+RewriteRule ^papers/[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})/?$ https://www.aclweb.org/anthology/$1$2-$3 [R=301,L]
 
 #
 # INTERNAL RETRIEVALS
@@ -51,20 +51,20 @@ RewriteRule ^papers/[A-Za-z]/[A-Za-z][0-9][0-9]/([A-Za-z])([0-9][0-9])\-([0-9][0
 #
 
 # Volume pages (e.g., redirect /W19-75 to /volumes/W19-75)
-RewriteRule ^([A-Za-z][0-9][0-9]\-[0-9]{1,2})/?$ /anthology/volumes/$1 [L,NC]
+RewriteRule ^([A-Za-z]\d{2}\-\d{1,2})/?$ /anthology/volumes/$1 [L,NC]
 RewriteRule ^(\d{4}\.[a-zA-Z\d]+\-[a-zA-Z\d]+)/?$ /anthology/volumes/$1 [L,NC]
 
 # Volume URLs (e.g., P17-1.pdf loads P/P17/P17-1.pdf, 2020.acl-main loads acl/2020.acl-main.pdf)
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9]{1,2})\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
+RewriteRule ^([A-Za-z])(\d{2})\-(\d{1,2})\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]
 RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+)\.pdf$ /anthology-files/pdf/$2/$1.$2-$3.pdf [L,NC]
 
 # PDF link, revisions, and errata (P17-1069[v2].pdf loads P/P17/P17-1069[v2].pdf --- with "v2" optional)
 # TODO: decide on a new format for revisions and errata
-RewriteRule ^([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])([ve][0-9]+)?\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
+RewriteRule ^([A-Za-z])(\d{2})\-(\d{4})([ve]\d+)?\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3$4.pdf [L,NC]
 RewriteRule ^(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+)\.(\d+([ve]\d+)?)\.pdf$ /anthology-files/pdf/$2/$1.$2-$3.$4.pdf [L,NC]
 
 # Attachments (e.g., P17-1069.Poster.pdf loads /anthology-files/attachments/P/P17/P17-1069.Poster.pdf)
-RewriteRule ^attachments/([A-Za-z])([0-9][0-9])\-([0-9][0-9][0-9][0-9])(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]
+RewriteRule ^attachments/([A-Za-z])(\d{2})\-(\d{4})(\..*)?$ /anthology-files/attachments/$1/$1$2/$1$2-$3$4 [L,NC]
 RewriteRule ^attachments/(\d{4})\.([a-zA-Z\d]+)\-([a-zA-Z\d]+\.\d+)\.(.*)$ /anthology-files/attachments/$2/$1.$2-$3.$4 [L,NC]
 
 # Thumbnails (e.g., /thumb/P17-1069.jpg loads /anthology-files/thumb/P17-1069.jpg)


### PR DESCRIPTION
Papers with no PDF currently generate a faulty URL field (see image), partially because of the confusion between URL and PDFs (#997). This adds the "url" attribute when there is no `<url>` tag in the XML, fixing this display issue.

![image](https://user-images.githubusercontent.com/455256/92772280-9418f280-f369-11ea-8c7e-706e113daf07.png)
