### PR TITLE
Remove acronyms from venue names

### DIFF
--- a/data/yaml/venues.yaml
+++ b/data/yaml/venues.yaml
@@ -190,7 +190,7 @@ cogalex:
 coling:
   acronym: COLING
   is_toplevel: true
-  name: International Conference on Computational Linguistics (COLING)
+  name: International Conference on Computational Linguistics
   oldstyle_letter: C
 comacoma:
   acronym: ComAComA
@@ -284,7 +284,7 @@ ethnlp:
   name: Workshop on Ethics in Natural Language Processing
 eval4nlp:
   acronym: Eval4NLP
-  name: The Workshop on Evaluation and Comparison of NLP Systems (Eval4NLP)
+  name: The Workshop on Evaluation and Comparison of NLP Systems
 evalnlgeval:
   acronym: EvalNLGEval
   name: Workshop on Evaluating NLG Evaluation
@@ -372,7 +372,7 @@ hlt:
   oldstyle_letter: H
 humeval:
   acronym: HumEval
-  name: The Workshop on Human Evaluation of NLP Systems (HumEval)
+  name: The Workshop on Human Evaluation of NLP Systems
   url: https://humeval.github.io/
 hytra:
   acronym: HyTra
@@ -588,7 +588,7 @@ ngt:
 nl4xai:
   acronym: NL4XAI
   name: Workshop on Interactive Natural Language Technology for Explainable Artificial
-    Intelligence (NL4XAI)
+    Intelligence
 nli:
   acronym: NLI
   is_acl: true
@@ -740,7 +740,7 @@ sadaatl:
   name: Workshop on Synchronic and Diachronic Approaches to Analyzing Technical Language
 scai:
   acronym: scai
-  name: International Workshop on Search-Oriented Conversational AI (SCAI)
+  name: International Workshop on Search-Oriented Conversational AI
 scil:
   acronym: SCiL
   name: Society for Computation in Linguistics
@@ -750,7 +750,7 @@ sclem:
   name: Workshop on Subword and Character LEvel Models in NLP
 sdp:
   acronym: sdp
-  name: Workshop on Scholarly Document Processing (SDP 2020)
+  name: Workshop on Scholarly Document Processing
 sedmt:
   acronym: SedMT
   is_acl: true


### PR DESCRIPTION
A few venues list their acronym in brackets as part of the name field, e.g. "International Conference on Computational Linguistics (COLING)". However, this information is already configured in the acronym field. On the venue's page this results in a duplication: "International Conference on Computational Linguistics (COLING) (COLING)"

This pull request removes the acronyms from the end of name fields.