### PR TITLE
Fixed author list for AMTA 2020 user track paper No. 25.

### DIFF
--- a/data/xml/2020.amta.xml
+++ b/data/xml/2020.amta.xml
@@ -327,9 +327,12 @@
     </paper>
     <paper id="25">
       <title>A Tale of Eight Countries or the <fixed-case>EU</fixed-case> Council Presidency Translator in Retrospect</title>
-      <author><first>Kristine</first><last>Metuzale</last></author>
-      <author><first>Alexandra</first><last>Soska</last></author>
       <author><first>Mārcis</first><last>Pinnis</last></author>
+      <author><first>Toms</first><last>Bergmanis</last></author>
+      <author><first>Kristīne</first><last>Metuzāle</last></author>
+      <author><first>Valters</first><last>Šics</last></author>
+      <author><first>Artūrs</first><last>Vasiļevskis</last></author>
+      <author><first>Andrejs</first><last>Vasiļjevs</last></author>
       <pages>525-546</pages>
       <url hash="e759a91a">2020.amta-user.25</url>
       <attachment type="presentation" hash="5f0d71c0">2020.amta-user.25.Presentation.pdf</attachment>


### PR DESCRIPTION
Hi!

As instructed by @mjpost, I am making a PR to correct the author list for the AMTA 2020 user track paper No. 25. The author list is in the same order as in the published PDF of the paper.

Thanks!

Best regards,
Mārcis