### PR TITLE
Renaming ROCLING

### DIFF
--- a/data/yaml/venues.yaml
+++ b/data/yaml/venues.yaml
@@ -739,11 +739,8 @@ robonlp:
   name: Workshop on Language Grounding for Robotics
 rocling:
   acronym: ROCLING
-  name: Conference on Computational Linguistics and Speech Processing
-roclingijclclp:
-  acronym: ROCLING/IJCLCLP
   is_toplevel: true
-  name: Rocling Computation Linguistics Conference and Journal
+  name: Conference on Computational Linguistics and Speech Processing
   oldstyle_letter: O
 s2mt:
   acronym: S2MT


### PR DESCRIPTION
ROCLING currently has two venue pages:

* [ROCLING/IJCLCLP](https://aclanthology.org/venues/roclingijclclp/)
* [ROCLING](https://aclanthology.org/venues/roclingijclclp/)

I think the latter is the one we should consolidate on, removing the former. But I am not sure.