### PR TITLE
Update 2020.eamt.xml

### DIFF
--- a/data/xml/2020.eamt.xml
+++ b/data/xml/2020.eamt.xml
@@ -3,21 +3,21 @@
   <volume id="1" ingest-date="2020-08-11">
     <meta>
       <booktitle>Proceedings of the 22nd Annual Conference of the European Association for Machine Translation</booktitle>
-      <editor><first>Mikel L.</first><last>Forcada</last></editor>
       <editor><first>André</first><last>Martins</last></editor>
       <editor><first>Helena</first><last>Moniz</last></editor>
-      <editor><first>Marco</first><last>Turchi</last></editor>
-      <editor><first>Arianna</first><last>Bisazza</last></editor>
-      <editor><first>Joss</first><last>Moorkens</last></editor>
-      <editor><first>Ana</first><last>Guerberof</last></editor>
-      <editor><first>Mary</first><last>Nurminen</last></editor>
-      <editor><first>Lena</first><last>Marg</last></editor>
       <editor><first>Sara</first><last>Fumega</last></editor>
       <editor><first>Bruno</first><last>Martins</last></editor>
       <editor><first>Fernando</first><last>Batista</last></editor>
       <editor><first>Luisa</first><last>Coheur</last></editor>
       <editor><first>Carla</first><last>Parra</last></editor>
       <editor><first>Isabel</first><last>Trancoso</last></editor>
+      <editor><first>Marco</first><last>Turchi</last></editor>
+      <editor><first>Arianna</first><last>Bisazza</last></editor>
+      <editor><first>Joss</first><last>Moorkens</last></editor>
+      <editor><first>Ana</first><last>Guerberof</last></editor>
+      <editor><first>Mary</first><last>Nurminen</last></editor>
+      <editor><first>Lena</first><last>Marg</last></editor>
+      <editor><first>Mikel L.</first><last>Forcada</last></editor>
       <publisher>European Association for Machine Translation</publisher>
       <address>Lisboa, Portugal</address>
       <month>November</month>


### PR DESCRIPTION
The "meta" file didn’t respect the correct order of the chairs, causing the editors to appear in the wrong order in the ACL website. This fixes the problem.

* The order of the editors in the [proceedings](https://www.aclweb.org/anthology/volumes/2020.eamt-1/) is now correct. 
