### PR TITLE
Update 2020.paclic.xml

### DIFF
--- a/data/xml/2020.paclic.xml
+++ b/data/xml/2020.paclic.xml
@@ -31,7 +31,7 @@
       <url hash="456adb46">2020.paclic-1.2</url>
     </paper>
     <paper id="3">
-      <title>A new look a99t <fixed-case>P</fixed-case>attani <fixed-case>M</fixed-case>alay Initial Geminates: a statistical and machine learning approach</title>
+      <title>A new look at <fixed-case>P</fixed-case>attani <fixed-case>M</fixed-case>alay Initial Geminates: a statistical and machine learning approach</title>
       <author><first>Francesco</first><last>Burroni</last></author>
       <author><first>Sireemas</first><last>Maspong</last></author>
       <author><first>Pittayawat</first><last>Pittayaporn</last></author>

--- a/data/xml/2020.paclic.xml
+++ b/data/xml/2020.paclic.xml
@@ -406,7 +406,7 @@
       <url hash="549ab4b1">2020.paclic-1.47</url>
     </paper>
     <paper id="48">
-      <titleA Simple and Efficient Ensemble Classifier Combining Multiple Neural Network Models on Social Media Datasets in <fixed-case>V</fixed-case>ietnamese</title>
+      <title>A Simple and Efficient Ensemble Classifier Combining Multiple Neural Network Models on Social Media Datasets in <fixed-case>V</fixed-case>ietnamese</title>
       <author><first>Huy Duc</first><last>Huynh</last></author>
       <author><first>Hang Thi-Thuy</first><last>Do</last></author>
       <author><first>Kiet Van</first><last>Nguyen</last></author>

--- a/data/xml/2020.paclic.xml
+++ b/data/xml/2020.paclic.xml
@@ -202,7 +202,7 @@
       <author><first>Fatma</first><last>Ghorbel</last></author>
       <author><first>Bilel</first><last>Gargouri</last></author>
       <author><first>Nada</first><last>Mimouni</last></author>
-      <author><first>Elisabeth</first><last>Metais</last></author>
+      <author><first>Elisabeth</first><last>Métais</last></author>
       <pages>199–206</pages>
       <url hash="d0bfcfc9">2020.paclic-1.23</url>
     </paper>
@@ -279,7 +279,7 @@
       <url hash="8085e9dc">2020.paclic-1.31</url>
     </paper>
     <paper id="32">
-      <title>Evaluation of <fixed-case>BERT</fixed-case> Models by Using Sentence Clustering</title>
+      <title>Evaluation of Pretrained <fixed-case>BERT</fixed-case> Model by Using Sentence Clustering</title>
       <author><first>Naoki</first><last>Shibayama</last></author>
       <author><first>Rui</first><last>Cao</last></author>
       <author><first>Jing</first><last>Bai</last></author>
@@ -375,7 +375,7 @@
       <url hash="58876ffe">2020.paclic-1.43</url>
     </paper>
     <paper id="44">
-      <title>Research on Prosody of Collaborative Construction in <fixed-case>M</fixed-case>andarin Conversation</title>
+      <title>Prosody Features of Collaborative Construction in <fixed-case>M</fixed-case>andarin Conversation</title>
       <author><first>Yue</first><last>Guan</last></author>
       <pages>383–394</pages>
       <url hash="789b43ba">2020.paclic-1.44</url>
@@ -399,14 +399,14 @@
       <url hash="ff8e9d81">2020.paclic-1.46</url>
     </paper>
     <paper id="47">
-      <title>Exploring Discourse of Same-sex Marriage in <fixed-case>T</fixed-case>aiwan: A Case Study of Near-Synonym of <fixed-case>HOMOSEXUAL</fixed-case> in Opposing Stances</title>
+      <title>Exploring Discourse on Same-sex Marriage in <fixed-case>T</fixed-case>aiwan: A Case Study of Near-Synonym of <fixed-case>HOMOSEXUAL</fixed-case> in Opposing Stances</title>
       <author><first>Han-Tang</first><last>Hung</last></author>
       <author><first>Shu-Kai</first><last>Hsieh</last></author>
       <pages>411–419</pages>
       <url hash="549ab4b1">2020.paclic-1.47</url>
     </paper>
     <paper id="48">
-      <title>A simple and efficient ensemble classifier combining multiple neural network models on social media datasets in <fixed-case>V</fixed-case>ietnamese</title>
+      <titleA Simple and Efficient Ensemble Classifier Combining Multiple Neural Network Models on Social Media Datasets in <fixed-case>V</fixed-case>ietnamese</title>
       <author><first>Huy Duc</first><last>Huynh</last></author>
       <author><first>Hang Thi-Thuy</first><last>Do</last></author>
       <author><first>Kiet Van</first><last>Nguyen</last></author>
@@ -456,7 +456,7 @@
       <url hash="37355ec9">2020.paclic-1.53</url>
     </paper>
     <paper id="54">
-      <title>Attention-based Domain adaption Using Transfer Learning for Part-of-Speech Tagging: An Experiment on the <fixed-case>H</fixed-case>indi language</title>
+      <title>Attention-based Domain Adaption Using Transfer Learning for Part-of-Speech Tagging: An Experiment on the <fixed-case>H</fixed-case>indi language</title>
       <author><first>Rajesh Kumar</first><last>Mundotiya</last></author>
       <author><first>Vikrant</first><last>Kumar</last></author>
       <author><first>Arpit</first><last>Mehta</last></author>
@@ -497,7 +497,7 @@
       <url hash="81ea3812">2020.paclic-1.58</url>
     </paper>
     <paper id="59">
-      <title>Redefining verbal nouns in <fixed-case>J</fixed-case>apanese: From the perspective of polycategoriality</title>
+      <title>Redefining Verbal Nouns in <fixed-case>J</fixed-case>apanese: From the Perspective of Polycategoriality</title>
       <author><first>David Y.</first><last>Oshima</last></author>
       <author><first>Midori</first><last>Hayashi</last></author>
       <pages>514–522</pages>


### PR DESCRIPTION
Metadata changes: 

Posted issue:
#1313 
2020.PACLIC-1.3 
Current title in metadata:  "A new look a99t Pattani Malay Initial Geminates: a statistical and machine learning approach"
Changed to:  "A new look at Pattani Malay Initial Geminates: a statistical and machine learning approach"

7 new corrections (due to different paper titles in EasyChair metadata and accent on author name):

2020.PACLIC-1.23
Current author name: "Elisabeth Metais"
Changed to: "Elisabeth Métais"

2020.PACLIC-1.32
Current title in metadata: "Evaluation of BERT Models by Using Sentence Clustering"
Changed to: "Evaluation of Pretrained BERT Model by Using Sentence Clustering"

2020.PACLIC-1.44
Current title in metadata: "Research on Prosody of Collaborative Construction in Mandarin Conversation"
Changed to: "Prosody Features of Collaborative Construction in Mandarin Conversation"

2020.PACLIC-1.47
Current title in metadata: "Exploring Discourse of Same-sex Marriage in Taiwan: A Case Study of Near-Synonym of HOMOSEXUAL in Opposing Stances"
Changed to: "Exploring Discourse on Same-sex Marriage in Taiwan: A Case Study of Near-Synonym of HOMOSEXUAL in Opposing Stances"

2020.PACLIC-1.48
Current title in metadata: "A simple and efficient ensemble classifier combining multiple neural network models on social media datasets in Vietnamese"	 
Changed to: "A Simple and Efficient Ensemble Classifier Combining Multiple Neural Network Models on Social Media Datasets in Vietnamese"

2020.PACLIC-1.54
Current title in metadata: "Attention-based Domain adaption Using Transfer Learning for Part-of-Speech Tagging: An Experiment on the Hindi language"
Changed to: "Attention-based Domain Adaption Using Transfer Learning for Part-of-Speech Tagging: An Experiment on the Hindi Language"

2020.PACLIC-1.59
Current title in metadata: "Redefining verbal nouns in Japanese: From the perspective of polycategoriality"
Changed to: "Redefining Verbal Nouns in Japanese: From the Perspective of Polycategoriality"