### PR TITLE
Bugfix : Uppercase 'NONE' creates a problem during the YAML files generation

### DIFF
--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -370,7 +370,7 @@ class AnthologyIndex:
         assert name not in self.name_to_ids, name
         slug = slugify(repr(name))
         if slug == "":
-            slug = "NONE"
+            slug = "none"
         return slug
 
     def get_papers(self, id_, role=None):

--- a/bin/create_bibtex.py
+++ b/bin/create_bibtex.py
@@ -74,7 +74,7 @@ def create_bibtex(anthology, trgdir, clean=False):
             with open("{}/volumes/{}.bib".format(trgdir, volume_id), "w") as file_volume:
                 for paper in volume:
                     with open(
-                        "{}/{}.bib".format(volume_dir, paper.full_id), "w"
+                        "{}/papers/{}.bib".format(volume_dir, paper.full_id), "w"
                     ) as file_paper:
                         contents = paper.as_bibtex()
                         print(contents, file=file_paper)

--- a/bin/create_bibtex.py
+++ b/bin/create_bibtex.py
@@ -74,7 +74,7 @@ def create_bibtex(anthology, trgdir, clean=False):
             with open("{}/volumes/{}.bib".format(trgdir, volume_id), "w") as file_volume:
                 for paper in volume:
                     with open(
-                        "{}/papers/{}.bib".format(volume_dir, paper.full_id), "w"
+                        "{}/{}.bib".format(volume_dir, paper.full_id), "w"
                     ) as file_paper:
                         contents = paper.as_bibtex()
                         print(contents, file=file_paper)


### PR DESCRIPTION
Uppercase 'NONE' creates a problem during the YAML files generation step.

The problem arises in **OSX**.

Let me explain the problem.
After cloning the repository, I run the below commands:
    1. make venv/bin/activate
    2. make build/.basedirs
    3. make build/.yaml

build/.yaml target produces people YAML files in build/data/people. As I understood, Anthology groups author data according to their first letter, and there are some papers without author info such as 'O09-2000' so you assign 'NONE' author id to these papers. OSX (HPS+ file system) does not support a case-sensitive file system so n.yaml and N.yaml files are the same. During the 'make build/.yaml' step, firstly, author names starting with 'n' produces the n.yaml file, finally, authors with NONE id (does not produces N.yaml) overrides n.yaml file.

Sorry for this long commit message. I hope I could explain and solved the problem.


