### PR TITLE
Update title of 2021.woah-1.17 according to pdf

### DIFF
--- a/data/xml/2021.woah.xml
+++ b/data/xml/2021.woah.xml
@@ -202,7 +202,7 @@
       <doi>10.18653/v1/2021.woah-1.16</doi>
     </paper>
     <paper id="17">
-      <title>Toxic Comment Collection: Making More Than 30 Datasets Easily Accessible in One Unified Format</title>
+      <title>Data Integration for Toxic Comment Classification: Making More Than 40 Datasets Easily Accessible in One Unified Format</title>
       <author><first>Julian</first><last>Risch</last></author>
       <author><first>Philipp</first><last>Schmidt</last></author>
       <author><first>Ralf</first><last>Krestel</last></author>


### PR DESCRIPTION
The title in the pdf of the paper 2021.woah-1.17 and in the meta data are not in sync (my fault).

Here is the link to the pdf, where the title is "Data Integration for Toxic Comment Classification: Making More Than 40 Datasets Easily Accessible in One Unified Format". I updated the meta data entry accordingly.
https://aclanthology.org/2021.woah-1.17.pdf