### PR TITLE
Update 2021.bionlp.xml for paper ID 2021.bionlp-1.28

### DIFF
--- a/data/xml/2021.bionlp.xml
+++ b/data/xml/2021.bionlp.xml
@@ -315,7 +315,7 @@
       <author><first>Seunghyun</first><last>Yoon</last></author>
       <author><first>Trung</first><last>Bui</last></author>
       <author><first>Walter</first><last>Chang</last></author>
-      <author><first>Emilias</first><last>Farcas</last></author>
+      <author><first>Emilia</first><last>Farcas</last></author>
       <author><first>Ndapa</first><last>Nakashole</last></author>
       <pages>257–262</pages>
       <abstract>In this paper, we describe our approach to question summarization and multi-answer summarization in the context of the 2021 MEDIQA shared task (Ben Abacha et al., 2021). We propose two kinds of transfer learning for the abstractive summarization of medical questions. First, we train on HealthCareMagic, a large question summarization dataset collected from an online healthcare service platform. Second, we leverage the ability of the BART encoder-decoder architecture to model both generation and classification tasks to train on the task of Recognizing Question Entailment (RQE) in the medical domain. We show that both transfer learning methods combined achieve the highest ROUGE scores. Finally, we cast the question-driven extractive summarization of multiple relevant answer documents as an Answer Sentence Selection (AS2) problem. We show how we can preprocess the MEDIQA-AnS dataset such that it can be trained in an AS2 setting. Our AS2 model is able to generate extractive summaries achieving high ROUGE scores.</abstract>


### PR DESCRIPTION
Fixing author name typo: Emilias Farcas => Emilia Farcas (paper id 2021.bionlp-1.28)
The PDF file does NOT need to be replaced.
