### PR TITLE
CoNLL 2020 venue

### DIFF
--- a/data/yaml/joint.yaml
+++ b/data/yaml/joint.yaml
@@ -333,7 +333,7 @@ eamt:
 - W15-49
 - W16-34
 emnlp:
-  2020: [2020.findings-emnlp, 2020.conll-1, 2020.conll-shared, 2020.alw-1, 2020.blackboxnlp-1, 2020.clinicalnlp-1, 2020.cmcl-1, 2020.codi-1, 2020.deelio-1, 2020.eval4nlp-1, 2020.insights-1, 2020.intexsempar-1, 2020.louhi-1, 2020.nlpbt-1, 2020.nlpcovid19-1, 2020.nlpcss-1, 2020.nlposs-1, 2020.privatenlp-1, 2020.scai-1, 2020.sdp-1, 2020.sigtyp-1, 2020.splu-1, 2020.spnlp-1, 2020.sustainlp-1, 2020.wnut-1]
+  2020: [2020.findings-emnlp, 2020.alw-1, 2020.blackboxnlp-1, 2020.clinicalnlp-1, 2020.cmcl-1, 2020.codi-1, 2020.deelio-1, 2020.eval4nlp-1, 2020.insights-1, 2020.intexsempar-1, 2020.louhi-1, 2020.nlpbt-1, 2020.nlpcovid19-1, 2020.nlpcss-1, 2020.nlposs-1, 2020.privatenlp-1, 2020.scai-1, 2020.sdp-1, 2020.sigtyp-1, 2020.splu-1, 2020.spnlp-1, 2020.sustainlp-1, 2020.wnut-1]
   1996:
   - W96-02
   1997:

--- a/data/yaml/sigs/signll.yaml
+++ b/data/yaml/sigs/signll.yaml
@@ -2,6 +2,9 @@ Name: Special Interest Group on Natural Language Learning (SIGNLL)
 ShortName: SIGNLL
 URL: http://www.signll.org/
 Meetings:
+  - 2020:
+    - 2020.conll-1 # 24th CoNLL
+    - 2020.conll-shared # 24th CoNLL shared task
   - 2019:
     - K19-1 # 23rd CoNLL
     - K19-2 # 23rd CoNLL shared task


### PR DESCRIPTION
- Following policy of previous years, don't list CoNLL as joint with EMNLP. (As it stands Zotero infers a conference abbreviation of "CoNLL-EMNLP", which is incorrect.)
- List CoNLL 2020 under SIGNLL
