### PR TITLE
Update Papers with Code action

### DIFF
--- a/.github/workflows/paperswithcode.yml
+++ b/.github/workflows/paperswithcode.yml
@@ -46,13 +46,17 @@ jobs:
     - uses: peter-evans/create-pull-request@v3
       id: create-pr
       name: Create pull request
-      if: steps.check-if-pr.outputs.lines-changed > 0 && (steps.check-if-pr.outputs.commits-this-week == 0 || steps.check-if-pr.outputs.lines-changed > 20)
+      if: steps.check-if-pr.outputs.lines-changed > 0
       with:
         token: ${{ secrets.PWC_BOT_TOKEN }}
         push-to-fork: acl-pwc-bot/acl-anthology
+        author: "acl-pwc-bot <acl-pwc-bot@bollmann.me>"
         commit-message: "Update metadata from Papers with Code"
         title: "[automated] Update metadata from Papers with Code"
-        body: "Automated changes via GitHub action."
+        body: |
+          **Auto-generated PR by GitHub action; will be merged automatically.**
+
+          Update ${{ steps.check-if-pr.outputs.lines-changed }} lines of XML data from [Papers with Code](https://paperswithcode.com/).
         delete-branch: true
 
     - uses: hmarr/auto-approve-action@v2


### PR DESCRIPTION
The action to auto-merge PwC changes now triggers, but [doesn't actually attempt to merge anything](https://github.com/acl-org/acl-anthology/actions/runs/1503675588). I believe that's because the commit in the [automated pull request](https://github.com/acl-org/acl-anthology/pull/1684) is currently attributed to Matt Post, and the automerge action by default doesn't attempt the merge if anyone except the designated account (here: acl-pwc-bot) made changes within it. That's a security measure, and I feel it's good to leave it activated.

This PR changes the workflow so that:
- Commits in the PwC action should now appear as authored by the acl-pwc-bot
- The PR is now triggered daily whenever there are changes (since we–hopefully–don't need to manually approve it)
- The body of the PR is a bit more descriptive
