### PR TITLE
Update metadata for 2022.computel-1.15: fix title

### DIFF
--- a/data/xml/2022.computel.xml
+++ b/data/xml/2022.computel.xml
@@ -186,7 +186,7 @@
       <bibkey>ni-chiarain-etal-2022-using</bibkey>
     </paper>
     <paper id="15">
-      <title>Closing the <fixed-case>NLP</fixed-case> Gap Documentary Linguistics and <fixed-case>NLP</fixed-case> Need a Shared Software Infrastructure</title>
+      <title>Closing the <fixed-case>NLP</fixed-case> Gap: Documentary Linguistics and <fixed-case>NLP</fixed-case> Need a Shared Software Infrastructure</title>
       <author><first>Luke</first><last>Gessler</last></author>
       <pages>119-126</pages>
       <abstract>For decades, researchers in natural language processing and computational linguistics have been developing models and algorithms that aim to serve the needs of language documentation projects. However, these models have seen little use in language documentation despite their great potential for making documentary linguistic artefacts better and easier to produce. In this work, we argue that a major reason for this NLP gap is the lack of a strong foundation of application software which can on the one hand serve the complex needs of language documentation and on the other hand provide effortless integration with NLP models. We further present and describe a work-in-progress system we have developed to serve this need, Glam.</abstract>


### PR DESCRIPTION
Colon was missing from the title, which was present in the OpenReview title. 