### PR TITLE
Remove CSS from preformatted citations

### DIFF
--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -208,10 +208,10 @@
       <dt class="acl-button-row">Bibkey:</dt>
       <dd class="acl-button-row">{{ with $paper.bibkey }}<button type="button" class="btn btn-clipboard-outside btn-secondary btn-sm d-none" data-clipboard-target="#citePaperBibkey"><i class="far fa-clipboard"></i><span id="citePaperBibkey" class="pl-2 text-monospace">{{ . }}</span></button>{{ end }}</dd>
       {{ with $paper.citation_acl }}
-      <dt>Cite (ACL):</dt><dd><span id="citeACL">{{ safeHTML . }}</span><button type="button" class="btn btn-clipboard btn-secondary btn-sm d-none ml-2" data-clipboard-target="#citeACL"><i class="far fa-clipboard"></i></button></dd>
+      <dt>Cite (ACL):</dt><dd><span id="citeACL" style="all: initial;">{{ safeHTML . }}</span><button type="button" class="btn btn-clipboard btn-secondary btn-sm d-none ml-2" data-clipboard-target="#citeACL"><i class="far fa-clipboard"></i></button></dd>
       {{ end }}
       {{ with $paper.citation }}
-      <dt>Cite (Informal):</dt><dd><span id="citeRichText">{{ markdownify . }}</span><button type="button" class="btn btn-clipboard btn-secondary btn-sm d-none ml-2" data-clipboard-target="#citeRichText"><i class="far fa-clipboard"></i></button></dd>
+      <dt>Cite (Informal):</dt><dd><span id="citeRichText" style="all: initial;">{{ markdownify . }}</span><button type="button" class="btn btn-clipboard btn-secondary btn-sm d-none ml-2" data-clipboard-target="#citeRichText"><i class="far fa-clipboard"></i></button></dd>
       {{ end }}
       <dt class="acl-button-row">Copy Citation:</dt>
       <dd class="acl-button-row">
@@ -399,7 +399,7 @@
               {{ with $paper.citation_acl }}
               <h5>ACL</h5>
               <ul class="mt-2">
-                <li id="citeACLstyleContent">{{- $paper.citation_acl | safeHTML -}}</li>
+                <li id="citeACLstyleContent" style="all: initial;">{{- $paper.citation_acl | safeHTML -}}</li>
               </ul>
               {{ end }}
               <div class="modal-footer pb-1">


### PR DESCRIPTION
Love the preformatted citations feature! :heart: 

This PR removes all CSS from the preformatted citations so that they can be copied smoothly into text editors. Firefox already seems to do this out of the box, but not Chrome:

![image](https://user-images.githubusercontent.com/5830820/157703557-9c6eca8f-6ecf-44e3-a2b7-2911435d06ff.png)

With this PR:

![image](https://user-images.githubusercontent.com/5830820/157704334-9470d55f-f59f-4c10-8fae-3dc2fb480cf3.png)

Note that "paste without formatting" is not sufficient, since this will also remove the HTML tags (hyperlink and italics).

How the preformatted citations will look on the website depends on the user settings. This is how they would look for me:

![image](https://user-images.githubusercontent.com/5830820/157705439-98fe409b-4fee-4a56-bc36-5d6cdaae7166.png)
