### PR TITLE
Fix Metadata for 2020.emnlp-demos.6

### DIFF
--- a/data/xml/2020.emnlp.xml
+++ b/data/xml/2020.emnlp.xml
@@ -7961,24 +7961,24 @@
     <paper id="6">
       <title>Transformers: State-of-the-Art Natural Language Processing</title>
       <author><first>Thomas</first><last>Wolf</last></author>
-      <author><first>Julien</first><last>Chaumond</last></author>
       <author><first>Lysandre</first><last>Debut</last></author>
       <author><first>Victor</first><last>Sanh</last></author>
+      <author><first>Julien</first><last>Chaumond</last></author>
       <author><first>Clement</first><last>Delangue</last></author>
       <author><first>Anthony</first><last>Moi</last></author>
       <author><first>Pierric</first><last>Cistac</last></author>
+      <author><first>Tim</first><last>Rault</last></author>
+      <author><first>Remi</first><last>Louf</last></author>
       <author><first>Morgan</first><last>Funtowicz</last></author>
       <author><first>Joe</first><last>Davison</last></author>
       <author><first>Sam</first><last>Shleifer</last></author>
-      <author><first>Remi</first><last>Louf</last></author>
       <author><first>Patrick</first><last>von Platen</last></author>
-      <author><first>Tim</first><last>Rault</last></author>
+      <author><first>Clara</first><last>Ma</last></author>
       <author><first>Yacine</first><last>Jernite</last></author>
+      <author><first>Julien</first><last>Plu</last></author>
+      <author><first>Canwen</first><last>Xu</last></author>
       <author><first>Teven</first><last>Le Scao</last></author>
       <author><first>Sylvain</first><last>Gugger</last></author>
-      <author><first>Julien</first><last>Plu</last></author>
-      <author><first>Clara</first><last>Ma</last></author>
-      <author><first>Canwei</first><last>Shen</last></author>
       <author><first>Mariama</first><last>Drame</last></author>
       <author><first>Quentin</first><last>Lhoest</last></author>
       <author><first>Alexander</first><last>Rush</last></author>


### PR DESCRIPTION
Fix metadata for EMNLP 2020 Demo "Transformers" (fixing author order and typo) to make it consistent with the [PDF version](https://arxiv.org/pdf/1910.03771). No PDF revision needed. We have already contacted EMNLP 2020 PC chairs, demo chairs, and publication chairs and they direct us to fix it here. @mjpost 