### PR TITLE
2020.findings-emnlp.195: adding $\forall$ as first author for

### DIFF
--- a/data/xml/2020.findings.xml
+++ b/data/xml/2020.findings.xml
@@ -2292,6 +2292,7 @@
     </paper>
     <paper id="195">
       <title>Participatory Research for Low-resourced Machine Translation: A Case Study in <fixed-case>A</fixed-case>frican Languages</title>
+      <author><first>$\forall$</first><last> </last></author>
       <author><first>Wilhelmina</first><last>Nekoto</last></author>
       <author><first>Vukosi</first><last>Marivate</last></author>
       <author><first>Tshinondiwa</first><last>Matsila</last></author>


### PR DESCRIPTION
Metadata change of 2020.findings-emnlp.195 by adding  $\forall$ as a first author, This is the correct first author mentioned in the paper. 

Potential risks or merging  with respect to XML parsing:
-  $\forall$  has some special chars that might break XML parsing 
- there's no last name associated with the first author so this might cause some issues. 


**Context:** 
The reason behind this, Masakhane would like to make a statement towards inclusivity by being cited as (∀et al., 2020), 
We chose this special character to represent the community as a whole.  
