### PR TITLE
Add authors to 2022.lrec-1.63

### DIFF
--- a/data/xml/2022.lrec.xml
+++ b/data/xml/2022.lrec.xml
@@ -769,9 +769,17 @@
     <paper id="63">
       <title><fixed-case>N</fixed-case>aija<fixed-case>S</fixed-case>enti: A Nigerian <fixed-case>T</fixed-case>witter Sentiment Corpus for Multilingual Sentiment Analysis</title>
       <author><first>Shamsuddeen Hassan</first><last>Muhammad</last></author>
-      <author><first>David</first><last>Adelani</last></author>
-      <author><first>Anuoluwapo</first><last>Aremu</last></author>
+      <author><first>David Ifeoluwa</first><last>Adelani</last></author>
+      <author><first>Sebastian</first><last>Ruder</last></author>
+      <author><first>Ibrahim Sa’id</first><last>Ahmad</last></author>
       <author><first>Idris</first><last>Abdulmumin</last></author>
+      <author><first>Bello Shehu</first><last>Bello</last></author>
+      <author><first>Monojit</first><last>Choudhury</last></author>
+      <author><first>Chris Chinenye</first><last>Emezue</last></author>
+      <author><first>Saheed Salahudeen</first><last>Abdullahi</last></author>
+      <author><first>Anuoluwapo</first><last>Aremu</last></author>
+      <author><first>Alípio</first><last>Jorge</last></author>
+      <author><first>Pavel</first><last>Brazdil</last></author>
       <pages>590–602</pages>
       <abstract>Sentiment analysis is one of the most widely studied applications in NLP, but most work focuses on languages with large amounts of data. We introduce the first large-scale human-annotated Twitter sentiment dataset for the four most widely spoken languages in Nigeria—Hausa, Igbo, Nigerian-Pidgin, and Yorùbá—consisting of around 30,000 annotated tweets per language, including a significant fraction of code-mixed tweets. We propose text collection, filtering, processing and labeling methods that enable us to create datasets for these low-resource languages. We evaluate a range of pre-trained models and transfer strategies on the dataset. We find that language-specific models and language-adaptive fine-tuning generally perform best. We release the datasets, trained models, sentiment lexicons, and code to incentivize research on sentiment analysis in under-represented languages.</abstract>
       <url hash="9bd48a35">2022.lrec-1.63</url>


### PR DESCRIPTION
Updated 2022.lrec-1.63 Metadata - Provided Missing Author Names and Corrected Wrong Author Names Arrangement (Consistent with Author Names and Arrangement in the Paper)