### PR TITLE
Preview lock

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+# only run one at a time
+concurrency: publish
+
 jobs:
   publish-aclanthology:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
We occasionally do multiple merges at once, which then all publish concurrently and cause rsync errors. This feature only allows one to run at a time.

[doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)