### PR TITLE
Remove incorrect software attachment for 2021.eval4nlp-1.5

### DIFF
--- a/data/xml/2021.eval4nlp.xml
+++ b/data/xml/2021.eval4nlp.xml
@@ -65,7 +65,6 @@
       <author><first>Constantine</first><last>Lignos</last></author>
       <pages>40–50</pages>
       <url hash="19ca8fed">2021.eval4nlp-1.5</url>
-      <attachment type="Software" hash="393e384a">2021.eval4nlp-1.5.Software.zip</attachment>
       <bibkey>palen-michel-etal-2021-seqscore</bibkey>
     </paper>
     <paper id="6">


### PR DESCRIPTION
I am one of the authors of the paper "SeqScore: Addressing Barriers to Reproducible Named Entity Recognition Evaluation", 2021.eval4nlp-1.5. The software attachment in the anthology is not from our paper and appears to be another copy of the software from paper 2021.eval4nlp-1.9. Our paper should not have any software attached to it.
