### PR TITLE
Correct author order and title capitalisation

### DIFF
--- a/data/xml/2019.gwc.xml
+++ b/data/xml/2019.gwc.xml
@@ -350,11 +350,11 @@
       <url hash="3f0b9c70">2019.gwc-1.39</url>
     </paper>
     <paper id="40">
-      <title>Building <fixed-case>ASLN</fixed-case>et, A <fixed-case>W</fixed-case>ordnet for <fixed-case>A</fixed-case>merican <fixed-case>S</fixed-case>ign <fixed-case>L</fixed-case>anguage</title>
+      <title>Building <fixed-case>ASLN</fixed-case>et, a <fixed-case>W</fixed-case>ordnet for <fixed-case>A</fixed-case>merican <fixed-case>S</fixed-case>ign <fixed-case>L</fixed-case>anguage</title>
       <author><first>Colin</first><last>Lualdi</last></author>
       <author><first>Jack</first><last>Hudson</last></author>
-      <author><first>Noah</first><last>Buchholz</last></author>
       <author><first>Christiane</first><last>Fellbaum</last></author>
+      <author><first>Noah</first><last>Buchholz</last></author>
       <pages>315–322</pages>
       <abstract>We discuss the creation of ASLNet by aligning the Princeton WordNet (PWN) with SignStudy, an online database of American Sign Language (ASL) signs. This alignment will have many immediate benefits for first and second-sign language learners as well as ASL researchers by highlighting semantic relations among signs. We begin to address the interesting theoretical question of to what extent the wordnet-style organization of the English lexicon (and those of wordnets in other spoken languages) is applicable to ASL, and whether ASL requires positing additional, language or modality-specific relations among signs. Significantly, the mapping of SignStudy and PWN provides a bridge between ASL and the worldwide wordnet community, which comprises speakers of dozens of languages working in academic and language technology settings.</abstract>
       <url hash="4ab0f7b8">2019.gwc-1.40</url>


### PR DESCRIPTION
Corrected the order of the authors to match that given in both the paper and the proceedings ToC. I also changed the title capitalisation to match that in the paper (although the current capitalisation can be found in the proceedings ToC).