### PR TITLE
Correct OCR error in author name Kemighan → Kernighan

### DIFF
--- a/data/xml/C90.xml
+++ b/data/xml/C90.xml
@@ -430,11 +430,11 @@
     </paper>
     <paper id="36">
       <title>A Spelling Correction Program Based on a Noisy Channel Model</title>
-      <author><first>Mark D.</first><last>Kemighan</last></author>
+      <author><first>Mark D.</first><last>Kernighan</last></author>
       <author><first>Kenneth W.</first><last>Church</last></author>
       <author><first>William A.</first><last>Gale</last></author>
       <url hash="93698224">C90-2036</url>
-      <bibkey>kemighan-etal-1990-spelling</bibkey>
+      <bibkey>kernighan-etal-1990-spelling</bibkey>
     </paper>
     <paper id="37">
       <title>Using Test Suites in Evaluation of Machine Translation Systems</title>


### PR DESCRIPTION
Classic m-looks-like-r-followed-by-n goof in the OCR of the proceedings, looks like.