### PR TITLE
fix proceedings author metadata

### DIFF
--- a/data/xml/2022.csrr.xml
+++ b/data/xml/2022.csrr.xml
@@ -3,8 +3,16 @@
   <volume id="1" ingest-date="2022-05-15">
     <meta>
       <booktitle>Proceedings of the First Workshop on Commonsense Representation and Reasoning (CSRR 2022)</booktitle>
-      <editor><first>Yash Kumar</first><last>Lal</last></editor>
+      <editor><first>Antoine</first><last>Bosselut</last></editor>
+      <editor><first>Xiang</first><last>Li</last></editor>
       <editor><first>Bill Yuchen</first><last>Lin</last></editor>
+      <editor><first>Vered</first><last>Shwartz</last></editor>
+      <editor><first>Bodhisattwa Prasad</first><last>Majumder</last></editor>
+      <editor><first>Yash Kumar</first><last>Lal</last></editor>
+      <editor><first>Rachel</first><last>Rudinger</last></editor>
+      <editor><first>Xiang</first><last>Ren</last></editor>
+      <editor><first>Niket</first><last>Tandon</last></editor>
+      <editor><first>Vilém</first><last>Zouhar</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Dublin, Ireland</address>
       <month>May</month>


### PR DESCRIPTION
## Option 1: Metadata correction

Link: https://aclanthology.org/2022.csrr-1.0/

The list of authors should be: Antoine Bosselut, Xiang Li, Bill Yuchen Lin, Vered Shwartz, Bodhisattwa Prasad Majumder, Yash Kumar Lal, Rachel Rudinger, Xiang Ren, Niket Tandon and Vilém Zouhar.

This PR makes the necessary changes for #1932 