### PR TITLE
Fixed casing for 2021.eacl-main.226

### DIFF
--- a/data/xml/2021.eacl.xml
+++ b/data/xml/2021.eacl.xml
@@ -4391,7 +4391,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
     </paper>
     <paper id="3">
-      <title>Finite-state script normalization and processing utilities: The Nisaba <fixed-case>B</fixed-case>rahmic library</title>
+      <title>Finite-state script normalization and processing utilities: The <fixed-case>N</fixed-case>isaba <fixed-case>B</fixed-case>rahmic library</title>
       <author><first>Cibu</first><last>Johny</last></author>
       <author><first>Lawrence</first><last>Wolf-Sonkin</last></author>
       <author><first>Alexander</first><last>Gutkin</last></author>


### PR DESCRIPTION
Fixing the formatting for the name of the software library. The name should begin with an upper-case letter, i.e. `Nisaba` rather than `nisaba`.