### PR TITLE
Correction to Anthology ID 2021.wat-1.24

### DIFF
--- a/data/xml/2021.wat.xml
+++ b/data/xml/2021.wat.xml
@@ -330,6 +330,7 @@
       <title>How far can we get with one <fixed-case>GPU</fixed-case> in 100 hours? <fixed-case>C</fixed-case>o<fixed-case>AS</fixed-case>ta<fixed-case>L</fixed-case> at <fixed-case>M</fixed-case>ulti<fixed-case>I</fixed-case>ndic<fixed-case>MT</fixed-case> Shared Task</title>
       <author><first>Rahul</first><last>Aralikatte</last></author>
       <author><first>Héctor Ricardo</first><last>Murrieta Bello</last></author>
+      <author><first>Miryam</first><last>de Lhoneux</last></author>
       <author><first>Daniel</first><last>Hershcovich</last></author>
       <author><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Anders</first><last>Søgaard</last></author>


### PR DESCRIPTION
My name is missing from our shared task paper. The workshop's organizers approval has been forwarded by email.