### PR TITLE
fixed a special character in the name of an editor

### DIFF
--- a/data/xml/2005.sigdial.xml
+++ b/data/xml/2005.sigdial.xml
@@ -3,7 +3,7 @@
   <volume id="1" ingest-date="2020-11-29">
     <meta>
       <booktitle>Proceedings of the 6th SIGdial Workshop on Discourse and Dialogue</booktitle>
-      <editor><first>Laila</first><last>Dybkj\ae{}r</last></editor>
+      <editor><first>Laila</first><last>Dybkjær</last></editor>
       <editor><first>Wolfgang</first><last>Minker</last></editor>
       <publisher>Special Interest Group on Discourse and Dialogue (SIGdial)</publisher>
       <address>Lisbon, Portugal</address>


### PR DESCRIPTION
I fixed a problem with a special character in the name of one of the editors of SIGDIAL 2005. Thank you! 
- Mikio Nakano (SIGdial Vice President)
