### PR TITLE
Fix pwc-automerge event trigger

### DIFF
--- a/.github/workflows/paperswithcode-automerge.yml
+++ b/.github/workflows/paperswithcode-automerge.yml
@@ -1,0 +1,26 @@
+name: Merge PRs from acl-pwc-bot
+
+on:
+  # Triggers when the required build check is completed
+  check_suite:
+    types:
+      - completed
+    workflows:
+      - 'check-build'
+
+jobs:
+  merge-me:
+    name: Merge PR if it's by acl-pwc-bot
+    runs-on: ubuntu-latest
+    steps:
+      - # Only attempt merge when the check was a success
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        name: Merge PR
+        uses: ridedott/merge-me-action@v2
+        with:
+          # Merge only PRs by acl-pwc-bot this way
+          GITHUB_LOGIN: acl-pwc-bot
+          # Merge with acl-pwc-bot credentials, so the merge will trigger our
+          # deployment workflow
+          GITHUB_TOKEN: ${{ secrets.PWC_BOT_TOKEN }}
+          MERGE_METHOD: SQUASH

--- a/.github/workflows/paperswithcode-automerge.yml
+++ b/.github/workflows/paperswithcode-automerge.yml
@@ -2,7 +2,7 @@ name: Merge PRs from acl-pwc-bot
 
 on:
   # Triggers when the required build check is completed
-  check_suite:
+  workflow_run:
     types:
       - completed
     workflows:


### PR DESCRIPTION
Somehow I put in the wrong event trigger (`check_suite` instead of `workflow_run`) when copying this workflow over from my personal fork... This fixes that.