### PR TITLE
Removed links to reviewing notes

### DIFF
--- a/data/xml/2021.acl.xml
+++ b/data/xml/2021.acl.xml
@@ -123,7 +123,6 @@
       <pages>93–102</pages>
       <abstract>Text style transfer aims to alter the style (e.g., sentiment) of a sentence while preserving its content. A common approach is to map a given sentence to content representation that is free of style, and the content representation is fed to a decoder with a target style. Previous methods in filtering style completely remove tokens with style at the token level, which incurs the loss of content information. In this paper, we propose to enhance content preservation by implicitly removing the style information of each token with reverse attention, and thereby retain the content. Furthermore, we fuse content information when building the target style representation, making it dynamic with respect to the content. Our method creates not only style-independent content representation, but also content-dependent style representation in transferring style. Empirical results show that our method outperforms the state-of-the-art baselines by a large margin in terms of content preservation. In addition, it is also competitive in terms of style transfer accuracy and fluency.</abstract>
       <url hash="cca9d69f">2021.acl-long.8</url>
-      <attachment type="notes_to_EAC" hash="df12dc4c">2021.acl-long.8.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.8</doi>
       <bibkey>lee-etal-2021-enhancing</bibkey>
     </paper>
@@ -679,7 +678,6 @@
       <pages>632–643</pages>
       <abstract>While there is an abundance of advice to podcast creators on how to speak in ways that engage their listeners, there has been little data-driven analysis of podcasts that relates linguistic style with engagement. In this paper, we investigate how various factors – vocabulary diversity, distinctiveness, emotion, and syntax, among others – correlate with engagement, based on analysis of the creators’ written descriptions and transcripts of the audio. We build models with different textual representations, and show that the identified features are highly predictive of engagement. Our analysis tests popular wisdom about stylistic elements in high-engagement podcasts, corroborating some pieces of advice and adding new perspectives on others.</abstract>
       <url hash="5a3030ef">2021.acl-long.52</url>
-      <attachment type="notes_to_EAC" hash="e417d218">2021.acl-long.52.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.52</doi>
       <bibkey>reddy-etal-2021-modeling</bibkey>
     </paper>
@@ -2049,7 +2047,6 @@
       <pages>2026–2039</pages>
       <abstract>Understanding manipulated media, from automatically generated ‘deepfakes’ to manually edited ones, raises novel research challenges. Because the vast majority of edited or manipulated images are benign, such as photoshopped images for visual enhancements, the key challenge is to understand the complex layers of underlying intents of media edits and their implications with respect to disinformation. In this paper, we study Edited Media Frames, a new formalism to understand visual media manipulation as structured annotations with respect to the intents, emotional reactions, attacks on individuals, and the overall implications of disinformation. We introduce a dataset for our task, EMU, with 56k question-answer pairs written in rich natural language. We evaluate a wide variety of vision-and-language models for our task, and introduce a new model PELICAN, which builds upon recent progress in pretrained multimodal representations. Our model obtains promising results on our dataset, with humans rating its answers as accurate 48.2% of the time. At the same time, there is still much work to be done – and we provide analysis that highlights areas for further progress.</abstract>
       <url hash="c5c4b557">2021.acl-long.158</url>
-      <attachment type="notes_to_EAC" hash="f7b9a009">2021.acl-long.158.notes_to_EAC.txt</attachment>
       <doi>10.18653/v1/2021.acl-long.158</doi>
       <bibkey>da-etal-2021-edited</bibkey>
     </paper>
@@ -2730,7 +2727,6 @@
       <pages>2700–2717</pages>
       <abstract>On social media platforms, hateful and offensive language negatively impact the mental well-being of users and the participation of people from diverse backgrounds. Automatic methods to detect offensive language have largely relied on datasets with categorical labels. However, comments can vary in their degree of offensiveness. We create the first dataset of English language Reddit comments that has fine-grained, real-valued scores between -1 (maximally supportive) and 1 (maximally offensive). The dataset was annotated using Best–Worst Scaling, a form of comparative annotation that has been shown to alleviate known biases of using rating scales. We show that the method produces highly reliable offensiveness scores. Finally, we evaluate the ability of widely-used neural models to predict offensiveness scores on this new dataset.</abstract>
       <url hash="76242902">2021.acl-long.210</url>
-      <attachment type="notes_to_EAC" hash="6f4bb267">2021.acl-long.210.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.210</doi>
       <bibkey>hada-etal-2021-ruddit</bibkey>
     </paper>
@@ -3250,7 +3246,6 @@
       <pages>3214–3225</pages>
       <abstract>Metaphor involves not only a linguistic phenomenon, but also a cognitive phenomenon structuring human thought, which makes understanding it challenging. As a means of cognition, metaphor is rendered by more than texts alone, and multimodal information in which vision/audio content is integrated with the text can play an important role in expressing and understanding metaphor. However, previous metaphor processing and understanding has focused on texts, partly due to the unavailability of large-scale datasets with ground truth labels of multimodal metaphor. In this paper, we introduce MultiMET, a novel multimodal metaphor dataset to facilitate understanding metaphorical information from multimodal text and image. It contains 10,437 text-image pairs from a range of sources with multimodal annotations of the occurrence of metaphors, domain relations, sentiments metaphors convey, and author intents. MultiMET opens the door to automatic metaphor understanding by investigating multimodal cues and their interplay. Moreover, we propose a range of strong baselines and show the importance of combining multimodal cues for metaphor understanding. MultiMET will be released publicly for research.</abstract>
       <url hash="c0c0f938">2021.acl-long.249</url>
-      <attachment type="notes_to_EAC" hash="d2d8637d">2021.acl-long.249.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.249</doi>
       <bibkey>zhang-etal-2021-multimet</bibkey>
     </paper>
@@ -4248,7 +4243,6 @@
       <pages>4229–4239</pages>
       <abstract>Most of the recent work on personality detection from online posts adopts multifarious deep neural networks to represent the posts and builds predictive models in a data-driven manner, without the exploitation of psycholinguistic knowledge that may unveil the connections between one’s language use and his psychological traits. In this paper, we propose a psycholinguistic knowledge-based tripartite graph network, TrigNet, which consists of a tripartite graph network and a BERT-based graph initializer. The graph network injects structural psycholinguistic knowledge in LIWC, a computerized instrument for psycholinguistic analysis, by constructing a heterogeneous tripartite graph. The initializer is employed to provide initial embeddings for the graph nodes. To reduce the computational cost in graph learning, we further propose a novel flow graph attention network (GAT) that only transmits messages between neighboring parties in the tripartite graph. Benefiting from the tripartite graph, TrigNet can aggregate post information from a psychological perspective, which is a novel way of exploiting domain knowledge. Extensive experiments on two datasets show that TrigNet outperforms the existing state-of-art model by 3.47 and 2.10 points in average F1. Moreover, the flow GAT reduces the FLOPS and Memory measures by 38% and 32%, respectively, in comparison to the original GAT in our setting.</abstract>
       <url hash="1ce7a5d7">2021.acl-long.326</url>
-      <attachment type="notes_to_EAC" hash="9fdf47ef">2021.acl-long.326.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.326</doi>
       <bibkey>yang-etal-2021-psycholinguistic</bibkey>
     </paper>
@@ -5008,7 +5002,6 @@
       <pages>4985–4999</pages>
       <abstract>An important risk that children face today is online grooming, where a so-called sexual predator establishes an emotional connection with a minor online with the objective of sexual abuse. Prior work has sought to automatically identify grooming chats, but only after an incidence has already happened in the context of legal prosecution. In this work, we instead investigate this problem from the point of view of prevention. We define and study the task of early sexual predator detection (eSPD) in chats, where the goal is to analyze a running chat from its beginning and predict grooming attempts as early and as accurately as possible. We survey existing datasets and their limitations regarding eSPD, and create a new dataset called PANC for more realistic evaluations. We present strong baselines built on BERT that also reach state-of-the-art results for conventional SPD. Finally, we consider coping with limited computational resources, as real-life applications require eSPD on mobile devices.</abstract>
       <url hash="bcd5f00f">2021.acl-long.386</url>
-      <attachment type="notes_to_EAC" hash="d5d13cf9">2021.acl-long.386.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.386</doi>
       <bibkey>vogt-etal-2021-early</bibkey>
     </paper>
@@ -5490,7 +5483,6 @@
       <pages>5446–5456</pages>
       <abstract>User interest modeling is critical for personalized news recommendation. Existing news recommendation methods usually learn a single user embedding for each user from their previous behaviors to represent their overall interest. However, user interest is usually diverse and multi-grained, which is difficult to be accurately modeled by a single user embedding. In this paper, we propose a news recommendation method with hierarchical user interest modeling, named HieRec. Instead of a single user embedding, in our method each user is represented in a hierarchical interest tree to better capture their diverse and multi-grained interest in news. We use a three-level hierarchy to represent 1) overall user interest; 2) user interest in coarse-grained topics like sports; and 3) user interest in fine-grained topics like football. Moreover, we propose a hierarchical user interest matching framework to match candidate news with different levels of user interest for more accurate user interest targeting. Extensive experiments on two real-world datasets validate our method can effectively improve the performance of user modeling for personalized news recommendation.</abstract>
       <url hash="5c346a48">2021.acl-long.423</url>
-      <attachment type="notes_to_EAC" hash="a5a000e4">2021.acl-long.423.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.423</doi>
       <bibkey>qi-etal-2021-hierec</bibkey>
     </paper>
@@ -5944,7 +5936,6 @@
       <pages>5894–5903</pages>
       <abstract>When evaluating an article and the claims it makes, a critical reader must be able to assess where the information presented comes from, and whether the various claims are mutually consistent and support the conclusion. This motivates the study of <i>claim provenance</i>, which seeks to trace and explain the origins of claims. In this paper, we introduce new techniques to model and reason about the provenance of <i>multiple</i> interacting claims, including how to capture <i>fine-grained</i> information about the context. Our solution hinges on first identifying the sentences that potentially contain important external information. We then develop a query generator with our novel <i>rank-aware cross attention</i> mechanism, which aims at generating metadata for the source article, based on the context and the signals collected from a search engine. This establishes relevant search queries, and it allows us to obtain source article candidates for each identified sentence and propose an ILP based algorithm to infer the best sources. We experiment with a newly created evaluation dataset, Politi-Prov, based on fact-checking articles from <url>www.politifact.com</url>; our experimental results show that our solution leads to a significant improvement over baselines.</abstract>
       <url hash="2b607c0f">2021.acl-long.458</url>
-      <attachment type="notes_to_EAC" hash="8fd575e6">2021.acl-long.458.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.458</doi>
       <bibkey>zhang-etal-2021-article</bibkey>
     </paper>
@@ -7075,7 +7066,6 @@
       <pages>6999–7013</pages>
       <abstract>Humans are increasingly interacting with machines through language, sometimes in contexts where the user may not know they are talking to a machine (like over the phone or a text chatbot). We aim to understand how system designers and researchers might allow their systems to confirm its non-human identity. We collect over 2,500 phrasings related to the intent of “Are you a robot?”. This is paired with over 2,500 adversarially selected utterances where only confirming the system is non-human would be insufficient or disfluent. We compare classifiers to recognize the intent and discuss the precision/recall and model complexity tradeoffs. Such classifiers could be integrated into dialog systems to avoid undesired deception. We then explore how both a generative research model (Blender) as well as two deployed systems (Amazon Alexa, Google Assistant) handle this intent, finding that systems often fail to confirm their non-human identity. Finally, we try to understand what a good response to the intent would be, and conduct a user study to compare the important aspects when responding to this intent.</abstract>
       <url hash="d893de79">2021.acl-long.544</url>
-      <attachment type="notes_to_EAC" hash="0d75dd81">2021.acl-long.544.notes_to_EAC.txt</attachment>
       <doi>10.18653/v1/2021.acl-long.544</doi>
       <bibkey>gros-etal-2021-r</bibkey>
     </paper>
@@ -8800,7 +8790,6 @@
       <pages>886–896</pages>
       <abstract>Under the pandemic of COVID-19, people experiencing COVID19-related symptoms have a pressing need to consult doctors. Because of the shortage of medical professionals, many people cannot receive online consultations timely. To address this problem, we aim to develop a medical dialog system that can provide COVID19-related consultations. We collected two dialog datasets – CovidDialog – (in English and Chinese respectively) containing conversations between doctors and patients about COVID-19. While the largest of their kind, these two datasets are still relatively small compared with general-domain dialog datasets. Training complex dialog generation models on small datasets bears high risk of overfitting. To alleviate overfitting, we develop a multi-task learning approach, which regularizes the data-deficient dialog generation task with a masked token prediction task. Experiments on the CovidDialog datasets demonstrate the effectiveness of our approach. We perform both human evaluation and automatic evaluation of dialogs generated by our method. Results show that the generated responses are promising in being doctor-like, relevant to conversation history, clinically informative and correct. The code and the data are available at https://github.com/UCSD-AI4H/COVID-Dialogue.</abstract>
       <url hash="2a7f9b48">2021.acl-short.112</url>
-      <attachment type="notes_to_EAC" hash="97dce853">2021.acl-short.112.notes_to_EAC.pdf</attachment>
       <attachment type="OptionalSupplementaryMaterial" hash="355f799d">2021.acl-short.112.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-short.112</doi>
       <bibkey>zhou-etal-2021-generation</bibkey>

--- a/data/xml/2021.case.xml
+++ b/data/xml/2021.case.xml
@@ -122,7 +122,6 @@
       <pages>68–78</pages>
       <abstract>The dynamics and influence of fake news on Twitter during the 2020 US presidential election remains to be clarified. Here, we use a dataset related to 2020 U.S Election that consists of news articles and tweets on those articles. Therefore, it is extremely important to stop the spread of fake news before it reaches a mass level, which is a big challenge. We propose a novel fake news detection framework that can address this challenge. Our proposed framework exploits the information from news articles and social contexts to detect fake news. The proposed model is based on a Transformer architecture, which can learn useful representations from fake news data and predicts the probability of a news as being fake or real. Experimental results on real-world data show that our model can detect fake news with higher accuracy and much earlier, compared to the baselines.</abstract>
       <url hash="f842afbb">2021.case-1.10</url>
-      <attachment type="notes_to_EAC" hash="8635d3ba">2021.case-1.10.notes_to_EAC.txt</attachment>
       <doi>10.18653/v1/2021.case-1.10</doi>
       <bibkey>raza-2021-automatic</bibkey>
     </paper>

--- a/data/xml/2021.findings.xml
+++ b/data/xml/2021.findings.xml
@@ -60,7 +60,6 @@
       <author><first>Manel</first><last>Zarrouk</last></author>
       <pages>41–56</pages>
       <url hash="1e095623">2021.findings-acl.4</url>
-      <attachment type="notes_to_EAC" hash="654141eb">2021.findings-acl.4.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.4</doi>
       <bibkey>azevedo-etal-2021-lux</bibkey>
     </paper>
@@ -148,7 +147,6 @@
       <author><first>Suma</first><last>Bhat</last></author>
       <pages>134–149</pages>
       <url hash="ac00bb38">2021.findings-acl.12</url>
-      <attachment type="notes_to_EAC" hash="40e3cf25">2021.findings-acl.12.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.12</doi>
       <bibkey>zhu-bhat-2021-generate</bibkey>
     </paper>
@@ -283,7 +281,6 @@
       <author><first>Xu</first><last>Sun</last></author>
       <pages>269–280</pages>
       <url hash="f8cd0955">2021.findings-acl.23</url>
-      <attachment type="notes_to_EAC" hash="8783ef3c">2021.findings-acl.23.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.23</doi>
       <bibkey>liu-etal-2021-contrastive</bibkey>
     </paper>
@@ -365,7 +362,6 @@
       <author><first>Wei</first><last>Lu</last></author>
       <pages>351–362</pages>
       <url hash="0dde8d27">2021.findings-acl.30</url>
-      <attachment type="notes_to_EAC" hash="3880a0a8">2021.findings-acl.30.notes_to_EAC.txt</attachment>
       <doi>10.18653/v1/2021.findings-acl.30</doi>
       <bibkey>zhou-etal-2021-entity</bibkey>
     </paper>
@@ -950,7 +946,6 @@
       <author><first>Marco</first><last>Guerini</last></author>
       <pages>899–914</pages>
       <url hash="1d1d9f3b">2021.findings-acl.79</url>
-      <attachment type="notes_to_EAC" hash="d9eb3d5e">2021.findings-acl.79.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.79</doi>
       <bibkey>chung-etal-2021-towards</bibkey>
     </paper>
@@ -1089,7 +1084,6 @@
       <author><first>Jie</first><last>Zhou</last></author>
       <pages>1057–1067</pages>
       <url hash="c7c49d84">2021.findings-acl.91</url>
-      <attachment type="notes_to_EAC" hash="95e2eba9">2021.findings-acl.91.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.91</doi>
       <bibkey>li-etal-2021-addressing</bibkey>
     </paper>
@@ -1216,7 +1210,6 @@
       <author><first>Yunbo</first><last>Cao</last></author>
       <pages>1190–1200</pages>
       <url hash="c14c9d6a">2021.findings-acl.101</url>
-      <attachment type="notes_to_EAC" hash="0879c117">2021.findings-acl.101.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.101</doi>
       <bibkey>zhang-etal-2021-enhancing</bibkey>
     </paper>
@@ -2170,7 +2163,6 @@
       <author><first>Peter</first><last>Chin</last></author>
       <pages>2086–2095</pages>
       <url hash="27c8dd09">2021.findings-acl.183</url>
-      <attachment type="notes_to_EAC" hash="55f7dac8">2021.findings-acl.183.notes_to_EAC.docx</attachment>
       <doi>10.18653/v1/2021.findings-acl.183</doi>
       <bibkey>colon-hernandez-etal-2021-retrogan</bibkey>
     </paper>
@@ -2307,7 +2299,6 @@
       <author><first>Mamoru</first><last>Komachi</last></author>
       <pages>2199–2213</pages>
       <url hash="7acf3fc7">2021.findings-acl.194</url>
-      <attachment type="notes_to_EAC" hash="accc0fd0">2021.findings-acl.194.notes_to_EAC.txt</attachment>
       <attachment type="OptionalSupplementaryMaterial" hash="69d21a70">2021.findings-acl.194.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.findings-acl.194</doi>
       <bibkey>chen-etal-2021-neural</bibkey>
@@ -2730,7 +2721,6 @@
       <author><first>Arun</first><last>Sacheti</last></author>
       <pages>2594–2603</pages>
       <url hash="a493c234">2021.findings-acl.229</url>
-      <attachment type="notes_to_EAC" hash="35d5e242">2021.findings-acl.229.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.229</doi>
       <bibkey>su-etal-2021-gem</bibkey>
     </paper>
@@ -2867,7 +2857,6 @@
       <author><first>Lei</first><last>Li</last></author>
       <pages>2739–2750</pages>
       <url hash="467059aa">2021.findings-acl.242</url>
-      <attachment type="notes_to_EAC" hash="195e1a45">2021.findings-acl.242.notes_to_EAC.txt</attachment>
       <doi>10.18653/v1/2021.findings-acl.242</doi>
       <bibkey>wang-etal-2021-contrastive</bibkey>
     </paper>
@@ -3230,7 +3219,6 @@
       <author><first>Rada</first><last>Mihalcea</last></author>
       <pages>3099–3113</pages>
       <url hash="3f43f9a9">2021.findings-acl.273</url>
-      <attachment type="notes_to_EAC" hash="6a9c0454">2021.findings-acl.273.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.273</doi>
       <bibkey>jin-etal-2021-good</bibkey>
     </paper>
@@ -3621,7 +3609,6 @@
       <author><first>John</first><last>Segrave</last></author>
       <pages>3509–3521</pages>
       <url hash="37af783d">2021.findings-acl.308</url>
-      <attachment type="notes_to_EAC" hash="15b19943">2021.findings-acl.308.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.308</doi>
       <bibkey>lopez-etal-2021-towards</bibkey>
     </paper>
@@ -3796,7 +3783,6 @@
       <author><first>Benjamin J.</first><last>Radford</last></author>
       <pages>3713–3720</pages>
       <url hash="c0e3f5a8">2021.findings-acl.325</url>
-      <attachment type="notes_to_EAC" hash="18d68ec1">2021.findings-acl.325.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.325</doi>
       <bibkey>halterman-radford-2021-shot</bibkey>
     </paper>
@@ -4033,7 +4019,6 @@
       <author><first>Victor</first><last>Zhong</last></author>
       <pages>3932–3944</pages>
       <url hash="dc7631f4">2021.findings-acl.344</url>
-      <attachment type="notes_to_EAC" hash="ef9288f5">2021.findings-acl.344.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.344</doi>
       <bibkey>reid-zhong-2021-lewis</bibkey>
     </paper>
@@ -4047,7 +4032,6 @@
       <author><first>Chitta</first><last>Baral</last></author>
       <pages>3945–3957</pages>
       <url hash="23ebcbc9">2021.findings-acl.345</url>
-      <attachment type="notes_to_EAC" hash="d6633d75">2021.findings-acl.345.notes_to_EAC.pdf</attachment>
       <attachment type="OptionalSupplementaryMaterial" hash="2869e37a">2021.findings-acl.345.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.findings-acl.345</doi>
       <bibkey>pal-etal-2021-constructing</bibkey>
@@ -4854,7 +4838,6 @@
       <author><first>William Yang</first><last>Wang</last></author>
       <pages>4718–4729</pages>
       <url hash="3d174b41">2021.findings-acl.416</url>
-      <attachment type="notes_to_EAC" hash="819a65c7">2021.findings-acl.416.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.416</doi>
       <bibkey>levy-etal-2021-investigating</bibkey>
     </paper>
@@ -4877,7 +4860,6 @@
       <author><first>Katharina</first><last>Kann</last></author>
       <pages>4739–4751</pages>
       <url hash="248bc591">2021.findings-acl.418</url>
-      <attachment type="notes_to_EAC" hash="914637fb">2021.findings-acl.418.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.418</doi>
       <bibkey>ganesh-etal-2021-teacher</bibkey>
     </paper>
@@ -5255,7 +5237,6 @@
       <author><first>Ting</first><last>Liu</last></author>
       <pages>5075–5084</pages>
       <url hash="14fdf687">2021.findings-acl.450</url>
-      <attachment type="notes_to_EAC" hash="174d0f56">2021.findings-acl.450.notes_to_EAC.pdf</attachment>
       <doi>10.18653/v1/2021.findings-acl.450</doi>
       <bibkey>zhang-etal-2021-refer</bibkey>
     </paper>

--- a/data/xml/2021.gem.xml
+++ b/data/xml/2021.gem.xml
@@ -51,7 +51,6 @@
       <pages>24–33</pages>
       <abstract>ROUGE is a widely used evaluation metric in text summarization. However, it is not suitable for the evaluation of abstractive summarization systems as it relies on lexical overlap between the gold standard and the generated summaries. This limitation becomes more apparent for agglutinative languages with very large vocabularies and high type/token ratios. In this paper, we present semantic similarity models for Turkish and apply them as evaluation metrics for an abstractive summarization task. To achieve this, we translated the English STSb dataset into Turkish and presented the first semantic textual similarity dataset for Turkish as well. We showed that our best similarity models have better alignment with average human judgments compared to ROUGE in both Pearson and Spearman correlations.</abstract>
       <url hash="e7d5e247">2021.gem-1.3</url>
-      <attachment type="OptionalSupplementaryMaterial" hash="3bfbe003">2021.gem-1.3.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.gem-1.3</doi>
       <bibkey>beken-fikri-etal-2021-semantic</bibkey>
     </paper>


### PR DESCRIPTION
Reviewing notes were inadvertently submitted for ingestion as attachments. This removes them. (I have already 404'd the attachments themselves).