### PR TITLE
Remove nested alias for volumes

### DIFF
--- a/bin/create_hugo_pages.py
+++ b/bin/create_hugo_pages.py
@@ -108,13 +108,13 @@ def create_volumes(srcdir, clean=False):
     for anthology_id, entry in data.items():
         with open("{}/content/volumes/{}.md".format(srcdir, anthology_id), "w") as f:
             print("---", file=f)
-            paper_dir = "/papers/{}/{}/".format(anthology_id.split("-")[0], anthology_id)
+            nested_dir = "/volumes/{}/".format(anthology_id)  # backwards-compatibility
             yaml.dump(
                 {
                     "anthology_id": anthology_id,
                     "title": entry["title"],
                     "aliases": [
-                        paper_dir,
+                        nested_dir,
                     ],
                 },
                 default_flow_style=False,

--- a/bin/create_hugo_pages.py
+++ b/bin/create_hugo_pages.py
@@ -108,14 +108,10 @@ def create_volumes(srcdir, clean=False):
     for anthology_id, entry in data.items():
         with open("{}/content/volumes/{}.md".format(srcdir, anthology_id), "w") as f:
             print("---", file=f)
-            nested_dir = "/volumes/{}/".format(anthology_id)  # backwards-compatibility
             yaml.dump(
                 {
                     "anthology_id": anthology_id,
                     "title": entry["title"],
-                    "aliases": [
-                        nested_dir,
-                    ],
                 },
                 default_flow_style=False,
                 stream=f,

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -5,4 +5,3 @@ staticDir = ["static", "data-export"]
 
 [permalinks]
   papers = "/:filename/"
-  volumes = "/:filename/"

--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -5,3 +5,4 @@ staticDir = ["static", "data-export"]
 
 [permalinks]
   papers = "/:filename/"
+  volumes = "/:filename/"


### PR DESCRIPTION
Removes the outdated alias under `/papers` that is still created for volumes, e.g.

- https://aclanthology.org/papers/2021.eacl/
- https://aclanthology.org/papers/2021.eacl/2021.eacl-main/

Closes #1087