### PR TITLE
Name correction for 2022.acl-long.273

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -3921,7 +3921,7 @@ in the Case of Unambiguous Gender</title>
       <title>Automatic Identification and Classification of Bragging in Social Media</title>
       <author><first>Mali</first><last>Jin</last></author>
       <author><first>Daniel</first><last>Preotiuc-Pietro</last></author>
-      <author><first>A.</first><last>Doğruöz</last></author>
+      <author><first>A. Seza</first><last>Doğruöz</last></author>
       <author><first>Nikolaos</first><last>Aletras</last></author>
       <pages>3945-3959</pages>
       <abstract>Bragging is a speech act employed with the goal of constructing a favorable self-image through positive statements about oneself. It is widespread in daily communication and especially popular in social media, where users aim to build a positive image of their persona directly or indirectly. In this paper, we present the first large scale study of bragging in computational linguistics, building on previous research in linguistics and pragmatics. To facilitate this, we introduce a new publicly available data set of tweets annotated for bragging and their types. We empirically evaluate different transformer-based models injected with linguistic information in (a) binary bragging classification, i.e., if tweets contain bragging statements or not; and (b) multi-class bragging type prediction including not bragging. Our results show that our models can predict bragging with macro F1 up to 72.42 and 35.95 in the binary and multi-class classification tasks respectively. Finally, we present an extensive linguistic and error analysis of bragging prediction to guide future research on this topic.</abstract>


### PR DESCRIPTION
A. Seza --> Correct name now displayed on the file for paper acl-long-273
