### PR TITLE
metadata fix for paper 2022.woah-1.24

### DIFF
--- a/data/xml/2022.woah.xml
+++ b/data/xml/2022.woah.xml
@@ -297,7 +297,7 @@
       <bibkey>ramesh-etal-2022-revisiting</bibkey>
     </paper>
     <paper id="24">
-      <title><fixed-case>HATE</fixed-case>-<fixed-case>ITA</fixed-case>: New Baselines for Hate Speech Detection in <fixed-case>I</fixed-case>talian</title>
+      <title><fixed-case>HATE</fixed-case>-<fixed-case>ITA</fixed-case>: Hate Speech Detection in <fixed-case>I</fixed-case>talian Social Media Text</title>
       <author><first>Debora</first><last>Nozza</last></author>
       <author><first>Federico</first><last>Bianchi</last></author>
       <author><first>Giuseppe</first><last>Attanasio</last></author>


### PR DESCRIPTION
Hello!

Issue:

WOAH2022 paper 24 has a different title in the pdf file.

[Metadata](https://aclanthology.org/2022.woah-1.24/): **HATE-ITA: New Baselines for Hate Speech Detection in Italian**
[PDF](https://aclanthology.org/2022.woah-1.24.pdf): **HATE-ITA: Hate Speech Detection in Italian Social Media Text**

This PR:

I have modified the metadata so that the title corresponds to the one in the paper (**HATE-ITA: Hate Speech Detection in Italian Social Media Text**)

Thank you!
