### PR TITLE
modify metada for 2022.lrec-1.442: change of title consistent with PDF

### DIFF
--- a/data/xml/2022.lrec.xml
+++ b/data/xml/2022.lrec.xml
@@ -5085,7 +5085,7 @@
       <bibkey>kumar-etal-2022-comma</bibkey>
     </paper>
     <paper id="442">
-      <title><fixed-case>TUSC</fixed-case>: Emotion Word Usage in Tweets from <fixed-case>US</fixed-case> and <fixed-case>C</fixed-case>anada</title>
+      <title><fixed-case>Tweet Emotion Dynamics</fixed-case>: Emotion Word Usage in Tweets from <fixed-case>US</fixed-case> and <fixed-case>C</fixed-case>anada</title>
       <author><first>Krishnapriya</first><last>Vishnubhotla</last></author>
       <author><first>Saif M.</first><last>Mohammad</last></author>
       <pages>4162–4176</pages>


### PR DESCRIPTION
Changing the Title in the metadata for ACL Anthology ID 2022.lrec-1.442 to make it consistent with the PDF: 
Current title: "TUSC: Emotion Word Usage in Tweets from US and Canada"
Updated title: "Tweet Emotion Dynamics: Emotion Word Usage in Tweets from US and Canada"
