### PR TITLE
Make Papers-with-Code workflow use acl-pwc-bot

### DIFF
--- a/.github/workflows/paperswithcode.yml
+++ b/.github/workflows/paperswithcode.yml
@@ -14,28 +14,50 @@ jobs:
   ingest-pwc:
     runs-on: ubuntu-20.04
     steps:
-    - name: update
+    - name: Update system
       run: sudo apt-get update
-    - name: install other deps
+    - name: Install dependencies
       run: sudo apt-get install -y jing bibutils openssh-client rsync libyaml-dev libpython3.8-dev python3-lxml
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+      name: Checkout master branch
       with:
+        ref: master
         fetch-depth: 0
 
-    # Fetch & update metadata
-    - name: Update PwC metadata
+    - id: update-pwc-metadata
+      name: Update PwC metadata
       run: |
         python3 bin/ingest_pwc.py
         git add data/xml/*xml
         make check_staged_xml
 
-    - name: Commit metadata updates
+    # Check conditions for creating a PR
+    # - commits-this-week: number of commits (on master) by the bot during the last 6 days
+    # - lines-changed: number of added + deleted lines by the update-pwc-metadata step
+    - id: check-if-pr
+      name: Check if PR should be created
+      if: steps.update-pwc-metadata.conclusion == 'success'
       run: |
-        if [ ! -z "$(git diff --cached)" ]; then
-            git config user.name github-actions
-            git config user.email github-actions@github.com
-            git commit -m "Update metadata from Papers with Code"
-            git push
-        fi
+        echo "::set-output name=commits-this-week::"$(git log --author='acl-pwc-bot' --after=$(date --date='6 days ago' +%Y-%m-%d) --oneline | wc -l)
+        echo "::set-output name=lines-changed::"$(git diff --cached --numstat data/xml/*xml | awk 'BEGIN {s=0} {s+=$1; s+=$2} END {print s}' -)
+
+    - uses: peter-evans/create-pull-request@v3
+      id: create-pr
+      name: Create pull request
+      if: steps.check-if-pr.outputs.lines-changed > 0 && (steps.check-if-pr.outputs.commits-this-week == 0 || steps.check-if-pr.outputs.lines-changed > 20)
+      with:
+        token: ${{ secrets.PWC_BOT_TOKEN }}
+        push-to-fork: acl-pwc-bot/acl-anthology
+        commit-message: "Update metadata from Papers with Code"
+        title: "[automated] Update metadata from Papers with Code"
+        body: "Automated changes via GitHub action."
+        delete-branch: true
+
+    - uses: hmarr/auto-approve-action@v2
+      name: Automatically approve PR
+      if: steps.create-pr.outputs.pull-request-operation == 'created'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
The current Papers-with-Code workflow doesn't work since **our master branch is protected** (by status checks + reviewer approval). There currently seems to be no way for workflows to bypass this, [unless we also allow all repo admins to bypass this](https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/34), which @mjpost would like to avoid.

This PR will therefore change the workflow as follows:

- Push changes to a fork owned by the new [acl-pwc-bot](https://github.com/acl-pwc-bot/) account, and **create a pull request** from that.
  
   The separate acl-pwc-bot is used so that the PR automatically triggers the build checks, which are required for merging. A pull request created by the workflow itself would _not_ trigger other workflows, such as the build checks. [See here for a detailed explanation and discussion.](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)

- **Automatically approve** the PR created this way. This works since it's the workflow token giving the approval, which is not identical to the bot account that created the PR.

- Run the workflow **daily** (as before), but _only_ create a PR **under one of these conditions:**

   1. The number of lines changed exceeds a certain threshold. (I've set 20, but we can tune that – I have no idea how much PwC info typically changes on a daily basis.)
   2. The last commit by acl-pwc-bot on master is at least a week old.

   My idea here is that we update the info _at least weekly,_ but have a way to trigger PRs more frequently than that if there were major updates (like when new conference proceedings were added, for example). We can remove those conditions and just run the workflow weekly if you feel this is too complex; but I thought it might be good to have this flexibility here.

   Note that if the workflow commits more changes before an existing PR has been merged, this workflow **will update that PR** and _not_ create a new one. So there will only ever be one open PR from this workflow at a time.

When I tested this on my own fork, it looked like this:

![grafik](https://user-images.githubusercontent.com/11348502/142207632-637949ad-84bf-4525-8dc4-645104037fd6.png)
