### PR TITLE
Name correction to 2022.findings-naacl.156 (closes #2024)

### DIFF
--- a/data/xml/2022.findings.xml
+++ b/data/xml/2022.findings.xml
@@ -6846,7 +6846,7 @@
     </paper>
     <paper id="156">
       <title>Beyond Distributional Hypothesis: Let Language Models Learn Meaning-Text Correspondence</title>
-      <author><first>M.j</first><last>Jang</last></author>
+      <author><first>Myeongjun</first><last>Jang</last></author>
       <author><first>Frank</first><last>Mtumbuka</last></author>
       <author><first>Thomas</first><last>Lukasiewicz</last></author>
       <pages>2030-2042</pages>


### PR DESCRIPTION
I fixed the name of the first author of the paper with an ID "2022.findings-naacl.156".
The name has changed from "M.j Jang" to "Myeongjun Jang".