### PR TITLE
Correction to 2020.wnut-1.18 (closes #1071)

### DIFF
--- a/data/xml/2020.wnut.xml
+++ b/data/xml/2020.wnut.xml
@@ -175,7 +175,7 @@
       <url hash="aef8ee80">2020.wnut-1.17</url>
     </paper>
     <paper id="18">
-      <title>Punctuation Restoration using Transformer Models for Resource-Rich and -Poor Languages</title>
+      <title>Punctuation Restoration using Transformer Models for High-and Low-Resource Languages</title>
       <author><first>Tanvirul</first><last>Alam</last></author>
       <author><first>Akib</first><last>Khan</last></author>
       <author><first>Firoj</first><last>Alam</last></author>


### PR DESCRIPTION
Updated paper title #1071 