### PR TITLE
SIGTYP 2022: Fixed typo in one paper's title.

### DIFF
--- a/data/xml/2022.sigtyp.xml
+++ b/data/xml/2022.sigtyp.xml
@@ -95,7 +95,7 @@
       <bibkey>jager-2022-bayesian</bibkey>
     </paper>
     <paper id="9">
-      <title>Mockingbird at the <fixed-case>SIGTYP</fixed-case> 2022 Shared Task: Two Types of Models forthe Prediction of Cognate Reflexes</title>
+      <title>Mockingbird at the <fixed-case>SIGTYP</fixed-case> 2022 Shared Task: Two Types of Models for the Prediction of Cognate Reflexes</title>
       <author><first>Christo</first><last>Kirov</last></author>
       <author><first>Richard</first><last>Sproat</last></author>
       <author><first>Alexander</first><last>Gutkin</last></author>


### PR DESCRIPTION
Fixing a silly typo.