### PR TITLE
Fix the order of authors in 2021.textgraphs-1.17

### DIFF
--- a/data/xml/2021.textgraphs.xml
+++ b/data/xml/2021.textgraphs.xml
@@ -208,9 +208,9 @@
     </paper>
     <paper id="17">
       <title><fixed-case>T</fixed-case>ext<fixed-case>G</fixed-case>raphs 2021 Shared Task on Multi-Hop Inference for Explanation Regeneration</title>
-      <author><first>Peter</first><last>Jansen</last></author>
       <author><first>Mokanarangan</first><last>Thayaparan</last></author>
       <author><first>Marco</first><last>Valentino</last></author>
+      <author><first>Peter</first><last>Jansen</last></author>
       <author><first>Dmitry</first><last>Ustalov</last></author>
       <pages>156–165</pages>
       <abstract>The Shared Task on Multi-Hop Inference for Explanation Regeneration asks participants to compose large multi-hop explanations to questions by assembling large chains of facts from a supporting knowledge base. While previous editions of this shared task aimed to evaluate explanatory completeness – finding a set of facts that form a complete inference chain, without gaps, to arrive from question to correct answer, this 2021 instantiation concentrates on the subtask of determining relevance in large multi-hop explanations. To this end, this edition of the shared task makes use of a large set of approximately 250k manual explanatory relevancy ratings that augment the 2020 shared task data. In this summary paper, we describe the details of the explanation regeneration task, the evaluation data, and the participating systems. Additionally, we perform a detailed analysis of participating systems, evaluating various aspects involved in the multi-hop inference process. The best performing system achieved an NDCG of 0.82 on this challenging task, substantially increasing performance over baseline methods by 32%, while also leaving significant room for future improvement.</abstract>

--- a/data/xml/2021.textgraphs.xml
+++ b/data/xml/2021.textgraphs.xml
@@ -215,7 +215,7 @@
       <pages>156–165</pages>
       <abstract>The Shared Task on Multi-Hop Inference for Explanation Regeneration asks participants to compose large multi-hop explanations to questions by assembling large chains of facts from a supporting knowledge base. While previous editions of this shared task aimed to evaluate explanatory completeness – finding a set of facts that form a complete inference chain, without gaps, to arrive from question to correct answer, this 2021 instantiation concentrates on the subtask of determining relevance in large multi-hop explanations. To this end, this edition of the shared task makes use of a large set of approximately 250k manual explanatory relevancy ratings that augment the 2020 shared task data. In this summary paper, we describe the details of the explanation regeneration task, the evaluation data, and the participating systems. Additionally, we perform a detailed analysis of participating systems, evaluating various aspects involved in the multi-hop inference process. The best performing system achieved an NDCG of 0.82 on this challenging task, substantially increasing performance over baseline methods by 32%, while also leaving significant room for future improvement.</abstract>
       <url hash="3b22be0b">2021.textgraphs-1.17</url>
-      <bibkey>jansen-etal-2021-textgraphs</bibkey>
+      <bibkey>thayaparan-etal-2021-textgraphs</bibkey>
       <doi>10.18653/v1/2021.textgraphs-1.17</doi>
     </paper>
     <paper id="18">


### PR DESCRIPTION
The order of authors in the published PDF does not match the one listed on ACL Anthology: https://aclanthology.org/2021.textgraphs-1.17/. This pull request fixes this inconsistency by sticking to the correct order in the PDF.