### PR TITLE
SIGMORPHON ST0 Extra Papers

### DIFF
--- a/data/xml/2021.sigmorphon.xml
+++ b/data/xml/2021.sigmorphon.xml
@@ -294,5 +294,115 @@
       <doi>10.18653/v1/2021.sigmorphon-1.24</doi>
       <bibkey>sharma-etal-2021-improved</bibkey>
     </paper>
+    <paper id="25">
+      <title>SIGMORPHON 2021 Shared Task on Morphological Reinflection: Generalization Across Languages</title>
+      <author><first>Tiago</first><last>Pimentel</last></author>
+      <author><first>Maria</first><last>Ryskina</last></author>
+      <author><first>Sabrina J.</first><last>Mielke</last></author>
+      <author><first>Shijie</first><last>Wu</last></author>
+      <author><first>Eleanor</first><last>Chodroff</last></author>
+      <author><first>Brian</first><last>Leonard</last></author>
+      <author><first>Garrett</first><last>Nicolai</last></author>
+      <author><first>Yustinus</first><last>Ghanggo Ate</last></author>
+      <author><first>Salam</first><last>Khalifa</last></author>
+      <author><first>Nizar</first><last>Habash</last></author>
+      <author><first>Charbel</first><last>El-Khaissi</last></author>
+      <author><first>Omer</first><last>Goldman</last></author>
+      <author><first>Michael</first><last>Gasser</last></author>
+      <author><first>William</first><last>Lane</last></author>
+      <author><first>Matt</first><last>Coler</last></author>
+      <author><first>Arturo</first><last>Oncevay</last></author>
+      <author><first>Jaime Rafael Montoya</first><last>Samame</last></author>
+      <author><first>Gema Celeste Silva</first><last>Villegas</last></author>
+      <author><first>Adam</first><last>Ek</last></author>
+      <author><first>Jean-Philippe</first><last>Bernardy</last></author>
+      <author><first>Andrey</first><last>Shcherbakov</last></author>
+      <author><first>Aziyana</first><last>Bayyr-ool</last></author>
+      <author><first>Karina</first><last>Sheifer</last></author>
+      <author><first>Sofya</first><last>Ganieva</last></author>
+      <author><first>Matvey</first><last>Plugaryov</last></author>
+      <author><first>Elena</first><last>Klyachko</last></author>
+      <author><first>Ali</first><last>Salehi</last></author>
+      <author><first>Andrew</first><last>Krizhanovsky</last></author>
+      <author><first>Natalia</first><last>Krizhanovsky</last></author>
+      <author><first>Clara</first><last>Vania</last></author>
+      <author><first>Sardana</first><last>Ivanova</last></author>
+      <author><first>Aelita</first><last>Salchak</last></author>
+      <author><first>Christopher</first><last>Straughn</last></author>
+      <author><first>Zoey</first><last>Liu</last></author>
+      <author><first>Jonathan North</first><last>Washington
+      <author><first>Duygu</first><last>Ataman</last></author>
+      <author><first>Witold</first><last>Kieraś</last></author>
+      <author><first>Marcin</first><last>Woliński</last></author>
+      <author><first>Totok</first><last>Suhardijanto</last></author>
+      <author><first>Niklas</first><last>Stoehr</last></author>
+      <author><first>Zahroh</first><last>Nuriah</last></author>
+      <author><first>Shyam</first><last>Ratan</last></author>
+      <author><first>Francis M.</first><last>Tyers</last></author>
+      <author><first>Edoardo M.</first><last>Ponti</last></author>
+      <author><first>Grant</first><last>Aiton</last></author>
+      <author><first>Richard J.</first><last>Hatcher</last></author>
+      <author><first>Emily</first><last>Prud'hommeaux</last></author>
+      <author><first>Ritesh</first><last>Kumar</last></author>
+      <author><first>Mans</first><last>Hulden</last></author>
+      <author><first>Botond</first><last>Barta</last></author>
+      <author><first>Dorina</first><last>Lakatos</last></author>
+      <author><first>Gábor</first><last>Szolnok</last></author>
+      <author><first>Judit</first><last>Ács</last></author>
+      <author><first>Mohit</first><last>Raj</last></author>
+      <author><first>David</first><last>Yarowsky</last></author>
+      <author><first>Ryan</first><last>Cotterell</last></author>
+      <author><first>Ben</first><last>Ambridge</last></author>
+      <author><first>Ekaterina</first><last>Vylomova</last></author>
+      <pages>1–31</pages>
+      <abstract>This year's iteration of the SIGMORPHON Shared Task on morphological reinflection focuses on typological diversity and cross-lingual variation of morphosyntactic features. In terms of the task, we enrich UniMorph with new data for  32 languages from 13 language families, with most of them being under-resourced: Kunwinjku, Classical Syriac, Arabic (Modern Standard, Egyptian, Gulf), Hebrew, Amharic, Aymara, Magahi, Braj, Kurdish (Central, Northern, Southern), Polish, Karelian, Livvi, Ludic, Veps, Võro, Evenki, Xibe, Tuvan, Sakha, Turkish, Indonesian, Kodi, Seneca, Asháninka, Yanesha, Chukchi, Itelmen, Eibela. We evaluate six systems on the new data and conduct an extensive error analysis of the systems' predictions. Transformer-based models generally demonstrate superior performance on the majority of languages, achieving >90% accuracy on 65% of them. The languages on which systems yielded low accuracy are mainly under-resourced, with a limited amount of data. Most errors made by the systems are due to allomorphy, honorificity, and form variation. In addition, we observe that systems especially struggle to inflect multiword lemmas. The systems also produce misspelled forms  or end up in repetitive loops (e.g., RNN-based models). Finally, we report a large drop in systems' performance on previously unseen lemmas.</abstract>
+      <url hash="51afc6c5">2021.sigmorphon-1.25</url>
+      <doi>10.18653/v1/2021.sigmorphon-1.25</doi>
+      <bibkey>pimentel-ryskina-etal-2021-sigmorphon</bibkey>
+    </paper>
+    <paper id="26">
+      <title>Training Strategies for Neural Multilingual Morphological Inflection</title>
+      <author><first>Adam</first><last>Ek</last></author>
+      <author><first>Jean-Philippe</first><last>Bernardy</last></author>
+      <pages>32–39</pages>
+      <abstract>This paper presents the submission of team GUCLASP to SIGMORPHON 2021 Shared Task on Generalization in Morphological Inflection Generation. We develop a multilingual model for Morphological Inflection and primarily focus on improving the model by using various training strategies to improve accuracy and generalization across languages.</abstract>
+      <url hash="a2f6d943">2021.sigmorphon-1.26</url>
+      <doi>10.18653/v1/2021.sigmorphon-1.26</doi>
+      <bibkey>ek-etal-2021-training</bibkey>
+    </paper>
+    <paper id="27">
+      <title>BME Submission for SIGMORPHON 2021 Shared Task 0. A Three Step Training Approach with Data Augmentation for Morphological Inflection</title>
+      <author><first>Gábor</first><last>Szolnok</last></author>
+      <author><first>Botond</first><last>Barta</last></author>
+      <author><first>Dorina</first><last>Lakatos</last></author>
+      <author><first>Judit</first><last>Ács</last></author>
+      <pages>40–45</pages>
+      <abstract>We present the BME submission for the SIGMORPHON 2021 Task 0 Part 1, Generalization Across Typologically Diverse Languages shared task. We use an LSTM encoder-decoder model with three step training that is first trained on all languages, then fine-tuned on each language family and finally fine-tuned on individual languages. We use a different type of data augmentation technique in the first two steps. Our system outperformed the only other submission. Although it remains worse than the Transformer baseline released by the organizers, our model is simpler and our data augmentation techniques are easily applicable to new languages. We perform ablation studies and show that the augmentation techniques and the three training steps often help but sometimes have a negative effect. Our code is publicly available.</abstract>
+      <url hash="eb3f6b82">2021.sigmorphon-1.27</url>
+      <doi>10.18653/v1/2021.sigmorphon-1.27</doi>
+      <bibkey>szolnok-barta-lakatos-etal-2021-bme</bibkey>
+    </paper>
+    <paper id="28">
+      <title>Not Quite There Yet: Combining Analogical Patterns and Encoder-Decoder Networks for Cognitively Plausible Inflection</title>
+      <author><first>Basilio</first><last>Calderone</last></author>
+      <author><first>Nabil</first><last>Hathout</last></author>
+      <author><first>Olivier</first><last>Bonami</last></author>
+      <pages>46–54</pages>
+      <abstract>The paper presents four models submitted to Part 2 of the SIGMORPHON 2021 Shared Task 0, which aims at replicating human judgements on the inflection of nonce lexemes. Our goal is to explore the usefulness of combining pre-compiled analogical patterns with an encoder-decoder architecture. Two models are designed using such patterns either in the input or the output of the network. Two extra models controlled for the role of raw similarity of nonce inflected forms to existing inflected forms in the same paradigm cell, and the role of the type frequency of analogical patterns. Our strategy is entirely endogenous in the sense that the models appealing solely to the data provided by the SIGMORPHON organisers, without using external resources. Our model 2 ranks second among all submitted systems, suggesting that the inclusion of analogical patterns in the network architecture is useful in mimicking speakers’ predictions.</abstract>
+      <url hash="7a950cab">2021.sigmorphon-1.28</url>
+      <doi>10.18653/v1/2021.sigmorphon-1.28</doi>
+      <bibkey>calderone-etal-2021-not-quite</bibkey>
+    </paper>
+    <paper id="29">
+      <title>Were We There Already? Applying Minimal Generalization to the SIGMORPHON-UniMorph Shared Task on Cognitively Plausible Morphological Inflection</title>
+      <author><first>Colin</first><last>Wilson</last></author>
+      <author><first>Jane S.Y.</first><last>Li</last></author>
+      <pages>55–63</pages>
+      <abstract>Morphological rules with various levels of specificity can be learned from example lexemes by recursive application of minimal generalization (Albright and Hayes, 2002, 2003).
+A model that learns rules solely through minimal generalization was used to predict average human wug-test ratings from German, English, and Dutch in the SIGMORPHON-UniMorph 2021 Shared Task, with competitive results. Some formal properties of the minimal generalization operation were proved. An automatic method was developed to create wug-test stimuli for future experiments that investigate whether the model’s morphological generalizations are too minimal.</abstract>
+      <url hash="0fc07fce">2021.sigmorphon-1.29</url>
+      <doi>10.18653/v1/2021.sigmorphon-1.29</doi>
+      <bibkey>wilson-etal-2021-were</bibkey>
+    </paper>
   </volume>
 </collection>


### PR DESCRIPTION

[2021.sigmorphon-1.25.pdf](https://github.com/acl-org/acl-anthology/files/7091191/2021.sigmorphon-1.25.pdf)
[2021.sigmorphon-1.26.pdf](https://github.com/acl-org/acl-anthology/files/7091192/2021.sigmorphon-1.26.pdf)
[2021.sigmorphon-1.27.pdf](https://github.com/acl-org/acl-anthology/files/7091193/2021.sigmorphon-1.27.pdf)
[2021.sigmorphon-1.28.pdf](https://github.com/acl-org/acl-anthology/files/7091194/2021.sigmorphon-1.28.pdf)
[2021.sigmorphon-1.29.pdf](https://github.com/acl-org/acl-anthology/files/7091195/2021.sigmorphon-1.29.pdf)
SIGMOPRHON 2021 ST0 Extra papers
