### PR TITLE
Update 2022.iwslt-1.15 author list to match final pdf

### DIFF
--- a/data/xml/2022.iwslt.xml
+++ b/data/xml/2022.iwslt.xml
@@ -215,6 +215,9 @@
       <author><first>Xinyuan</first><last>Zhou</last></author>
       <author><first>Jing</first><last>Yang</last></author>
       <author><first>Jianwei</first><last>Cui</last></author>
+      <author><first>Pan</first><last>Deng</last></author>
+      <author><first>Mohan</first><last>Shi</last></author>
+      <author><first>Yifan</first><last>Song</last></author>
       <author><first>Dan</first><last>Liu</last></author>
       <author><first>Junhua</first><last>Liu</last></author>
       <author><first>Lirong</first><last>Dai</last></author>


### PR DESCRIPTION
Update author list to match final camera-ready pdf, 3 authors missing in submission form. 

Corresponding author: [zwt2021@mail.ustc.edu.cn](mailto:zwt2021@mail.ustc.edu.cn)