### PR TITLE
Fix casing in SIGMORPHON 2021's papers

### DIFF
--- a/data/xml/2021.sigmorphon.xml
+++ b/data/xml/2021.sigmorphon.xml
@@ -305,7 +305,7 @@
       <bibkey>sharma-etal-2021-improved</bibkey>
     </paper>
     <paper id="25">
-      <title>SIGMORPHON 2021 Shared Task on Morphological Reinflection: Generalization Across Languages</title>
+      <title><fixed-case>SIGMORPHON</fixed-case> 2021 Shared Task on Morphological Reinflection: Generalization Across Languages</title>
       <author><first>Tiago</first><last>Pimentel</last></author>
       <author><first>Maria</first><last>Ryskina</last></author>
       <author><first>Sabrina J.</first><last>Mielke</last></author>
@@ -381,7 +381,7 @@
       <bibkey>ek-etal-2021-training</bibkey>
     </paper>
     <paper id="27">
-      <title>BME Submission for SIGMORPHON 2021 Shared Task 0. A Three Step Training Approach with Data Augmentation for Morphological Inflection</title>
+      <title><fixed-case>BME</fixed-case> Submission for <fixed-case>SIGMORPHON</fixed-case> 2021 Shared Task 0. <fixed-case>A</fixed-case> Three Step Training Approach with Data Augmentation for Morphological Inflection</title>
       <author><first>Gábor</first><last>Szolnok</last></author>
       <author><first>Botond</first><last>Barta</last></author>
       <author><first>Dorina</first><last>Lakatos</last></author>
@@ -404,7 +404,7 @@
       <bibkey>calderone-etal-2021-not-quite</bibkey>
     </paper>
     <paper id="29">
-      <title>Were We There Already? Applying Minimal Generalization to the SIGMORPHON-UniMorph Shared Task on Cognitively Plausible Morphological Inflection</title>
+      <title>Were We There Already? <fixed-case>A</fixed-case>pplying Minimal Generalization to the <fixed-case>SIGMORPHON</fixed-case>-<fixed-case>U</fixed-case>ni<fixed-case>M</fixed-case>orph Shared Task on Cognitively Plausible Morphological Inflection</title>
       <author><first>Colin</first><last>Wilson</last></author>
       <author><first>Jane S.Y.</first><last>Li</last></author>
       <pages>283–291</pages>


### PR DESCRIPTION
The titles of the following three paper do not have protected cases (with the proper fixed-case tags):
2021.sigmorphon-1.25
2021.sigmorphon-1.27
2021.sigmorphon-1.29

This PR adds that protection.

Closes #2124 