### PR TITLE
Author name metadata alteration

### DIFF
--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -6173,7 +6173,7 @@
       <title>Information-Theoretic Probing for Linguistic Structure</title>
       <author><first>Tiago</first><last>Pimentel</last></author>
       <author><first>Josef</first><last>Valvoda</last></author>
-      <author><first>Rowan</first><last>Hall Maudslay</last></author>
+      <author><first>Rowan Hall</first><last>Maudslay</last></author>
       <author><first>Ran</first><last>Zmigrod</last></author>
       <author><first>Adina</first><last>Williams</last></author>
       <author><first>Ryan</first><last>Cotterell</last></author>
@@ -9750,7 +9750,7 @@
     </paper>
     <paper id="659">
       <title>A Tale of a Probe and a Parser</title>
-      <author><first>Rowan</first><last>Hall Maudslay</last></author>
+      <author><first>Rowan Hall</first><last>Maudslay</last></author>
       <author><first>Josef</first><last>Valvoda</last></author>
       <author><first>Tiago</first><last>Pimentel</last></author>
       <author><first>Adina</first><last>Williams</last></author>

--- a/data/xml/2020.emnlp.xml
+++ b/data/xml/2020.emnlp.xml
@@ -4910,7 +4910,7 @@
     <paper id="328">
       <title>Speakers Fill Lexical Semantic Gaps with Context</title>
       <author><first>Tiago</first><last>Pimentel</last></author>
-      <author><first>Rowan</first><last>Hall Maudslay</last></author>
+      <author><first>Rowan Hall</first><last>Maudslay</last></author>
       <author><first>Damian</first><last>Blasi</last></author>
       <author><first>Ryan</first><last>Cotterell</last></author>
       <pages>4004–4015</pages>

--- a/data/xml/2020.figlang.xml
+++ b/data/xml/2020.figlang.xml
@@ -382,7 +382,7 @@
     </paper>
     <paper id="30">
       <title>Metaphor Detection using Context and Concreteness</title>
-      <author><first>Rowan</first><last>Hall Maudslay</last></author>
+      <author><first>Rowan Hall</first><last>Maudslay</last></author>
       <author><first>Tiago</first><last>Pimentel</last></author>
       <author><first>Ryan</first><last>Cotterell</last></author>
       <author><first>Simone</first><last>Teufel</last></author>

--- a/data/xml/2020.sigmorphon.xml
+++ b/data/xml/2020.sigmorphon.xml
@@ -24,7 +24,7 @@
       <author><first>Sabrina J.</first><last>Mielke</last></author>
       <author><first>Shijie</first><last>Wu</last></author>
       <author><first>Edoardo Maria</first><last>Ponti</last></author>
-      <author><first>Rowan</first><last>Hall Maudslay</last></author>
+      <author><first>Rowan Hall</first><last>Maudslay</last></author>
       <author><first>Ran</first><last>Zmigrod</last></author>
       <author><first>Josef</first><last>Valvoda</last></author>
       <author><first>Svetlana</first><last>Toldova</last></author>

--- a/data/xml/2021.naacl.xml
+++ b/data/xml/2021.naacl.xml
@@ -162,7 +162,7 @@
     </paper>
     <paper id="11">
       <title>Do Syntactic Probes Probe Syntax? Experiments with Jabberwocky Probing</title>
-      <author><first>Rowan</first><last>Hall Maudslay</last></author>
+      <author><first>Rowan Hall</first><last>Maudslay</last></author>
       <author><first>Ryan</first><last>Cotterell</last></author>
       <pages>124–131</pages>
       <abstract>Analysing whether neural language models encode linguistic information has become popular in NLP. One method of doing so, which is frequently cited to support the claim that models like BERT encode syntax, is called probing; probes are small supervised models trained to extract linguistic information from another model’s output. If a probe is able to predict a particular structure, it is argued that the model whose output it is trained on must have implicitly learnt to encode it. However, drawing a generalisation about a model’s linguistic knowledge about a specific phenomena based on what a probe is able to learn may be problematic: in this work, we show that semantic cues in training data means that syntactic probes do not properly isolate syntax. We generate a new corpus of semantically nonsensical but syntactically well-formed Jabberwocky sentences, which we use to evaluate two probes trained on normal data. We train the probes on several popular language models (BERT, GPT-2, and RoBERTa), and find that in all settings they perform worse when evaluated on these data, for one probe by an average of 15.4 UUAS points absolute. Although in most cases they still outperform the baselines, their lead is reduced substantially, e.g. by 53% in the case of BERT for one probe. This begs the question: what empirical scores constitute knowing syntax?</abstract>

--- a/data/xml/D19.xml
+++ b/data/xml/D19.xml
@@ -7320,7 +7320,7 @@
     </paper>
     <paper id="530">
       <title>It’s All in the Name: Mitigating Gender Bias with Name-Based Counterfactual Data Substitution</title>
-      <author><first>Rowan</first><last>Hall Maudslay</last></author>
+      <author><first>Rowan Hall</first><last>Maudslay</last></author>
       <author><first>Hila</first><last>Gonen</last></author>
       <author><first>Ryan</first><last>Cotterell</last></author>
       <author><first>Simone</first><last>Teufel</last></author>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -10462,3 +10462,6 @@
 - canonical: {first: Pedro, last: Ortiz Suarez}
   variants:
   - {first: Pedro Javier, last: Ortiz Suárez}
+- canonical: {first: Rowan Hall, last: Maudslay}
+  variants:
+  - {first: Rowan, last: Hall Maudslay}


### PR DESCRIPTION
Change name metadata for Rowan Hall Maudslay:
First name 'Rowan' surname 'Hall Maudslay' -> First name 'Rowan Hall' surname 'Maudslay'
Still matches PDFs etc.

Discussed this with Matt Post over email way back in March, and he said to create a PR, but I only just got round to it. I think I've changed it in all the necessary places (conferences XMLs, and added line to name_variants.yaml)