### PR TITLE
Change PWC merge frequency to 1x / week

### DIFF
--- a/.github/workflows/paperswithcode.yml
+++ b/.github/workflows/paperswithcode.yml
@@ -2,10 +2,12 @@
 name: Update Papers with Code
 
 # Controls when the workflow will run
+# Currently set to run Thursdays just after midnight,
+# to minimize merge commits.
 on:
   # Triggers the workflow at 0:30 UTC daily
   schedule:
-  - cron: '30 0 * * *'
+  - cron: '30 0 * * 4'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/paperswithcode.yml
+++ b/.github/workflows/paperswithcode.yml
@@ -1,11 +1,10 @@
 # Fetches metadata from Papers with Code and commits changes
 name: Update Papers with Code
 
-# Controls when the workflow will run
-# Currently set to run Thursdays just after midnight,
-# to minimize merge commits.
+# Controls when the workflow will run.
+# We run it once a week to minimize merge commits.
 on:
-  # Triggers the workflow at 0:30 UTC daily
+  # Triggers the workflow at 0:30 UTC every Thursday
   schedule:
   - cron: '30 0 * * 4'
 


### PR DESCRIPTION
Per private discussion, we decided to change the PWC merges to once a week. The motivation was to have cleaner commit histories (we are currently seeing a commit every day or two, the majority of all commits) and the justification is that the data is not urgent.