### PR TITLE
Make acl-pwc-bot push to local branch

### DIFF
--- a/.github/workflows/paperswithcode.yml
+++ b/.github/workflows/paperswithcode.yml
@@ -49,7 +49,7 @@ jobs:
       if: steps.check-if-pr.outputs.lines-changed > 0
       with:
         token: ${{ secrets.PWC_BOT_TOKEN }}
-        push-to-fork: acl-pwc-bot/acl-anthology
+        branch: automated/update-pwc-metadata
         author: "acl-pwc-bot <acl-pwc-bot@bollmann.me>"
         commit-message: "Update metadata from Papers with Code"
         title: "[automated] Update metadata from Papers with Code"


### PR DESCRIPTION
This PR changes the Papers-with-Code action to push to a local branch named `automated/update-pwc-metadata`. Currently, it pushes to a fork of our repo, which [is the likely reason for the auto-merge action to not see the pull request data](https://github.com/acl-org/acl-anthology/pull/1686#issuecomment-980065627).

@mjpost Does @acl-pwc-bot have permission to push commits to our repo? I believe you said you gave the bot more restricted permissions initially. Either way, this PR shouldn't merged unless we (want to) give the bot those permissions.
