### PR TITLE
Fixed casing in gorman-2016-pynini (SIGFSM).

### DIFF
--- a/data/xml/W16.xml
+++ b/data/xml/W16.xml
@@ -4992,7 +4992,7 @@
       <bibkey>asaadi-rudolph-2016-correspondence</bibkey>
     </paper>
     <paper id="9">
-      <title><fixed-case>P</fixed-case>ynini: A Python library for weighted finite-state grammar compilation</title>
+      <title><fixed-case>P</fixed-case>ynini: A <fixed-case>P</fixed-case>ython library for weighted finite-state grammar compilation</title>
       <author><first>Kyle</first><last>Gorman</last></author>
       <pages>75–80</pages>
       <url hash="9bf9b1f6">W16-2409</url>


### PR DESCRIPTION
Trivial change in casing: "python" -> "Python".