### PR TITLE
TLT 2020 videos

### DIFF
--- a/data/xml/2020.tlt.xml
+++ b/data/xml/2020.tlt.xml
@@ -24,6 +24,7 @@
       <pages>1–17</pages>
       <url hash="f745218d">2020.tlt-1.1</url>
       <doi>10.18653/v1/2020.tlt-1.1</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/RsQhHgA4wyArAAU"/>
     </paper>
     <paper id="2">
       <title>Building a Treebank for <fixed-case>C</fixed-case>hinese Literature for Translation Studies</title>
@@ -38,6 +39,7 @@
       <pages>18–30</pages>
       <url hash="6987bf4f">2020.tlt-1.2</url>
       <doi>10.18653/v1/2020.tlt-1.2</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/0S3eniLPzZtadyk"/>
     </paper>
     <paper id="3">
       <title>Meta-dating the <fixed-case>PA</fixed-case>rsed Corpus of <fixed-case>T</fixed-case>ibetan (<fixed-case>PACT</fixed-case>ib)</title>
@@ -46,6 +48,7 @@
       <pages>31–42</pages>
       <url hash="2d2af14c">2020.tlt-1.3</url>
       <doi>10.18653/v1/2020.tlt-1.3</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/MoPnztVjCxmNNNy"/>
     </paper>
     <paper id="4">
       <title>Fine-Grained Morpho-Syntactic Analysis for the Under-Resourced Language Chaghatay</title>
@@ -56,6 +59,7 @@
       <pages>43–54</pages>
       <url hash="20ff5ac4">2020.tlt-1.4</url>
       <doi>10.18653/v1/2020.tlt-1.4</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/vdk5octdb1mykri"/>
     </paper>
     <paper id="5">
       <title>Automatic Extraction of Tree-Wrapping Grammars for Multiple Languages</title>
@@ -66,6 +70,7 @@
       <pages>55–61</pages>
       <url hash="4b2ab796">2020.tlt-1.5</url>
       <doi>10.18653/v1/2020.tlt-1.5</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/SmTnSlpmMpkX3dd"/>
     </paper>
     <paper id="6">
       <title>Cross-Lingual Domain Adaptation for Dependency Parsing</title>
@@ -73,6 +78,7 @@
       <pages>62–69</pages>
       <url hash="a5cda9ff">2020.tlt-1.6</url>
       <doi>10.18653/v1/2020.tlt-1.6</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/d5pfoPyTWsptff5"/>
     </paper>
     <paper id="7">
       <title>How tight is your language? A semantic typology based on Mutual Information</title>
@@ -80,6 +86,7 @@
       <pages>70–78</pages>
       <url hash="d0e914b1">2020.tlt-1.7</url>
       <doi>10.18653/v1/2020.tlt-1.7</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/NZCSxkAPhGp9U2f"/>
     </paper>
     <paper id="8">
       <title>Subjects tend to be coded only once: Corpus-based and grammar-based evidence for an efficiency-driven trade-off</title>
@@ -89,6 +96,7 @@
       <pages>79–92</pages>
       <url hash="3c357c62">2020.tlt-1.8</url>
       <doi>10.18653/v1/2020.tlt-1.8</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/RDHX5o0kZoGU8zO"/>
     </paper>
     <paper id="9">
       <title>Estimating <fixed-case>POS</fixed-case> Annotation Consistency of Different Treebanks in a Language</title>
@@ -97,6 +105,7 @@
       <pages>93–110</pages>
       <url hash="5a046b33">2020.tlt-1.9</url>
       <doi>10.18653/v1/2020.tlt-1.9</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/l8TsIyOY66JaW7m"/>
     </paper>
     <paper id="10">
       <title>Intelligenti Pauca - Probing a Novel Alternative to <fixed-case>U</fixed-case>niversal <fixed-case>D</fixed-case>ependencies for Under-Resourced Languages on <fixed-case>L</fixed-case>atin</title>
@@ -105,6 +114,7 @@
       <pages>111–123</pages>
       <url hash="e5b47132">2020.tlt-1.10</url>
       <doi>10.18653/v1/2020.tlt-1.10</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/p83wRQptf2Io1YP"/>
     </paper>
     <paper id="11">
       <title><fixed-case>A</fixed-case>kkadian Treebank for early Neo-Assyrian Royal Inscriptions</title>
@@ -115,6 +125,7 @@
       <pages>124–134</pages>
       <url hash="ab20b238">2020.tlt-1.11</url>
       <doi>10.18653/v1/2020.tlt-1.11</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/AGKngN8YuUqbtS1"/>
     </paper>
     <paper id="12">
       <title>Dependency Relations for <fixed-case>S</fixed-case>anskrit Parsing and Treebank</title>
@@ -126,6 +137,7 @@
       <pages>135–150</pages>
       <url hash="f338f372">2020.tlt-1.12</url>
       <doi>10.18653/v1/2020.tlt-1.12</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/hM7t9LivQMY2zMt"/>
     </paper>
     <paper id="13">
       <title><fixed-case>A</fixed-case>lpino<fixed-case>G</fixed-case>raph: A Graph-based Search Engine for Flexible and Efficient Treebank Search</title>
@@ -134,6 +146,7 @@
       <pages>151–161</pages>
       <url hash="dac74346">2020.tlt-1.13</url>
       <doi>10.18653/v1/2020.tlt-1.13</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/wg97bnr5QS7B7CP"/>
     </paper>
     <paper id="14">
       <title>Implementing an End-to-End Treebank-Informed Pipeline for <fixed-case>B</fixed-case>ulgarian</title>
@@ -143,6 +156,7 @@
       <pages>162–167</pages>
       <url hash="2813c906">2020.tlt-1.14</url>
       <doi>10.18653/v1/2020.tlt-1.14</doi>
+      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/rTwzcycnRWkJ3zL"/>
     </paper>
   </volume>
 </collection>

--- a/data/xml/2020.tlt.xml
+++ b/data/xml/2020.tlt.xml
@@ -24,7 +24,6 @@
       <pages>1–17</pages>
       <url hash="f745218d">2020.tlt-1.1</url>
       <doi>10.18653/v1/2020.tlt-1.1</doi>
-      <video tag="video" href="https://uni-duesseldorf.sciebo.de/s/RsQhHgA4wyArAAU"/>
     </paper>
     <paper id="2">
       <title>Building a Treebank for <fixed-case>C</fixed-case>hinese Literature for Translation Studies</title>


### PR DESCRIPTION
Added links to TLT 2020 videos. Source: https://tlt2020.phil.hhu.de/schedule/