### PR TITLE
Name correction for 2022.acl-long.451

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -5527,7 +5527,7 @@ in the Case of Unambiguous Gender</title>
     </paper>
     <paper id="451">
       <title><fixed-case>CLUES</fixed-case>: A Benchmark for Learning Classifiers using Natural Language Explanations</title>
-      <author><first>Rakesh</first><last>Menon</last></author>
+      <author><first>Rakesh</first><last>R. Menon</last></author>
       <author><first>Sayan</first><last>Ghosh</last></author>
       <author><first>Shashank</first><last>Srivastava</last></author>
       <pages>6523-6546</pages>


### PR DESCRIPTION
Name change from Rakesh Menon to Rakesh R. Menon in ACL 2022 paper.

Changed file: [data/xml/2022.acl.xml](https://github.com/acl-org/acl-anthology/blob/master/data/xml/2022.acl.xml)
