### PR TITLE
Update 2021 CALCS WS Organizer Information

### DIFF
--- a/data/xml/2021.calcs.xml
+++ b/data/xml/2021.calcs.xml
@@ -9,8 +9,8 @@
       <editor><first>Mona</first><last>Diab</last></editor>
       <editor><first>Sunayana</first><last>Sitaram</last></editor>
       <editor><first>Victor</first><last>Soto</last></editor>
-      <editor><first>Anirudh</first><last>Srinivasan</last></editor>
       <editor><first>Emre</first><last>Yilmaz</last></editor>
+      <editor><first>Anirudh</first><last>Srinivasan</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Online</address>
       <month>June</month>

--- a/data/xml/2021.calcs.xml
+++ b/data/xml/2021.calcs.xml
@@ -9,6 +9,7 @@
       <editor><first>Mona</first><last>Diab</last></editor>
       <editor><first>Sunayana</first><last>Sitaram</last></editor>
       <editor><first>Victor</first><last>Soto</last></editor>
+      <editor><first>Anirudh</first><last>Srinivasan</last></editor>
       <editor><first>Emre</first><last>Yilmaz</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Online</address>


### PR DESCRIPTION
The [entry](https://www.aclweb.org/anthology/2021.calcs-1.0/) for the 2021 Code-Switching Workshop, held at NAACL, is missing the name of one of the workshop organizers. Both the [workshop website](https://code-switching.github.io/2021) and the [PDF](https://www.aclweb.org/anthology/2021.calcs-1.0.pdf) uploaded along with the entry have the name (check Page 5 in the PDF).

I've made a PR, adding the missing name to the entry.