### PR TITLE
Remove video link from N19-1116 upon first author's request

### DIFF
--- a/data/xml/N19.xml
+++ b/data/xml/N19.xml
@@ -1348,7 +1348,6 @@
       <abstract>We introduce the deep inside-outside recursive autoencoder (DIORA), a fully-unsupervised method for discovering syntax that simultaneously learns representations for constituents within the induced tree. Our approach predicts each word in an input sentence conditioned on the rest of the sentence. During training we use dynamic programming to consider all possible binary trees over the sentence, and for inference we use the CKY algorithm to extract the highest scoring parse. DIORA outperforms previously reported results for unsupervised binary constituency parsing on the benchmark WSJ dataset.</abstract>
       <url hash="ca457e13">N19-1116</url>
       <doi>10.18653/v1/N19-1116</doi>
-      <video href="https://vimeo.com/364678824" tag="video"/>
     </paper>
     <paper id="117">
       <title>Knowledge-Augmented Language Model and Its Application to Unsupervised Named-Entity Recognition</title>


### PR DESCRIPTION
The video has the wrong audio track and is therefore not comprehensible.