### PR TITLE
Refactor "dummy frontmatter" (fixes #1405)

### DIFF
--- a/bin/anthology/anthology.py
+++ b/bin/anthology/anthology.py
@@ -103,6 +103,13 @@ class Anthology:
                 front_matter = volume.content[0]
                 self.pindex.register(front_matter)
                 self.papers[front_matter.full_id] = front_matter
+            else:
+                # dummy front matter to make sure that editors of
+                # volume get registered as people in author database
+                dummy_front_matter = Paper(
+                    "0", volume.content[0].ingest_date, volume, self.formatter
+                )
+                self.pindex.register(dummy_front_matter)
 
             self.volumes[volume.full_id] = volume
             for paper_xml in volume_xml.findall("paper"):

--- a/bin/anthology/anthology.py
+++ b/bin/anthology/anthology.py
@@ -106,9 +106,7 @@ class Anthology:
             else:
                 # dummy front matter to make sure that editors of
                 # volume get registered as people in author database
-                dummy_front_matter = Paper(
-                    "0", volume.content[0].ingest_date, volume, self.formatter
-                )
+                dummy_front_matter = Paper("0", None, volume, self.formatter)
                 self.pindex.register(dummy_front_matter)
 
             self.volumes[volume.full_id] = volume

--- a/bin/anthology/anthology.py
+++ b/bin/anthology/anthology.py
@@ -107,7 +107,7 @@ class Anthology:
                 # dummy front matter to make sure that editors of
                 # volume get registered as people in author database
                 dummy_front_matter = Paper("0", None, volume, self.formatter)
-                self.pindex.register(dummy_front_matter)
+                self.pindex.register(dummy_front_matter, dummy=True)
 
             self.volumes[volume.full_id] = volume
             for paper_xml in volume_xml.findall("paper"):

--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -230,7 +230,7 @@ class AnthologyIndex:
         self.bibkeys.add(bibkey)
         return bibkey
 
-    def register(self, paper):
+    def register(self, paper, dummy=False):
         """Register all names associated with the given paper."""
         from .papers import Paper
 
@@ -264,9 +264,10 @@ class AnthologyIndex:
                     explicit = True
 
                 self.id_to_used[id_].add(name)
-                # Register paper
-                self.id_to_papers[id_][role].append(paper.full_id)
-                self.name_to_papers[name][explicit].append(paper.full_id)
+                if not dummy:
+                    # Register paper
+                    self.id_to_papers[id_][role].append(paper.full_id)
+                    self.name_to_papers[name][explicit].append(paper.full_id)
                 # Register co-author(s)
                 for co_name, co_id in paper.get(role):
                     if co_id is None:

--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -231,7 +231,13 @@ class AnthologyIndex:
         return bibkey
 
     def register(self, paper, dummy=False):
-        """Register all names associated with the given paper."""
+        """Register all names associated with the given paper.
+
+        :param dummy: If True, will only resolve the author/editor names without
+        actually linking them to the given paper.  This is used for volumes
+        without frontmatter to make sure their editors still get registered
+        here, but without creating links to a non-existent paper.
+        """
         from .papers import Paper
 
         assert isinstance(paper, Paper), "Expected Paper, got {} ({})".format(

--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -264,16 +264,17 @@ class AnthologyIndex:
                     explicit = True
 
                 self.id_to_used[id_].add(name)
+
                 if not dummy:
                     # Register paper
                     self.id_to_papers[id_][role].append(paper.full_id)
                     self.name_to_papers[name][explicit].append(paper.full_id)
-                # Register co-author(s)
-                for co_name, co_id in paper.get(role):
-                    if co_id is None:
-                        co_id = self.resolve_name(co_name)["id"]
-                    if co_id != id_:
-                        self.coauthors[id_][co_id] += 1
+                    # Register co-author(s)
+                    for co_name, co_id in paper.get(role):
+                        if co_id is None:
+                            co_id = self.resolve_name(co_name)["id"]
+                        if co_id != id_:
+                            self.coauthors[id_][co_id] += 1
 
     def verify(self):
         ## no longer issuing a warning for unused variants

--- a/bin/anthology/volumes.py
+++ b/bin/anthology/volumes.py
@@ -84,11 +84,7 @@ class Volume:
         front_matter_xml = volume_xml.find("frontmatter")
         if front_matter_xml is not None:
             front_matter = Paper.from_xml(front_matter_xml, volume, formatter)
-        else:
-            # dummy front matter to make sure that editors of
-            # volume get registered as people in author database
-            front_matter = Paper("0", ingest_date, volume, formatter)
-        volume.add_frontmatter(front_matter)
+            volume.add_frontmatter(front_matter)
 
         return volume
 


### PR DESCRIPTION
Fixes #1405.

This means some people [can have empty paper listings](https://preview.aclanthology.org/fix-dummy-frontmatter/people/k/kathryn-b-taylor/) when they only ever appear as editors of proceedings without front matter.

A better way would be to make the code keep a separate index for volume editors and generate entries from that, but that also adds more complexity to the code – I could look into that if you think it's worth it.
