### PR TITLE
Name correction on ACL 2022 paper and DialDoc 2022 paper

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -6106,7 +6106,7 @@ in the Case of Unambiguous Gender</title>
     <paper id="500">
       <title>One Country, 700+ Languages: <fixed-case>NLP</fixed-case> Challenges for Underrepresented Languages and Dialects in <fixed-case>I</fixed-case>ndonesia</title>
       <author><first>Alham</first><last>Aji</last></author>
-      <author><first>Genta</first><last>Winata</last></author>
+      <author><first>Genta Indra</first><last>Winata</last></author>
       <author><first>Fajri</first><last>Koto</last></author>
       <author><first>Samuel</first><last>Cahyawijaya</last></author>
       <author><first>Ade</first><last>Romadhony</last></author>

--- a/data/xml/2022.dialdoc.xml
+++ b/data/xml/2022.dialdoc.xml
@@ -123,7 +123,7 @@
       <author><first>Etsuko</first><last>Ishii</last></author>
       <author><first>Samuel</first><last>Cahyawijaya</last></author>
       <author><first>Zihan</first><last>Liu</last></author>
-      <author><first>Genta</first><last>Winata</last></author>
+      <author><first>Genta Indra</first><last>Winata</last></author>
       <author><first>Andrea</first><last>Madotto</last></author>
       <author><first>Dan</first><last>Su</last></author>
       <author><first>Pascale</first><last>Fung</last></author>


### PR DESCRIPTION
Correcting first name on ACL 2022 paper and DialDoc 2022 paper
from "Genta" to "Genta Indra" following the published papers

No paper revision is needed