### PR TITLE
Update title of 2022.eamt-1.7

### DIFF
--- a/data/xml/2022.eamt.xml
+++ b/data/xml/2022.eamt.xml
@@ -83,7 +83,7 @@
       <bibkey>soto-etal-2022-comparing</bibkey>
     </paper>
     <paper id="7">
-      <title>Passing Parser Uncertainty to the Transformer. Labeled Dependency Distributions for Neural Machine Translation.</title>
+      <title>Passing Parser Uncertainty to the Transformer: Labeled Dependency Distributions for Neural Machine Translation</title>
       <author><first>Dongqi</first><last>Pu</last></author>
       <author><first>Khalil</first><last>Sima’an</last></author>
       <pages>41–50</pages>


### PR DESCRIPTION
The author of [paper 7](https://aclanthology.org/2022.eamt-1.7) contacted us with a request to change the title to a more common format.

Changes the title from 

`Passing Parser Uncertainty to the Transformer. Labeled Dependency Distributions for Neural Machine Translation.`

to

`Passing Parser Uncertainty to the Transformer: Labeled Dependency Distributions for Neural Machine Translation`

I assume that the corresponding bibtex will be updated accordingly?