### PR TITLE
Added address, publisher and month for `C94.xml` and updated (pages, DOI) ``

### DIFF
--- a/data/xml/C94.xml
+++ b/data/xml/C94.xml
@@ -3,6 +3,10 @@
   <volume id="1">
     <meta>
       <booktitle><fixed-case>COLING</fixed-case> 1994 Volume 1: The 15th <fixed-case>I</fixed-case>nternational <fixed-case>C</fixed-case>onference on <fixed-case>C</fixed-case>omputational <fixed-case>L</fixed-case>inguistics</booktitle>
+      <publisher>Association for Computational Linguistics</publisher>
+      <address>Kyoto, Japan</address>
+      <month>August</month>
+      <year>1994</year>
     </meta>
     <frontmatter>
       <url hash="a6f6ea69">C94-1000</url>
@@ -492,7 +496,9 @@
     <paper id="66">
       <title>Constructing Lexical Transducers</title>
       <author><first>Lauri</first><last>Karttunen</last></author>
+      <doi>10.3115/991886.991957</doi>
       <url hash="7e410362">C94-1066</url>
+      <pages>406–411</pages>
       <bibkey>karttunen-1994-constructing</bibkey>
     </paper>
     <paper id="67">


### PR DESCRIPTION
1.  Added address, publisher and month metadata for Volume 1 of COLING 1994 proceedings.
1.  Augmented `karttunen-1994-constructing`: pages and DOI.
