### PR TITLE
Update MWE-LEX 2020 metadata (2020.mwe) to conform to PDF

### DIFF
--- a/data/xml/2020.mwe.xml
+++ b/data/xml/2020.mwe.xml
@@ -22,8 +22,8 @@
     <paper id="1">
       <title><fixed-case>C</fixed-case>oll<fixed-case>F</fixed-case>r<fixed-case>E</fixed-case>n: Rich Bilingual <fixed-case>E</fixed-case>nglish–<fixed-case>F</fixed-case>rench Collocation Resource</title>
       <author><first>Beatriz</first><last>Fisas</last></author>
-      <author><first>Joan</first><last>Codina-Filbá</last></author>
       <author><first>Luis</first><last>Espinosa Anke</last></author>
+      <author><first>Joan</first><last>Codina-Filbá</last></author>
       <author><first>Leo</first><last>Wanner</last></author>
       <pages>1–12</pages>
       <abstract>Collocations in the sense of idiosyncratic lexical co-occurrences of two syntactically bound words traditionally pose a challenge to language learners and many Natural Language Processing (NLP) applications alike. Reliable ground truth (i.e., ideally manually compiled) resources are thus of high value. We present a manually compiled bilingual English–French collocation resource with 7,480 collocations in English and 6,733 in French. Each collocation is enriched with information that facilitates its downstream exploitation in NLP tasks such as machine translation, word sense disambiguation, natural language generation, relation classification, and so forth. Our proposed enrichment covers: the semantic category of the collocation (its lexical function), its vector space representation (for each individual word as well as their joint collocation embedding), a subcategorization pattern of both its elements, as well as their corresponding BabelNet id, and finally, indices of their occurrences in large scale reference corpora.</abstract>
@@ -91,7 +91,7 @@
       <url hash="d1c2a98e">2020.mwe-1.8</url>
     </paper>
     <paper id="9">
-      <title>Generationary or: “How We Went beyond Sense Inventories and Learnedto Gloss”</title>
+      <title>Generationary or: "How We Went beyond Sense Inventories and Learned to Gloss"</title>
       <author><first>Roberto</first><last>Navigli</last></author>
       <pages>73</pages>
       <abstract>In this talk I present Generationary, an approach that goes beyond the mainstream assumption that word senses can be represented as discrete items of a predefined inventory, and put forward a unified model which produces contextualized definitions for arbitrary lexical items, from words to phrases and even sentences. Generationary employs a novel span-based encoding scheme to fine-tune an English pre-trained Encoder-Decoder system and generate new definitions. Our model outperforms previous approaches in the generative task of Definition Modeling in many settings, but it also matches or surpasses the state of the art in discriminative tasks such as Word Sense Disambiguation and Word-in-Context. Finally, we show that Generationary benefits from training on definitions from multiple inventories, with strong gains across benchmarks, including a novel dataset of definitions for free adjective-noun phrases.</abstract>
@@ -99,9 +99,9 @@
     </paper>
     <paper id="10">
       <title>Multi-word Expressions for Abusive Speech Detection in <fixed-case>S</fixed-case>erbian</title>
-      <author><first>Ranka</first><last>Stankovic</last></author>
+      <author><first>Ranka</first><last>Stanković</last></author>
       <author><first>Jelena</first><last>Mitrović</last></author>
-      <author><first>Danka</first><last>Jokic</last></author>
+      <author><first>Danka</first><last>Jokić</last></author>
       <author><first>Cvetana</first><last>Krstev</last></author>
       <pages>74–84</pages>
       <abstract>This paper presents our work on the refinement and improvement of the Serbian language part of Hurtlex, a multilingual lexicon of words to hurt. We pay special attention to adding Multi-word expressions that can be seen as abusive, as such lexical entries are very important in obtaining good results in a plethora of abusive language detection tasks. We use Serbian morphological dictionaries as a basis for data cleaning and MWE dictionary creation. A connection to other lexical and semantic resources in Serbian is outlined and building of abusive language detection systems based on that connection is foreseen.</abstract>
@@ -142,7 +142,7 @@
       <author><first>Archna</first><last>Bhatia</last></author>
       <author><first>Uxoa</first><last>Iñurrieta</last></author>
       <author><first>Voula</first><last>Giouli</last></author>
-      <author><first>Tunga</first><last>Gungor</last></author>
+      <author><first>Tunga</first><last>Güngör</last></author>
       <author><first>Menghan</first><last>Jiang</last></author>
       <author><first>Timm</first><last>Lichte</last></author>
       <author><first>Chaya</first><last>Liebeskind</last></author>
@@ -175,7 +175,7 @@
     <paper id="17">
       <title><fixed-case>ERMI</fixed-case> at <fixed-case>PARSEME</fixed-case> Shared Task 2020: Embedding-Rich Multiword Expression Identification</title>
       <author><first>Zeynep</first><last>Yirmibeşoğlu</last></author>
-      <author><first>Tunga</first><last>Gungor</last></author>
+      <author><first>Tunga</first><last>Güngör</last></author>
       <pages>130–135</pages>
       <abstract>This paper describes the ERMI system submitted to the closed track of the PARSEME shared task 2020 on automatic identification of verbal multiword expressions (VMWEs). ERMI is an embedding-rich bidirectional LSTM-CRF model, which takes into account the embeddings of the word, its POS tag, dependency relation, and its head word. The results are reported for 14 languages, where the system is ranked 1st in the general cross-lingual ranking of the closed track systems, according to the Unseen MWE-based F1.</abstract>
       <url hash="0ee06cf4">2020.mwe-1.17</url>
@@ -197,7 +197,7 @@
       <url hash="50a7c4a7">2020.mwe-1.19</url>
     </paper>
     <paper id="20">
-      <title><fixed-case>M</fixed-case>ulti<fixed-case>V</fixed-case>itamin<fixed-case>B</fixed-case>ooster and <fixed-case>M</fixed-case>ulti<fixed-case>V</fixed-case>itamin<fixed-case>R</fixed-case>egressor at <fixed-case>PARSEME</fixed-case> Shared Task 2020: Combining Window- and Dependency-Based Features with Multilingual Contextualized Word Embeddings for Detecting Verbal Multiword Expressions</title>
+      <title><fixed-case>M</fixed-case>ulti<fixed-case>V</fixed-case>itamin<fixed-case>B</fixed-case>ooster at <fixed-case>PARSEME</fixed-case> Shared Task 2020: Combining Window- and Dependency-Based Features with Multilingual Contextualised Word Embeddings for <fixed-case>VMWE</fixed-case> Detection</title>
       <author><first>Sebastian</first><last>Gombert</last></author>
       <author><first>Sabine</first><last>Bartsch</last></author>
       <pages>149–155</pages>

--- a/data/xml/2020.mwe.xml
+++ b/data/xml/2020.mwe.xml
@@ -91,10 +91,10 @@
       <url hash="d1c2a98e">2020.mwe-1.8</url>
     </paper>
     <paper id="9">
-      <title>Generationary or: "How We Went beyond Sense Inventories and Learned to Gloss"</title>
+      <title>Invited Talk: Generationary or: "How We Went beyond Sense Inventories and Learned to Gloss"</title>
       <author><first>Roberto</first><last>Navigli</last></author>
       <pages>73</pages>
-      <abstract>In this talk I present Generationary, an approach that goes beyond the mainstream assumption that word senses can be represented as discrete items of a predefined inventory, and put forward a unified model which produces contextualized definitions for arbitrary lexical items, from words to phrases and even sentences. Generationary employs a novel span-based encoding scheme to fine-tune an English pre-trained Encoder-Decoder system and generate new definitions. Our model outperforms previous approaches in the generative task of Definition Modeling in many settings, but it also matches or surpasses the state of the art in discriminative tasks such as Word Sense Disambiguation and Word-in-Context. Finally, we show that Generationary benefits from training on definitions from multiple inventories, with strong gains across benchmarks, including a novel dataset of definitions for free adjective-noun phrases.</abstract>
+      <abstract>In this talk I present Generationary, an approach that goes beyond the mainstream assumption that word senses can be represented as discrete items of a predefined inventory, and put forward a unified model which produces contextualized definitions for arbitrary lexical items, from words to phrases and even sentences. Generationary employs a novel span-based encoding scheme to fine-tune an English pre-trained Encoder-Decoder system and generate new definitions. Our model outperforms previous approaches in the generative task of Definition Modeling in many settings, but it also matches or surpasses the state of the art in discriminative tasks such as Word Sense Disambiguation and Word-in-Context. I also show that Generationary benefits from training on definitions from multiple inventories, with strong gains across benchmarks, including a novel dataset of definitions for free adjective-noun phrases, and discuss interesting examples of generated definitions. Joint work with Michele Bevilacqua and Marco Maru.</abstract>
       <url hash="11c576a8">2020.mwe-1.9</url>
     </paper>
     <paper id="10">


### PR DESCRIPTION
* **2020.mwe-1.1** - Order of authors (exchange 2nd and 3rd)
  _Beatriz Fisas, **Luis Espinosa-Anke, Joan Codina-Filbá** and Leo Wanner_
  instead of
  _Beatriz Fisas, **Joan Codina-Filbá, Luis Espinosa-Anke** and Leo Wanner_

* **2020-mwe-1.9** - Tite (add "Invited Talk: " prefix, correct typos, update abstract)
  _Generationary or: "How We Went beyond Sense Inventories and **Learned to** Gloss"_
  instead of
  _**Invited Talk:** Generationary or: “How We Went beyond Sense Inventories and **Learnedto** Gloss”_
  Without the prefix, the title would be identical to an [EMNLP 2020 paper](https://www.aclweb.org/anthology/2020.emnlp-main.585/) by the speaker and two co-authors. Meta-data needs to ensure that this invited talk is clearly distinguishable from the EMNLP 2020 paper.
  Abstract was missing co-authors' names.

* **2020.mwe-1.10** - Author names (diacritic ć missing on 1st and 3rd authors)
  _Ranka **Stanković**, Jelena Mitrović, Danka **Jokić** and Cvetana Krstev_
  instead of
  _Ranka **Stankovic**, Jelena Mitrović, Danka **Jokic** and Cvetana Krstev_

* 2020.mwe-1.14 - Author names (diacritics ü and ö missing on 11th author)
  _Carlos Ramisch, Agata Savary, Bruno Guillaume, Jakub Waszczuk, Marie Candito, Ashwini Vaidya, Verginica Barbu Mititelu, Archna Bhatia, Uxoa Iñurrieta, Voula Giouli, Tunga **Güngör**, Menghan Jiang, Timm Lichte, Chaya Liebeskind, Johanna Monti, Renata Ramisch, Sara Stymne, Abigail Walsh, Hongzhi Xu_
  instead of
  _Carlos Ramisch, Agata Savary, Bruno Guillaume, Jakub Waszczuk, Marie Candito, Ashwini Vaidya, Verginica Barbu Mititelu, Archna Bhatia, Uxoa Iñurrieta, Voula Giouli, Tunga **Gungor**, Menghan Jiang, Timm Lichte, Chaya Liebeskind, Johanna Monti, Renata Ramisch, Sara Stymne, Abigail Walsh, Hongzhi Xu_

* **2020.mwe-1.17** - Author names as in PDF: diacritics ü and ö were missing on 2nd
  _Zeynep Yirmibeşoglu and Tunga **Güngör**_
  instead of
  _Zeynep Yirmibeşoglu and Tunga **Gungor**_

* 2020.mwe-1.20 - Title (final version update was missed on START)
  _**MultiVitaminBooster** at PARSEME Shared Task 2020: Combining Window- and Dependency-Based Features with Multilingual Contextuali**s**ed Word Embeddings for **VMWE Detection**_
  instead of
  _MultiVitaminBooster **and MultiVitaminRegressor** at PARSEME Shared Task 2020: Combining Window- and Dependency-Based Features with Multilingual Contextuali**z**ed Word Embeddings for **Detecting Verbal Multiword Expressions**_
