### PR TITLE
Fixed author ordering for W19-1102 to reflect PDF content

### DIFF
--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -1152,14 +1152,14 @@
     </paper>
     <paper id="2">
       <title>Towards Natural Language Story Understanding with Rich Logical Schemas</title>
-      <author><first>Gene Louis</first><last>Kim</last></author>
       <author><first>Lane</first><last>Lawley</last></author>
+      <author><first>Gene Louis</first><last>Kim</last></author>
       <author><first>Lenhart</first><last>Schubert</last></author>
       <pages>11–22</pages>
       <abstract>Generating “commonsense’’ knowledge for intelligent understanding and reasoning is a difficult, long-standing problem, whose scale challenges the capacity of any approach driven primarily by human input. Furthermore, approaches based on mining statistically repetitive patterns fail to produce the rich representations humans acquire, and fall far short of human efficiency in inducing knowledge from text. The idea of our approach to this problem is to provide a learning system with a “head start” consisting of a semantic parser, some basic ontological knowledge, and most importantly, a small set of very general schemas about the kinds of patterns of events (often purposive, causal, or socially conventional) that even a one- or two-year-old could reasonably be presumed to possess. We match these initial schemas to simple children’s stories, obtaining concrete instances, and combining and abstracting these into new candidate schemas. Both the initial and generated schemas are specified using a rich, expressive logical form. While modern approaches to schema reasoning often only use slot-and-filler structures, this logical form allows us to specify complex relations and constraints over the slots. Though formal, the representations are language-like, and as such readily relatable to NL text. The agents, objects, and other roles in the schemas are represented by typed variables, and the event variables can be related through partial temporal ordering and causal relations. To match natural language stories with existing schemas, we first parse the stories into an underspecified variant of the logical form used by the schemas, which is suitable for most concrete stories. We include a walkthrough of matching a children’s story to these schemas and generating inferences from these matches.</abstract>
       <url hash="ffc9b833">W19-1102</url>
       <doi>10.18653/v1/W19-1102</doi>
-      <bibkey>kim-etal-2019-towards</bibkey>
+      <bibkey>lawley-etal-2019-towards</bibkey>
     </paper>
     <paper id="3">
       <title>Questions in Dependent Type Semantics</title>


### PR DESCRIPTION
The author ordering for paper W19-1102 was inconsistent with the underlying PDF. This change fixes that ordering, and re-names the generated citation ID accordingly.