### PR TITLE
Fix CRAC 2020/2021 listings in joint.yaml

### DIFF
--- a/data/yaml/joint.yaml
+++ b/data/yaml/joint.yaml
@@ -323,6 +323,9 @@ crac:
   2021:
   - 2021.codi-main
   - 2021.codi-sharedtask
+  - 2021.crac-1
+  2020:
+  - 2020.crac-1
   2018:
   - W18-07
   2019:
@@ -360,7 +363,7 @@ eamt:
 - W15-49
 - W16-34
 emnlp:
-  2021: [2021.findings-emnlp, 2021.codi-main, 2021.codi-sharedtask, 2021.argmining-1, 2021.blackboxnlp-1, 2021.cinlp-1, 2021-crac.1, 2021.conll-1, 2021.disrpt-1, 2021-eancs.1, 2021.econlp-1, 2021.eval4nlp-1, 2021.fever-1, 2021.latechclfl-1, 2021.law-1, 2021.mrl-1, 2021.mrqa-1, 2021.nllp-1, 2021.nlp4convai-1, 2021.sustainlp-1, 2021.newsum-1, 2021.insights-1, 2021.wnut-1]
+  2021: [2021.findings-emnlp, 2021.codi-main, 2021.codi-sharedtask, 2021.argmining-1, 2021.blackboxnlp-1, 2021.cinlp-1, 2021.crac-1, 2021.conll-1, 2021.disrpt-1, 2021.eancs-1, 2021.econlp-1, 2021.eval4nlp-1, 2021.fever-1, 2021.latechclfl-1, 2021.law-1, 2021.mrl-1, 2021.mrqa-1, 2021.nllp-1, 2021.nlp4convai-1, 2021.sustainlp-1, 2021.newsum-1, 2021.insights-1, 2021.wnut-1]
   2020: [2020.findings-emnlp, 2020.alw-1, 2020.blackboxnlp-1, 2020.clinicalnlp-1, 2020.cmcl-1, 2020.codi-1, 2020.deelio-1, 2020.eval4nlp-1, 2020.insights-1, 2020.intexsempar-1, 2020.louhi-1, 2020.nlpbt-1, 2020.nlpcovid19-2, 2020.nlpcss-1, 2020.nlposs-1, 2020.privatenlp-1, 2020.scai-1, 2020.sdp-1, 2020.sigtyp-1, 2020.splu-1, 2020.spnlp-1, 2020.sustainlp-1, 2020.wmt-1, 2020.wnut-1]
   1996:
   - W96-02


### PR DESCRIPTION
- add CRAC 2020/2021 under crac
- fix spelling of CRAC 2021 under EMNLP 2021 (dash -> dot); also for EANCS.
Fixes #1633
