### PR TITLE
ingested mt-summit 2017

### DIFF
--- a/data/xml/2017.mtsummit.xml
+++ b/data/xml/2017.mtsummit.xml
@@ -1,0 +1,453 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection id="2017.mtsummit">
+  <volume id="papers" ingest-date="2022-08-30">
+    <meta>
+      <booktitle>Proceedings of Machine Translation Summit XVI: Research Track</booktitle>
+      <editor><first>Sadao</first><last>Kurohashi</last></editor>
+      <editor><first>Pascale</first><last>Fung</last></editor>
+      <address>Nagoya Japan</address>
+      <month>September 18 – September 22</month>
+      <year>2017</year>
+      <url hash="024f9e96">2017.mtsummit-papers</url>
+    </meta>
+    <frontmatter>
+      <url hash="7801235b">2017.mtsummit-papers.0</url>
+      <bibkey>mtsummit-2017-machine</bibkey>
+    </frontmatter>
+    <paper id="1">
+      <title>Empirical Study of Dropout Scheme for Neural Machine Translation</title>
+      <author><first>Xiaolin</first><last>Wang</last></author>
+      <author><first>Masao</first><last>Utiyama</last></author>
+      <author><first>Eiichiro</first><last>Sumita</last></author>
+      <pages>1-14</pages>
+      <url hash="00708fe4">2017.mtsummit-papers.1</url>
+      <bibkey>wang-etal-2017-empirical</bibkey>
+    </paper>
+    <paper id="2">
+      <title>A Target Attention Model for Neural Machine Translation</title>
+      <author><first>Hideya</first><last>Mino</last></author>
+      <author><first>Andrew</first><last>Finch</last></author>
+      <author><first>Eiichiro</first><last>Sumita</last></author>
+      <pages>15-26</pages>
+      <url hash="1b1fe0c7">2017.mtsummit-papers.2</url>
+      <bibkey>mino-etal-2017-target</bibkey>
+    </paper>
+    <paper id="3">
+      <title>Neural Pre-Translation for Hybrid Machine Translation</title>
+      <author><first>Jinhua</first><last>Du</last></author>
+      <author><first>Andy</first><last>Way</last></author>
+      <pages>27-40</pages>
+      <url hash="d766cceb">2017.mtsummit-papers.3</url>
+      <bibkey>du-way-2017-neural</bibkey>
+    </paper>
+    <paper id="4">
+      <title>Neural and Statistical Methods for Leveraging Meta-information in Machine Translation</title>
+      <author><first>Shahram</first><last>Khadivi</last></author>
+      <author><first>Patrick</first><last>Wilken</last></author>
+      <author><first>Leonard</first><last>Dahlmann</last></author>
+      <author><first>Evgeny</first><last>Matusov</last></author>
+      <pages>41-54</pages>
+      <url hash="db6a3352">2017.mtsummit-papers.4</url>
+      <bibkey>khadivi-etal-2017-neural</bibkey>
+    </paper>
+    <paper id="5">
+      <title>Translation Quality and Productivity: A Study on Rich Morphology Languages</title>
+      <author><first>Lucia</first><last>Specia</last></author>
+      <author><first>Kim</first><last>Harris</last></author>
+      <author><first>Frédéric</first><last>Blain</last></author>
+      <author><first>Aljoscha</first><last>Burchardt</last></author>
+      <author><first>Viviven</first><last>Macketanz</last></author>
+      <author><first>Inguna</first><last>Skadin</last></author>
+      <author><first>Matteo</first><last>Negri</last></author>
+      <author><first>Marco</first><last>Turchi</last></author>
+      <pages>55-71</pages>
+      <url hash="d3ad3e03">2017.mtsummit-papers.5</url>
+      <bibkey>specia-etal-2017-translation</bibkey>
+    </paper>
+    <paper id="6">
+      <title>The <fixed-case>M</fixed-case>icrosoft Speech Language Translation (<fixed-case>MSLT</fixed-case>) Corpus for <fixed-case>C</fixed-case>hinese and <fixed-case>J</fixed-case>apanese: Conversational Test data for Machine Translation and Speech Recognition</title>
+      <author><first>Christian</first><last>Federmann</last></author>
+      <author><first>William D.</first><last>Lewis</last></author>
+      <pages>72-85</pages>
+      <url hash="8cfca0bc">2017.mtsummit-papers.6</url>
+      <bibkey>federmann-lewis-2017-microsoft</bibkey>
+    </paper>
+    <paper id="7">
+      <title>Paying Attention to Multi-Word Expressions in Neural Machine Translation</title>
+      <author><first>Matīss</first><last>Rikters</last></author>
+      <author><first>Ondřej</first><last>Bojar</last></author>
+      <pages>86-95</pages>
+      <url hash="d6d7b87c">2017.mtsummit-papers.7</url>
+      <bibkey>rikters-bojar-2017-paying</bibkey>
+    </paper>
+    <paper id="8">
+      <title>Enabling Multi-Source Neural Machine Translation By Concatenating Source Sentences In Multiple Languages</title>
+      <author><first>Raj</first><last>Dabre</last></author>
+      <author><first>Fabien</first><last>Cromieres</last></author>
+      <author><first>Sadao</first><last>Kurohashi</last></author>
+      <pages>96-107</pages>
+      <url hash="a4eaedd4">2017.mtsummit-papers.8</url>
+      <bibkey>dabre-etal-2017-enabling</bibkey>
+    </paper>
+    <paper id="9">
+      <title>Learning an Interactive Attention Policy for Neural Machine Translation</title>
+      <author><first>Samee</first><last>Ibraheem</last></author>
+      <author><first>Nicholas</first><last>Altieri</last></author>
+      <author><first>John</first><last>DeNero</last></author>
+      <pages>108-115</pages>
+      <url hash="506e0ed8">2017.mtsummit-papers.9</url>
+      <bibkey>ibraheem-etal-2017-learning</bibkey>
+    </paper>
+    <paper id="10">
+      <title>A Comparative Quality Evaluation of <fixed-case>PBSMT</fixed-case> and <fixed-case>NMT</fixed-case> using Professional Translators</title>
+      <author><first>Sheila</first><last>Castilho</last></author>
+      <author><first>Joss</first><last>Moorkens</last></author>
+      <author><first>Federico</first><last>Gaspari</last></author>
+      <author><first>Rico</first><last>Sennrich</last></author>
+      <author><first>Vilelmini</first><last>Sosoni</last></author>
+      <author><first>Panayota</first><last>Georgakopoulou</last></author>
+      <author><first>Pintu</first><last>Lohar</last></author>
+      <author><first>Andy</first><last>Way</last></author>
+      <author><first>Antonio Valerio</first><last>Miceli-Barone</last></author>
+      <author><first>Maria</first><last>Gialama</last></author>
+      <pages>116-131</pages>
+      <url hash="c3472fb3">2017.mtsummit-papers.10</url>
+      <bibkey>castilho-etal-2017-comparative</bibkey>
+    </paper>
+    <paper id="11">
+      <title>One-parameter models for sentence-level post-editing effort estimation</title>
+      <author><first>Mikel L. Miquel Esplà-Gomis</first><last>Forcada</last></author>
+      <author><first>Felipe</first><last>Sánchez-Martínez</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
+      <pages>132-143</pages>
+      <url hash="3b1eb27a">2017.mtsummit-papers.11</url>
+      <bibkey>forcada-etal-2017-one</bibkey>
+    </paper>
+    <paper id="12">
+      <title>A Minimal Cognitive Model for Translating and Post-editing</title>
+      <author><first>Moritz</first><last>Schaeffer</last></author>
+      <author><first>Michael</first><last>Carl</last></author>
+      <pages>144-155</pages>
+      <url hash="a803d275">2017.mtsummit-papers.12</url>
+      <bibkey>schaeffer-carl-2017-minimal</bibkey>
+    </paper>
+    <paper id="13">
+      <title>Fine-Tuning for Neural Machine Translation with Limited Degradation across In- and Out-of-Domain Data</title>
+      <author><first>Praveen</first><last>Dakwale</last></author>
+      <author><first>Christof</first><last>Monz</last></author>
+      <pages>156-169</pages>
+      <url hash="4a151b06">2017.mtsummit-papers.13</url>
+      <bibkey>dakwale-monz-2017-fine</bibkey>
+    </paper>
+    <paper id="14">
+      <title>Exploiting Relative Frequencies for Data Selection</title>
+      <author><first>Thierry</first><last>Etchegoyhen</last></author>
+      <author><first>Andoni</first><last>Azpeitia</last></author>
+      <author><first>Eva</first><last>Martinez García</last></author>
+      <pages>170-184</pages>
+      <url hash="3db4c6b5">2017.mtsummit-papers.14</url>
+      <bibkey>etchegoyhen-etal-2017-exploiting</bibkey>
+    </paper>
+    <paper id="15">
+      <title>Low Resourced Machine Translation via Morpho-syntactic Modeling: The Case of Dialectal <fixed-case>A</fixed-case>rabic</title>
+      <author><first>Alexander</first><last>Erdmann</last></author>
+      <author><first>Nizar</first><last>Habash</last></author>
+      <author><first>Dima</first><last>Taji</last></author>
+      <author><first>Houda</first><last>Bouamor</last></author>
+      <pages>185-200</pages>
+      <url hash="40a39348">2017.mtsummit-papers.15</url>
+      <bibkey>erdmann-etal-2017-low</bibkey>
+    </paper>
+    <paper id="16">
+      <title>Elastic-substitution decoding for Hierarchical <fixed-case>SMT</fixed-case>: efficiency, richer search and double labels</title>
+      <author><first>Gideon</first><last>Maillette de Buy Wenniger</last></author>
+      <author><first>Khalil</first><last>Sima’an</last></author>
+      <author><first>Andy</first><last>Way</last></author>
+      <pages>201-215</pages>
+      <url hash="2f4a2a39">2017.mtsummit-papers.16</url>
+      <bibkey>maillette-de-buy-wenniger-etal-2017-elastic</bibkey>
+    </paper>
+    <paper id="17">
+      <title>Development of a classifiers/quantifiers dictionary towards <fixed-case>F</fixed-case>rench-<fixed-case>J</fixed-case>apanese <fixed-case>MT</fixed-case></title>
+      <author><first>Mutsuko</first><last>Tomokiyo</last></author>
+      <author><first>Mathieu</first><last>Mangeot</last></author>
+      <author><first>Christian</first><last>Boitet</last></author>
+      <pages>216-226</pages>
+      <url hash="952acad3">2017.mtsummit-papers.17</url>
+      <bibkey>tomokiyo-etal-2017-development</bibkey>
+    </paper>
+    <paper id="18">
+      <title>Neural Machine Translation Model with a Large Vocabulary Selected by Branching Entropy</title>
+      <author><first>Zi</first><last>Long</last></author>
+      <author><first>Ryuichiro</first><last>Kimura</last></author>
+      <author><first>Takehito</first><last>Utsuro</last></author>
+      <author><first>Tomoharu</first><last>Mitsuhashi</last></author>
+      <author><first>Mikio</first><last>Yamamoto</last></author>
+      <pages>227-240</pages>
+      <url hash="84cfe48c">2017.mtsummit-papers.18</url>
+      <bibkey>long-etal-2017-neural</bibkey>
+    </paper>
+    <paper id="19">
+      <title>Usefulness of <fixed-case>MT</fixed-case> output for comprehension — an analysis from the point of view of linguistic intercomprehension</title>
+      <author><first>Kenneth</first><last>Jordan Núñez</last></author>
+      <author><first>Mikel L.</first><last>Forcada</last></author>
+      <author><first>Esteve</first><last>Clua</last></author>
+      <pages>241-253</pages>
+      <url hash="fa09c597">2017.mtsummit-papers.19</url>
+      <bibkey>jordan-nunez-etal-2017-usefulness</bibkey>
+    </paper>
+    <paper id="20">
+      <title>Machine Translation as an Academic Writing Aid for Medical Practitioners</title>
+      <author><first>Carla</first><last>Parra Escartín</last></author>
+      <author><first>Sharon</first><last>O’Brien</last></author>
+      <author><first>Marie-Josée</first><last>Goulet</last></author>
+      <author><first>Michel</first><last>Simard</last></author>
+      <pages>254-267</pages>
+      <url hash="46e0a069">2017.mtsummit-papers.20</url>
+      <bibkey>parra-escartin-etal-2017-machine</bibkey>
+    </paper>
+    <paper id="21">
+      <title>A Multilingual Parallel Corpus for Improving Machine Translation on <fixed-case>S</fixed-case>outheast <fixed-case>A</fixed-case>sian Languages</title>
+      <author><first>Hai-Long</first><last>Trieu</last></author>
+      <author><first>Le-Minh</first><last>Nguyen</last></author>
+      <pages>268-281</pages>
+      <url hash="75848541">2017.mtsummit-papers.21</url>
+      <bibkey>trieu-nguyen-2017-multilingual</bibkey>
+    </paper>
+    <paper id="22">
+      <title>Exploring Hypotheses Spaces in Neural Machine Translation</title>
+      <author><first>Frédéric</first><last>Blain</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
+      <author><first>Pranava</first><last>Madhyastha</last></author>
+      <pages>282-298</pages>
+      <url hash="1ad31cb7">2017.mtsummit-papers.22</url>
+      <bibkey>blain-etal-2017-exploring</bibkey>
+    </paper>
+    <paper id="23">
+      <title>Confidence through Attention</title>
+      <author><first>Matīss</first><last>Rikters</last></author>
+      <author><first>Mark</first><last>Fishel</last></author>
+      <pages>299-311</pages>
+      <url hash="3899e5c8">2017.mtsummit-papers.23</url>
+      <bibkey>rikters-fishel-2017-confidence</bibkey>
+    </paper>
+    <paper id="24">
+      <title>Disentangling <fixed-case>ASR</fixed-case> and <fixed-case>MT</fixed-case> Errors in Speech Translation</title>
+      <author><first>Ngoc-Tien</first><last>Le</last></author>
+      <author><first>Benjamin</first><last>Lecouteux</last></author>
+      <author><first>Laurent</first><last>Besacier</last></author>
+      <pages>312-323</pages>
+      <url hash="8ae7b0f0">2017.mtsummit-papers.24</url>
+      <bibkey>le-etal-2017-disentangling</bibkey>
+    </paper>
+    <paper id="25">
+      <title>Temporality as Seen through Translation: A Case Study on <fixed-case>H</fixed-case>indi Texts</title>
+      <author><first>Sabyasachi</first><last>Kamila</last></author>
+      <author><first>Sukanta</first><last>Sen</last></author>
+      <author><first>Mohammad</first><last>Hasanuzzaman</last></author>
+      <author><first>Asif</first><last>Ekbal</last></author>
+      <author><first>Andy</first><last>Way</last></author>
+      <author><first>Pushpak</first><last>Bhattacharyya</last></author>
+      <pages>324-336</pages>
+      <url hash="b2a67947">2017.mtsummit-papers.25</url>
+      <bibkey>kamila-etal-2017-temporality</bibkey>
+    </paper>
+    <paper id="26">
+      <title>A Neural Network Transliteration Model in Low Resource Settings</title>
+      <author><first>Tan</first><last>Le</last></author>
+      <author><first>Fatiha</first><last>Sadat</last></author>
+      <pages>337-345</pages>
+      <url hash="2ee95698">2017.mtsummit-papers.26</url>
+      <bibkey>le-sadat-2017-neural</bibkey>
+    </paper>
+  </volume>
+  <volume id="commercial" ingest-date="2022-08-30">
+    <meta>
+      <booktitle>Proceedings of Machine Translation Summit XVI: Commercial MT Users and Translators Track</booktitle>
+      <editor><first>Masaru</first><last>Yamada</last></editor>
+      <editor><first>Mark</first><last>Seligman</last></editor>
+      <address>Nagoya Japan</address>
+      <month>September 18 – September 22</month>
+      <year>2017</year>
+      <url hash="672af14b">2017.mtsummit-commercial</url>
+    </meta>
+    <frontmatter>
+      <url hash="042ac875">2017.mtsummit-commercial.0</url>
+      <bibkey>mtsummit-2017-machine-translation</bibkey>
+    </frontmatter>
+    <paper id="1">
+      <title>Zero-Shot Translation for <fixed-case>I</fixed-case>ndian Languages with Sparse Data</title>
+      <author><first>Giulia</first><last>Mattoni</last></author>
+      <author><first>Pat</first><last>Nagle</last></author>
+      <author><first>Carlos</first><last>Collantes</last></author>
+      <author><first>Dimitar</first><last>Shterionov</last></author>
+      <pages>1-10</pages>
+      <url hash="df2ad8cd">2017.mtsummit-commercial.1</url>
+      <bibkey>mattoni-etal-2017-zero</bibkey>
+    </paper>
+    <paper id="2">
+      <title>Feature-rich <fixed-case>NMT</fixed-case> and <fixed-case>SMT</fixed-case> post-edited corpora for productivity and evaluation tasks with a subset of <fixed-case>MQM</fixed-case>-annotated data</title>
+      <author><first>Kim</first><last>Harris</last></author>
+      <author><first>Lucia</first><last>Specia</last></author>
+      <author><first>Aljoscha</first><last>Burchardt</last></author>
+      <pages>11-12</pages>
+      <url hash="901501d6">2017.mtsummit-commercial.2</url>
+      <bibkey>harris-etal-2017-feature</bibkey>
+    </paper>
+    <paper id="3">
+      <title>Usability of web-based <fixed-case>MT</fixed-case> post-editing environments for screen reader users</title>
+      <author><first>Silvia</first><last>Rodríguez Vázquez</last></author>
+      <author><first>Sharon</first><last>O’Brien</last></author>
+      <author><first>Dónal</first><last>Fitzpatrick</last></author>
+      <pages>13-25</pages>
+      <url hash="214e24e5">2017.mtsummit-commercial.3</url>
+      <bibkey>rodriguez-vazquez-etal-2017-usability</bibkey>
+    </paper>
+    <paper id="4">
+      <title>Live presentations to a multilingual audience: personal universal translator</title>
+      <author><first>Chris</first><last>Wendt</last></author>
+      <pages>26</pages>
+      <url hash="570604d0">2017.mtsummit-commercial.4</url>
+      <bibkey>wendt-2017-live</bibkey>
+    </paper>
+    <paper id="5">
+      <title>Toward a full-scale neural machine translation in production: the Booking.com use case</title>
+      <author><first>Pavel</first><last>Levin</last></author>
+      <author><first>Nishikant</first><last>Dhanuka</last></author>
+      <author><first>Talaat</first><last>Khalil</last></author>
+      <author><first>Fedor</first><last>Kovalev</last></author>
+      <author><first>Maxim</first><last>Khalilov</last></author>
+      <pages>27-37</pages>
+      <url hash="747655de">2017.mtsummit-commercial.5</url>
+      <bibkey>levin-etal-2017-toward</bibkey>
+    </paper>
+    <paper id="6">
+      <title>The <fixed-case>INTERACT</fixed-case> Project and Crisis <fixed-case>MT</fixed-case></title>
+      <author><first>Sharon</first><last>O’Brien</last></author>
+      <author><first>Chao-Hong</first><last>Liu</last></author>
+      <author><first>Andy</first><last>Way</last></author>
+      <author><first>João</first><last>Graça</last></author>
+      <author><first>André</first><last>Martins</last></author>
+      <author><first>Helena</first><last>Moniz</last></author>
+      <author><first>Ellie</first><last>Kemp</last></author>
+      <author><first>Rebecca</first><last>Petras</last></author>
+      <pages>38-48</pages>
+      <url hash="ab933a78">2017.mtsummit-commercial.6</url>
+      <bibkey>obrien-etal-2017-interact</bibkey>
+    </paper>
+    <paper id="7">
+      <title>A Case Study of Machine Translation in Financial Sentiment Analysis</title>
+      <author><first>Chong</first><last>Zhang</last></author>
+      <author><first>Matteo</first><last>Capelletti</last></author>
+      <author><first>Alexandros</first><last>Poulis</last></author>
+      <author><first>Thorben</first><last>Stemann</last></author>
+      <author><first>Jane</first><last>Nemcova</last></author>
+      <pages>49-58</pages>
+      <url hash="44829881">2017.mtsummit-commercial.7</url>
+      <bibkey>zhang-etal-2017-case</bibkey>
+    </paper>
+    <paper id="8">
+      <title>A New Methodology to Maximize the Strength of <fixed-case>SMT</fixed-case> and <fixed-case>NMT</fixed-case></title>
+      <author><first>Yu</first><last>Gong</last></author>
+      <pages>59-66</pages>
+      <url hash="6de944c4">2017.mtsummit-commercial.8</url>
+      <bibkey>gong-2017-new</bibkey>
+    </paper>
+    <paper id="9">
+      <title>Rule-based <fixed-case>MT</fixed-case> and <fixed-case>UTX</fixed-case> Glossary Management – Honda’s Case Dealing with Thousands of Technical Terms</title>
+      <author><first>Saemi</first><last>Hirayama</last></author>
+      <author><first>Yuji</first><last>Yamamoto</last></author>
+      <pages>67-78</pages>
+      <url hash="4b4b0634">2017.mtsummit-commercial.9</url>
+      <bibkey>hirayama-yamamoto-2017-rule</bibkey>
+    </paper>
+    <paper id="10">
+      <title>A detailed investigation of Bias Errors in Post-editing of <fixed-case>MT</fixed-case> output</title>
+      <author><first>Silvio</first><last>Picinini</last></author>
+      <author><first>Nicola</first><last>Ueffing</last></author>
+      <pages>79-90</pages>
+      <url hash="2fe80b9e">2017.mtsummit-commercial.10</url>
+      <bibkey>picinini-ueffing-2017-detailed</bibkey>
+    </paper>
+    <paper id="11">
+      <title>Terminology post-editing of neural <fixed-case>MT</fixed-case> by <fixed-case>UTX</fixed-case> glossary data</title>
+      <author><first>Yamamoto</first><last>Yuji</last></author>
+      <pages>91-108</pages>
+      <url hash="a4115887">2017.mtsummit-commercial.11</url>
+      <bibkey>yuji-2017-terminology</bibkey>
+    </paper>
+    <paper id="12">
+      <title>Harvesting Polysemous Terms from e-commerce Data to Enhance <fixed-case>QA</fixed-case></title>
+      <author><first>Silvio</first><last>Picinini</last></author>
+      <pages>109-115</pages>
+      <url hash="8812440b">2017.mtsummit-commercial.12</url>
+      <bibkey>picinini-2017-harvesting</bibkey>
+    </paper>
+    <paper id="13">
+      <title>Translation Dictation vs. Post-editing with Cloud-based Voice Recognition: A Pilot Experiment</title>
+      <author><first>Julián</first><last>Zapata</last></author>
+      <author><first>Sheila</first><last>Castilho</last></author>
+      <author><first>Joss</first><last>Moorkens</last></author>
+      <pages>116-129</pages>
+      <url hash="405a778c">2017.mtsummit-commercial.13</url>
+      <bibkey>zapata-etal-2017-translation</bibkey>
+    </paper>
+    <paper id="14">
+      <title>Will neural <fixed-case>MT</fixed-case> be a breakthrough in <fixed-case>E</fixed-case>nglish-to-<fixed-case>J</fixed-case>apanese technical translation?</title>
+      <author><first>Tsunao</first><last>Mikasa</last></author>
+      <author><first>Nobuko</first><last>Kasahara</last></author>
+      <pages>130-141</pages>
+      <url hash="3449c092">2017.mtsummit-commercial.14</url>
+      <bibkey>mikasa-kasahara-2017-will</bibkey>
+    </paper>
+    <paper id="15">
+      <title>The Impact of <fixed-case>MT</fixed-case> Quality Estimation on Post-Editing Effort</title>
+      <author><first>Carlos</first><last>Teixeira</last></author>
+      <author><first>Sharon</first><last>O’Brien</last></author>
+      <pages>142-153</pages>
+      <url hash="337c1007">2017.mtsummit-commercial.15</url>
+      <bibkey>teixeira-obrien-2017-impact</bibkey>
+    </paper>
+    <paper id="16">
+      <title>Utilizing Neural <fixed-case>MT</fixed-case> Engines in Industrial Translation</title>
+      <author><first>Toru</first><last>Shishido</last></author>
+      <pages>154-165</pages>
+      <url hash="b8bf7c9b">2017.mtsummit-commercial.16</url>
+      <bibkey>shishido-2017-utilizing</bibkey>
+    </paper>
+    <paper id="17">
+      <title>Comparative Evaluation of <fixed-case>NMT</fixed-case> with Established <fixed-case>SMT</fixed-case> Programs</title>
+      <author><first>Lena</first><last>Marg</last></author>
+      <author><first>Naoko</first><last>Miyazaki</last></author>
+      <author><first>Elaine</first><last>O’Curran</last></author>
+      <author><first>Tanja</first><last>Schmidt</last></author>
+      <pages>166-178</pages>
+      <url hash="15cda580">2017.mtsummit-commercial.17</url>
+      <bibkey>marg-etal-2017-comparative</bibkey>
+    </paper>
+    <paper id="18">
+      <title>Journey around Neural Machine Translation quality</title>
+      <author><first>Marco</first><last>Ganci</last></author>
+      <pages>179-205</pages>
+      <url hash="65413a44">2017.mtsummit-commercial.18</url>
+      <bibkey>ganci-2017-journey</bibkey>
+    </paper>
+    <paper id="19">
+      <title>A Reception Study of Machine Translated Subtitles for <fixed-case>MOOC</fixed-case>s</title>
+      <author><first>Ke</first><last>Hu</last></author>
+      <author><first>Sharon</first><last>O’Brien</last></author>
+      <author><first>Dorothy</first><last>Kenny</last></author>
+      <pages>206-213</pages>
+      <url hash="c7224de2">2017.mtsummit-commercial.19</url>
+      <bibkey>hu-etal-2017-reception</bibkey>
+    </paper>
+    <paper id="20">
+      <title><fixed-case>T</fixed-case>ra<fixed-case>MOOC</fixed-case>: Translation for Massive Open Online Courses</title>
+      <author><first>Joss</first><last>Moorkens</last></author>
+      <author><first>Yota</first><last>Georgakopoulou</last></author>
+      <pages>214-225</pages>
+      <url hash="18453e29">2017.mtsummit-commercial.20</url>
+      <bibkey>moorkens-georgakopoulou-2017-tramooc</bibkey>
+    </paper>
+  </volume>
+</collection>

--- a/data/xml/2017.mtsummit.xml
+++ b/data/xml/2017.mtsummit.xml
@@ -116,7 +116,8 @@
     </paper>
     <paper id="11">
       <title>One-parameter models for sentence-level post-editing effort estimation</title>
-      <author><first>Mikel L. Miquel Esplà-Gomis</first><last>Forcada</last></author>
+      <author><first>Mikel L.</first><last>Forcada</last></author>
+      <author><first>Miquel</first><last>Esplà-Gomis</last></author>
       <author><first>Felipe</first><last>Sánchez-Martínez</last></author>
       <author><first>Lucia</first><last>Specia</last></author>
       <pages>132-143</pages>


### PR DESCRIPTION
Ingested mt-summit 2017. See [here](http://aamt.info/app-def/S-102/mtsummit/2017/wp-content/uploads/sites/2/2017/09/MTSummitXVI_ResearchTrack.pdf) and [here](http://aamt.info/app-def/S-102/mtsummit/2017/wp-content/uploads/sites/2/2017/09/MTSummitXVI_UserTrack_printer_friendly_version.pdf) for the original proceedings PDFs, consisting of two volumes.