### PR TITLE
Bump to Python 3.8 in README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ifeq (, $(shell which python3 ))
   $(error "python3 not found in $(PATH)")
 endif
 
-PYTHON_VERSION_MIN=3.7
+PYTHON_VERSION_MIN=3.8
 PYTHON_VERSION=$(shell python3 -c 'import sys; print("%d.%d"% sys.version_info[0:2])' )
 PYTHON_VERSION_OK=$(shell python3 -c 'import sys; print(int(float("%d.%d"% sys.version_info[0:2]) >= $(PYTHON_VERSION_MIN)))' )
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The official home of this repository is <https://github.com/acl-org/acl-antholog
 
 To build the Anthology website, you will need:
 
-+ **Python 3.7** or higher
++ **Python 3.8** or higher
 + Python packages listed in `bin/requirements.txt`; to install, run `pip -r bin/requirements.txt`
 + [**Hugo 0.58.3**](https://gohugo.io) or higher (can be [downloaded directly from
   their repo](https://github.com/gohugoio/hugo/releases); the ***extended version*** is required!)


### PR DESCRIPTION
We're using `functools.cached_property` which requires Python 3.8, but the README and Makefile still list 3.7.

I noticed this by running [vermin](https://github.com/netromdk/vermin). This could also be added to the build check to ensure we're staying compatible with a given Python version, though I'm not sure how useful/needed that is.