### PR TITLE
Venues should not refer to specific events

### DIFF
--- a/data/yaml/venues.yaml
+++ b/data/yaml/venues.yaml
@@ -278,7 +278,7 @@ eval4nlp:
   name: The Workshop on Evaluation and Comparison of NLP Systems (Eval4NLP)
 evalnlgeval:
   acronym: EvalNLGEval
-  name: 1st Workshop on Evaluating NLG Evaluation
+  name: Workshop on Evaluating NLG Evaluation
 events:
   acronym: EVENTS
   is_acl: true
@@ -395,7 +395,7 @@ iwcs:
   name: International Conference on Computational Semantics
 iwdp:
   acronym: iwdp
-  name: The Second International Workshop of Discourse Processing
+  name: International Workshop of Discourse Processing
 iwltp:
   acronym: IWLTP
   name: International Workshop on Language Technology Platforms
@@ -416,11 +416,11 @@ jeptalnrecital:
   oldstyle_letter: F
 knlp:
   acronym: knlp
-  name: 'Knowledgeable NLP: the First Workshop on Integrating Structured Knowledge
+  name: 'Knowledgeable NLP: Workshop on Integrating Structured Knowledge
     and Neural Networks for NLP'
 lantern:
   acronym: LANTERN
-  name: 'The Second Workshop Beyond Vision and LANguage: inTEgrating Real-world kNowledge'
+  name: 'The Workshop Beyond Vision and LANguage: inTEgrating Real-world kNowledge'
 lasm:
   acronym: LASM
   is_acl: true
@@ -456,7 +456,7 @@ lglp:
   name: Workshop on Lexical and Grammatical Resources for Language Processing
 lifelongnlp:
   acronym: lifelongnlp
-  name: The 2nd Workshop on Life-long Learning for Spoken Language Systems
+  name: Workshop on Life-long Learning for Spoken Language Systems
 lilt:
   acronym: LILT
   is_toplevel: true
@@ -466,7 +466,7 @@ lincr:
   name: Linguistic and Neurocognitive Resources
 loresmt:
   acronym: loresmt
-  name: The 3rd Workshop on Technologies for MT of Low Resource Languages
+  name: Workshop on Technologies for MT of Low Resource Languages
 louhi:
   acronym: Louhi
   is_acl: true
@@ -565,7 +565,7 @@ ngt:
   name: Workshop on Neural Generation and Translation
 nl4xai:
   acronym: NL4XAI
-  name: 2nd Workshop on Interactive Natural Language Technology for Explainable Artificial
+  name: Workshop on Interactive Natural Language Technology for Explainable Artificial
     Intelligence (NL4XAI)
 nli:
   acronym: NLI

--- a/hugo/content/info/contrib.md
+++ b/hugo/content/info/contrib.md
@@ -64,6 +64,14 @@ The following information in the spreadsheet is especially important:
    A [slugified](https://en.wikipedia.org/wiki/Clean_URL#Slug) version of this acronym, containing only numerals and lowercase ASCII letters, is used in the URL for the venue's page on the Anthology (e.g., [ACL → acl](https://www.aclweb.org/anthology/venues/acl), [JEP/TALN/RECITAL → jeptalnrecital](https://www.aclweb.org/anthology/venues/jeptalnrecital)), and also forms a component of the [Anthology ID]({{< relref "ids.md" >}}).
    For existing venues, be sure to look up [the venue's existing identifier](https://www.aclweb.org/anthology/venues/).
    New venues must have their venue identifier confirmed by the Anthology director.
+   Note: a common mistake is to include the year in the venue identifier, e.g., ACL2020 (perhaps in part because Softconf often uses this).
+   This confuses a *meeting* of a venue with the venue itself.
+   The identifier should not have the year or meeting number in it.
+-  **Venue name**. Each venue has a name.
+   These names are attached to the venue identifier and stored in [our database](https://github.com/acl-org/acl-anthology/blob/master/data/yaml/venues.yaml).
+   If your venue is new, please enter the venue name.
+   Note: similar to the caveat about about the venue identifier, this is the name of the venue, not a particular meeting of the venue.
+   When submitting a new venue to the Anthology, please make sure *not* to put the year or meeting number in the venue name.
 -  **Volume titles**. These are the titles of the volumes that will be published, e.g., *Proceedings of the...*.
    We recommend you choose a name consistent with your prior years' volumes.
    The full titles should not contain abbreviations, except parenthetically.


### PR DESCRIPTION
I noticed that some workshop names were entered into `venues.yaml` with specific event names ("The 3rd Workshop on ..." instead of just "Workshop on ..."). This works while there's only a single event belonging to that venue, but it's technically wrong and has the potential to break in the future (when we add another event to the same venue).

@mjpost Maybe you also want to make a note about this somewhere for future ingestions?