### PR TITLE
Fixed the YouTube-URL of the Retico demo paper

### DIFF
--- a/data/xml/2020.sigdial.xml
+++ b/data/xml/2020.sigdial.xml
@@ -92,7 +92,7 @@
       <pages>49–52</pages>
       <abstract>In this paper we present the newest version of retico - a python-based incremental dialogue framework to create state-of-the-art spoken dialogue systems and simulations. Retico provides a range of incremental modules that are based on services like Google ASR, Google TTS and Rasa NLU. Incremental networks can be created either in code or with a graphical user interface. In this demo we present three use cases that are implemented in retico: a spoken translation tool that translates speech in real-time, a conversation simulation that models turn-taking and a spoken dialogue restaurant information service.</abstract>
       <url hash="8b8de6cb">2020.sigdial-1.6</url>
-      <video href="https://youtube.com/watch?v=1tW_GFxW8dM"/>
+      <video href="https://youtube.com/watch?v=ExnADSR4FaQ"/>
       <bibkey>michael-2020-retico</bibkey>
     </paper>
     <paper id="7">


### PR DESCRIPTION
Hi,

I've seen that in the ACL Anthology, there is a wrong youtube link from my demo paper submitted to SIGdial 2020:
https://aclanthology.org/2020.sigdial-1.6/

I've changed the link here in the XML file and hope this is the right place to edit.

Best,
Thilo