### PR TITLE
Replace name with Vagrant

### DIFF
--- a/data/xml/2021.sigmorphon.xml
+++ b/data/xml/2021.sigmorphon.xml
@@ -201,7 +201,7 @@
     </paper>
     <paper id="16">
       <title>Avengers, Ensemble! Benefits of ensembling in grapheme-to-phoneme prediction</title>
-      <author><first>Vasundhara</first><last>Gautam</last></author>
+      <author><first>Vagrant</first><last>Gautam</last></author>
       <author><first>Wang Yau</first><last>Li</last></author>
       <author><first>Zafarullah</first><last>Mahmood</last></author>
       <author><first>Frederic</first><last>Mailhot</last></author>


### PR DESCRIPTION
Replaces name with Vagrant in 2021.sigmorphon-1.16.

Revised PDF is attached. [SIGMORPHON2021_Shared_Task_1.pdf](https://github.com/acl-org/acl-anthology/files/8645816/SIGMORPHON2021_Shared_Task_1.pdf)

