### PR TITLE
Add missing author to 2022.acl-long.91

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -1331,12 +1331,13 @@
     </paper>
     <paper id="91">
       <title>Tracing Origins: Coreference-aware Machine Reading Comprehension</title>
+      <author><first>Baorong</first><last>Huang</last></author>
       <author><first>Zhuosheng</first><last>Zhang</last></author>
       <author><first>Hai</first><last>Zhao</last></author>
       <pages>1281-1292</pages>
       <abstract>Machine reading comprehension is a heavily-studied research and test field for evaluating new pre-trained language models (PrLMs) and fine-tuning strategies, and recent studies have enriched the pre-trained language models with syntactic, semantic and other linguistic information to improve the performance of the models. In this paper, we imitate the human reading process in connecting the anaphoric expressions and explicitly leverage the coreference information of the entities to enhance the word embeddings from the pre-trained language model, in order to highlight the coreference mentions of the entities that must be identified for coreference-intensive question answering in QUOREF, a relatively new dataset that is specifically designed to evaluate the coreference-related performance of a model. We use two strategies to fine-tune a pre-trained language model, namely, placing an additional encoder layer after a pre-trained language model to focus on the coreference mentions or constructing a relational graph convolutional network to model the coreference relations. We demonstrate that the explicit incorporation of coreference information in the fine-tuning stage performs better than the incorporation of the coreference information in pre-training a language model.</abstract>
       <url hash="c93f243c">2022.acl-long.91</url>
-      <bibkey>zhang-zhao-2022-tracing</bibkey>
+      <bibkey>huang-etal-2022-tracing</bibkey>
       <pwccode url="https://github.com/bright2013/CorefAwareMRC" additional="false">bright2013/CorefAwareMRC</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/newsqa">NewsQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quac">QuAC</pwcdataset>


### PR DESCRIPTION
One author Baorong Huang is missing from the citation information for https://aclanthology.org/2022.acl-long.91/. There are three authors for this paper, as indicated in the PDF file https://aclanthology.org/2022.acl-long.91.pdf.