### PR TITLE
ingested iwslt 2017

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -47,7 +47,7 @@ class Paper:
         self.venue_index = venue_index
         self._id = paper_id
         self._ingest_date = ingest_date
-        self._bibkey = False
+        self._bibkey = None
         self._citeproc_json = None
         self.is_volume = paper_id == "0"
 

--- a/data/xml/2017.iwslt.xml
+++ b/data/xml/2017.iwslt.xml
@@ -1,0 +1,233 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection id="2017.iwslt">
+  <volume id="1" ingest-date="2022-03-02">
+    <meta>
+      <booktitle>Proceedings of the 14th International Conference on Spoken Language Translation</booktitle>
+      <publisher>International Workshop on Spoken Language Translation</publisher>
+      <address>Tokyo, Japan</address>
+      <month>December 14-15</month>
+      <year>2017</year>
+      <url hash="00cdbb61">2017.iwslt-1</url>
+      <editor><first>Sakriani</first><last>Sakti</last></editor>
+      <editor><first>Masao</first><last>Utiyama</last></editor>
+    </meta>
+    <frontmatter>
+      <url hash="5c71d442">2017.iwslt-1.0</url>
+      <bibkey>iwslt-2017-international</bibkey>
+    </frontmatter>
+    <paper id="1">
+      <title>Overview of the <fixed-case>IWSLT</fixed-case> 2017 Evaluation Campaign</title>
+      <author><first>Mauro</first><last>Cettolo</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <author><first>Luisa</first><last>Bentivogli</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Sebastian</first><last>Stüker</last></author>
+      <author><first>Katsuhito</first><last>Sudoh</last></author>
+      <author><first>Koichiro</first><last>Yoshino</last></author>
+      <author><first>Christian</first><last>Federmann</last></author>
+      <pages>2-14</pages>
+      <abstract>The IWSLT 2017 evaluation campaign has organised three tasks. The Multilingual task, which is about training machine translation systems handling many-to-many language directions, including so-called zero-shot directions. The Dialogue task, which calls for the integration of context information in machine translation, in order to resolve anaphoric references that typically occur in human-human dialogue turns. And, finally, the Lecture task, which offers the challenge of automatically transcribing and translating real-life university lectures. Following the tradition of these reports, we will described all tasks in detail and present the results of all runs submitted by their participants.</abstract>
+      <url hash="460b7b05">2017.iwslt-1.1</url>
+      <bibkey>cettolo-etal-2017-overview</bibkey>
+    </paper>
+    <paper id="2">
+      <title>Going beyond zero-shot <fixed-case>MT</fixed-case>: combining phonological, morphological and semantic factors. The <fixed-case>U</fixed-case>d<fixed-case>S</fixed-case>-<fixed-case>DFKI</fixed-case> System at <fixed-case>IWSLT</fixed-case> 2017</title>
+      <author><first>Cristina</first><last>España-Bonet</last></author>
+      <author><first>Josef</first><last>van Genabith</last></author>
+      <pages>15-22</pages>
+      <abstract>This paper describes the UdS-DFKI participation to the multilingual task of the IWSLT Evaluation 2017. Our approach is based on factored multilingual neural translation systems following the small data and zero-shot training conditions. Our systems are designed to fully exploit multilinguality by including factors that increase the number of common elements among languages such as phonetic coarse encodings and synsets, besides shallow part-of-speech tags, stems and lemmas. Document level information is also considered by including the topic of every document. This approach improves a baseline without any additional factor for all the language pairs and even allows beyond-zero-shot translation. That is, the translation from unseen languages is possible thanks to the common elements —especially synsets in our models— among languages.</abstract>
+      <url hash="15b6343f">2017.iwslt-1.2</url>
+      <bibkey>espana-bonet-van-genabith-2017-going</bibkey>
+    </paper>
+    <paper id="3">
+      <title>The <fixed-case>S</fixed-case>amsung and <fixed-case>U</fixed-case>niversity of <fixed-case>E</fixed-case>dinburgh’s submission to <fixed-case>IWSLT</fixed-case>17</title>
+      <author><first>Pawel</first><last>Przybysz</last></author>
+      <author><first>Marcin</first><last>Chochowski</last></author>
+      <author><first>Rico</first><last>Sennrich</last></author>
+      <author><first>Barry</first><last>Haddow</last></author>
+      <author><first>Alexandra</first><last>Birch</last></author>
+      <pages>23-28</pages>
+      <abstract>This paper describes the joint submission of Samsung Research and Development, Warsaw, Poland and the University of Edinburgh team to the IWSLT MT task for TED talks. We took part in two translation directions, en-de and de-en. We also participated in the en-de and de-en lectures SLT task. The models have been trained with an attentional encoder-decoder model using the BiDeep model in Nematus. We filtered the training data to reduce the problem of noisy data, and we use back-translated monolingual data for domain-adaptation. We demonstrate the effectiveness of the different techniques that we applied via ablation studies. Our submission system outperforms our baseline, and last year’s University of Edinburgh submission to IWSLT, by more than 5 BLEU.</abstract>
+      <url hash="4c7ec154">2017.iwslt-1.3</url>
+      <bibkey>przybysz-etal-2017-samsung</bibkey>
+    </paper>
+    <paper id="4">
+      <title>The <fixed-case>RWTH</fixed-case> <fixed-case>A</fixed-case>achen Machine Translation Systems for <fixed-case>IWSLT</fixed-case> 2017</title>
+      <author><first>Parnia</first><last>Bahar</last></author>
+      <author><first>Jan</first><last>Rosendahl</last></author>
+      <author><first>Nick</first><last>Rossenbach</last></author>
+      <author><first>Hermann</first><last>Ney</last></author>
+      <pages>29-34</pages>
+      <abstract>This work describes the Neural Machine Translation (NMT) system of the RWTH Aachen University developed for the English$German tracks of the evaluation campaign of the International Workshop on Spoken Language Translation (IWSLT) 2017. We use NMT systems which are augmented by state-of-the-art extensions. Furthermore, we experiment with techniques that include data filtering, a larger vocabulary, two extensions to the attention mechanism and domain adaptation. Using these methods, we can show considerable improvements over the respective baseline systems and our IWSLT 2016 submission.</abstract>
+      <url hash="b5a701b8">2017.iwslt-1.4</url>
+      <bibkey>bahar-etal-2017-rwth</bibkey>
+    </paper>
+    <paper id="5">
+      <title><fixed-case>FBK</fixed-case>’s Multilingual Neural Machine Translation System for <fixed-case>IWSLT</fixed-case> 2017</title>
+      <author><first>Surafel M.</first><last>Lakew</last></author>
+      <author><first>Quintino F.</first><last>Lotito</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
+      <author><first>Matteo</first><last>Negri</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <pages>35-41</pages>
+      <abstract>Neural Machine Translation has been shown to enable inference and cross-lingual knowledge transfer across multiple language directions using a single multilingual model. Focusing on this multilingual translation scenario, this work summarizes FBK’s participation in the IWSLT 2017 shared task. Our submissions rely on two multilingual systems trained on five languages (English, Dutch, German, Italian, and Romanian). The first one is a 20 language direction model, which handles all possible combinations of the five languages. The second multilingual system is trained only on 16 directions, leaving the others as zero-shot translation directions (i.e representing a more complex inference task on language pairs not seen at training time). More specifically, our zero-shot directions are Dutch$German and Italian$Romanian (resulting in four language combinations). Despite the small amount of parallel data used for training these systems, the resulting multilingual models are effective, even in comparison with models trained separately for every language pair (i.e. in more favorable conditions). We compare and show the results of the two multilingual models against a baseline single language pair systems. Particularly, we focus on the four zero-shot directions and show how a multilingual model trained with small data can provide reasonable results. Furthermore, we investigate how pivoting (i.e using a bridge/pivot language for inference in a source!pivot!target translations) using a multilingual model can be an alternative to enable zero-shot translation in a low resource setting.</abstract>
+      <url hash="682be457">2017.iwslt-1.5</url>
+      <bibkey>lakew-etal-2017-fbks</bibkey>
+    </paper>
+    <paper id="6">
+      <title><fixed-case>KIT</fixed-case>’s Multilingual Neural Machine Translation systems for <fixed-case>IWSLT</fixed-case> 2017</title>
+      <author><first>Ngoc-Quan</first><last>Pham</last></author>
+      <author><first>Matthias</first><last>Sperber</last></author>
+      <author><first>Elizabeth</first><last>Salesky</last></author>
+      <author><first>Thanh-Le</first><last>Ha</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Alexander</first><last>Waibel</last></author>
+      <pages>42-47</pages>
+      <abstract>In this paper, we present KIT’s multilingual neural machine translation (NMT) systems for the IWSLT 2017 evaluation campaign machine translation (MT) and spoken language translation (SLT) tasks. For our MT task submissions, we used our multi-task system, modified from a standard attentional neural machine translation framework, instead of building 20 individual NMT systems. We investigated different architectures as well as different data corpora in training such a multilingual system. We also suggested an effective adaptation scheme for multilingual systems which brings great improvements compared to monolingual systems. For the SLT track, in addition to a monolingual neural translation system used to generate correct punctuations and true cases of the data prior to training our multilingual system, we introduced a noise model in order to make our system more robust. Results show that our novel modifications improved our systems considerably on all tasks.</abstract>
+      <url hash="039845c0">2017.iwslt-1.6</url>
+      <bibkey>pham-etal-2017-kits</bibkey>
+    </paper>
+    <paper id="7">
+      <title>Towards better translation performance on spoken language</title>
+      <author><first>Chao</first><last>Bei</last></author>
+      <author><first>Hao</first><last>Zong</last></author>
+      <pages>48-54</pages>
+      <abstract>In this paper, we describe GTCOM’s neural machine translation(NMT) systems for the International Workshop on Spoken Language Translation(IWSLT) 2017. We participated in the English-to-Chinese and Chinese-to-English tracks in the small data condition of the bilingual task and the zero-shot condition of the multilingual task. Our systems are based on the encoder-decoder architecture with attention mechanism. We build byte pair encoding (BPE) models in parallel data and back-translated monolingual training data provided in the small data condition. Other techniques we explored in our system include two deep architectures, layer nomalization, weight normalization and training models with annealing Adam, etc. The official scores of English-to-Chinese, Chinese-to-English are 28.13 and 21.35 on test set 2016 and 28.30 and 22.16 on test set 2017. The official scores on German-to-Dutch, Dutch-to-German, Italian-to-Romanian and Romanian-to-Italian are 19.59, 17.95, 18.62 and 20.39 respectively.</abstract>
+      <url hash="0dac76a9">2017.iwslt-1.7</url>
+      <bibkey>bei-zong-2017-towards</bibkey>
+    </paper>
+    <paper id="8">
+      <title><fixed-case>K</fixed-case>yoto <fixed-case>U</fixed-case>niversity <fixed-case>MT</fixed-case> System Description for <fixed-case>IWSLT</fixed-case> 2017</title>
+      <author><first>Raj</first><last>Dabre</last></author>
+      <author><first>Fabien</first><last>Cromieres</last></author>
+      <author><first>Sadao</first><last>Kurohashi</last></author>
+      <abstract>We describe here our Machine Translation (MT) model and the results we obtained for the IWSLT 2017 Multilingual Shared Task. Motivated by Zero Shot NMT [1] we trained a Multilingual Neural Machine Translation by combining all the training data into one single collection by appending the tokens to the source sentences in order to indicate the target language they should be translated to. We observed that even in a low resource situation we were able to get translations whose quality surpass the quality of those obtained by Phrase Based Statistical Machine Translation by several BLEU points. The most surprising result we obtained was in the zero shot setting for Dutch-German and Italian-Romanian where we observed that despite using no parallel corpora between these language pairs, the NMT model was able to translate between these languages and the translations were either as good as or better (in terms of BLEU) than the non zero resource setting. We also verify that the NMT models that use feed forward layers and self attention instead of recurrent layers are extremely fast in terms of training which is useful in a NMT experimental setting.</abstract>
+      <pages>55-59</pages>
+      <url hash="83724615">2017.iwslt-1.8</url>
+      <bibkey>dabre-etal-2017-kyoto</bibkey>
+    </paper>
+    <paper id="9">
+      <title>The 2017 <fixed-case>KIT</fixed-case> <fixed-case>IWSLT</fixed-case> Speech-to-Text Systems for <fixed-case>E</fixed-case>nglish and <fixed-case>G</fixed-case>erman</title>
+      <author><first>Thai-Son</first><last>Nguyen</last></author>
+      <author><first>Markus</first><last>Müller</last></author>
+      <author><first>Matthias</first><last>Sperber</last></author>
+      <author><first>Thomas</first><last>Zenkel</last></author>
+      <author><first>Sebastian</first><last>Stüker</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <pages>60-64</pages>
+      <abstract>This paper describes our German and English Speech-to-Text (STT) systems for the 2017 IWSLT evaluation campaign. The campaign focuses on the transcription of unsegmented lecture talks. Our setup includes systems using both the Janus and Kaldi frameworks. We combined the outputs using both ROVER [1] and confusion network combination (CNC) [2] to achieve a good overall performance. The individual subsystems are built by using different speaker-adaptive feature combination (e.g., lMEL with i-vector or bottleneck speaker vector), acoustic models (GMM or DNN) and speaker adaptation (MLLR or fMLLR). Decoding is performed in two stages, where the GMM and DNN systems are adapted on the combination of the first stage outputs using MLLR, and fMLLR. The combination setup produces a final hypothesis that has a significantly lower WER than any of the individual sub-systems. For the English lecture task, our best combination system has a WER of 8.3% on the tst2015 development set while our other combinations gained 25.7% WER for German lecture tasks.</abstract>
+      <url hash="7eecb830">2017.iwslt-1.9</url>
+      <bibkey>nguyen-etal-2017-2017</bibkey>
+    </paper>
+    <paper id="10">
+      <title>Neural Machine Translation Training in a Multi-Domain Scenario</title>
+      <author><first>Hassan</first><last>Sajjad</last></author>
+      <author><first>Nadir</first><last>Durrani</last></author>
+      <author><first>Fahim</first><last>Dalvi</last></author>
+      <author><first>Yonatan</first><last>Belinkov</last></author>
+      <author><first>Stephan</first><last>Vogel</last></author>
+      <pages>66-73</pages>
+      <abstract>In this paper, we explore alternative ways to train a neural machine translation system in a multi-domain scenario. We investigate data concatenation (with fine tuning), model stacking (multi-level fine tuning), data selection and multi-model ensemble. Our findings show that the best translation quality can be achieved by building an initial system on a concatenation of available out-of-domain data and then fine-tuning it on in-domain data. Model stacking works best when training begins with the furthest out-of-domain data and the model is incrementally fine-tuned with the next furthest domain and so on. Data selection did not give the best results, but can be considered as a decent compromise between training time and translation quality. A weighted ensemble of different individual models performed better than data selection. It is beneficial in a scenario when there is no time for fine-tuning an already trained model.</abstract>
+      <url hash="8e19d4d2">2017.iwslt-1.10</url>
+      <bibkey>sajjad-etal-2017-neural</bibkey>
+    </paper>
+    <paper id="11">
+      <title>Domain-independent Punctuation and Segmentation Insertion</title>
+      <author><first>Eunah</first><last>Cho</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <pages>74-81</pages>
+      <abstract>Punctuation and segmentation is crucial in spoken language translation, as it has a strong impact to translation performance. However, the impact of rare or unknown words in the performance of punctuation and segmentation insertion has not been thoroughly studied. In this work, we simulate various degrees of domain-match in testing scenario and investigate their impact to the punctuation insertion task. We explore three rare word generalizing schemes using part-of-speech (POS) tokens. Experiments show that generalizing rare and unknown words greatly improves the punctuation insertion performance, reaching up to 8.8 points of improvement in F-score when applied to the out-of-domain test scenario. We show that this improvement in punctuation quality has a positive impact on a following machine translation (MT) performance, improving it by 2 BLEU points.</abstract>
+      <url hash="6adc9900">2017.iwslt-1.11</url>
+      <bibkey>cho-etal-2017-domain</bibkey>
+    </paper>
+    <paper id="12">
+      <title>Synthetic Data for Neural Machine Translation of Spoken-Dialects</title>
+      <author><first>Hany</first><last>Hassan</last></author>
+      <author><first>Mostafa</first><last>Elaraby</last></author>
+      <author><first>Ahmed Y.</first><last>Tawfik</last></author>
+      <pages>82-89</pages>
+      <abstract>In this paper, we introduce a novel approach to generate synthetic data for training Neural Machine Translation systems. The proposed approach supports language variants and dialects with very limited parallel training data. This is achieved using a seed data to project words from a closely-related resource-rich language to an under-resourced language variant via word embedding representations. The proposed approach is based on localized embedding projection of distributed representations which utilizes monolingual embeddings and approximate nearest neighbors queries to transform parallel data across language variants. Our approach is language independent and can be used to generate data for any variant of the source language such as slang or spoken dialect or even for a different language that is related to the source language. We report experimental results on Levantine to English translation using Neural Machine Translation. We show that the synthetic data can provide significant improvements over a very large scale system by more than 2.8 Bleu points and it can be used to provide a reliable translation system for a spoken dialect which does not have sufficient parallel data.</abstract>
+      <url hash="3f02021f">2017.iwslt-1.12</url>
+      <bibkey>hassan-etal-2017-synthetic</bibkey>
+    </paper>
+    <paper id="13">
+      <title>Toward Robust Neural Machine Translation for Noisy Input Sequences</title>
+      <author><first>Matthias</first><last>Sperber</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Alex</first><last>Waibel</last></author>
+      <pages>90-96</pages>
+      <abstract>Translating noisy inputs, such as the output of a speech recognizer, is a difficult but important challenge for neural machine translation. One way to increase robustness of neural models is by introducing artificial noise to the training data. In this paper, we experiment with appropriate forms of such noise, exploring a middle ground between general-purpose regularizers and highly task-specific forms of noise induction. We show that with a simple generative noise model, moderate gains can be achieved in translating erroneous speech transcripts, provided that type and amount of noise are properly calibrated. The optimal amount of noise at training time is much smaller than the amount of noise in our test data, indicating limitations due to trainability issues. We note that unlike our baseline model, models trained on noisy data are able to generate outputs of proper length even for noisy inputs, while gradually reducing output length for higher amount of noise, as might also be expected from a human translator. We discuss these findings in details and give suggestions for future work.</abstract>
+      <url hash="a49b29e5">2017.iwslt-1.13</url>
+      <bibkey>sperber-etal-2017-toward</bibkey>
+    </paper>
+    <paper id="14">
+      <title>Monolingual Embeddings for Low Resourced Neural Machine Translation</title>
+      <author><first>Mattia Antonino</first><last>Di Gangi</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <pages>97-104</pages>
+      <abstract>Neural machine translation (NMT) is the state of the art for machine translation, and it shows the best performance when there is a considerable amount of data available. When only little data exist for a language pair, the model cannot produce good representations for words, particularly for rare words. One common solution consists in reducing data sparsity by segmenting words into sub-words, in order to allow rare words to have shared representations with other words. Taking a different approach, in this paper we present a method to feed an NMT network with word embeddings trained on monolingual data, which are combined with the task-specific embeddings learned at training time. This method can leverage an embedding matrix with a huge number of words, which can therefore extend the word-level vocabulary. Our experiments on two language pairs show good results for the typical low-resourced data scenario (IWSLT in-domain dataset). Our consistent improvements over the baselines represent a positive proof about the possibility to leverage models pre-trained on monolingual data in NMT.</abstract>
+      <url hash="7977636b">2017.iwslt-1.14</url>
+      <bibkey>di-gangi-federico-2017-monolingual</bibkey>
+    </paper>
+    <paper id="15">
+      <title>Effective Strategies in Zero-Shot Neural Machine Translation</title>
+      <author><first>Thanh-Le</first><last>Ha</last></author>
+      <author><first>Jan</first><last>Niehues</last></author>
+      <author><first>Alexander</first><last>Waibel</last></author>
+      <pages>105-112</pages>
+      <abstract>In this paper, we proposed two strategies which can be applied to a multilingual neural machine translation system in order to better tackle zero-shot scenarios despite not having any parallel corpus. The experiments show that they are effective in terms of both performance and computing resources, especially in multilingual translation of unbalanced data in real zero-resourced condition when they alleviate the language bias problem.</abstract>
+      <url hash="c3a1c766">2017.iwslt-1.15</url>
+      <bibkey>ha-etal-2017-effective</bibkey>
+    </paper>
+    <paper id="16">
+      <title>Improving Zero-Shot Translation of Low-Resource Languages</title>
+      <author><first>Surafel M.</first><last>Lakew</last></author>
+      <author><first>Quintino F.</first><last>Lotito</last></author>
+      <author><first>Matteo</first><last>Negri</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
+      <author><first>Marcello</first><last>Federico</last></author>
+      <pages>113-119</pages>
+      <abstract>Recent work on multilingual neural machine translation reported competitive performance with respect to bilingual models and surprisingly good performance even on (zero-shot) translation directions not observed at training time. We investigate here a zero-shot translation in a particularly low-resource multilingual setting. We propose a simple iterative training procedure that leverages a duality of translations directly generated by the system for the zero-shot directions. The translations produced by the system (sub-optimal since they contain mixed language from the shared vocabulary), are then used together with the original parallel data to feed and iteratively re-train the multilingual network. Over time, this allows the system to learn from its own generated and increasingly better output. Our approach shows to be effective in improving the two zero-shot directions of our multilingual model. In particular, we observed gains of about 9 BLEU points over a baseline multilingual model and up to 2.08 BLEU over a pivoting mechanism using two bilingual models. Further analysis shows that there is also a slight improvement in the non-zero-shot language directions.</abstract>
+      <url hash="1c11d008">2017.iwslt-1.16</url>
+      <bibkey>lakew-etal-2017-improving</bibkey>
+    </paper>
+    <paper id="17">
+      <title>Evolution Strategy Based Automatic Tuning of Neural Machine Translation Systems</title>
+      <author><first>Hao</first><last>Qin</last></author>
+      <author><first>Takahiro</first><last>Shinozaki</last></author>
+      <author><first>Kevin</first><last>Duh</last></author>
+      <pages>120-128</pages>
+      <abstract>Neural machine translation (NMT) systems have demonstrated promising results in recent years. However, non-trivial amounts of manual effort are required for tuning network architectures, training configurations, and pre-processing settings such as byte pair encoding (BPE). In this study, we propose an evolution strategy based automatic tuning method for NMT. In particular, we apply the covariance matrix adaptation-evolution strategy (CMA-ES), and investigate a Pareto-based multi-objective CMA-ES to optimize the translation performance and computational time jointly. Experimental results show that the proposed method automatically finds NMT systems that outperform the initial manual setting.</abstract>
+      <url hash="0eeb9eba">2017.iwslt-1.17</url>
+      <bibkey>qin-etal-2017-evolution</bibkey>
+    </paper>
+    <paper id="18">
+      <title>Continuous Space Reordering Models for Phrase-based <fixed-case>MT</fixed-case></title>
+      <author><first>Nadir</first><last>Durrani</last></author>
+      <author><first>Fahim</first><last>Dalvi</last></author>
+      <pages>129-136</pages>
+      <abstract>Bilingual sequence models improve phrase-based translation and reordering by overcoming phrasal independence assumption and handling long range reordering. However, due to data sparsity, these models often fall back to very small context sizes. This problem has been previously addressed by learning sequences over generalized representations such as POS tags or word clusters. In this paper, we explore an alternative based on neural network models. More concretely we train neuralized versions of lexicalized reordering [1] and the operation sequence models [2] using feed-forward neural network. Our results show improvements of up to 0.6 and 0.5 BLEU points on top of the baseline German!English and English!German systems. We also observed improvements compared to the systems that used POS tags and word clusters to train these models. Because we modify the bilingual corpus to integrate reordering operations, this allows us to also train a sequence-to-sequence neural MT model having explicit reordering triggers. Our motivation was to directly enable reordering information in the encoder-decoder framework, which otherwise relies solely on the attention model to handle long range reordering. We tried both coarser and fine-grained reordering operations. However, these experiments did not yield any improvements over the baseline Neural MT systems.</abstract>
+      <url hash="6e17ef76">2017.iwslt-1.18</url>
+      <bibkey>durrani-dalvi-2017-continuous</bibkey>
+    </paper>
+    <paper id="19">
+      <title>Data Selection with Cluster-Based Language Difference Models and Cynical Selection</title>
+      <author><first>Lucía</first><last>Santamaría</last></author>
+      <author><first>Amittai</first><last>Axelrod</last></author>
+      <pages>137-145</pages>
+      <abstract>We present and apply two methods for addressing the problem of selecting relevant training data out of a general pool for use in tasks such as machine translation. Building on existing work on class-based language difference models [1], we first introduce a cluster-based method that uses Brown clusters to condense the vocabulary of the corpora. Secondly, we implement the cynical data selection method [2], which incrementally constructs a training corpus to efficiently model the task corpus. Both the cluster-based and the cynical data selection approaches are used for the first time within a machine translation system, and we perform a head-to-head comparison. Our intrinsic evaluations show that both new methods outperform the standard Moore-Lewis approach (cross-entropy difference), in terms of better perplexity and OOV rates on in-domain data. The cynical approach converges much quicker, covering nearly all of the in-domain vocabulary with 84% less data than the other methods. Furthermore, the new approaches can be used to select machine translation training data for training better systems. Our results confirm that class-based selection using Brown clusters is a viable alternative to POS-based class-based methods, and removes the reliance on a part-of-speech tagger. Additionally, we are able to validate the recently proposed cynical data selection method, showing that its performance in SMT models surpasses that of traditional cross-entropy difference methods and more closely matches the sentence length of the task corpus.</abstract>
+      <url hash="799bbdd1">2017.iwslt-1.19</url>
+      <bibkey>santamaria-axelrod-2017-data</bibkey>
+    </paper>
+    <paper id="20">
+      <title><fixed-case>CHARCUT</fixed-case>: Human-Targeted Character-Based <fixed-case>MT</fixed-case> Evaluation with Loose Differences</title>
+      <author><first>Adrien</first><last>Lardilleux</last></author>
+      <author><first>Yves</first><last>Lepage</last></author>
+      <pages>146-153</pages>
+      <abstract>We present CHARCUT, a character-based machine translation evaluation metric derived from a human-targeted segment difference visualisation algorithm. It combines an iterative search for longest common substrings between the candidate and the reference translation with a simple length-based threshold, enabling loose differences that limit noisy character matches. Its main advantage is to produce scores that directly reflect human-readable string differences, making it a useful support tool for the manual analysis of MT output and its display to end users. Experiments on WMT16 metrics task data show that it is on par with the best “un-trained” metrics in terms of correlation with human judgement, well above BLEU and TER baselines, on both system and segment tasks.</abstract>
+      <url hash="5c0e39e5">2017.iwslt-1.20</url>
+      <bibkey>lardilleux-lepage-2017-charcut</bibkey>
+    </paper>
+  </volume>
+</collection>


### PR DESCRIPTION
See [here](https://workshop2017.iwslt.org/index.php) for the website and [here](https://workshop2017.iwslt.org/downloads/iwslt2017_proceeding_v2.pdf) for the proceedings PDF.

- The `bin/write_bibkeys_to_xml.py` script failed with the following error: `ERROR    Paper 2017.iwslt-1.1 has bibkey that is not unique (False)!` (for all papers). To solve this, I changed `self._bibkey` init value to `None` instead of `False` in `bin/anthology/papers.py`, based on a comment from @mbollmann in #1833. I do not think this creates new bugs, but I'm not sure.
- I ran into issues related to `pdftk`. It failed to split the PDF. The error is similar to [this one](https://stackoverflow.com/questions/36613976/pdftk-throws-a-java-exception-when-attempting-to-use-fill-form-function). I tried to debug it and restore the PDF but failed to do so; in the end I splitted the PDF manually. If this is a common issue it might be worthwhile to use another pdf splitter.