### PR TITLE
https doi url prefix instead of http

### DIFF
--- a/bin/anthology/data.py
+++ b/bin/anthology/data.py
@@ -47,7 +47,7 @@ LIST_ELEMENTS = (
 JOURNAL_IDS = ("cl", "tacl")
 
 # Constants associated with DOI assignation
-DOI_URL_PREFIX = "http://dx.doi.org/"
+DOI_URL_PREFIX = "https://dx.doi.org/"
 DOI_PREFIX = "10.18653/v1/"
 
 # Default ingestion date (= unknown)


### PR DESCRIPTION
Currently the doi links are all http. I think they should be https for better security and privacy.