### PR TITLE
removed 2020.emnlp-main.401

### DIFF
--- a/data/xml/2020.emnlp.xml
+++ b/data/xml/2020.emnlp.xml
@@ -4159,20 +4159,6 @@
       <abstract>We focus on the problem of capturing declarative knowledge about entities in the learned parameters of a language model. We introduce a new model—Entities as Experts (EaE)—that can access distinct memories of the entities mentioned in a piece of text. Unlike previous efforts to integrate entity knowledge into sequence models, EaE’s entity representations are learned directly from text. We show that EaE’s learned representations capture sufficient knowledge to answer TriviaQA questions such as “Which Dr. Who villain has been played by Roger Delgado, Anthony Ainley, Eric Roberts?”, outperforming an encoder-generator Transformer model with 10x the parameters on this task. According to the Lama knowledge probes, EaE contains more factual knowledge than a similar sized Bert, as well as previous approaches that integrate external sources of entity knowledge.Because EaE associates parameters with specific entities, it only needs to access a fraction of its parameters at inference time, and we show that the correct identification and representation of entities is essential to EaE’s performance.</abstract>
       <url hash="697ad17c">2020.emnlp-main.400</url>
     </paper>
-    <paper id="401">
-      <title><fixed-case>H</fixed-case>2<fixed-case>KGAT</fixed-case>: Hierarchical Hyperbolic Knowledge Graph Attention Network</title>
-      <author><first>Shen</first><last>Wang</last></author>
-      <author><first>Xiaokai</first><last>Wei</last></author>
-      <author><first>Cicero</first><last>Nogueira dos Santos</last></author>
-      <author><first>Zhiguo</first><last>Wang</last></author>
-      <author><first>Ramesh</first><last>Nallapati</last></author>
-      <author><first>Andrew</first><last>Arnold</last></author>
-      <author><first>Bing</first><last>Xiang</last></author>
-      <author><first>Philip S.</first><last>Yu</last></author>
-      <pages>4952–4962</pages>
-      <abstract>Knowledge Graphs encode rich relationships among large number of entities. Embedding entities and relations in low-dimensional space has shed light on representing knowledge graphs and reasoning over them, e.g., predicting missing relations between pairs of entities. Existing knowledge graph embedding approaches concentrate on modeling symmetry/asymmetry, inversion, and composition typed relations but overlook the hierarchical nature of relations. Recent studies have observed that there exist rich semantic hierarchical relations in knowledge graphs such as WordNet, where synsets are linked together in a hierarchy. To fill this gap, in this paper, we propose Hierarchical Hyperbolic Knowledge Graph Attention Network (H2KGAT), a novel knowledge graph embedding framework, which is able to better model and infer hierarchical relation patterns. Specifically, H2KGAT defines each entity in a hyperbolic polar embedding space. In addition, we propose an attentional neural context aggregator to enhance embedding learning, which can adaptively integrate the relational context. Our empirical study offers insights into the efficacy of modeling the semantic hierarchies in knowledge graphs, and we achieve significant performance gains compared to existing state-of-the-art methods on benchmark datasets for link prediction task, particularly at low dimensionality.</abstract>
-      <url hash="d3e37f55">2020.emnlp-main.401</url>
-    </paper>
     <paper id="402">
       <title>Does the <fixed-case>O</fixed-case>bjective <fixed-case>M</fixed-case>atter? <fixed-case>C</fixed-case>omparing <fixed-case>T</fixed-case>raining <fixed-case>O</fixed-case>bjectives for <fixed-case>P</fixed-case>ronoun <fixed-case>R</fixed-case>esolution</title>
       <author><first>Yordan</first><last>Yordanov</last></author>


### PR DESCRIPTION
This paper was withdrawn prior to the conference and was not presented there, so should not have been included with the proceedings.