### PR TITLE
Fixed dummy frontmatter

### DIFF
--- a/bin/ingest.py
+++ b/bin/ingest.py
@@ -250,16 +250,20 @@ def main(args):
             os.makedirs(pdfs_dest_dir)
 
         # copy the book
+        book_dest_path = (
+            os.path.join(pdfs_dest_dir, f"{collection_id}-{volume_name}") + ".pdf"
+        )
+
+        # try the standard filename, e.g., 2021.naacl-main.pdf
         book_src_filename = f'{year}.{meta["abbrev"]}-{volume_name}.pdf'
         book_src_path = os.path.join(root_path, book_src_filename)
-        book_dest_path = None
-        if os.path.exists(book_src_path):
-            book_dest_path = (
-                os.path.join(pdfs_dest_dir, f"{collection_id}-{volume_name}") + ".pdf"
-            )
+        if not os.path.exists(book_src_path):
+            # try a different filename, e.g., "NLP4CALL-2021.pdf"
+            book_src_filename = f'{meta["abbrev"]}-{year}.pdf'
+            book_src_path = os.path.join(root_path, book_src_filename)
 
-            if not args.dry_run:
-                maybe_copy(book_src_path, book_dest_path)
+        if os.path.exists(book_src_path) and not args.dry_run:
+            maybe_copy(book_src_path, book_dest_path)
 
         # copy the paper PDFs
         pdf_src_dir = os.path.join(root_path, "pdf")

--- a/data/xml/2021.motra.xml
+++ b/data/xml/2021.motra.xml
@@ -11,9 +11,10 @@
       <address>online</address>
       <month>May</month>
       <year>2021</year>
+      <url hash="b3b09ef9">2021.motra-1</url>
     </meta>
     <frontmatter>
-      <url hash="b2669b3e">2021.motra-1.0</url>
+      <url hash="a1f205fe">2021.motra-1.0</url>
     </frontmatter>
     <paper id="1">
       <title>Do not Rely on Relay Translations: Multilingual Parallel Direct <fixed-case>E</fixed-case>uroparl</title>

--- a/data/xml/2021.nlp4call.xml
+++ b/data/xml/2021.nlp4call.xml
@@ -12,6 +12,7 @@
       <address>Online</address>
       <month>May</month>
       <year>2021</year>
+      <url hash="742860c4">2021.nlp4call-1</url>
     </meta>
     <frontmatter>
       <url hash="8d11d9d1">2021.nlp4call-1.0</url>

--- a/data/xml/2021.nodalida.xml
+++ b/data/xml/2021.nodalida.xml
@@ -9,6 +9,7 @@
       <address>Reykjavik, Iceland (Online)</address>
       <month>May 31--2 June</month>
       <year>2021</year>
+      <url hash="d102b425">2021.nodalida-main</url>
     </meta>
     <frontmatter>
       <url hash="4da07233">2021.nodalida-main.0</url>


### PR DESCRIPTION
The submitters submitted a dummy front matter. This replaces it, and adds the full book proceedings.