### PR TITLE
Update 2021.mtsummit.xml

### DIFF
--- a/data/xml/2021.mtsummit.xml
+++ b/data/xml/2021.mtsummit.xml
@@ -199,7 +199,7 @@ Our models outperform massively multilingual models such as Google (<tex-math>+8
     </paper>
     <paper id="16">
       <title>Sentiment-based Candidate Selection for <fixed-case>NMT</fixed-case></title>
-      <author><first>Alexander G.</first><last>Jones</last></author>
+      <author><first>Alexander</first><last>Jones</last></author>
       <author><first>Derry</first><last>Wijaya</last></author>
       <pages>188-201</pages>
       <url hash="6b20bd43">2021.mtsummit-research.16</url>


### PR DESCRIPTION
I am the first author on "Sentiment-based Candidate Selection for NMT" (Paper ID 16). I would like to remove my middle initial from my name so that this publication shows up alongside my other publications in the anthology: "Alexander G. Jones" -> "Alexander Jones."