### PR TITLE
Fix name metadata for Proc. of NLP-OSS 2020, add a name variant

### DIFF
--- a/data/xml/2020.nlposs.xml
+++ b/data/xml/2020.nlposs.xml
@@ -6,7 +6,7 @@
       <editor><first>Eunjeong L.</first><last>Park</last></editor>
       <editor><first>Masato</first><last>Hagiwara</last></editor>
       <editor><first>Dmitrijs</first><last>Milajevs</last></editor>
-      <editor><first>Nelson</first><last>Liu</last></editor>
+      <editor><first>Nelson F.</first><last>Liu</last></editor>
       <editor><first>Geeticka</first><last>Chauhan</last></editor>
       <editor><first>Liling</first><last>Tan</last></editor>
       <publisher>Association for Computational Linguistics</publisher>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -5414,6 +5414,9 @@
 - canonical: {first: Mei-Chun, last: Liu}
   variants:
   - {first: Mei-chun, last: Liu}
+- canonical: {first: Nelson F., last: Liu}
+  variants:
+  - {first: Nelson, last: Liu}
 - canonical: {first: Pengyuan, last: Liu}
   variants:
   - {first: PengYuan, last: Liu}


### PR DESCRIPTION
Hi!

My name was incorrectly input when we were producing the proceedings, and a duplicate author page was created for me.

- Canonical (with the middle initial): https://www.aclweb.org/anthology/people/n/nelson-f-liu/
- Duplicate (without the middle initial): https://www.aclweb.org/anthology/people/n/nelson-liu/

Following prior PRs, I tried to fix (1) the metadata of the NLP-OSS proceedings and (2) add a variant for my name. Let me know if there's anything else I need to do.

Thanks in advance!