### PR TITLE
add three video links

### DIFF
--- a/data/xml/2021.acl.xml
+++ b/data/xml/2021.acl.xml
@@ -3222,6 +3222,7 @@
       <url hash="98f2cdc4">2021.acl-long.247</url>
       <doi>10.18653/v1/2021.acl-long.247</doi>
       <bibkey>zeinert-etal-2021-annotating</bibkey>
+      <video tag="video" href="https://www.youtube.com/watch?v=xayfVkt7gwo"/>
     </paper>
     <paper id="248">
       <title>Few-<fixed-case>NERD</fixed-case>: A Few-shot Named Entity Recognition Dataset</title>

--- a/data/xml/E14.xml
+++ b/data/xml/E14.xml
@@ -1369,6 +1369,7 @@
       <url hash="7445688f">E14-4014</url>
       <doi>10.3115/v1/E14-4014</doi>
       <bibkey>derczynski-bontcheva-2014-passive</bibkey>
+      <video tag="video" href="https://www.youtube.com/watch?v=heYj8sCmWCo"/>
     </paper>
     <paper id="15">
       <title>Accelerated Estimation of Conditional Random Fields using a Pseudo-Likelihood-inspired Perceptron Variant</title>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -4442,6 +4442,7 @@
       <abstract>Crowdsourcing is an emerging collaborative approach that can be used for the acquisition of annotated corpora and a wide range of other linguistic resources. Although the use of this approach is intensifying in all its key genres (paid-for crowdsourcing, games with a purpose, volunteering-based approaches), the community still lacks a set of best-practice guidelines similar to the annotation best practices for traditional, expert-based corpus acquisition. In this paper we focus on the use of crowdsourcing methods for corpus acquisition and propose a set of best practice guidelines based in our own experiences in this area and an overview of related literature. We also introduce GATE Crowd, a plugin of the GATE platform that relies on these guidelines and offers tool support for using crowdsourcing in a more principled and efficient manner.</abstract>
       <url>http://www.lrec-conf.org/proceedings/lrec2014/pdf/497_Paper.pdf</url>
       <bibkey>sabou-etal-2014-corpus</bibkey>
+      <video tag="video" href="https://www.youtube.com/watch?v=cMl-z0-p0wI"/>
     </paper>
     <paper id="413">
       <author><first>Ioannis</first><last>Korkontzelos</last></author>


### PR DESCRIPTION
Add three public video links, including to an ACL 2021 talk where Underline don't have the correct video in place but do have a working Anthology link.