### PR TITLE
correct the dataset link in paper 2020.aacl-main.82

### DIFF
--- a/data/xml/2020.aacl.xml
+++ b/data/xml/2020.aacl.xml
@@ -1045,7 +1045,7 @@
       <abstract>We propose a newly annotated dataset for information extraction on recipes. Unlike previous approaches to machine comprehension of procedural texts, we avoid a priori pre-defining domain-specific predicates to recognize (e.g., the primitive instructionsin MILK) and focus on basic understanding of the expressed semantics rather than directly reduce them to a simplified state representation (e.g., ProPara). We thus frame the semantic comprehension of procedural text such as recipes, as fairly generic NLP subtasks, covering (i) entity recognition (ingredients, tools and actions), (ii) relation extraction (what ingredients and tools are involved in the actions), and (iii) zero anaphora resolution (link actions to implicit arguments, e.g., results from previous recipe steps). Further, our Recipe Instruction Semantic Corpus (RISeC) dataset includes textual descriptions for the zero anaphora, to facilitate language generation thereof. Besides the dataset itself, we contribute a pipeline neural architecture that addresses entity and relation extractionas well an identification of zero anaphora. These basic building blocks can facilitate more advanced downstream applications (e.g., question answering, conversational agents).</abstract>
       <url hash="2d2e2afa">2020.aacl-main.82</url>
       <bibkey>jiang-etal-2020-recipe</bibkey>
-      <pwcdataset url="https://paperswithcode.com/dataset/propara">ProPara</pwcdataset>
+      <pwcdataset url="https://https://github.com/YiweiJiang2015/RISeC">RISeC</pwcdataset>
     </paper>
     <paper id="83">
       <title>Stronger Baselines for Grammatical Error Correction Using a Pretrained Encoder-Decoder Model</title>


### PR DESCRIPTION
Hi, I am the author of this[ AACL-2020 paper](https://aclanthology.org/2020.aacl-main.82/) (RISeC). In that page, I found the dataset linked to a wrong place. Therefore, I correct the metadata to where I released [my dataset](https://github.com/YiweiJiang2015/RISeC) in this PR. 
