### PR TITLE
merged two author pages of Yang Janet Liu

### DIFF
--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -3554,7 +3554,7 @@
     <paper id="8">
       <title>A Discourse Signal Annotation System for <fixed-case>RST</fixed-case> Trees</title>
       <author><first>Luke</first><last>Gessler</last></author>
-      <author id="yang-liu-georgetown"><first>Yang</first><last>Liu</last></author>
+      <author id="yang-janet-liu"><first>Yang</first><last>Liu</last></author>
       <author><first>Amir</first><last>Zeldes</last></author>
       <pages>56–61</pages>
       <abstract>This paper presents a new system for open-ended discourse relation signal annotation in the framework of Rhetorical Structure Theory (RST), implemented on top of an online tool for RST annotation. We discuss existing projects annotating textual signals of discourse relations, which have so far not allowed simultaneously structuring and annotating words signaling hierarchical discourse trees, and demonstrate the design and applications of our interface by extending existing RST annotations in the freely available GUM corpus.</abstract>
@@ -3575,7 +3575,7 @@
     </paper>
     <paper id="10">
       <title>Beyond The <fixed-case>W</fixed-case>all <fixed-case>S</fixed-case>treet <fixed-case>J</fixed-case>ournal: Anchoring and Comparing Discourse Signals across Genres</title>
-      <author id="yang-liu-georgetown"><first>Yang</first><last>Liu</last></author>
+      <author id="yang-janet-liu"><first>Yang</first><last>Liu</last></author>
       <pages>72–81</pages>
       <abstract>Recent research on discourse relations has found that they are cued not only by discourse markers (DMs) but also by other textual signals and that signaling information is indicative of genres. While several corpora exist with discourse relation signaling information such as the Penn Discourse Treebank (PDTB, Prasad et al. 2008) and the Rhetorical Structure Theory Signalling Corpus (RST-SC, Das and Taboada 2018), they both annotate the Wall Street Journal (WSJ) section of the Penn Treebank (PTB, Marcus et al. 1993), which is limited to the news domain. Thus, this paper adapts the signal identification and anchoring scheme (Liu and Zeldes, 2019) to three more genres, examines the distribution of signaling devices across relations and genres, and provides a taxonomy of indicative signals found in this dataset.</abstract>
       <url hash="bff4a7ac">W19-2710</url>
@@ -3665,7 +3665,7 @@
       <title><fixed-case>G</fixed-case>um<fixed-case>D</fixed-case>rop at the <fixed-case>DISRPT</fixed-case>2019 Shared Task: A Model Stacking Approach to Discourse Unit Segmentation and Connective Detection</title>
       <author><first>Yue</first><last>Yu</last></author>
       <author><first>Yilun</first><last>Zhu</last></author>
-      <author id="yang-liu-georgetown"><first>Yang</first><last>Liu</last></author>
+      <author id="yang-janet-liu"><first>Yang</first><last>Liu</last></author>
       <author><first>Yan</first><last>Liu</last></author>
       <author><first>Siyao</first><last>Peng</last></author>
       <author><first>Mackenzie</first><last>Gong</last></author>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -5483,6 +5483,10 @@
   comment: Microsoft Cognitive Services Research
   id: yang-liu-microsoft
 - canonical: {first: Yang, last: Liu}
+  comment: May refer to several people
+  id: yang-liu
+  similar: [yang-janet-liu]
+- canonical: {first: Yang, last: Liu}
   comment: Univ. of Michigan, UC Santa Cruz
   id: yang-liu-umich
 - canonical: {first: Yang, last: Liu}

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -5468,7 +5468,7 @@
   comment: 刘洋; ICT, Tsinghua, Beijing Academy of Artificial Intelligence
   id: yang-liu-ict
 - canonical: {first: Yang Janet, last: Liu}
-  comment: Georgetown University
+  comment: Georgetown University; 刘洋
   id: yang-janet-liu
 - canonical: {first: Miruna, last: Clinciu}
   variants:
@@ -5483,18 +5483,11 @@
   comment: Microsoft Cognitive Services Research
   id: yang-liu-microsoft
 - canonical: {first: Yang, last: Liu}
-  comment: May refer to several people
-  id: yang-liu
-  similar: [yang-liu-georgetown]
-- canonical: {first: Yang, last: Liu}
   comment: Univ. of Michigan, UC Santa Cruz
   id: yang-liu-umich
 - canonical: {first: Yang, last: Liu}
   comment: University of Helsinki
   id: yang-liu-Helsinki
-- canonical: {first: Yang (Janet), last: Liu}
-  comment: 刘洋; Georgetown
-  id: yang-liu-georgetown
 - canonical: {first: Yang, last: Liu}
   comment: 3M Health Information Systems
   id: yang-liu-3m


### PR DESCRIPTION
updated author ids of three papers in `data/xml/W19.xml` in order to merge two author pages: the [Yang Janet Liu author page](https://aclanthology.org/people/y/yang-janet-liu/) is kept and [this one](https://aclanthology.org/people/y/yang-liu-georgetown/) should be gone. This PR was created to follow up on the corresponding Github Issue #2063.
