### PR TITLE
Update 2021.mtsummit-LoResMT.14 - Rectify Spelling mistake on Author's name

### DIFF
--- a/data/xml/2021.mtsummit.xml
+++ b/data/xml/2021.mtsummit.xml
@@ -958,7 +958,7 @@ Our models outperform massively multilingual models such as Google (<tex-math>+8
       <author><first>Karthik</first><last>Puranik</last></author>
       <author><first>Adeep</first><last>Hande</last></author>
       <author><first>Ruba</first><last>Priyadharshini</last></author>
-      <author><first>Thenmozhi</first><last>Durairaj</last></author>
+      <author><first>Thenmozhi</first><last>D</last></author>
       <author><first>Anbukkarasi</first><last>Sampath</last></author>
       <author><first>Kingston</first><last>Pal Thamburaj</last></author>
       <author><first>Bharathi Raja</first><last>Chakravarthi</last></author>

--- a/data/xml/2021.mtsummit.xml
+++ b/data/xml/2021.mtsummit.xml
@@ -958,7 +958,7 @@ Our models outperform massively multilingual models such as Google (<tex-math>+8
       <author><first>Karthik</first><last>Puranik</last></author>
       <author><first>Adeep</first><last>Hande</last></author>
       <author><first>Ruba</first><last>Priyadharshini</last></author>
-      <author><first>Thenmozi</first><last>Durairaj</last></author>
+      <author><first>Thenmozhi</first><last>Durairaj</last></author>
       <author><first>Anbukkarasi</first><last>Sampath</last></author>
       <author><first>Kingston</first><last>Pal Thamburaj</last></author>
       <author><first>Bharathi Raja</first><last>Chakravarthi</last></author>


### PR DESCRIPTION
Rectify spelling mistakes in Author's name.
Paper: https://aclanthology.org/2021.mtsummit-LoResMT.14/

# Correction:
```Thenmozi Durairaj``` to ```Thenmozhi D```
