### PR TITLE
fix author first name in W18-02 and W19-03

### DIFF
--- a/data/xml/W18.xml
+++ b/data/xml/W18.xml
@@ -171,7 +171,7 @@
       <title>New Baseline in Automatic Speech Recognition for <fixed-case>N</fixed-case>orthern <fixed-case>S</fixed-case>ámi</title>
       <author><first>Juho</first> <last>Leinonen</last></author>
       <author><first>Peter</first> <last>Smit</last></author>
-      <author><first>Sámi</first> <last>Virpioja</last></author>
+      <author><first>Sami</first> <last>Virpioja</last></author>
       <author><first>Mikko</first> <last>Kurimo</last></author>
       <pages>87–97</pages>
       <url hash="5be57d3e">W18-0208</url>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -279,7 +279,7 @@
     <paper id="2">
       <title><fixed-case>N</fixed-case>orth <fixed-case>S</fixed-case>ámi morphological segmentation with low-resource semi-supervised sequence labeling</title>
       <author><first>Stig-Arne</first><last>Grönroos</last></author>
-      <author><first>Sámi</first><last>Virpioja</last></author>
+      <author><first>Sami</first><last>Virpioja</last></author>
       <author><first>Mikko</first><last>Kurimo</last></author>
       <pages>15–26</pages>
       <url hash="3c4c6379">W19-0302</url>


### PR DESCRIPTION
Amusingly, for some strange reason, in both of my two publications that have the language "Sámi" in the title, my first name has been set to "Sámi" instead of "Sami".