### PR TITLE
Rewrite acl.ldc.upenn.edu URLs

### DIFF
--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -29,6 +29,7 @@ RewriteEngine On
 # 301 redirects are guarded with a RewriteCond.
 
 RewriteCond %{HTTPS} !=on [OR]
+RewriteCond %{HTTP_HOST} acl\.ldc\.upenn\.edu [OR]
 RewriteCond %{HTTP_HOST} www\.aclanthology\.org [NC]
 RewriteRule ^(.*)$ https://aclanthology.org/$1 [R=301,L]
 


### PR DESCRIPTION
We got the LDC to redirect old `acl.ldc.upenn.edu` URLs to the Anthology, but we weren't rewriting them, and they're starting to show up in Google. This fixes that.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/455256/131068688-daaa38a2-67c2-4002-acdc-a69ef09deb5d.png">
