### PR TITLE
Correction to Anthology ID D19-1074 metadata

### DIFF
--- a/data/xml/D19.xml
+++ b/data/xml/D19.xml
@@ -947,6 +947,11 @@
     <paper id="74">
       <title>Towards Linear Time Neural Machine Translation with Capsule Networks</title>
       <author><first>Mingxuan</first><last>Wang</last></author>
+      <author><first>Jun</first><last>Xie</last></author>
+      <author><first>Zhixing</first><last>Tan</last></author>
+      <author><first>Jinsong</first><last>Su</last></author>
+      <author><first>Deyi</first><last>Xiong</last></author>
+      <author><first>Lei</first><last>Li</last></author>
       <pages>803–812</pages>
       <abstract>In this study, we first investigate a novel capsule network with dynamic routing for linear time Neural Machine Translation (NMT), referred as CapsNMT. CapsNMT uses an aggregation mechanism to map the source sentence into a matrix with pre-determined size, and then applys a deep LSTM network to decode the target sequence from the source representation. Unlike the previous work (CITATION) to store the source sentence with a passive and bottom-up way, the dynamic routing policy encodes the source sentence with an iterative process to decide the credit attribution between nodes from lower and higher layers. CapsNMT has two core properties: it runs in time that is linear in the length of the sequences and provides a more flexible way to aggregate the part-whole information of the source sentence. On WMT14 English-German task and a larger WMT14 English-French task, CapsNMT achieves comparable results with the Transformer system. To the best of our knowledge, this is the first work that capsule networks have been empirically investigated for sequence to sequence problems.</abstract>
       <url hash="08fdfea0">D19-1074</url>


### PR DESCRIPTION
**Description of changes**

## Changes to the author list

The previous meta data in xml is not consistent with the author list in the PDF file. Correct the authors according to the PDF's author list.
