### PR TITLE
Metadata correction for 2022.iwslt-1.20

### DIFF
--- a/data/xml/2022.iwslt.xml
+++ b/data/xml/2022.iwslt.xml
@@ -315,6 +315,7 @@
     </paper>
     <paper id="20">
       <title>The <fixed-case>HW</fixed-case>-<fixed-case>TSC</fixed-case>’s Offline Speech Translation System for <fixed-case>IWSLT</fixed-case> 2022 Evaluation</title>
+      <author><first>Yinglu</first><last>Li</last></author>
       <author><first>Minghan</first><last>Wang</last></author>
       <author><first>Jiaxin</first><last>Guo</last></author>
       <author><first>Xiaosong</first><last>Qiao</last></author>


### PR DESCRIPTION
Adds missing author for 2022.iwslt.20 in metadata
Corresponding authors: [wangmh1994@gmail.com](wangmh1994@gmail.com), [liyinglu@huawei.com](liyinglu@huawei.com)