### PR TITLE
Correction of metadata - typo in author's name

### DIFF
--- a/data/xml/2018.gwc.xml
+++ b/data/xml/2018.gwc.xml
@@ -124,7 +124,7 @@
       <title>Using <fixed-case>O</fixed-case>pen<fixed-case>W</fixed-case>ordnet-<fixed-case>PT</fixed-case> for Question Answering on Legal Domain</title>
       <author><first>Pedro</first><last>Delfino</last></author>
       <author><first>Bruno</first><last>Cuconato</last></author>
-      <author><first>Guillherme Paulino</first><last>Passos</last></author>
+      <author><first>Guilherme</first><last>Paulino-Passos</last></author>
       <author><first>Gerson</first><last>Zaverucha</last></author>
       <author><first>Alexandre</first><last>Rademaker</last></author>
       <pages>105–112</pages>


### PR DESCRIPTION
Hello,

This is a fix for the metadata for a paper I have authored. There was a typo in the first name and an incorrect split of first and last name. With this fix it now agrees with the PDF: [https://aclanthology.org/2018.gwc-1.13.pdf](https://aclanthology.org/2018.gwc-1.13.pdf)

Thank you very much!