### PR TITLE
correction to 2022.acl-long.395

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -5683,7 +5683,7 @@ in the Case of Unambiguous Gender</title>
       <abstract>Information extraction suffers from its varying targets, heterogeneous structures, and demand-specific schemas. In this paper, we propose a unified text-to-structure generation framework, namely UIE, which can universally model different IE tasks, adaptively generate targeted structures, and collaboratively learn general IE abilities from different knowledge sources. Specifically, UIE uniformly encodes different extraction structures via a structured extraction language, adaptively generates target extractions via a schema-based prompt mechanism – structural schema instructor, and captures the common IE abilities via a large-scale pretrained text-to-structure model. Experiments show that UIE achieved the state-of-the-art performance on 4 IE tasks, 13 datasets, and on all supervised, low-resource, and few-shot settings for a wide range of entity, relation, event and sentiment extraction tasks and their unification. These results verified the effectiveness, universality, and transferability of UIE.</abstract>
       <url hash="275e634d">2022.acl-long.395</url>
       <bibkey>lu-etal-2022-unified</bibkey>
-      <pwccode url="https://github.com/PaddlePaddle/PaddleNLP/tree/develop/model_zoo/uie" additional="false">PaddlePaddle/PaddleNLP</pwccode>
+      <pwccode url="https://github.com/universal-ie/UIE" additional="false">universal-ie/UIE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
     </paper>


### PR DESCRIPTION
Paper-with-code first add the another GitHub url, I have fixed it.

reference: https://paperswithcode.com/paper/unified-structure-generation-for-universal
