### PR TITLE
Add uncompressed full bib

### DIFF
--- a/bin/create_bibtex.py
+++ b/bin/create_bibtex.py
@@ -60,7 +60,9 @@ def create_bibtex(anthology, trgdir, clean=False):
         return
 
     log.info("Creating BibTeX files for all papers...")
-    with gzip.open(
+    with open(
+        "{}/anthology.bib".format(trgdir), "wt", encoding="utf-8"
+    ) as file_anthology_raw, gzip.open(
         "{}/anthology.bib.gz".format(trgdir), "wt", encoding="utf-8"
     ) as file_anthology, gzip.open(
         "{}/anthology+abstracts.bib.gz".format(trgdir), "wt", encoding="utf-8"
@@ -83,6 +85,7 @@ def create_bibtex(anthology, trgdir, clean=False):
                         concise_contents = paper.as_bibtex(concise=True)
                         print(concise_contents, file=file_volume)
                         print(concise_contents, file=file_anthology)
+                        print(concise_contents, file=file_anthology_raw)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This generates (but doesn't advertise) the full bib file, uncompressed. The main motivation is that this allows direct import into Overleaf (which doesn't support compressed files).