### PR TITLE
Add 2020.nlpcovid19 acl submission number 18

### DIFF
--- a/data/xml/2020.nlpcovid19.xml
+++ b/data/xml/2020.nlpcovid19.xml
@@ -198,6 +198,15 @@
       <abstract>We present a simple NLP methodology for detecting COVID-19 misinformation videos on YouTube by leveraging user comments. We use transfer learning pre-trained models to generate a multi-label classifier that can categorize conspiratorial content. We use the percentage of misinformation comments on each video as a new feature for video classification.</abstract>
       <url hash="2520463f">2020.nlpcovid19-acl.17</url>
     </paper>
+    <paper id="18">
+      <title><fixed-case>COVID-QA</fixed-case>: A Question Answering Dataset for <fixed-case>COVID</fixed-case>-19</title>
+      <author><first>Timo</first><last>Möller</last></author>
+      <author><first>Anthony</first><last>Reina</last></author>
+      <author><first>Raghavan</first><last>Jayakumar</last></author>
+      <author><first>Malte</first><last>Pietsch</last></author>
+      <abstract>We present COVID-QA, a Question Answering dataset consisting of 2,019 question/answer pairs annotated by volunteer biomedical experts on scientific articles related to COVID-19. To evaluate the dataset we compared a RoBERTa base model fine-tuned on SQuAD with the same model trained on SQuAD and our COVID-QA dataset. We found that the additional training on this domain-specific data leads to significant gains in performance. Both the trained model and the annotated dataset have been open-sourced at: https://github.com/deepset-ai/COVID-QA</abstract>
+      <url hash="8552b8ac">2020.nlpcovid19-acl.18</url>
+    </paper>
   </volume>
   <volume id="2" ingest-date="2020-11-06">
     <meta>


### PR DESCRIPTION
As discussed with Karin Verspoor we can add our accepted ACL covid workshop [submission](https://openreview.net/forum?id=JENSKEEzsoU&noteId=TjyVZ690KGJ) to the proceedings.

I hope the PR is correct: 
- I double-checked the crc32 of other submissions - the tool I am using seems correct.
- I get a "404 Not Found" at https://www.aclweb.org/anthology/2020.nlpcovid19-acl.18.pdf I guess you will need to upload the pdf once the xml changed? 

If you need any more assistance, please let me know.