### PR TITLE
Metadata correction - Adding missing middle initial for Jonathan K. Kummerfeld

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -1889,7 +1889,7 @@
       <title>Leveraging Similar Users for Personalized Language Modeling with Limited Data</title>
       <author><first>Charles</first><last>Welch</last></author>
       <author><first>Chenxi</first><last>Gu</last></author>
-      <author><first>Jonathan</first><last>Kummerfeld</last></author>
+      <author><first>Jonathan K.</first><last>Kummerfeld</last></author>
       <author><first>Veronica</first><last>Perez-Rosas</last></author>
       <author><first>Rada</first><last>Mihalcea</last></author>
       <pages>1742-1752</pages>

--- a/data/xml/2022.naacl.xml
+++ b/data/xml/2022.naacl.xml
@@ -4784,7 +4784,7 @@
     <paper id="338">
       <title>Using Paraphrases to Study Properties of Contextual Embeddings</title>
       <author><first>Laura</first><last>Burdick</last></author>
-      <author><first>Jonathan</first><last>Kummerfeld</last></author>
+      <author><first>Jonathan K.</first><last>Kummerfeld</last></author>
       <author><first>Rada</first><last>Mihalcea</last></author>
       <pages>4558-4568</pages>
       <abstract>We use paraphrases as a unique source of data to analyze contextualized embeddings, with a particular focus on BERT. Because paraphrases naturally encode consistent word and phrase semantics, they provide a unique lens for investigating properties of embeddings. Using the Paraphrase Database’s alignments, we study words within paraphrases as well as phrase representations. We find that contextual embeddings effectively handle polysemous words, but give synonyms surprisingly different representations in many cases. We confirm previous findings that BERT is sensitive to word order, but find slightly different patterns than prior work in terms of the level of contextualization across BERT’s layers.</abstract>


### PR DESCRIPTION
This PR corrects the metadata for two papers to add my middle initial. The middle initial is present in the PDFs:

- https://aclanthology.org/2022.naacl-main.338/ vs. https://aclanthology.org/2022.naacl-main.338.pdf
- https://aclanthology.org/2022.acl-long.122/ vs. https://aclanthology.org/2022.acl-long.122.pdf
