### PR TITLE
Add workflow to automatically merge acl-pwc-bot's PRs

### DIFF
--- a/.github/workflows/paperswithcode-automerge.yml
+++ b/.github/workflows/paperswithcode-automerge.yml
@@ -1,0 +1,26 @@
+name: Merge PRs from acl-pwc-bot
+
+on:
+  # Triggers when the required build check is completed
+  check_suite:
+    types:
+      - completed
+    workflows:
+      - 'check-build'
+
+jobs:
+  merge-me:
+    name: Merge PR if it's by acl-pwc-bot
+    runs-on: ubuntu-latest
+    steps:
+      - # Only attempt merge when the check was a success
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        name: Merge PR
+        uses: ridedott/merge-me-action@v2
+        with:
+          # Merge only PRs by acl-pwc-bot this way
+          GITHUB_LOGIN: acl-pwc-bot
+          # Merge with acl-pwc-bot credentials, so the merge will trigger our
+          # deployment workflow
+          GITHUB_TOKEN: ${{ secrets.PWC_BOT_TOKEN }}
+          MERGE_METHOD: SQUASH


### PR DESCRIPTION
The documentation led me to believe that we can't automatically merge PRs to a protected branch, but [testing on my personal fork](https://github.com/mbollmann/acl-anthology/pull/12) suggests that it might work after all.

This action would:
- Trigger whenever a build check is completed.
- When the build check belongs to a PR by acl-pwc-bot, attempt to automatically squash-merge it.
- Merging uses @acl-pwc-bot's credentials, since merging via the default token wouldn't trigger our deployment/publish workflow. **This would require inviting @acl-pwc-bot as a collaborator to our repo.** (@mjpost)

