### PR TITLE
Mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ The anthology can be viewed locally by running `hugo server` in the
 `hugo/` directory.  Note that it rebuilds the site and therefore takes
 about a minute to start.
 
+## Mirroring
+
+Once built (with `make`), the Anthology can be hosted anywhere.
+However, PDFs will link to the canonical Anthology location
+(https://www.aclweb.org/anthology/). If you wish to mirror the PDFs as
+well, you need to adjust `ANTHOLOGY_PREFIX` in
+`bin/anthology/data.py`. For example:
+
+    ANTHOLOGY_PREFIX = "https://mirror.aclweb.org/anthology"
+
 ## Contributing
 
 If you'd like to contribute to the ACL Anthology, please take a look at:

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -31,17 +31,17 @@ RewriteRule ^/?(.*) https://www.aclweb.org/anthology/$1 [R=301,L]
 # **Note**: at this point, paths are relative to /anthology, that is, they *do not include* the /anthology/ text.
 RewriteCond %{HTTPS} !=on [OR]
 RewriteCond %{HTTP_HOST} !^www\. [NC]
-RewriteRule ^(.*)$ https://www.aclweb.org/anthology/$1 [R=301,L]
+RewriteRule ^(.*)$ https://%{SERVER_NAME}/$1 [R=301,L]
 
 ## Nested file paths
 # Redirect old nested file paths (e.g., P/P17/P17-1069.pdf -> https://www.aclweb.org/anthology/P17-1069.pdf)
 # Note that since capture patterns can't be reused in the capture portion of the string, this is a leaky match
 # that will also redirect X/Z19/P17-1069.pdf -> /anthology-files/pdf/P/P17/P17-1069.pdf
-RewriteRule ^[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})(/|\.[a-z]+)?$ https://www.aclweb.org/anthology/$1$2-$3$4 [R=301,L]
+RewriteRule ^[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})(/|\.[a-z]+)?$ $1$2-$3$4 [R=301,L]
 
 # Redirect nested paper pages to the canonical location (e.g., papers/P/P19/P19-1001/ -> P19-1001)
 # This way there is only one page. Should maintain for backward compatibility for some time after August 2019.
-RewriteRule ^papers/[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})/?$ https://www.aclweb.org/anthology/$1$2-$3 [R=301,L]
+RewriteRule ^papers/[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})/?$ $1$2-$3 [R=301,L]
 
 #
 # INTERNAL RETRIEVALS
@@ -51,8 +51,8 @@ RewriteRule ^papers/[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})/?$ https:/
 #
 
 # Volume pages (e.g., redirect /W19-75 to /volumes/W19-75)
-RewriteRule ^([A-Za-z]\d{2}\-\d{1,2})/?$ /anthology/volumes/$1 [L,NC]
-RewriteRule ^(\d{4}\.[a-zA-Z\d]+\-[a-zA-Z\d]+)/?$ /anthology/volumes/$1 [L,NC]
+RewriteRule ^([A-Za-z]\d{2}\-\d{1,2})/?$ volumes/$1 [L,NC]
+RewriteRule ^(\d{4}\.[a-zA-Z\d]+\-[a-zA-Z\d]+)/?$ volumes/$1 [L,NC]
 
 # Volume URLs (e.g., P17-1.pdf loads P/P17/P17-1.pdf, 2020.acl-main loads acl/2020.acl-main.pdf)
 RewriteRule ^([A-Za-z])(\d{2})\-(\d{1,2})\.pdf$ /anthology-files/pdf/$1/$1$2/$1$2-$3.pdf [L,NC]


### PR DESCRIPTION
This PR is for discussion of mirroring (#295).

The minor modifications here are in place at http://anthology.aclweb.org/, which was pretty easy to setup. However, a few minor problems remain:

* The `/anthology` subdirectory appears to be hard-coded in some places (I had to add a symlink from `anthology` → `.` to get things working)
* Setting the prefix in `bin/anthology/data.py` may be a bit too hidden. Also, if it's empty, PDFs (strangely) link to domains, e.g., `http://2020.emnlp-main.1/`
* We should be sure to mark all links with the Anthology canonical URLs, so that indexing sites will correctly manage the redundancy. Or we turn off crawling.