### PR TITLE
ingested iwslt 2011

### DIFF
--- a/data/xml/2011.iwslt.xml
+++ b/data/xml/2011.iwslt.xml
@@ -1,0 +1,418 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection id="2011.iwslt">
+  <volume id="keynotes" ingest-date="2021-08-08">
+    <meta>
+      <booktitle>Proceedings of the 8th International Workshop on Spoken Language Translation: Keynotes</booktitle>
+      <address>San Francisco, California</address>
+      <month>December 8-9</month>
+      <year>2011</year>
+      <editor><first>Marcello</first><last>Federico</last></editor>
+      <editor><first>Mei-Yuh</first><last>Hwang</last></editor>
+      <editor><first>Margit</first><last>Rödder</last></editor>
+      <editor><first>Sebastian</first><last>Stüker</last></editor>
+    </meta>
+    <paper id="1">
+      <title>Data-intensive approaches for <fixed-case>ASR</fixed-case></title>
+      <author><first>Sadaoki</first><last>Furui</last></author>
+      <url hash="0489e794">2011.iwslt-keynotes.1</url>
+      <bibkey>furui-2011-data</bibkey>
+    </paper>
+    <paper id="2">
+      <title>Meaning-equivalent semantics forunderstanding, generation, translation, and evaluation</title>
+      <author><first>Daniel</first><last>Marcu</last></author>
+      <url hash="0489e794">2011.iwslt-keynotes.2</url>
+      <bibkey>marcu-2011-meaning</bibkey>
+    </paper>
+    <paper id="3">
+      <title>Resource-rich research on natural language processing and understanding</title>
+      <author><first>Junichi</first><last>Tsujii</last></author>
+      <url hash="0489e794">2011.iwslt-keynotes.3</url>
+      <bibkey>tsujii-2011-resource</bibkey>
+    </paper>
+  </volume>
+  <volume id="evaluation" ingest-date="2021-08-08">
+    <meta>
+      <booktitle>Proceedings of the 8th International Workshop on Spoken Language Translation: Evaluation Campaign</booktitle>
+      <address>San Francisco, California</address>
+      <month>December 8-9</month>
+      <year>2011</year>
+      <editor><first>Marcello</first><last>Federico</last></editor>
+      <editor><first>Mei-Yuh</first><last>Hwang</last></editor>
+      <editor><first>Margit</first><last>Rödder</last></editor>
+      <editor><first>Sebastian</first><last>Stüker</last></editor>
+    </meta>
+    <paper id="1">
+      <title>Overview of the <fixed-case>IWSLT</fixed-case> 2011 evaluation campaign</title>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <author><first>Luisa</first><last>Bentivogli</last></author>
+      <author><first>Michael</first><last>Paul</last></author>
+      <author><first>Sebastian</first><last>Stüker</last></author>
+      <url hash="113d55e2">2011.iwslt-evaluation.1</url>
+      <bibkey>federico-etal-2011-overview</bibkey>
+    </paper>
+    <paper id="2">
+      <title>The <fixed-case>NICT</fixed-case> <fixed-case>ASR</fixed-case> system for <fixed-case>IWSLT</fixed-case>2011</title>
+      <author><first>Kazuhiko</first><last>Abe</last></author>
+      <author><first>Youzheng</first><last>Wu</last></author>
+      <author><first>Chien-lin</first><last>Huang</last></author>
+      <author><first>Paul R.</first><last>Dixon</last></author>
+      <author><first>Shigeki</first><last>Matsuda</last></author>
+      <author><first>Chiori</first><last>Hori</last></author>
+      <author><first>Hideki</first><last>Kashioka</last></author>
+      <url hash="9148faa7">2011.iwslt-evaluation.2</url>
+      <bibkey>abe-etal-2011-nict</bibkey>
+    </paper>
+    <paper id="3">
+      <title>The <fixed-case>MIT</fixed-case>-<fixed-case>LL</fixed-case>/<fixed-case>AFRL</fixed-case> <fixed-case>IWSLT</fixed-case>-2011 <fixed-case>MT</fixed-case> system</title>
+      <author><first>A. Ryan</first><last>Aminzadeh</last></author>
+      <author><first>Tim</first><last>Anderson</last></author>
+      <author><first>Ray</first><last>Slyh</last></author>
+      <author><first>Brian</first><last>Ore</last></author>
+      <author><first>Eric</first><last>Hansen</last></author>
+      <author><first>Wade</first><last>Shen</last></author>
+      <author><first>Jennifer</first><last>Drexler</last></author>
+      <author><first>Terry</first><last>Gleason</last></author>
+      <url hash="de12b0c4">2011.iwslt-evaluation.3</url>
+      <bibkey>aminzadeh-etal-2011-mit</bibkey>
+    </paper>
+    <paper id="4">
+      <title>The <fixed-case>DCU</fixed-case> machine translation systems for <fixed-case>IWSLT</fixed-case> 2011</title>
+      <author><first>Pratyush</first><last>Banerjee</last></author>
+      <author><first>Hala</first><last>Almaghout</last></author>
+      <author><first>Sudip</first><last>Naskar</last></author>
+      <author><first>Johann</first><last>Roturier</last></author>
+      <author><first>Jie</first><last>Jiang</last></author>
+      <author><first>Andy</first><last>Way</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
+      <url hash="d878f84c">2011.iwslt-evaluation.4</url>
+      <bibkey>banerjee-etal-2011-dcu</bibkey>
+    </paper>
+    <paper id="5">
+      <title>The <fixed-case>NICT</fixed-case> translation system for <fixed-case>IWSLT</fixed-case> 2011</title>
+      <author><first>Andrew</first><last>Finch</last></author>
+      <author><first>Chooi-Ling</first><last>Goh</last></author>
+      <author><first>Graham</first><last>Neubig</last></author>
+      <author><first>Eiichiro</first><last>Sumita</last></author>
+      <url hash="938d69c8">2011.iwslt-evaluation.5</url>
+      <bibkey>finch-etal-2011-nict</bibkey>
+    </paper>
+    <paper id="6">
+      <title>The <fixed-case>MSR</fixed-case> system for <fixed-case>IWSLT</fixed-case> 2011 evaluation</title>
+      <author><first>Xiaodong</first><last>He</last></author>
+      <author><first>Amittai</first><last>Axelrod</last></author>
+      <author><first>Li</first><last>Deng</last></author>
+      <author><first>Alex</first><last>Acero</last></author>
+      <author><first>Mei-Yuh</first><last>Hwang</last></author>
+      <author><first>Alisa</first><last>Nguyen</last></author>
+      <author><first>Andrew</first><last>Wang</last></author>
+      <author><first>Xiahui</first><last>Huang</last></author>
+      <url hash="b43a503c">2011.iwslt-evaluation.6</url>
+      <bibkey>he-etal-2011-msr</bibkey>
+    </paper>
+    <paper id="7">
+      <title><fixed-case>LIMSI</fixed-case>’s experiments in domain adaptation for <fixed-case>IWSLT</fixed-case>11</title>
+      <author><first>Thomas</first><last>Lavergne</last></author>
+      <author><first>Alexandre</first><last>Allauzen</last></author>
+      <author><first>Hai-Son</first><last>Le</last></author>
+      <author><first>François</first><last>Yvon</last></author>
+      <url hash="061a09f3">2011.iwslt-evaluation.7</url>
+      <bibkey>lavergne-etal-2011-limsis</bibkey>
+    </paper>
+    <paper id="8">
+      <title><fixed-case>LIG</fixed-case> <fixed-case>E</fixed-case>nglish-<fixed-case>F</fixed-case>rench spoken language translation system for <fixed-case>IWSLT</fixed-case> 2011</title>
+      <author><first>Benjamin</first><last>Lecouteux</last></author>
+      <author><first>Laurent</first><last>Besacier</last></author>
+      <author><first>Hervé</first><last>Blanchon</last></author>
+      <url hash="b04f7a68">2011.iwslt-evaluation.8</url>
+      <bibkey>lecouteux-etal-2011-lig</bibkey>
+    </paper>
+    <paper id="9">
+      <title>The <fixed-case>KIT</fixed-case> <fixed-case>E</fixed-case>nglish-<fixed-case>F</fixed-case>rench translation systems for <fixed-case>IWSLT</fixed-case> 2011</title>
+      <author><first>Mohammed</first><last>Mediani</last></author>
+      <author><first>Eunach</first><last>Cho</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Teresa</first><last>Herrmann</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <url hash="27a8d529">2011.iwslt-evaluation.9</url>
+      <bibkey>mediani-etal-2011-kit</bibkey>
+    </paper>
+    <paper id="10">
+      <title><fixed-case>LIUM</fixed-case>’s systems for the <fixed-case>IWSLT</fixed-case> 2011 speech translation tasks</title>
+      <author><first>Anthony</first><last>Rousseau</last></author>
+      <author><first>Fethi</first><last>Bougares</last></author>
+      <author><first>Paul</first><last>Deléglise</last></author>
+      <author><first>Holger</first><last>Schwenk</last></author>
+      <author><first>Yannick</first><last>Estève</last></author>
+      <url hash="2d5ccc2c">2011.iwslt-evaluation.10</url>
+      <bibkey>rousseau-etal-2011-liums</bibkey>
+    </paper>
+    <paper id="11">
+      <title><fixed-case>FBK</fixed-case>@<fixed-case>IWSLT</fixed-case> 2011</title>
+      <author><first>N.</first><last>Ruiz</last></author>
+      <author><first>A.</first><last>Bisazza</last></author>
+      <author><first>F.</first><last>Brugnara</last></author>
+      <author><first>D.</first><last>Falavigna</last></author>
+      <author><first>D.</first><last>Giuliani</last></author>
+      <author><first>S.</first><last>Jaber</last></author>
+      <author><first>R.</first><last>Gretter</last></author>
+      <author><first>M.</first><last>Federico</last></author>
+      <url hash="30b6364c">2011.iwslt-evaluation.11</url>
+      <bibkey>ruiz-etal-2011-fbk</bibkey>
+    </paper>
+    <paper id="12">
+      <title>The 2011 <fixed-case>KIT</fixed-case> <fixed-case>E</fixed-case>nglish <fixed-case>ASR</fixed-case> system for the <fixed-case>IWSLT</fixed-case> evaluation</title>
+      <author><first>Sebastian</first><last>Stüker</last></author>
+      <author><first>Kevin</first><last>Kilgour</last></author>
+      <author><first>Christian</first><last>Saam</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <url hash="b6da6b7b">2011.iwslt-evaluation.12</url>
+      <bibkey>stuker-etal-2011-2011</bibkey>
+    </paper>
+    <paper id="13">
+      <title><fixed-case>DFKI</fixed-case>’s <fixed-case>SC</fixed-case> and <fixed-case>MT</fixed-case> submissions to <fixed-case>IWSLT</fixed-case> 2011</title>
+      <author><first>David</first><last>Vilar</last></author>
+      <author><first>Eleftherios</first><last>Avramidis</last></author>
+      <author><first>Maja</first><last>Popović</last></author>
+      <author><first>Sabine</first><last>Hunsicker</last></author>
+      <url hash="d667bfbc">2011.iwslt-evaluation.13</url>
+      <bibkey>vilar-etal-2011-dfkis</bibkey>
+    </paper>
+    <paper id="14">
+      <title>The <fixed-case>RWTH</fixed-case> <fixed-case>A</fixed-case>achen machine translation system for <fixed-case>IWSLT</fixed-case> 2011</title>
+      <author><first>Joern</first><last>Wuebker</last></author>
+      <author><first>Matthias</first><last>Huck</last></author>
+      <author><first>Saab</first><last>Mansour</last></author>
+      <author><first>Markus</first><last>Freitag</last></author>
+      <author><first>Minwei</first><last>Feng</last></author>
+      <author><first>Stephan</first><last>Peitz</last></author>
+      <author><first>Christoph</first><last>Schmidt</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <url hash="05e5a9d7">2011.iwslt-evaluation.14</url>
+      <bibkey>wuebker-etal-2011-rwth</bibkey>
+    </paper>
+    <paper id="15">
+      <title>Advances on spoken language translation in the Quaero program</title>
+      <author><first>Karim</first><last>Boudahmane</last></author>
+      <author><first>Bianka</first><last>Buschbeck</last></author>
+      <author><first>Eunah</first><last>Cho</last></author>
+      <author><first>Josep Maria</first><last>Crego</last></author>
+      <author><first>Markus</first><last>Freitag</last></author>
+      <author><first>Thomas</first><last>Lavergne</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Stephan</first><last>Peitz</last></author>
+      <author><first>Jean</first><last>Senellart</last></author>
+      <author><first>Artem</first><last>Sokolov</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <author><first>Tonio</first><last>Wandmacher</last></author>
+      <author><first>Joern</first><last>Wuebker</last></author>
+      <author><first>François</first><last>Yvon</last></author>
+      <url hash="3572d751">2011.iwslt-evaluation.15</url>
+      <bibkey>boudahmane-etal-2011-advances</bibkey>
+    </paper>
+    <paper id="16">
+      <title>Speech recognition for machine translation in Quaero</title>
+      <author><first>Lori</first><last>Lamel</last></author>
+      <author><first>Sandrine</first><last>Courcinous</last></author>
+      <author><first>Julien</first><last>Despres</last></author>
+      <author><first>Jean-Luc</first><last>Gauvain</last></author>
+      <author><first>Yvan</first><last>Josse</last></author>
+      <author><first>Kevin</first><last>Kilgour</last></author>
+      <author><first>Florian</first><last>Kraft</last></author>
+      <author><first>Viet-Bac</first><last>Le</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <author><first>Markus</first><last>Nußbaum-Thom</last></author>
+      <author><first>Ilya</first><last>Oparin</last></author>
+      <author><first>Tim</first><last>Schlippe</last></author>
+      <author><first>Ralf</first><last>Schlüter</last></author>
+      <author><first>Tanja</first><last>Schultz</last></author>
+      <author><first>Thiago</first><last>Fraga da Silva</last></author>
+      <author><first>Sebastian</first><last>Stüker</last></author>
+      <author><first>Martin</first><last>Sundermeyer</last></author>
+      <author><first>Bianca</first><last>Vieru</last></author>
+      <author><first>Ngoc Thang</first><last>Vu</last></author>
+      <author><first>Alexander</first><last>Waibel</last></author>
+      <author><first>Cécile</first><last>Woehrling</last></author>
+      <url hash="2cbe7229">2011.iwslt-evaluation.16</url>
+      <bibkey>lamel-etal-2011-speech</bibkey>
+    </paper>
+    <paper id="17">
+      <title>Protocol and lessons learnt from the production of parallel corpora for the evaluation of speech translation systems</title>
+      <author><first>Victoria</first><last>Arranz</last></author>
+      <author><first>Olivier</first><last>Hamon</last></author>
+      <author><first>Karim</first><last>Boudahmane</last></author>
+      <author><first>Martine</first><last>Garnier-Rizet</last></author>
+      <url hash="ed5f2c65">2011.iwslt-evaluation.17</url>
+      <bibkey>arranz-etal-2011-protocol</bibkey>
+    </paper>
+    <paper id="18">
+      <title>Fill-up versus interpolation methods for phrase-based <fixed-case>SMT</fixed-case> adaptation</title>
+      <author><first>Arianna</first><last>Bisazza</last></author>
+      <author><first>Nick</first><last>Ruiz</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <url hash="1ada6040">2011.iwslt-evaluation.18</url>
+      <bibkey>bisazza-etal-2011-fill</bibkey>
+    </paper>
+    <paper id="19">
+      <title>Semantic smoothing and fabrication of phrase pairs for <fixed-case>SMT</fixed-case></title>
+      <author><first>Boxing</first><last>Chen</last></author>
+      <author><first>Roland</first><last>Kuhn</last></author>
+      <author><first>George</first><last>Foster</last></author>
+      <url hash="46e7782b">2011.iwslt-evaluation.19</url>
+      <bibkey>chen-etal-2011-semantic</bibkey>
+    </paper>
+    <paper id="20">
+      <title><fixed-case>SCFG</fixed-case> latent annotation for machine translation</title>
+      <author><first>Tagyoung</first><last>Chung</last></author>
+      <author><first>Licheng</first><last>Fang</last></author>
+      <author><first>Daniel</first><last>Gildea</last></author>
+      <url hash="203d363e">2011.iwslt-evaluation.20</url>
+      <bibkey>chung-etal-2011-scfg</bibkey>
+    </paper>
+    <paper id="21">
+      <title>Long-distance hierarchical structure transformation rules utilizing function words</title>
+      <author><first>Chenchen</first><last>Ding</last></author>
+      <author><first>Takashi</first><last>Inui</last></author>
+      <author><first>Mikio</first><last>Yamamoto</last></author>
+      <url hash="c7b447fc">2011.iwslt-evaluation.21</url>
+      <bibkey>ding-etal-2011-long</bibkey>
+    </paper>
+    <paper id="22">
+      <title>Investigation of the effects of <fixed-case>ASR</fixed-case> tuning on speech translation performance</title>
+      <author><first>Paul R.</first><last>Dixon</last></author>
+      <author><first>Andrew</first><last>Finch</last></author>
+      <author><first>Chiori</first><last>Hori</last></author>
+      <author><first>Hideki</first><last>Kashioka</last></author>
+      <url hash="b94f7a70">2011.iwslt-evaluation.22</url>
+      <bibkey>dixon-etal-2011-investigation</bibkey>
+    </paper>
+    <paper id="23">
+      <title>Extending a probabilistic phrase alignment approach for <fixed-case>SMT</fixed-case></title>
+      <author><first>Mridul</first><last>Gupta</last></author>
+      <author><first>Sanjika</first><last>Hewavitharana</last></author>
+      <author><first>Stephan</first><last>Vogel</last></author>
+      <url hash="fba3de80">2011.iwslt-evaluation.23</url>
+      <bibkey>gupta-etal-2011-extending</bibkey>
+    </paper>
+    <paper id="24">
+      <title>Left language model state for syntactic machine translation</title>
+      <author><first>Kenneth</first><last>Heafield</last></author>
+      <author><first>Hieu</first><last>Hoang</last></author>
+      <author><first>Philipp</first><last>Koehn</last></author>
+      <author><first>Tetsuo</first><last>Kiso</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <url hash="0ed91638">2011.iwslt-evaluation.24</url>
+      <bibkey>heafield-etal-2011-left</bibkey>
+    </paper>
+  </volume>
+  <volume id="papers" ingest-date="2021-08-08">
+    <meta>
+      <booktitle>Proceedings of the 8th International Workshop on Spoken Language Translation: Papers</booktitle>
+      <address>San Francisco, California</address>
+      <month>December 8-9</month>
+      <year>2011</year>
+      <editor><first>Marcello</first><last>Federico</last></editor>
+      <editor><first>Mei-Yuh</first><last>Hwang</last></editor>
+      <editor><first>Margit</first><last>Rödder</last></editor>
+      <editor><first>Sebastian</first><last>Stüker</last></editor>
+    </meta>
+    <paper id="1">
+      <title>Lexicon models for hierarchical phrase-based machine translation</title>
+      <author><first>Matthias</first><last>Huck</last></author>
+      <author><first>Saab</first><last>Mansour</last></author>
+      <author><first>Simon</first><last>Wiesler</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <url hash="32e16503">2011.iwslt-papers.1</url>
+      <bibkey>huck-etal-2011-lexicon</bibkey>
+    </paper>
+    <paper id="2">
+      <title>The 2011 <fixed-case>KIT</fixed-case> <fixed-case>QUAERO</fixed-case> speech-to-text system for <fixed-case>S</fixed-case>panish</title>
+      <author><first>Kevin</first><last>Kilgour</last></author>
+      <author><first>Christian</first><last>Saam</last></author>
+      <author><first>Christian</first><last>Mohr</last></author>
+      <author><first>Sebastian</first><last>Stüker</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <url hash="feecd0c9">2011.iwslt-papers.2</url>
+      <bibkey>kilgour-etal-2011-2011</bibkey>
+    </paper>
+    <paper id="3">
+      <title>Named entity translation using anchor texts</title>
+      <author><first>Wang</first><last>Ling</last></author>
+      <author><first>Pável</first><last>Calado</last></author>
+      <author><first>Bruno</first><last>Martins</last></author>
+      <author><first>Isabel</first><last>Trancoso</last></author>
+      <author><first>Alan</first><last>Black</last></author>
+      <author><first>Luísa</first><last>Coheur</last></author>
+      <url hash="5c15b5a0">2011.iwslt-papers.3</url>
+      <bibkey>ling-etal-2011-named</bibkey>
+    </paper>
+    <paper id="4">
+      <title>Unsupervised vocabulary selection for simultaneous lecture translation</title>
+      <author><first>Paul</first><last>Maergner</last></author>
+      <author><first>Kevin</first><last>Kilgour</last></author>
+      <author><first>Ian</first><last>Lane</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <url hash="dcbe1e2e">2011.iwslt-papers.4</url>
+      <bibkey>maergner-etal-2011-unsupervised</bibkey>
+    </paper>
+    <paper id="5">
+      <title>Combining translation and language model scoring for domain-specific data filtering</title>
+      <author><first>Saab</first><last>Mansour</last></author>
+      <author><first>Joern</first><last>Wuebker</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <url hash="cb3df999">2011.iwslt-papers.5</url>
+      <bibkey>mansour-etal-2011-combining</bibkey>
+    </paper>
+    <paper id="6">
+      <title>Using <fixed-case>W</fixed-case>ikipedia to translate domain-specific terms in <fixed-case>SMT</fixed-case></title>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <url hash="70e6ac10">2011.iwslt-papers.6</url>
+      <bibkey>niehues-waibel-2011-using</bibkey>
+    </paper>
+    <paper id="7">
+      <title>Modeling punctuation prediction as machine translation</title>
+      <author><first>Stephan</first><last>Peitz</last></author>
+      <author><first>Markus</first><last>Freitag</last></author>
+      <author><first>Arne</first><last>Mauser</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <url hash="d8249e50">2011.iwslt-papers.7</url>
+      <bibkey>peitz-etal-2011-modeling</bibkey>
+    </paper>
+    <paper id="8">
+      <title>Soft string-to-dependency hierarchical machine translation</title>
+      <author><first>Jan-Thorsten</first><last>Peter</last></author>
+      <author><first>Matthias</first><last>Huck</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <author><first>Daniel</first><last>Stein</last></author>
+      <url hash="5cfa3382">2011.iwslt-papers.8</url>
+      <bibkey>peter-etal-2011-soft</bibkey>
+    </paper>
+    <paper id="9">
+      <title>Speaker alignment in synthesised, machine translation communication</title>
+      <author><first>Anne H.</first><last>Schneider</last></author>
+      <author><first>Saturnino</first><last>Luz</last></author>
+      <url hash="ac991f1c">2011.iwslt-papers.9</url>
+      <bibkey>schneider-luz-2011-speaker</bibkey>
+    </paper>
+    <paper id="10">
+      <title>How good are your phrases? Assessing phrase quality with single class classification</title>
+      <author><first>Nadi</first><last>Tomeh</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
+      <author><first>Guillaume</first><last>Wisinewski</last></author>
+      <author><first>Alexandre</first><last>Allauzen</last></author>
+      <author><first>François</first><last>Yvon</last></author>
+      <url hash="937f67eb">2011.iwslt-papers.10</url>
+      <bibkey>tomeh-etal-2011-good</bibkey>
+    </paper>
+    <paper id="11">
+      <title>Annotating data selection for improving machine translation</title>
+      <author><first>Keiji</first><last>Yasuda</last></author>
+      <author><first>Hideo</first><last>Okuma</last></author>
+      <author><first>Masao</first><last>Utiyama</last></author>
+      <author><first>Eiichiro</first><last>Sumita</last></author>
+      <url hash="7c003b73">2011.iwslt-papers.11</url>
+      <bibkey>yasuda-etal-2011-annotating</bibkey>
+    </paper>
+  </volume>
+</collection>


### PR DESCRIPTION
See https://aclanthology.org/www.mt-archive.info/10/IWSLT-2011-TOC.htm for original.

* I have called the volume with keynotes `keynotes` instead of `plenaries`. What do you think? Should I change previous editions to `keynotes` as well, since they only include keynotes?
* For the Evaluation Campaign / Papers volume split I have used this website: https://www.isca-speech.org/archive/iwslt_11/
