### PR TITLE
Top level previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: mshick/add-pr-comment@v1
       with:
         message: |
-          Build successful. You can preview it here: https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }} |
+          Build successful. You can preview it here: https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}
           This preview will be removed when the branch is merged.
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -34,13 +34,14 @@ jobs:
     - name: preview
       shell: bash
       env:
-        ANTHOLOGY_PREFIX: https://aclanthology.org/previews/${{ steps.extract_branch.outputs.branch }}
+        ANTHOLOGY_PREFIX: https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}
       run: |
         make ANTHOLOGY_PREFIX=${ANTHOLOGY_PREFIX} NOBIB=true check site preview
     - uses: mshick/add-pr-comment@v1
       with:
         message: |
-          Build successful. You can preview it here: https://aclanthology.org/previews/${{ steps.extract_branch.outputs.branch }}
+          Build successful. You can preview it here: ${ANTHOLOGY_PREFIX} |
+          This preview will be removed when the branch is merged.
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
         allow-repeats: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: mshick/add-pr-comment@v1
       with:
         message: |
-          Build successful. You can preview it here: ${ANTHOLOGY_PREFIX} |
+          Build successful. You can preview it here: https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }} |
           This preview will be removed when the branch is merged.
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens

--- a/Makefile
+++ b/Makefile
@@ -326,10 +326,10 @@ upload-mirror:
 .PHONY: preview
 preview:
 	make --version
-	@if [[ "$(ANTHOLOGYDIR)" =~ ^previews ]]; then \
+	@if [[ "$(ANTHOLOGYDIR)" != "" ]]; then \
 	  echo "INFO     Running rsync for the '$(ANTHOLOGYDIR)' branch preview..."; \
-	  rsync -aze "ssh -o StrictHostKeyChecking=accept-new" build/website/${ANTHOLOGYDIR}/ anthologizer@aclanthology.org:/var/www/aclanthology.org/${ANTHOLOGYDIR}; \
+	  rsync -aze "ssh -o StrictHostKeyChecking=accept-new" build/website/${ANTHOLOGYDIR}/ anthologizer@aclanthology.org:/var/www/preview.aclanthology.org/${ANTHOLOGYDIR}; \
 	else \
-	  echo "FATAL    ANTHOLOGYDIR must have the format previews/{branch_name} (found '$(ANTHOLOGYDIR)')"; \
+	  echo "FATAL    ANTHOLOGYDIR must contain the preview name, but was empty"; \
 	  exit 1; \
 	fi

--- a/bin/aclanthology.org/README
+++ b/bin/aclanthology.org/README
@@ -1,0 +1,1 @@
+Scripts used on the server.

--- a/bin/aclanthology.org/remove-previews.sh
+++ b/bin/aclanthology.org/remove-previews.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Removes previews of branches that have been deleted on Github.
+# Requires $PREVIEW_DIR to be set.
+
+. ~/.bashrc
+
+set -eu
+
+if [[ -d $PREVIEW_DIR ]]; then
+	cd $PREVIEW_DIR
+	for branch in *; do
+		curl -s -o /dev/null -f https://github.com/acl-org/acl-anthology/tree/$branch
+		if [[ $? -ne 0 ]]; then
+			echo "* Removing Anthology preview $branch"
+			rm -rf "./$branch"
+		fi
+	done
+fi


### PR DESCRIPTION
Per @akoehn's suggestion, this PR moves previews from their old location at `https://aclanthlogy.org/previews/{branch}` to a new top-level location at `https://preview.aclanthology.org/{branch}`. The main benefits are:

* Previews are no longer nested within the main site, simplifying syncing and cleanup
* The word "preview" in the domain increases the visibility of the nature of the preview