### PR TITLE
Adding NAACL main conference videos

### DIFF
--- a/data/xml/2022.naacl.xml
+++ b/data/xml/2022.naacl.xml
@@ -25,6 +25,7 @@
       <url hash="d6d6c103">2022.naacl-main.1</url>
       <bibkey>abrams-scheutz-2022-social</bibkey>
       <doi>10.18653/v1/2022.naacl-main.1</doi>
+      <video href="2022.naacl-main.1.mp4"/>
     </paper>
     <paper id="2">
       <title>Learning Natural Language Generation with Truncated Reinforcement Learning</title>
@@ -42,6 +43,7 @@
       <doi>10.18653/v1/2022.naacl-main.2</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/clevr">CLEVR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vqg">VQG</pwcdataset>
+      <video href="2022.naacl-main.2.mp4"/>
     </paper>
     <paper id="3">
       <title>Language Model Augmented Monotonic Attention for Simultaneous Translation</title>
@@ -56,6 +58,7 @@
       <bibkey>indurthi-etal-2022-language</bibkey>
       <doi>10.18653/v1/2022.naacl-main.3</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
+      <video href="2022.naacl-main.3.mp4"/>
     </paper>
     <paper id="4">
       <title>What Makes a Good and Useful Summary? <fixed-case>I</fixed-case>ncorporating Users in Automatic Summarization Research</title>
@@ -67,6 +70,7 @@
       <url hash="a5360123">2022.naacl-main.4</url>
       <bibkey>ter-hoeve-etal-2022-makes</bibkey>
       <doi>10.18653/v1/2022.naacl-main.4</doi>
+      <video href="2022.naacl-main.4.mp4"/>
     </paper>
     <paper id="5">
       <title><fixed-case>E</fixed-case>r<fixed-case>AC</fixed-case>on<fixed-case>D</fixed-case>: Error Annotated Conversational Dialog Dataset for Grammatical Error Correction</title>
@@ -80,6 +84,7 @@
       <bibkey>yuan-etal-2022-eracond</bibkey>
       <doi>10.18653/v1/2022.naacl-main.5</doi>
       <pwccode url="https://github.com/yuanxun-yx/eracond" additional="false">yuanxun-yx/eracond</pwccode>
+      <video href="2022.naacl-main.5.mp4"/>
     </paper>
     <paper id="6">
       <title>Semantic Diversity in Dialogue with Natural Language Inference</title>
@@ -96,6 +101,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.6.mp4"/>
     </paper>
     <paper id="7">
       <title><fixed-case>LEA</fixed-case>: Meta Knowledge-Driven Self-Attentive Document Embedding for Few-Shot Text Classification</title>
@@ -107,6 +113,7 @@
       <bibkey>hong-jang-2022-lea</bibkey>
       <doi>10.18653/v1/2022.naacl-main.7</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/rcv1">RCV1</pwcdataset>
+      <video href="2022.naacl-main.7.mp4"/>
     </paper>
     <paper id="8">
       <title>Enhancing Self-Attention with Knowledge-Assisted Attention Maps</title>
@@ -129,6 +136,7 @@
       <url hash="9a15b169">2022.naacl-main.8</url>
       <bibkey>bai-etal-2022-enhancing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.8</doi>
+      <video href="2022.naacl-main.8.mp4"/>
     </paper>
     <paper id="9">
       <title>Batch-Softmax Contrastive Loss for Pairwise Sentence Scoring Tasks</title>
@@ -141,6 +149,7 @@
       <url hash="93a09c01">2022.naacl-main.9</url>
       <bibkey>chernyavskiy-etal-2022-batch</bibkey>
       <doi>10.18653/v1/2022.naacl-main.9</doi>
+      <video href="2022.naacl-main.9.mp4"/>
     </paper>
     <paper id="10">
       <title><fixed-case>N</fixed-case>ews<fixed-case>E</fixed-case>dits: A News Article Revision Dataset and a Novel Document-Level Reasoning Challenge</title>
@@ -155,6 +164,7 @@
       <bibkey>spangher-etal-2022-newsedits</bibkey>
       <doi>10.18653/v1/2022.naacl-main.10</doi>
       <pwccode url="https://github.com/isi-nlp/newsedits" additional="false">isi-nlp/newsedits</pwccode>
+      <video href="2022.naacl-main.10.mp4"/>
     </paper>
     <paper id="11">
       <title>Putting the Con in Context: Identifying Deceptive Actors in the Game of Mafia</title>
@@ -167,6 +177,7 @@
       <bibkey>ibraheem-etal-2022-putting</bibkey>
       <doi>10.18653/v1/2022.naacl-main.11</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/the-mafia-dataset">The Mafia Dataset</pwcdataset>
+      <video href="2022.naacl-main.11.mp4"/>
     </paper>
     <paper id="12">
       <title><fixed-case>SUBS</fixed-case>: Subtree Substitution for Compositional Semantic Parsing</title>
@@ -179,6 +190,7 @@
       <bibkey>yang-etal-2022-subs</bibkey>
       <doi>10.18653/v1/2022.naacl-main.12</doi>
       <pwccode url="https://github.com/gt-salt/subs" additional="false">gt-salt/subs</pwccode>
+      <video href="2022.naacl-main.12.mp4"/>
     </paper>
     <paper id="13">
       <title>Two Contrasting Data Annotation Paradigms for Subjective <fixed-case>NLP</fixed-case> Tasks</title>
@@ -192,6 +204,7 @@
       <bibkey>rottger-etal-2022-two</bibkey>
       <doi>10.18653/v1/2022.naacl-main.13</doi>
       <pwccode url="https://github.com/paul-rottger/annotation-paradigms" additional="false">paul-rottger/annotation-paradigms</pwccode>
+      <video href="2022.naacl-main.13.mp4"/>
     </paper>
     <paper id="14">
       <title>Do Deep Neural Nets Display Human-like Attention in Short Answer Scoring?</title>
@@ -205,6 +218,7 @@
       <attachment type="software" hash="6c07b878">2022.naacl-main.14.software.zip</attachment>
       <bibkey>zeng-etal-2022-deep</bibkey>
       <doi>10.18653/v1/2022.naacl-main.14</doi>
+      <video href="2022.naacl-main.14.mp4"/>
     </paper>
     <paper id="15">
       <title>Knowledge-Grounded Dialogue Generation with a Unified Knowledge Representation</title>
@@ -223,6 +237,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/inspired">Inspired</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/opendialkg">OpenDialKG</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.15.mp4"/>
     </paper>
     <paper id="16">
       <title><fixed-case>CERES</fixed-case>: Pretraining of Graph-Conditioned Transformer for Semi-Structured Session Data</title>
@@ -251,6 +266,7 @@
       <bibkey>sinno-etal-2022-political</bibkey>
       <doi>10.18653/v1/2022.naacl-main.17</doi>
       <pwccode url="https://github.com/bernovie/political-polarization" additional="false">bernovie/political-polarization</pwccode>
+      <video href="2022.naacl-main.17.mp4"/>
     </paper>
     <paper id="18">
       <title>Cooperative Self-training of Machine Reading Comprehension</title>
@@ -269,6 +285,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mrqa-2019">MRQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
+      <video href="2022.naacl-main.18.mp4"/>
     </paper>
     <paper id="19">
       <title><fixed-case>G</fixed-case>lob<fixed-case>E</fixed-case>nc: Quantifying Global Token Attribution by Incorporating the Whole Encoder Layer in Transformers</title>
@@ -285,6 +302,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/hatexplain">HateXplain</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.19.mp4"/>
     </paper>
     <paper id="20">
       <title>A Robustly Optimized <fixed-case>BMRC</fixed-case> for Aspect Sentiment Triplet Extraction</title>
@@ -298,6 +316,7 @@
       <doi>10.18653/v1/2022.naacl-main.20</doi>
       <pwccode url="https://github.com/itkaven/robmrc" additional="false">itkaven/robmrc</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aste-data-v2">ASTE-Data-V2</pwcdataset>
+      <video href="2022.naacl-main.20.mp4"/>
     </paper>
     <paper id="21">
       <title>Seed-Guided Topic Discovery with Out-of-Vocabulary Seeds</title>
@@ -313,6 +332,7 @@
       <doi>10.18653/v1/2022.naacl-main.21</doi>
       <pwccode url="https://github.com/yuzhimanhua/seetopic" additional="false">yuzhimanhua/seetopic</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/scidocs">SciDocs</pwcdataset>
+      <video href="2022.naacl-main.21.mp4"/>
     </paper>
     <paper id="22">
       <title>Towards Process-Oriented, Modular, and Versatile Question Generation that Meets Educational Needs</title>
@@ -326,6 +346,7 @@
       <bibkey>wang-etal-2022-towards</bibkey>
       <doi>10.18653/v1/2022.naacl-main.22</doi>
       <pwccode url="https://github.com/olivia-fsm/p2mcq" additional="false">olivia-fsm/p2mcq</pwccode>
+      <video href="2022.naacl-main.22.mp4"/>
     </paper>
     <paper id="23">
       <title><fixed-case>S</fixed-case>wah<fixed-case>BERT</fixed-case>: Language Model of <fixed-case>S</fixed-case>wahili</title>
@@ -341,6 +362,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/isear">ISEAR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/masakhaner">MasakhaNER</pwcdataset>
+      <video href="2022.naacl-main.23.mp4"/>
     </paper>
     <paper id="24">
       <title>Deconstructing <fixed-case>NLG</fixed-case> Evaluation: Evaluation Practices, Assumptions, and Their Implications</title>
@@ -355,6 +377,7 @@
       <url hash="982cc5db">2022.naacl-main.24</url>
       <bibkey>zhou-etal-2022-deconstructing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.24</doi>
+      <video href="2022.naacl-main.24.mp4"/>
     </paper>
     <paper id="25">
       <title><fixed-case>TSTR</fixed-case>: Too Short to Represent, Summarize with Details! Intro-Guided Extended Summary Generation</title>
@@ -365,6 +388,7 @@
       <url hash="91fa9d7a">2022.naacl-main.25</url>
       <bibkey>sotudeh-goharian-2022-tstr</bibkey>
       <doi>10.18653/v1/2022.naacl-main.25</doi>
+      <video href="2022.naacl-main.25.mp4"/>
     </paper>
     <paper id="26">
       <title>Empathic Machines: Using Intermediate Features as Levers to Emulate Emotions in Text-To-Speech Systems</title>
@@ -378,6 +402,7 @@
       <url hash="f2fc7e29">2022.naacl-main.26</url>
       <bibkey>kosgi-etal-2022-empathic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.26</doi>
+      <video href="2022.naacl-main.26.mp4"/>
     </paper>
     <paper id="27">
       <title>The Why and The How: A Survey on Natural Language Interaction in Visualization</title>
@@ -391,6 +416,7 @@
       <url hash="c61417a2">2022.naacl-main.27</url>
       <bibkey>voigt-etal-2022-survey</bibkey>
       <doi>10.18653/v1/2022.naacl-main.27</doi>
+      <video href="2022.naacl-main.27.mp4"/>
     </paper>
     <paper id="28">
       <title>Understand before Answer: Improve Temporal Reading Comprehension via Precise Question Understanding</title>
@@ -405,6 +431,7 @@
       <doi>10.18653/v1/2022.naacl-main.28</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/torque">Torque</pwcdataset>
+      <video href="2022.naacl-main.28.mp4"/>
     </paper>
     <paper id="29">
       <title>User-Driven Research of Medical Note Generation Software</title>
@@ -424,6 +451,7 @@
       <url hash="7a8dd40b">2022.naacl-main.29</url>
       <bibkey>knoll-etal-2022-user</bibkey>
       <doi>10.18653/v1/2022.naacl-main.29</doi>
+      <video href="2022.naacl-main.29.mp4"/>
     </paper>
     <paper id="30">
       <title>Ask Me Anything in Your Native Language</title>
@@ -440,6 +468,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
+      <video href="2022.naacl-main.30.mp4"/>
     </paper>
     <paper id="31">
       <title>Diversifying Neural Dialogue Generation via Negative Distillation</title>
@@ -453,6 +482,7 @@
       <bibkey>li-etal-2022-diversifying</bibkey>
       <doi>10.18653/v1/2022.naacl-main.31</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
+      <video href="2022.naacl-main.31.mp4"/>
     </paper>
     <paper id="32">
       <title>On Synthetic Data for Back Translation</title>
@@ -469,6 +499,7 @@
       <bibkey>xu-etal-2022-synthetic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.32</doi>
       <pwccode url="https://github.com/jiahao004/data-for-bt" additional="false">jiahao004/data-for-bt</pwccode>
+      <video href="2022.naacl-main.32.mp4"/>
     </paper>
     <paper id="33">
       <title>Mapping the Design Space of Human-<fixed-case>AI</fixed-case> Interaction in Text Summarization</title>
@@ -482,6 +513,7 @@
       <url hash="7b50ba93">2022.naacl-main.33</url>
       <bibkey>cheng-etal-2022-mapping</bibkey>
       <doi>10.18653/v1/2022.naacl-main.33</doi>
+      <video href="2022.naacl-main.33.mp4"/>
     </paper>
     <paper id="34">
       <title>Towards Robust and Semantically Organised Latent Representations for Unsupervised Text Style Transfer</title>
@@ -496,6 +528,7 @@
       <pwccode url="https://github.com/sharan21/epaae" additional="false">sharan21/epaae</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/styleptb">StylePTB</pwcdataset>
+      <video href="2022.naacl-main.34.mp4"/>
     </paper>
     <paper id="35">
       <title>An Exploration of Post-Editing Effectiveness in Text Summarization</title>
@@ -512,6 +545,7 @@
       <bibkey>lai-etal-2022-exploration</bibkey>
       <doi>10.18653/v1/2022.naacl-main.35</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/reddit-tifu">Reddit TIFU</pwcdataset>
+      <video href="2022.naacl-main.35.mp4"/>
     </paper>
     <paper id="36">
       <title>Automatic Correction of Human Translations</title>
@@ -549,6 +583,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
+      <video href="2022.naacl-main.37.mp4"/>
     </paper>
     <paper id="38">
       <title>Explaining Why: How Instructions and User Interfaces Impact Annotator Rationales When Labeling Text Data</title>
@@ -567,6 +602,7 @@
       <attachment type="software" hash="4f0b0dff">2022.naacl-main.38.software.zip</attachment>
       <bibkey>sullivan-etal-2022-explaining</bibkey>
       <doi>10.18653/v1/2022.naacl-main.38</doi>
+      <video href="2022.naacl-main.38.mp4"/>
     </paper>
     <paper id="39">
       <title>Fine-tuning Pre-trained Language Models for Few-shot Intent Detection: Supervised Pre-training and Isotropization</title>
@@ -585,6 +621,7 @@
       <doi>10.18653/v1/2022.naacl-main.39</doi>
       <pwccode url="https://github.com/fanolabs/isointentbert-main" additional="false">fanolabs/isointentbert-main</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hint3">HINT3</pwcdataset>
+      <video href="2022.naacl-main.39.mp4"/>
     </paper>
     <paper id="40">
       <title>Cross-document Misinformation Detection based on Event Graph Reasoning</title>
@@ -599,6 +636,7 @@
       <doi>10.18653/v1/2022.naacl-main.40</doi>
       <pwccode url="https://github.com/shirley-wu/cross-doc-misinfo-detection" additional="false">shirley-wu/cross-doc-misinfo-detection</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/realnews">RealNews</pwcdataset>
+      <video href="2022.naacl-main.40.mp4"/>
     </paper>
     <paper id="41">
       <title>Disentangled Action Recognition with Knowledge Bases</title>
@@ -614,6 +652,7 @@
       <bibkey>luo-etal-2022-disentangled</bibkey>
       <doi>10.18653/v1/2022.naacl-main.41</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/charades">Charades</pwcdataset>
+      <video href="2022.naacl-main.41.mp4"/>
     </paper>
     <paper id="42">
       <title>Machine-in-the-Loop Rewriting for Creative Image Captioning</title>
@@ -625,6 +664,7 @@
       <bibkey>padmakumar-he-2022-machine</bibkey>
       <doi>10.18653/v1/2022.naacl-main.42</doi>
       <pwccode url="https://github.com/vishakhpk/mil-creative-captioning" additional="false">vishakhpk/mil-creative-captioning</pwccode>
+      <video href="2022.naacl-main.42.mp4"/>
     </paper>
     <paper id="43">
       <title>A Word is Worth A Thousand Dollars: Adversarial Attack on Tweets Fools Stock Prediction</title>
@@ -641,6 +681,7 @@
       <doi>10.18653/v1/2022.naacl-main.43</doi>
       <pwccode url="https://github.com/yonxie/advfintweet" additional="false">yonxie/advfintweet</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/stocknet-1">StockNet</pwcdataset>
+      <video href="2022.naacl-main.43.mp4"/>
     </paper>
     <paper id="44">
       <title>Building Multilingual Machine Translation Systems That Serve Arbitrary <fixed-case>XY</fixed-case> Translations</title>
@@ -653,6 +694,7 @@
       <url hash="190af786">2022.naacl-main.44</url>
       <bibkey>eriguchi-etal-2022-building</bibkey>
       <doi>10.18653/v1/2022.naacl-main.44</doi>
+      <video href="2022.naacl-main.44.mp4"/>
     </paper>
     <paper id="45">
       <title>Non-Autoregressive Neural Machine Translation with Consistency Regularization Optimized Variational Framework</title>
@@ -664,6 +706,7 @@
       <url hash="6818ed7d">2022.naacl-main.45</url>
       <bibkey>zhu-etal-2022-non</bibkey>
       <doi>10.18653/v1/2022.naacl-main.45</doi>
+      <video href="2022.naacl-main.45.mp4"/>
     </paper>
     <paper id="46">
       <title>User-Centric Gender Rewriting</title>
@@ -677,6 +720,7 @@
       <doi>10.18653/v1/2022.naacl-main.46</doi>
       <pwccode url="https://github.com/camel-lab/gender-rewriting" additional="false">camel-lab/gender-rewriting</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
+      <video href="2022.naacl-main.46.mp4"/>
     </paper>
     <paper id="47">
       <title>Reframing Human-<fixed-case>AI</fixed-case> Collaboration for Generating Free-Text Explanations</title>
@@ -695,6 +739,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/commonsenseqa">CommonsenseQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/e-snli">e-SNLI</pwcdataset>
+      <video href="2022.naacl-main.47.mp4"/>
     </paper>
     <paper id="48">
       <title><fixed-case>E</fixed-case>m<fixed-case>R</fixed-case>el: Joint Representation of Entities and Embedded Relations for Multi-triple Extraction</title>
@@ -712,6 +757,7 @@
       <doi>10.18653/v1/2022.naacl-main.48</doi>
       <pwccode url="https://github.com/benfengxu/emrel" additional="false">benfengxu/emrel</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
+      <video href="2022.naacl-main.48.mp4"/>
     </paper>
     <paper id="49">
       <title>Meta Learning for Natural Language Processing: A Survey</title>
@@ -724,6 +770,7 @@
       <bibkey>lee-etal-2022-meta</bibkey>
       <doi>10.18653/v1/2022.naacl-main.49</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
+      <video href="2022.naacl-main.49.mp4"/>
     </paper>
     <paper id="50">
       <title>Analyzing Modality Robustness in Multimodal Sentiment Analysis</title>
@@ -739,6 +786,7 @@
       <bibkey>hazarika-etal-2022-analyzing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.50</doi>
       <pwccode url="https://github.com/declare-lab/msa-robustness" additional="false">declare-lab/msa-robustness</pwccode>
+      <video href="2022.naacl-main.50.mp4"/>
     </paper>
     <paper id="51">
       <title>Fuse It More Deeply! A Variational Transformer with Layer-Wise Latent Variable Inference for Text Generation</title>
@@ -757,6 +805,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
+      <video href="2022.naacl-main.51.mp4"/>
     </paper>
     <paper id="52">
       <title>Easy Adaptation to Mitigate Gender Bias in Multilingual Text Classification</title>
@@ -768,6 +817,7 @@
       <bibkey>huang-2022-easy</bibkey>
       <doi>10.18653/v1/2022.naacl-main.52</doi>
       <pwccode url="https://github.com/xiaoleihuang/domainfairness" additional="false">xiaoleihuang/domainfairness</pwccode>
+      <video href="2022.naacl-main.52.mp4"/>
     </paper>
     <paper id="53">
       <title>On the Use of External Data for Spoken Named Entity Recognition</title>
@@ -782,6 +832,7 @@
       <bibkey>pasad-etal-2022-use</bibkey>
       <doi>10.18653/v1/2022.naacl-main.53</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/slue">SLUE</pwcdataset>
+      <video href="2022.naacl-main.53.mp4"/>
     </paper>
     <paper id="54">
       <title>Long-term Control for Dialogue Generation: Methods and Evaluation</title>
@@ -797,6 +848,7 @@
       <bibkey>ramakrishnan-etal-2022-long</bibkey>
       <doi>10.18653/v1/2022.naacl-main.54</doi>
       <pwccode url="https://github.com/asappresearch/constrained-dialogue-generation" additional="false">asappresearch/constrained-dialogue-generation</pwccode>
+      <video href="2022.naacl-main.54.mp4"/>
     </paper>
     <paper id="55">
       <title>Learning Dialogue Representations from Consecutive Utterances</title>
@@ -819,6 +871,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/clinc150">CLINC150</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dstc7-task-1">DSTC7 Task 1</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
+      <video href="2022.naacl-main.55.mp4"/>
     </paper>
     <paper id="56">
       <title>On the Machine Learning of Ethical Judgments from Natural Language</title>
@@ -834,6 +887,7 @@
       <bibkey>talat-etal-2022-machine</bibkey>
       <doi>10.18653/v1/2022.naacl-main.56</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/ethics-1">ETHICS</pwcdataset>
+      <video href="2022.naacl-main.56.mp4"/>
     </paper>
     <paper id="57">
       <title><fixed-case>N</fixed-case>euro<fixed-case>L</fixed-case>ogic A*esque Decoding: Constrained Text Generation with Lookahead Heuristics</title>
@@ -871,6 +925,7 @@
       <pwccode url="https://github.com/machelreid/paradise" additional="false">machelreid/paradise</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/paws-x">PAWS-X</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
+      <video href="2022.naacl-main.58.mp4"/>
     </paper>
     <paper id="59">
       <title>Explaining Toxic Text via Knowledge Enhanced Text Generation</title>
@@ -884,6 +939,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/implicit-hate">Implicit Hate</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sbic">SBIC</pwcdataset>
+      <video href="2022.naacl-main.59.mp4"/>
     </paper>
     <paper id="60">
       <title>Teaching <fixed-case>BERT</fixed-case> to Wait: Balancing Accuracy and Latency for Streaming Disfluency Detection</title>
@@ -896,6 +952,7 @@
       <url hash="9d36635c">2022.naacl-main.60</url>
       <bibkey>chen-etal-2022-teaching</bibkey>
       <doi>10.18653/v1/2022.naacl-main.60</doi>
+      <video href="2022.naacl-main.60.mp4"/>
     </paper>
     <paper id="61">
       <title><fixed-case>GRAM</fixed-case>: <fixed-case>F</fixed-case>ast <fixed-case>F</fixed-case>ine-tuning of <fixed-case>P</fixed-case>re-trained <fixed-case>L</fixed-case>anguage <fixed-case>M</fixed-case>odels for <fixed-case>C</fixed-case>ontent-based <fixed-case>C</fixed-case>ollaborative <fixed-case>F</fixed-case>iltering</title>
@@ -909,6 +966,7 @@
       <bibkey>yang-etal-2022-gram</bibkey>
       <doi>10.18653/v1/2022.naacl-main.61</doi>
       <pwccode url="https://github.com/yoonseok312/gram" additional="false">yoonseok312/gram</pwccode>
+      <video href="2022.naacl-main.61.mp4"/>
     </paper>
     <paper id="62">
       <title>Generating Repetitions with Appropriate Repeated Words</title>
@@ -922,6 +980,7 @@
       <bibkey>kawamoto-etal-2022-generating</bibkey>
       <doi>10.18653/v1/2022.naacl-main.62</doi>
       <pwccode url="https://github.com/titech-nlp/repetition-generation" additional="false">titech-nlp/repetition-generation</pwccode>
+      <video href="2022.naacl-main.62.mp4"/>
     </paper>
     <paper id="63">
       <title>Textless Speech-to-Speech Translation on Real Data</title>
@@ -942,6 +1001,7 @@
       <bibkey>lee-etal-2022-textless</bibkey>
       <doi>10.18653/v1/2022.naacl-main.63</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/europarl-st">Europarl-ST</pwcdataset>
+      <video href="2022.naacl-main.63.mp4"/>
     </paper>
     <paper id="64">
       <title><fixed-case>WALNUT</fixed-case>: A Benchmark on Semi-weakly Supervised Learning for Natural Language Understanding</title>
@@ -958,6 +1018,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
+      <video href="2022.naacl-main.64.mp4"/>
     </paper>
     <paper id="65">
       <title><fixed-case>C</fixed-case>ompact<fixed-case>IE</fixed-case>: Compact Facts in Open Information Extraction</title>
@@ -970,6 +1031,7 @@
       <bibkey>fatahi-bayat-etal-2022-compactie</bibkey>
       <doi>10.18653/v1/2022.naacl-main.65</doi>
       <pwccode url="https://github.com/farimafatahi/compactie" additional="false">farimafatahi/compactie</pwccode>
+      <video href="2022.naacl-main.65.mp4"/>
     </paper>
     <paper id="66">
       <title><fixed-case>C</fixed-case>o<fixed-case>SI</fixed-case>m: Commonsense Reasoning for Counterfactual Scene Imagination</title>
@@ -986,6 +1048,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/vcr">VCR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
+      <video href="2022.naacl-main.66.mp4"/>
     </paper>
     <paper id="67">
       <title>Abstraction not Memory: <fixed-case>BERT</fixed-case> and the <fixed-case>E</fixed-case>nglish Article System</title>
@@ -997,6 +1060,7 @@
       <url hash="e01e2baf">2022.naacl-main.67</url>
       <bibkey>tayyar-madabushi-etal-2022-abstraction</bibkey>
       <doi>10.18653/v1/2022.naacl-main.67</doi>
+      <video href="2022.naacl-main.67.mp4"/>
     </paper>
     <paper id="68">
       <title><fixed-case>O</fixed-case>mni<fixed-case>T</fixed-case>ab: Pretraining with Natural and Synthetic Data for Few-shot Table-based Question Answering</title>
@@ -1013,6 +1077,7 @@
       <pwccode url="https://github.com/jzbjyb/omnitab" additional="false">jzbjyb/omnitab</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitablequestions">WikiTableQuestions</pwcdataset>
+      <video href="2022.naacl-main.68.mp4"/>
     </paper>
     <paper id="69">
       <title>Provably Confidential Language Modelling</title>
@@ -1025,6 +1090,7 @@
       <bibkey>zhao-etal-2022-provably</bibkey>
       <doi>10.18653/v1/2022.naacl-main.69</doi>
       <pwccode url="https://github.com/xuandongzhao/crt" additional="false">xuandongzhao/crt</pwccode>
+      <video href="2022.naacl-main.69.mp4"/>
     </paper>
     <paper id="70">
       <title><fixed-case>KAT</fixed-case>: A Knowledge Augmented Transformer for Vision-and-Language</title>
@@ -1041,6 +1107,7 @@
       <doi>10.18653/v1/2022.naacl-main.70</doi>
       <pwccode url="https://github.com/guilk/kat" additional="false">guilk/kat</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ok-vqa">OK-VQA</pwcdataset>
+      <video href="2022.naacl-main.70.mp4"/>
     </paper>
     <paper id="71">
       <title>When a sentence does not introduce a discourse entity, Transformer-based models still sometimes refer to it</title>
@@ -1053,6 +1120,7 @@
       <doi>10.18653/v1/2022.naacl-main.71</doi>
       <pwccode url="https://github.com/sebschu/discourse-entity-lm" additional="false">sebschu/discourse-entity-lm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/lambada">LAMBADA</pwcdataset>
+      <video href="2022.naacl-main.71.mp4"/>
     </paper>
     <paper id="72">
       <title>On Curriculum Learning for Commonsense Reasoning</title>
@@ -1072,6 +1140,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
+      <video href="2022.naacl-main.72.mp4"/>
     </paper>
     <paper id="73">
       <title><fixed-case>D</fixed-case>oc<fixed-case>T</fixed-case>ime: A Document-level Temporal Dependency Graph Parser</title>
@@ -1089,6 +1158,7 @@
       <url hash="6d6087f2">2022.naacl-main.73</url>
       <bibkey>mathur-etal-2022-doctime</bibkey>
       <doi>10.18653/v1/2022.naacl-main.73</doi>
+      <video href="2022.naacl-main.73.mp4"/>
     </paper>
     <paper id="74">
       <title><fixed-case>F</fixed-case>act<fixed-case>PEGASUS</fixed-case>: Factuality-Aware Pre-training and Fine-tuning for Abstractive Summarization</title>
@@ -1101,6 +1171,7 @@
       <doi>10.18653/v1/2022.naacl-main.74</doi>
       <pwccode url="https://github.com/meetdavidwan/factpegasus" additional="false">meetdavidwan/factpegasus</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikihow">WikiHow</pwcdataset>
+      <video href="2022.naacl-main.74.mp4"/>
     </paper>
     <paper id="75">
       <title><fixed-case>S</fixed-case>c<fixed-case>AN</fixed-case>: Suicide Attempt and Ideation Events Dataset</title>
@@ -1114,6 +1185,7 @@
       <bibkey>rawat-etal-2022-scan</bibkey>
       <doi>10.18653/v1/2022.naacl-main.75</doi>
       <pwccode url="https://github.com/bsinghpratap/scan" additional="false">bsinghpratap/scan</pwccode>
+      <video href="2022.naacl-main.75.mp4"/>
     </paper>
     <paper id="76">
       <title>Socially Aware Bias Measurements for <fixed-case>H</fixed-case>indi Language Representations</title>
@@ -1129,6 +1201,7 @@
       <bibkey>malik-etal-2022-socially</bibkey>
       <doi>10.18653/v1/2022.naacl-main.76</doi>
       <pwccode url="https://github.com/vijit-m/sochindi" additional="false">vijit-m/sochindi</pwccode>
+      <video href="2022.naacl-main.76.mp4"/>
     </paper>
     <paper id="77">
       <title><fixed-case>A</fixed-case>mbi<fixed-case>P</fixed-case>un: Generating Humorous Puns with Ambiguous Context</title>
@@ -1142,6 +1215,7 @@
       <doi>10.18653/v1/2022.naacl-main.77</doi>
       <pwccode url="https://github.com/pluslabnlp/ambipun" additional="false">pluslabnlp/ambipun</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/billion-word-benchmark">Billion Word Benchmark</pwcdataset>
+      <video href="2022.naacl-main.77.mp4"/>
     </paper>
     <paper id="78">
       <title><fixed-case>E</fixed-case>mp<fixed-case>H</fixed-case>i: Generating Empathetic Responses with Human-like Intents</title>
@@ -1154,6 +1228,7 @@
       <bibkey>chen-etal-2022-emphi</bibkey>
       <doi>10.18653/v1/2022.naacl-main.78</doi>
       <pwccode url="https://github.com/mattc95/emphi" additional="false">mattc95/emphi</pwccode>
+      <video href="2022.naacl-main.78.mp4"/>
     </paper>
     <paper id="79">
       <title>Yes, No or <fixed-case>IDK</fixed-case>: The Challenge of Unanswerable Yes/No Questions</title>
@@ -1169,6 +1244,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
+      <video href="2022.naacl-main.79.mp4"/>
     </paper>
     <paper id="80">
       <title>Inducing and Using Alignments for Transition-based <fixed-case>AMR</fixed-case> Parsing</title>
@@ -1185,6 +1261,7 @@
       <bibkey>drozdov-etal-2022-inducing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.80</doi>
       <pwccode url="https://github.com/IBM/transition-amr-parser" additional="false">IBM/transition-amr-parser</pwccode>
+      <video href="2022.naacl-main.80.mp4"/>
     </paper>
     <paper id="81">
       <title>Masked Part-Of-Speech Model: Does Modeling Long Context Help Unsupervised <fixed-case>POS</fixed-case>-tagging?</title>
@@ -1197,6 +1274,7 @@
       <bibkey>zhou-etal-2022-masked</bibkey>
       <doi>10.18653/v1/2022.naacl-main.81</doi>
       <pwccode url="https://github.com/owenzx/mposm" additional="false">owenzx/mposm</pwccode>
+      <video href="2022.naacl-main.81.mp4"/>
     </paper>
     <paper id="82">
       <title><fixed-case>DREAM</fixed-case>: Improving Situational <fixed-case>QA</fixed-case> by First Elaborating the Situation</title>
@@ -1213,6 +1291,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ethics-1">ETHICS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/moral-stories">Moral Stories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/story-commonsense">Story Commonsense</pwcdataset>
+      <video href="2022.naacl-main.82.mp4"/>
     </paper>
     <paper id="83">
       <title><fixed-case>C</fixed-case>o<fixed-case>S</fixed-case>e-Co: Text Conditioned Generative <fixed-case>C</fixed-case>ommon<fixed-case>S</fixed-case>ense Contextualizer</title>
@@ -1231,6 +1310,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qasc">QASC</pwcdataset>
+      <video href="2022.naacl-main.83.mp4"/>
     </paper>
     <paper id="84">
       <title>Probing via Prompting</title>
@@ -1245,6 +1325,7 @@
       <pwccode url="https://github.com/rycolab/probing-via-prompting" additional="false">rycolab/probing-via-prompting</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
+      <video href="2022.naacl-main.84.mp4"/>
     </paper>
     <paper id="85">
       <title>Database Search Results Disambiguation for Task-Oriented Dialog Systems</title>
@@ -1264,6 +1345,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sgd">SGD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/simmc">SIMMC</pwcdataset>
+      <video href="2022.naacl-main.85.mp4"/>
     </paper>
     <paper id="86">
       <title>Unsupervised Slot Schema Induction for Task-oriented Dialog</title>
@@ -1296,6 +1378,7 @@
       <url hash="99e88881">2022.naacl-main.87</url>
       <bibkey>sanders-etal-2022-towards</bibkey>
       <doi>10.18653/v1/2022.naacl-main.87</doi>
+      <video href="2022.naacl-main.87.mp4"/>
     </paper>
     <paper id="88">
       <title>Cross-Domain Detection of <fixed-case>GPT</fixed-case>-2-Generated Technical Text</title>
@@ -1313,6 +1396,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semantic-scholar">Semantic Scholar</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
+      <video href="2022.naacl-main.88.mp4"/>
     </paper>
     <paper id="89">
       <title><fixed-case>DISAPERE</fixed-case>: A Dataset for Discourse Structure in Peer Review Discussions</title>
@@ -1330,6 +1414,7 @@
       <url hash="3971e932">2022.naacl-main.89</url>
       <bibkey>kennard-etal-2022-disapere</bibkey>
       <doi>10.18653/v1/2022.naacl-main.89</doi>
+      <video href="2022.naacl-main.89.mp4"/>
     </paper>
     <paper id="90">
       <title><fixed-case>M</fixed-case>ulti<fixed-case>S</fixed-case>pan<fixed-case>QA</fixed-case>: A Dataset for Multi-Span Question Answering</title>
@@ -1355,6 +1440,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiqa">WikiQA</pwcdataset>
+      <video href="2022.naacl-main.90.mp4"/>
     </paper>
     <paper id="91">
       <title>Context-Aware Abbreviation Expansion Using Large Language Models</title>
@@ -1370,6 +1456,7 @@
       <bibkey>cai-etal-2022-context</bibkey>
       <doi>10.18653/v1/2022.naacl-main.91</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
+      <video href="2022.naacl-main.91.mp4"/>
     </paper>
     <paper id="92">
       <title>Theory-Grounded Measurement of <fixed-case>U</fixed-case>.<fixed-case>S</fixed-case>. Social Stereotypes in <fixed-case>E</fixed-case>nglish Language Models</title>
@@ -1384,6 +1471,7 @@
       <bibkey>cao-etal-2022-theory</bibkey>
       <doi>10.18653/v1/2022.naacl-main.92</doi>
       <pwccode url="https://github.com/tristacao/u.s_stereotypes" additional="false">tristacao/u.s_stereotypes</pwccode>
+      <video href="2022.naacl-main.92.mp4"/>
     </paper>
     <paper id="93">
       <title>Sort by Structure: Language Model Ranking as Dependency Probing</title>
@@ -1395,6 +1483,7 @@
       <url hash="798ce526">2022.naacl-main.93</url>
       <bibkey>muller-eberstein-etal-2022-sort</bibkey>
       <doi>10.18653/v1/2022.naacl-main.93</doi>
+      <video href="2022.naacl-main.93.mp4"/>
     </paper>
     <paper id="94">
       <title>Quantifying Synthesis and Fusion and their Impact on Machine Translation</title>
@@ -1409,6 +1498,7 @@
       <url hash="02c840f4">2022.naacl-main.94</url>
       <bibkey>oncevay-etal-2022-quantifying</bibkey>
       <doi>10.18653/v1/2022.naacl-main.94</doi>
+      <video href="2022.naacl-main.94.mp4"/>
     </paper>
     <paper id="95">
       <title>Commonsense and Named Entity Aware Knowledge Grounded Dialogue Generation</title>
@@ -1423,6 +1513,7 @@
       <doi>10.18653/v1/2022.naacl-main.95</doi>
       <pwccode url="https://github.com/deekshavarshney/cntf" additional="false">deekshavarshney/cntf</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.95.mp4"/>
     </paper>
     <paper id="96">
       <title>Efficient Hierarchical Domain Adaptation for Pretrained Language Models</title>
@@ -1435,6 +1526,7 @@
       <bibkey>chronopoulou-etal-2022-efficient</bibkey>
       <doi>10.18653/v1/2022.naacl-main.96</doi>
       <pwccode url="https://github.com/alexandra-chron/hierarchical-domain-adaptation" additional="false">alexandra-chron/hierarchical-domain-adaptation</pwccode>
+      <video href="2022.naacl-main.96.mp4"/>
     </paper>
     <paper id="97">
       <title><fixed-case>H</fixed-case>atemoji: A Test Suite and Adversarially-Generated Dataset for Benchmarking and Detecting Emoji-Based Hate</title>
@@ -1450,6 +1542,7 @@
       <doi>10.18653/v1/2022.naacl-main.97</doi>
       <pwccode url="https://github.com/HannahKirk/Hatemoji" additional="false">HannahKirk/Hatemoji</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hatemojicheck">HatemojiCheck</pwcdataset>
+      <video href="2022.naacl-main.97.mp4"/>
     </paper>
     <paper id="98">
       <title>On the Economics of Multilingual Few-shot Learning: Modeling the Cost-Performance Trade-offs of Machine Translated and Manual Data</title>
@@ -1463,6 +1556,7 @@
       <doi>10.18653/v1/2022.naacl-main.98</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tydiqa-goldp">TyDiQA-GoldP</pwcdataset>
+      <video href="2022.naacl-main.98.mp4"/>
     </paper>
     <paper id="99">
       <title>Learning to Selectively Learn for Weakly Supervised Paraphrase Generation with Model-based Reinforcement Learning</title>
@@ -1475,6 +1569,7 @@
       <bibkey>yin-etal-2022-learning</bibkey>
       <doi>10.18653/v1/2022.naacl-main.99</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
+      <video href="2022.naacl-main.99.mp4"/>
     </paper>
     <paper id="100">
       <title>Quality-Aware Decoding for Neural Machine Translation</title>
@@ -1491,6 +1586,7 @@
       <bibkey>fernandes-etal-2022-quality</bibkey>
       <doi>10.18653/v1/2022.naacl-main.100</doi>
       <pwccode url="https://github.com/deep-spin/qaware-decode" additional="false">deep-spin/qaware-decode</pwccode>
+      <video href="2022.naacl-main.100.mp4"/>
     </paper>
     <paper id="101">
       <title>Pretrained Models for Multilingual Federated Learning</title>
@@ -1506,6 +1602,7 @@
       <doi>10.18653/v1/2022.naacl-main.101</doi>
       <pwccode url="https://github.com/orionw/multilingual-federated-learning" additional="false">orionw/multilingual-federated-learning</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mtnt">MTNT</pwcdataset>
+      <video href="2022.naacl-main.101.mp4"/>
     </paper>
     <paper id="102">
       <title><fixed-case>A</fixed-case>c<fixed-case>T</fixed-case>une: Uncertainty-Based Active Self-Training for Active Fine-Tuning of Pretrained Language Models</title>
@@ -1524,6 +1621,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/pubmed-rct">PubMed RCT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wrench">Wrench</pwcdataset>
+      <video href="2022.naacl-main.102.mp4"/>
     </paper>
     <paper id="103">
       <title>Label Anchored Contrastive Learning for Language Understanding</title>
@@ -1541,6 +1639,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fewglue">FewGlue</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
+      <video href="2022.naacl-main.103.mp4"/>
     </paper>
     <paper id="104">
       <title>Go Back in Time: Generating Flashbacks in Stories with Event Temporal Prompts</title>
@@ -1558,6 +1657,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
+      <video href="2022.naacl-main.104.mp4"/>
     </paper>
     <paper id="105">
       <title>Forecasting <fixed-case>COVID</fixed-case>-19 Caseloads Using Unsupervised Embedding Clusters of Social Media Posts</title>
@@ -1569,6 +1669,7 @@
       <url hash="82ccf3e0">2022.naacl-main.105</url>
       <bibkey>drinkall-etal-2022-forecasting</bibkey>
       <doi>10.18653/v1/2022.naacl-main.105</doi>
+      <video href="2022.naacl-main.105.mp4"/>
     </paper>
     <paper id="106">
       <title>Many Hands Make Light Work: Using Essay Traits to Automatically Score Essays</title>
@@ -1584,6 +1685,7 @@
       <doi>10.18653/v1/2022.naacl-main.106</doi>
       <pwccode url="https://github.com/ASAP-AEG/MTL-Essay-Traits-Scoring" additional="false">ASAP-AEG/MTL-Essay-Traits-Scoring</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/asap">ASAP</pwcdataset>
+      <video href="2022.naacl-main.106.mp4"/>
     </paper>
     <paper id="107">
       <title>Natural Language Inference with Self-Attention for Veracity Assessment of Pandemic Claims</title>
@@ -1602,6 +1704,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coaid">CoAID</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mm-covid">MM-COVID</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
+      <video href="2022.naacl-main.107.mp4"/>
     </paper>
     <paper id="108">
       <title>Beyond Emotion: A Multi-Modal Dataset for Human Desire Understanding</title>
@@ -1619,6 +1722,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multimodal-opinionlevel-sentiment-intensity">Multimodal Opinionlevel Sentiment Intensity</pwcdataset>
+      <video href="2022.naacl-main.108.mp4"/>
     </paper>
     <paper id="109">
       <title>Relation-Specific Attentions over Entity Mentions for Enhanced Document-Level Relation Extraction</title>
@@ -1633,6 +1737,7 @@
       <pwccode url="https://github.com/fduyjx/rsman" additional="false">fduyjx/rsman</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dwie">DWIE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
+      <video href="2022.naacl-main.109.mp4"/>
     </paper>
     <paper id="110">
       <title><fixed-case>T</fixed-case>witter-<fixed-case>COMM</fixed-case>s: Detecting Climate, <fixed-case>COVID</fixed-case>, and Military Multimodal Misinformation</title>
@@ -1647,6 +1752,7 @@
       <doi>10.18653/v1/2022.naacl-main.110</doi>
       <pwccode url="https://github.com/giscardbiamby/twitter-comms" additional="false">giscardbiamby/twitter-comms</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/twitter-comms">Twitter-COMMs</pwcdataset>
+      <video href="2022.naacl-main.110.mp4"/>
     </paper>
     <paper id="111">
       <title><fixed-case>BlonDe</fixed-case>: An Automatic Evaluation Metric for Document-level Machine Translation</title>
@@ -1666,6 +1772,7 @@
       <bibkey>jiang-etal-2022-blonde</bibkey>
       <doi>10.18653/v1/2022.naacl-main.111</doi>
       <pwccode url="https://github.com/eleanorjiang/blonde" additional="false">eleanorjiang/blonde</pwccode>
+      <video href="2022.naacl-main.111.mp4"/>
     </paper>
     <paper id="112">
       <title>Disentangled Learning of Stance and Aspect Topics for Vaccine Attitude Detection in Social Media</title>
@@ -1680,6 +1787,7 @@
       <bibkey>zhu-etal-2022-disentangled</bibkey>
       <doi>10.18653/v1/2022.naacl-main.112</doi>
       <pwccode url="https://github.com/somethingx1202/vadet" additional="false">somethingx1202/vadet</pwccode>
+      <video href="2022.naacl-main.112.mp4"/>
     </paper>
     <paper id="113">
       <title><fixed-case>SKILL</fixed-case>: Structured Knowledge Infusion for Large Language Models</title>
@@ -1699,6 +1807,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikihop">WikiHop</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikimovies">WikiMovies</pwcdataset>
+      <video href="2022.naacl-main.113.mp4"/>
     </paper>
     <paper id="114">
       <title>Same Neurons, Different Languages: Probing Morphosyntax in Multilingual Pre-trained Models</title>
@@ -1713,6 +1822,7 @@
       <bibkey>stanczak-etal-2022-neurons</bibkey>
       <doi>10.18653/v1/2022.naacl-main.114</doi>
       <pwccode url="https://github.com/copenlu/multilingual-typology-probing" additional="false">copenlu/multilingual-typology-probing</pwccode>
+      <video href="2022.naacl-main.114.mp4"/>
     </paper>
     <paper id="115">
       <title>Aspect Is Not You Need: No-aspect Differential Sentiment Framework for Aspect-based Sentiment Analysis</title>
@@ -1726,6 +1836,7 @@
       <url hash="f8baaf83">2022.naacl-main.115</url>
       <bibkey>cao-etal-2022-aspect</bibkey>
       <doi>10.18653/v1/2022.naacl-main.115</doi>
+      <video href="2022.naacl-main.115.mp4"/>
     </paper>
     <paper id="116">
       <title><fixed-case>M</fixed-case>o<fixed-case>EBERT</fixed-case>: from <fixed-case>BERT</fixed-case> to Mixture-of-Experts via Importance-Guided Adaptation</title>
@@ -1747,6 +1858,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.116.mp4"/>
     </paper>
     <paper id="117">
       <title>Implicit n-grams Induced by Recurrence</title>
@@ -1762,6 +1874,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.117.mp4"/>
     </paper>
     <paper id="118">
       <title>Guiding Visual Question Generation</title>
@@ -1776,6 +1889,7 @@
       <bibkey>vedd-etal-2022-guiding</bibkey>
       <doi>10.18653/v1/2022.naacl-main.118</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
+      <video href="2022.naacl-main.118.mp4"/>
     </paper>
     <paper id="119">
       <title><fixed-case>OPERA</fixed-case>: Operation-Pivoted Discrete Reasoning over Text</title>
@@ -1796,6 +1910,7 @@
       <doi>10.18653/v1/2022.naacl-main.119</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
+      <video href="2022.naacl-main.119.mp4"/>
     </paper>
     <paper id="120">
       <title>Improving Multi-Document Summarization through Referenced Flexible Extraction with Credit-Awareness</title>
@@ -1811,6 +1926,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multi-news">Multi-News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multi-xscience">Multi-XScience</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikicatsum">WikiCatSum</pwcdataset>
+      <video href="2022.naacl-main.120.mp4"/>
     </paper>
     <paper id="121">
       <title>Improving Constituent Representation with Hypertree Neural Networks</title>
@@ -1822,6 +1938,7 @@
       <url hash="67fc824b">2022.naacl-main.121</url>
       <bibkey>zhou-etal-2022-improving</bibkey>
       <doi>10.18653/v1/2022.naacl-main.121</doi>
+      <video href="2022.naacl-main.121.mp4"/>
     </paper>
     <paper id="122">
       <title>Measuring Fairness with Biased Rulers: A Comparative Study on Bias Metrics for Pre-trained Language Models</title>
@@ -1838,6 +1955,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/crows-pairs">CrowS-Pairs</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/stereoset">StereoSet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
+      <video href="2022.naacl-main.122.mp4"/>
     </paper>
     <paper id="123">
       <title><fixed-case>M</fixed-case>u<fixed-case>CPAD</fixed-case>: A Multi-Domain <fixed-case>C</fixed-case>hinese Predicate-Argument Dataset</title>
@@ -1854,6 +1972,7 @@
       <doi>10.18653/v1/2022.naacl-main.123</doi>
       <pwccode url="https://github.com/suda-la/mucpad" additional="false">suda-la/mucpad</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
+      <video href="2022.naacl-main.123.mp4"/>
     </paper>
     <paper id="124">
       <title>Representation Learning for Conversational Data using Discourse Mutual Information Maximization</title>
@@ -1872,6 +1991,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog-1">DailyDialog++</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mutual">MuTual</pwcdataset>
+      <video href="2022.naacl-main.124.mp4"/>
     </paper>
     <paper id="125">
       <title><fixed-case>V</fixed-case>al<fixed-case>CAT</fixed-case>: Variable-Length Contextualized Adversarial Transformations Using Encoder-Decoder Language Model</title>
@@ -1893,6 +2013,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.125.mp4"/>
     </paper>
     <paper id="126">
       <title>A Study of Syntactic Multi-Modality in Non-Autoregressive Machine Translation</title>
@@ -1908,6 +2029,7 @@
       <url hash="289b5008">2022.naacl-main.126</url>
       <bibkey>zhang-etal-2022-study</bibkey>
       <doi>10.18653/v1/2022.naacl-main.126</doi>
+      <video href="2022.naacl-main.126.mp4"/>
     </paper>
     <paper id="127">
       <title><fixed-case>CIA</fixed-case>ug: Equipping Interpolative Augmentation with Curriculum Learning</title>
@@ -1928,6 +2050,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.127.mp4"/>
     </paper>
     <paper id="128">
       <title>Proposition-Level Clustering for Multi-Document Summarization</title>
@@ -1944,6 +2067,7 @@
       <bibkey>ernst-etal-2022-proposition</bibkey>
       <doi>10.18653/v1/2022.naacl-main.128</doi>
       <pwccode url="https://github.com/oriern/procluster" additional="true">oriern/procluster</pwccode>
+      <video href="2022.naacl-main.128.mp4"/>
     </paper>
     <paper id="129">
       <title>Non-Autoregressive Machine Translation: It’s Not as Fast as it Seems</title>
@@ -1956,6 +2080,7 @@
       <bibkey>helcl-etal-2022-non</bibkey>
       <doi>10.18653/v1/2022.naacl-main.129</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
+      <video href="2022.naacl-main.129.mp4"/>
     </paper>
     <paper id="130">
       <title><fixed-case>BAD</fixed-case>-<fixed-case>X</fixed-case>: Bilingual Adapters Improve Zero-Shot Cross-Lingual Transfer</title>
@@ -1969,6 +2094,7 @@
       <bibkey>parovic-etal-2022-bad</bibkey>
       <doi>10.18653/v1/2022.naacl-main.130</doi>
       <pwccode url="https://github.com/parovicm/badx" additional="false">parovicm/badx</pwccode>
+      <video href="2022.naacl-main.130.mp4"/>
     </paper>
     <paper id="131">
       <title>Combining Humor and Sarcasm for Improving Political Parody Detection</title>
@@ -1982,6 +2108,7 @@
       <bibkey>ao-etal-2022-combining</bibkey>
       <doi>10.18653/v1/2022.naacl-main.131</doi>
       <pwccode url="https://github.com/iamoscar1/multi_encoder_model_for_political_parody_prediction" additional="false">iamoscar1/multi_encoder_model_for_political_parody_prediction</pwccode>
+      <video href="2022.naacl-main.131.mp4"/>
     </paper>
     <paper id="132">
       <title><fixed-case>TIE</fixed-case>: Topological Information Enhanced Structural Reading Comprehension on Web Pages</title>
@@ -1997,6 +2124,7 @@
       <bibkey>zhao-etal-2022-tie</bibkey>
       <doi>10.18653/v1/2022.naacl-main.132</doi>
       <pwccode url="https://github.com/x-lance/tie" additional="false">x-lance/tie</pwccode>
+      <video href="2022.naacl-main.132.mp4"/>
     </paper>
     <paper id="133">
       <title><fixed-case>RSTG</fixed-case>en: Imbuing Fine-Grained Interpretable Control into Long-<fixed-case>F</fixed-case>orm<fixed-case>T</fixed-case>ext Generators</title>
@@ -2009,6 +2137,7 @@
       <bibkey>adewoyin-etal-2022-rstgen</bibkey>
       <doi>10.18653/v1/2022.naacl-main.133</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
+      <video href="2022.naacl-main.133.mp4"/>
     </paper>
     <paper id="134">
       <title>Intent Detection and Discovery from User Logs via Deep Semi-Supervised Contrastive Clustering</title>
@@ -2026,6 +2155,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/clinc150">CLINC150</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dbpedia">DBpedia</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
+      <video href="2022.naacl-main.134.mp4"/>
     </paper>
     <paper id="135">
       <title>Extending Multi-Text Sentence Fusion Resources via Pyramid Annotations</title>
@@ -2039,6 +2169,7 @@
       <bibkey>brook-weiss-etal-2022-extending</bibkey>
       <doi>10.18653/v1/2022.naacl-main.135</doi>
       <pwccode url="https://github.com/danielabweiss/extending-sentence-fusion-resources" additional="false">danielabweiss/extending-sentence-fusion-resources</pwccode>
+      <video href="2022.naacl-main.135.mp4"/>
     </paper>
     <paper id="136">
       <title>The Devil is in the Details: On the Pitfalls of Vocabulary Selection in Neural Machine Translation</title>
@@ -2054,6 +2185,7 @@
       <bibkey>domhan-etal-2022-devil</bibkey>
       <doi>10.18653/v1/2022.naacl-main.136</doi>
       <pwccode url="https://github.com/awslabs/sockeye" additional="false">awslabs/sockeye</pwccode>
+      <video href="2022.naacl-main.136.mp4"/>
     </paper>
     <paper id="137">
       <title><fixed-case>M</fixed-case>ulti<fixed-case>C</fixed-case>ite: Modeling realistic citations requires moving beyond the single-sentence single-label setting</title>
@@ -2073,6 +2205,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multicite">MultiCite</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qasper">QASPER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
+      <video href="2022.naacl-main.137.mp4"/>
     </paper>
     <paper id="138">
       <title><fixed-case>DEGREE</fixed-case>: A Data-Efficient Generation-Based Event Extraction Model</title>
@@ -2090,6 +2223,7 @@
       <bibkey>hsu-etal-2022-degree</bibkey>
       <doi>10.18653/v1/2022.naacl-main.138</doi>
       <pwccode url="https://github.com/pluslabnlp/degree" additional="false">pluslabnlp/degree</pwccode>
+      <video href="2022.naacl-main.138.mp4"/>
     </paper>
     <paper id="139">
       <title>Bridging the Gap between Language Models and Cross-Lingual Sequence Labeling</title>
@@ -2106,6 +2240,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mlqa">MLQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiann-1">WikiAnn</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
+      <video href="2022.naacl-main.139.mp4"/>
     </paper>
     <paper id="140">
       <title>Hero-Gang Neural Model For Named Entity Recognition</title>
@@ -2126,6 +2261,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ontonotes-5-0">OntoNotes 5.0</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2016-ner">WNUT 2016 NER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
+      <video href="2022.naacl-main.140.mp4"/>
     </paper>
     <paper id="141">
       <title><fixed-case>MGIMN</fixed-case>: Multi-Grained Interactive Matching Network for Few-shot Text Classification</title>
@@ -2139,6 +2275,7 @@
       <url hash="de8050d0">2022.naacl-main.141</url>
       <bibkey>zhang-etal-2022-mgimn</bibkey>
       <doi>10.18653/v1/2022.naacl-main.141</doi>
+      <video href="2022.naacl-main.141.mp4"/>
     </paper>
     <paper id="142">
       <title>All You May Need for <fixed-case>VQA</fixed-case> are Image Captions</title>
@@ -2164,6 +2301,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/vqg">VQG</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering-v2-0">Visual Question Answering v2.0</pwcdataset>
+      <video href="2022.naacl-main.142.mp4"/>
     </paper>
     <paper id="143">
       <title>Frustratingly Easy System Combination for Grammatical Error Correction</title>
@@ -2178,6 +2316,7 @@
       <doi>10.18653/v1/2022.naacl-main.143</doi>
       <pwccode url="https://github.com/nusnlp/esc" additional="false">nusnlp/esc</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/locness-corpus">WI-LOCNESS</pwcdataset>
+      <video href="2022.naacl-main.143.mp4"/>
     </paper>
     <paper id="144">
       <title>Simple Local Attentions Remain Competitive for Long-Context Tasks</title>
@@ -2197,6 +2336,7 @@
       <pwccode url="https://github.com/pytorch/fairseq" additional="false">pytorch/fairseq</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/lra">LRA</pwcdataset>
+      <video href="2022.naacl-main.144.mp4"/>
     </paper>
     <paper id="145">
       <title><fixed-case>E</fixed-case>ven the Simplest Baseline Needs Careful Re-investigation: A Case Study on <fixed-case>XML</fixed-case>-<fixed-case>CNN</fixed-case></title>
@@ -2211,6 +2351,7 @@
       <attachment type="software" hash="a8267bc0">2022.naacl-main.145.software.zip</attachment>
       <bibkey>chen-etal-2022-even</bibkey>
       <doi>10.18653/v1/2022.naacl-main.145</doi>
+      <video href="2022.naacl-main.145.mp4"/>
     </paper>
     <paper id="146">
       <title>Multi-Relational Graph Transformer for Automatic Short Answer Grading</title>
@@ -2225,6 +2366,7 @@
       <bibkey>agarwal-etal-2022-multi</bibkey>
       <doi>10.18653/v1/2022.naacl-main.146</doi>
       <pwccode url="https://github.com/kvarun07/asag-gt" additional="false">kvarun07/asag-gt</pwccode>
+      <video href="2022.naacl-main.146.mp4"/>
     </paper>
     <paper id="147">
       <title>Event Schema Induction with Double Graph Autoencoders</title>
@@ -2237,6 +2379,7 @@
       <attachment type="software" hash="a29300d0">2022.naacl-main.147.software.zip</attachment>
       <bibkey>jin-etal-2022-event</bibkey>
       <doi>10.18653/v1/2022.naacl-main.147</doi>
+      <video href="2022.naacl-main.147.mp4"/>
     </paper>
     <paper id="148">
       <title><fixed-case>CS</fixed-case>1<fixed-case>QA</fixed-case>: A Dataset for Assisting Code-based Question Answering in an Introductory Programming Course</title>
@@ -2252,6 +2395,7 @@
       <pwccode url="https://github.com/cyoon47/cs1qa" additional="false">cyoon47/cs1qa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/codeqa">CodeQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/codesearchnet">CodeSearchNet</pwcdataset>
+      <video href="2022.naacl-main.148.mp4"/>
     </paper>
     <paper id="149">
       <title>Unsupervised Cross-Lingual Transfer of Structured Predictors without Source Data</title>
@@ -2265,6 +2409,7 @@
       <bibkey>kurniawan-etal-2022-unsupervised</bibkey>
       <doi>10.18653/v1/2022.naacl-main.149</doi>
       <pwccode url="https://github.com/kmkurn/uxtspwsd" additional="false">kmkurn/uxtspwsd</pwccode>
+      <video href="2022.naacl-main.149.mp4"/>
     </paper>
     <paper id="150">
       <title>Don’t Take It Literally: An Edit-Invariant Sequence Loss for Text Generation</title>
@@ -2283,6 +2428,7 @@
       <bibkey>liu-etal-2022-dont</bibkey>
       <doi>10.18653/v1/2022.naacl-main.150</doi>
       <pwccode url="https://github.com/guangyliu/EISL" additional="false">guangyliu/EISL</pwccode>
+      <video href="2022.naacl-main.150.mp4"/>
     </paper>
     <paper id="151">
       <title>Modeling Exemplification in Long-form Question Answering via Retrieval</title>
@@ -2299,6 +2445,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/eli5">ELI5</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
+      <video href="2022.naacl-main.151.mp4"/>
     </paper>
     <paper id="152">
       <title><fixed-case>D</fixed-case>2<fixed-case>U</fixed-case>: Distance-to-Uniform Learning for Out-of-Scope Detection</title>
@@ -2310,6 +2457,7 @@
       <bibkey>yilmaz-toraman-2022-d2u</bibkey>
       <doi>10.18653/v1/2022.naacl-main.152</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
+      <video href="2022.naacl-main.152.mp4"/>
     </paper>
     <paper id="153">
       <title>Reference-free Summarization Evaluation via Semantic Correlation and Compression Ratio</title>
@@ -2323,6 +2471,7 @@
       <bibkey>liu-etal-2022-reference</bibkey>
       <doi>10.18653/v1/2022.naacl-main.153</doi>
       <pwccode url="https://github.com/yizhuliu/summeval" additional="false">yizhuliu/summeval</pwccode>
+      <video href="2022.naacl-main.153.mp4"/>
     </paper>
     <paper id="154">
       <title><fixed-case>K</fixed-case>ronecker<fixed-case>BERT</fixed-case>: Significant Compression of Pre-trained Language Models Through Kronecker Decomposition and Knowledge Distillation</title>
@@ -2342,6 +2491,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.154.mp4"/>
     </paper>
     <paper id="155">
       <title>Building a Role Specified Open-Domain Dialogue System Leveraging Large-Scale Language Models</title>
@@ -2359,6 +2509,7 @@
       <doi>10.18653/v1/2022.naacl-main.155</doi>
       <pwccode url="https://github.com/naver-ai/carecall-corpus" additional="false">naver-ai/carecall-corpus</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/carecall">CareCall</pwcdataset>
+      <video href="2022.naacl-main.155.mp4"/>
     </paper>
     <paper id="156">
       <title>Sentence-Level Resampling for Named Entity Recognition</title>
@@ -2370,6 +2521,7 @@
       <bibkey>wang-wang-2022-sentence</bibkey>
       <doi>10.18653/v1/2022.naacl-main.156</doi>
       <pwccode url="https://github.com/xiaochen-w/ner_adaptive_resampling" additional="false">xiaochen-w/ner_adaptive_resampling</pwccode>
+      <video href="2022.naacl-main.156.mp4"/>
     </paper>
     <paper id="157">
       <title>Word Tour: One-dimensional Word Embeddings via the Traveling Salesman Problem</title>
@@ -2381,6 +2533,7 @@
       <bibkey>sato-2022-word</bibkey>
       <doi>10.18653/v1/2022.naacl-main.157</doi>
       <pwccode url="https://github.com/joisino/wordtour" additional="false">joisino/wordtour</pwccode>
+      <video href="2022.naacl-main.157.mp4"/>
     </paper>
     <paper id="158">
       <title>On the Diversity and Limits of Human Explanations</title>
@@ -2391,6 +2544,7 @@
       <bibkey>tan-2022-diversity</bibkey>
       <doi>10.18653/v1/2022.naacl-main.158</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/e-snli">e-SNLI</pwcdataset>
+      <video href="2022.naacl-main.158.mp4"/>
     </paper>
     <paper id="159">
       <title>Locally Aggregated Feature Attribution on Natural Language Model Understanding</title>
@@ -2404,6 +2558,7 @@
       <bibkey>zhang-etal-2022-locally</bibkey>
       <doi>10.18653/v1/2022.naacl-main.159</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.159.mp4"/>
     </paper>
     <paper id="160">
       <title>Generic and Trend-aware Curriculum Learning for Relation Extraction</title>
@@ -2414,6 +2569,7 @@
       <url hash="3ff0792d">2022.naacl-main.160</url>
       <bibkey>vakil-amiri-2022-generic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.160</doi>
+      <video href="2022.naacl-main.160.mp4"/>
     </paper>
     <paper id="161">
       <title>On Systematic Style Differences between Unsupervised and Supervised <fixed-case>MT</fixed-case> and an Application for High-Resource Machine Translation</title>
@@ -2425,6 +2581,7 @@
       <url hash="caab7332">2022.naacl-main.161</url>
       <bibkey>marchisio-etal-2022-systematic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.161</doi>
+      <video href="2022.naacl-main.161.mp4"/>
     </paper>
     <paper id="162">
       <title>Evidentiality-guided Generation for Knowledge-Intensive <fixed-case>NLP</fixed-case> Tasks</title>
@@ -2443,6 +2600,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.162.mp4"/>
     </paper>
     <paper id="163">
       <title>Modularized Transfer Learning with Multiple Knowledge Graphs for Zero-shot Commonsense Reasoning</title>
@@ -2462,6 +2620,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/piqa">PIQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/social-iqa">SIQA</pwcdataset>
+      <video href="2022.naacl-main.163.mp4"/>
     </paper>
     <paper id="164">
       <title>Learning to Express in Knowledge-Grounded Conversation</title>
@@ -2477,6 +2636,7 @@
       <bibkey>zhao-etal-2022-learning-express</bibkey>
       <doi>10.18653/v1/2022.naacl-main.164</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.164.mp4"/>
     </paper>
     <paper id="165">
       <title>End-to-End <fixed-case>C</fixed-case>hinese Speaker Identification</title>
@@ -2488,6 +2648,7 @@
       <url hash="13e37f2f">2022.naacl-main.165</url>
       <bibkey>yu-etal-2022-end</bibkey>
       <doi>10.18653/v1/2022.naacl-main.165</doi>
+      <video href="2022.naacl-main.165.mp4"/>
     </paper>
     <paper id="166">
       <title><fixed-case>MINION</fixed-case>: a Large-Scale and Diverse Dataset for Multilingual Event Detection</title>
@@ -2500,6 +2661,7 @@
       <url hash="0b6a29c0">2022.naacl-main.166</url>
       <bibkey>pouran-ben-veyseh-etal-2022-minion</bibkey>
       <doi>10.18653/v1/2022.naacl-main.166</doi>
+      <video href="2022.naacl-main.166.mp4"/>
     </paper>
     <paper id="167">
       <title>Do Prompt-Based Models Really Understand the Meaning of Their Prompts?</title>
@@ -2513,6 +2675,7 @@
       <pwccode url="https://github.com/awebson/prompt_semantics" additional="false">awebson/prompt_semantics</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/anli">ANLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
+      <video href="2022.naacl-main.167.mp4"/>
     </paper>
     <paper id="168">
       <title><fixed-case>GPL</fixed-case>: Generative Pseudo Labeling for Unsupervised Domain Adaptation of Dense Retrieval</title>
@@ -2532,6 +2695,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paq">PAQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scifact">SciFact</pwcdataset>
+      <video href="2022.naacl-main.168.mp4"/>
     </paper>
     <paper id="169">
       <title>Sparse Distillation: Speeding Up Text Classification by Using Bigger Student Models</title>
@@ -2551,6 +2715,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paq">PAQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.169.mp4"/>
     </paper>
     <paper id="170">
       <title>Towards Understanding Large-Scale Discourse Structures in Pre-Trained and Fine-Tuned Language Models</title>
@@ -2565,6 +2730,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.170.mp4"/>
     </paper>
     <paper id="171">
       <title><fixed-case>SAIS</fixed-case>: Supervising and Augmenting Intermediate Steps for Document-Level Relation Extraction</title>
@@ -2582,6 +2748,7 @@
       <pwccode url="https://github.com/xiaoyuxin1002/sais" additional="false">xiaoyuxin1002/sais</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cdr">CDR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
+      <video href="2022.naacl-main.171.mp4"/>
     </paper>
     <paper id="172">
       <title><fixed-case>LITE</fixed-case>: <fixed-case>I</fixed-case>ntent-based Task Representation Learning Using Weak Supervision</title>
@@ -2597,6 +2764,7 @@
       <bibkey>otani-etal-2022-lite</bibkey>
       <doi>10.18653/v1/2022.naacl-main.172</doi>
       <pwccode url="https://github.com/microsoft/intent-based-task-representation-learning" additional="false">microsoft/intent-based-task-representation-learning</pwccode>
+      <video href="2022.naacl-main.172.mp4"/>
     </paper>
     <paper id="173">
       <title>Does Summary Evaluation Survive Translation to Other Languages?</title>
@@ -2609,6 +2777,7 @@
       <url hash="c47d16e2">2022.naacl-main.173</url>
       <bibkey>braun-etal-2022-summary</bibkey>
       <doi>10.18653/v1/2022.naacl-main.173</doi>
+      <video href="2022.naacl-main.173.mp4"/>
     </paper>
     <paper id="174">
       <title>A Shoulder to Cry on: Towards A Motivational Virtual Assistant for Assuaging Mental Agony</title>
@@ -2622,6 +2791,7 @@
       <url hash="87513f45">2022.naacl-main.174</url>
       <bibkey>saha-etal-2022-shoulder</bibkey>
       <doi>10.18653/v1/2022.naacl-main.174</doi>
+      <video href="2022.naacl-main.174.mp4"/>
     </paper>
     <paper id="175">
       <title><fixed-case>S</fixed-case>ue<fixed-case>N</fixed-case>es: A Weakly Supervised Approach to Evaluating Single-Document Summarization via Negative Sampling</title>
@@ -2641,6 +2811,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bigpatent">BigPatent</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/billsum">BillSum</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsroom">NEWSROOM</pwcdataset>
+      <video href="2022.naacl-main.175.mp4"/>
     </paper>
     <paper id="176">
       <title>Combating the Curse of Multilinguality in Cross-Lingual <fixed-case>WSD</fixed-case> by Aligning Sparse Contextualized Word Representations</title>
@@ -2652,6 +2823,7 @@
       <doi>10.18653/v1/2022.naacl-main.176</doi>
       <pwccode url="https://github.com/begab/sparsity_makes_sense" additional="false">begab/sparsity_makes_sense</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/word2word">word2word</pwcdataset>
+      <video href="2022.naacl-main.176.mp4"/>
     </paper>
     <paper id="177">
       <title>Cheat Codes to Quantify Missing Source Information in Neural Machine Translation</title>
@@ -2662,6 +2834,7 @@
       <url hash="dfb36df8">2022.naacl-main.177</url>
       <bibkey>pal-heafield-2022-cheat</bibkey>
       <doi>10.18653/v1/2022.naacl-main.177</doi>
+      <video href="2022.naacl-main.177.mp4"/>
     </paper>
     <paper id="178">
       <title><fixed-case>W</fixed-case>i<fixed-case>C</fixed-case> = <fixed-case>TSV</fixed-case> = <fixed-case>WSD</fixed-case>: On the Equivalence of Three Semantic Tasks</title>
@@ -2675,6 +2848,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wic-tsv">WiC-TSV</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
+      <video href="2022.naacl-main.178.mp4"/>
     </paper>
     <paper id="179">
       <title>What do tokens know about their characters and how do they know it?</title>
@@ -2687,6 +2861,7 @@
       <doi>10.18653/v1/2022.naacl-main.179</doi>
       <pwccode url="https://github.com/ayushk4/character-probing-pytorch" additional="false">ayushk4/character-probing-pytorch</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/the-pile">The Pile</pwcdataset>
+      <video href="2022.naacl-main.179.mp4"/>
     </paper>
     <paper id="180">
       <title><fixed-case>A</fixed-case>nswer<fixed-case>S</fixed-case>umm: A Manually-Curated Dataset and Pipeline for Answer Summarization</title>
@@ -2704,6 +2879,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/answersumm">AnswerSumm</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cqasumm">CQASUMM</pwcdataset>
+      <video href="2022.naacl-main.180.mp4"/>
     </paper>
     <paper id="181">
       <title>Paragraph-based Transformer Pre-training for Multi-Sentence Inference</title>
@@ -2721,6 +2897,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/trecqa">TrecQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiqa">WikiQA</pwcdataset>
+      <video href="2022.naacl-main.181.mp4"/>
     </paper>
     <paper id="182">
       <title>Text Style Transfer via Optimal Transport</title>
@@ -2732,6 +2909,7 @@
       <bibkey>nouri-2022-text</bibkey>
       <doi>10.18653/v1/2022.naacl-main.182</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
+      <video href="2022.naacl-main.182.mp4"/>
     </paper>
     <paper id="183">
       <title>Exploring the Role of Task Transferability in Large-Scale Multi-Task Learning</title>
@@ -2750,6 +2928,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ncbi-disease-1">NCBI Disease</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
+      <video href="2022.naacl-main.183.mp4"/>
     </paper>
     <paper id="184">
       <title>Interactive Query-Assisted Summarization via Deep Reinforcement Learning</title>
@@ -2764,6 +2943,7 @@
       <bibkey>shapira-etal-2022-interactive</bibkey>
       <doi>10.18653/v1/2022.naacl-main.184</doi>
       <pwccode url="https://github.com/orishapira/interexp_deeprl" additional="false">orishapira/interexp_deeprl</pwccode>
+      <video href="2022.naacl-main.184.mp4"/>
     </paper>
     <paper id="185">
       <title>Data Augmentation with Dual Training for Offensive Span Detection</title>
@@ -2773,6 +2953,7 @@
       <url hash="66d5ff3b">2022.naacl-main.185</url>
       <bibkey>nouri-2022-data</bibkey>
       <doi>10.18653/v1/2022.naacl-main.185</doi>
+      <video href="2022.naacl-main.185.mp4"/>
     </paper>
     <paper id="186">
       <title>Training Mixed-Domain Translation Models via Federated Learning</title>
@@ -2786,6 +2967,7 @@
       <url hash="4ba52dd5">2022.naacl-main.186</url>
       <bibkey>passban-etal-2022-training</bibkey>
       <doi>10.18653/v1/2022.naacl-main.186</doi>
+      <video href="2022.naacl-main.186.mp4"/>
     </paper>
     <paper id="187">
       <title><fixed-case>QAF</fixed-case>act<fixed-case>E</fixed-case>val: Improved <fixed-case>QA</fixed-case>-Based Factual Consistency Evaluation for Summarization</title>
@@ -2804,6 +2986,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qa2d">QA2D</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
+      <video href="2022.naacl-main.187.mp4"/>
     </paper>
     <paper id="188">
       <title>How Gender Debiasing Affects Internal Model Representations, and Why It Matters</title>
@@ -2818,6 +3001,7 @@
       <pwccode url="https://github.com/technion-cs-nlp/gender_internal" additional="true">technion-cs-nlp/gender_internal</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gap-coreference-dataset">GAP Coreference Dataset</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
+      <video href="2022.naacl-main.188.mp4"/>
     </paper>
     <paper id="189">
       <title>A Structured Span Selector</title>
@@ -2831,6 +3015,7 @@
       <bibkey>liu-etal-2022-structured</bibkey>
       <doi>10.18653/v1/2022.naacl-main.189</doi>
       <pwccode url="https://github.com/lyutyuh/structured-span-selector" additional="false">lyutyuh/structured-span-selector</pwccode>
+      <video href="2022.naacl-main.189.mp4"/>
     </paper>
     <paper id="190">
       <title>Unified Semantic Typing with Meaningful Label Inference</title>
@@ -2849,6 +3034,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/open-entity-1">Open Entity</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tacred">TACRED</pwcdataset>
+      <video href="2022.naacl-main.190.mp4"/>
     </paper>
     <paper id="191">
       <title>Learning To Retrieve Prompts for In-Context Learning</title>
@@ -2862,6 +3048,7 @@
       <doi>10.18653/v1/2022.naacl-main.191</doi>
       <pwccode url="https://github.com/ohadrubin/epr" additional="false">ohadrubin/epr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/the-pile">The Pile</pwcdataset>
+      <video href="2022.naacl-main.191.mp4"/>
     </paper>
     <paper id="192">
       <title>Necessity and Sufficiency for Explaining Text Classifiers: A Case Study in Hate Speech Detection</title>
@@ -2876,6 +3063,7 @@
       <bibkey>balkir-etal-2022-necessity</bibkey>
       <doi>10.18653/v1/2022.naacl-main.192</doi>
       <pwccode url="https://github.com/esmab/necessity-sufficiency" additional="false">esmab/necessity-sufficiency</pwccode>
+      <video href="2022.naacl-main.192.mp4"/>
     </paper>
     <paper id="193">
       <title>Learning to Retrieve Passages without Supervision</title>
@@ -2895,6 +3083,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
+      <video href="2022.naacl-main.193.mp4"/>
     </paper>
     <paper id="194">
       <title><fixed-case>R</fixed-case>e2<fixed-case>G</fixed-case>: Retrieve, Rerank, Generate</title>
@@ -2916,6 +3105,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/t-rex">T-REx</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.194.mp4"/>
     </paper>
     <paper id="195">
       <title>Don’t sweat the small stuff, classify the rest: Sample Shielding to protect text classifiers against adversarial attacks</title>
@@ -2928,6 +3118,7 @@
       <bibkey>rusert-srinivasan-2022-dont</bibkey>
       <doi>10.18653/v1/2022.naacl-main.195</doi>
       <pwccode url="https://github.com/jonrusert/sampleshielding" additional="false">jonrusert/sampleshielding</pwccode>
+      <video href="2022.naacl-main.195.mp4"/>
     </paper>
     <paper id="196">
       <title>Federated Learning with Noisy User Feedback</title>
@@ -2944,6 +3135,7 @@
       <url hash="665da144">2022.naacl-main.196</url>
       <bibkey>sharma-etal-2022-federated</bibkey>
       <doi>10.18653/v1/2022.naacl-main.196</doi>
+      <video href="2022.naacl-main.196.mp4"/>
     </paper>
     <paper id="197">
       <title>Gender Bias in Masked Language Models for Multiple Languages</title>
@@ -2957,6 +3149,7 @@
       <bibkey>kaneko-etal-2022-gender</bibkey>
       <doi>10.18653/v1/2022.naacl-main.197</doi>
       <pwccode url="https://github.com/kanekomasahiro/bias_eval_in_multiple_mlm" additional="false">kanekomasahiro/bias_eval_in_multiple_mlm</pwccode>
+      <video href="2022.naacl-main.197.mp4"/>
     </paper>
     <paper id="198">
       <title>Multi-Domain Targeted Sentiment Analysis</title>
@@ -2971,6 +3164,7 @@
       <doi>10.18653/v1/2022.naacl-main.198</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/mams">MAMS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/yaso">YASO</pwcdataset>
+      <video href="2022.naacl-main.198.mp4"/>
     </paper>
     <paper id="199">
       <title>Falsesum: Generating Document-level <fixed-case>NLI</fixed-case> Examples for Recognizing Factual Inconsistency in Summarization</title>
@@ -2986,6 +3180,7 @@
       <pwccode url="https://github.com/joshbambrick/falsesum" additional="false">joshbambrick/falsesum</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
+      <video href="2022.naacl-main.199.mp4"/>
     </paper>
     <paper id="200">
       <title>Dynamic Gazetteer Integration in Multilingual Models for Cross-Lingual and Cross-Domain Named Entity Recognition</title>
@@ -2998,6 +3193,7 @@
       <url hash="c7f56069">2022.naacl-main.200</url>
       <bibkey>fetahu-etal-2022-dynamic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.200</doi>
+      <video href="2022.naacl-main.200.mp4"/>
     </paper>
     <paper id="201">
       <title><fixed-case>M</fixed-case>eta<fixed-case>ICL</fixed-case>: Learning to Learn In Context</title>
@@ -3013,6 +3209,7 @@
       <pwccode url="https://github.com/facebookresearch/metaicl" additional="false">facebookresearch/metaicl</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hate-speech">Hate Speech</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-instructions">Natural Instructions</pwcdataset>
+      <video href="2022.naacl-main.201.mp4"/>
     </paper>
     <paper id="202">
       <title>Enhancing Knowledge Selection for Grounded Dialogues via Document Semantic Graphs</title>
@@ -3030,6 +3227,7 @@
       <doi>10.18653/v1/2022.naacl-main.202</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/holl-e">Holl-E</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.202.mp4"/>
     </paper>
     <paper id="203">
       <title>Using Natural Sentence Prompts for Understanding Biases in Language Models</title>
@@ -3041,6 +3239,7 @@
       <url hash="21231b3c">2022.naacl-main.203</url>
       <bibkey>alnegheimish-etal-2022-using</bibkey>
       <doi>10.18653/v1/2022.naacl-main.203</doi>
+      <video href="2022.naacl-main.203.mp4"/>
     </paper>
     <paper id="204">
       <title>Robust Conversational Agents against Imperceptible Toxicity Triggers</title>
@@ -3055,6 +3254,7 @@
       <doi>10.18653/v1/2022.naacl-main.204</doi>
       <pwccode url="https://github.com/ninarehm/robust-agents" additional="false">ninarehm/robust-agents</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.204.mp4"/>
     </paper>
     <paper id="205">
       <title>Selective Differential Privacy for Language Modeling</title>
@@ -3071,6 +3271,7 @@
       <doi>10.18653/v1/2022.naacl-main.205</doi>
       <pwccode url="https://github.com/wyshi/lm_privacy" additional="false">wyshi/lm_privacy</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
+      <video href="2022.naacl-main.205.mp4"/>
     </paper>
     <paper id="206">
       <title>Do Trajectories Encode Verb Meaning?</title>
@@ -3083,6 +3284,7 @@
       <bibkey>ebert-etal-2022-trajectories</bibkey>
       <doi>10.18653/v1/2022.naacl-main.206</doi>
       <pwccode url="https://github.com/dylanebert/simulated" additional="false">dylanebert/simulated</pwccode>
+      <video href="2022.naacl-main.206.mp4"/>
     </paper>
     <paper id="207">
       <title>Long Context Question Answering via Supervised Contrastive Learning</title>
@@ -3098,6 +3300,7 @@
       <pwccode url="https://github.com/aviclu/long-context-qa-contrast" additional="true">aviclu/long-context-qa-contrast</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qasper">QASPER</pwcdataset>
+      <video href="2022.naacl-main.207.mp4"/>
     </paper>
     <paper id="208">
       <title>The <fixed-case>USMLE</fixed-case>® Step 2 Clinical Skills Patient Note Corpus</title>
@@ -3112,6 +3315,7 @@
       <url hash="c9a0a64d">2022.naacl-main.208</url>
       <bibkey>yaneva-etal-2022-usmle</bibkey>
       <doi>10.18653/v1/2022.naacl-main.208</doi>
+      <video href="2022.naacl-main.208.mp4"/>
     </paper>
     <paper id="209">
       <title>Learning to Borrow– Relation Representation for Without-Mention Entity-Pairs for Knowledge Graph Completion</title>
@@ -3126,6 +3330,7 @@
       <doi>10.18653/v1/2022.naacl-main.209</doi>
       <pwccode url="https://github.com/huda-hakami/learning-to-borrow-for-kgs" additional="false">huda-hakami/learning-to-borrow-for-kgs</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
+      <video href="2022.naacl-main.209.mp4"/>
     </paper>
     <paper id="210">
       <title>Improving Entity Disambiguation by Reasoning over a Knowledge Base</title>
@@ -3142,6 +3347,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/aida-conll-yago">AIDA CoNLL-YAGO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/aquaint">AQUAINT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
+      <video href="2022.naacl-main.210.mp4"/>
     </paper>
     <paper id="211">
       <title>Modal Dependency Parsing via Language Model Priming</title>
@@ -3154,6 +3360,7 @@
       <bibkey>yao-etal-2022-modal</bibkey>
       <doi>10.18653/v1/2022.naacl-main.211</doi>
       <pwccode url="https://github.com/jryao/mdp_prompt" additional="false">jryao/mdp_prompt</pwccode>
+      <video href="2022.naacl-main.211.mp4"/>
     </paper>
     <paper id="212">
       <title>Document-Level Relation Extraction with Sentences Importance Estimation and Focusing</title>
@@ -3169,6 +3376,7 @@
       <pwccode url="https://github.com/xwjim/sief" additional="false">xwjim/sief</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dialogre">DialogRE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
+      <video href="2022.naacl-main.212.mp4"/>
     </paper>
     <paper id="213">
       <title>Are All the Datasets in Benchmark Necessary? A Pilot Study of Dataset Evaluation for Text Classification</title>
@@ -3187,6 +3395,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
+      <video href="2022.naacl-main.213.mp4"/>
     </paper>
     <paper id="214">
       <title>Triggerless Backdoor Attack for <fixed-case>NLP</fixed-case> Tasks with Clean Labels</title>
@@ -3207,6 +3416,7 @@
       <pwccode url="https://github.com/leileigan/clean_label_textual_backdoor_attack" additional="false">leileigan/clean_label_textual_backdoor_attack</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/olid">OLID</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.214.mp4"/>
     </paper>
     <paper id="215">
       <title><fixed-case>PPL-MCTS</fixed-case>: <fixed-case>C</fixed-case>onstrained Textual Generation Through Discriminator-Guided <fixed-case>MCTS</fixed-case> Decoding</title>
@@ -3219,6 +3429,7 @@
       <bibkey>chaffin-etal-2022-ppl</bibkey>
       <doi>10.18653/v1/2022.naacl-main.215</doi>
       <pwccode url="https://github.com/NohTow/PPL-MCTS" additional="false">NohTow/PPL-MCTS</pwccode>
+      <video href="2022.naacl-main.215.mp4"/>
     </paper>
     <paper id="216">
       <title>Interpretable Proof Generation via Iterative Backward Reasoning</title>
@@ -3234,6 +3445,7 @@
       <doi>10.18653/v1/2022.naacl-main.216</doi>
       <pwccode url="https://github.com/find-knowledge/ibr" additional="false">find-knowledge/ibr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/proofwriter">ProofWriter</pwcdataset>
+      <video href="2022.naacl-main.216.mp4"/>
     </paper>
     <paper id="217">
       <title>Domain Confused Contrastive Learning for Unsupervised Domain Adaptation</title>
@@ -3246,6 +3458,7 @@
       <url hash="20af2c89">2022.naacl-main.217</url>
       <bibkey>long-etal-2022-domain</bibkey>
       <doi>10.18653/v1/2022.naacl-main.217</doi>
+      <video href="2022.naacl-main.217.mp4"/>
     </paper>
     <paper id="218">
       <title>Incorporating Centering Theory into Neural Coreference Resolution</title>
@@ -3259,6 +3472,7 @@
       <doi>10.18653/v1/2022.naacl-main.218</doi>
       <pwccode url="https://github.com/haixiachai/ct-coref" additional="false">haixiachai/ct-coref</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gap-coreference-dataset">GAP Coreference Dataset</pwcdataset>
+      <video href="2022.naacl-main.218.mp4"/>
     </paper>
     <paper id="219">
       <title>Progressive Class Semantic Matching for Semi-supervised Text Classification</title>
@@ -3274,6 +3488,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/yahoo-answers">Yahoo! Answers</pwcdataset>
+      <video href="2022.naacl-main.219.mp4"/>
     </paper>
     <paper id="220">
       <title>Low Resource Style Transfer via Domain Adaptive Meta Learning</title>
@@ -3286,6 +3501,7 @@
       <url hash="4b4b5550">2022.naacl-main.220</url>
       <bibkey>li-etal-2022-low</bibkey>
       <doi>10.18653/v1/2022.naacl-main.220</doi>
+      <video href="2022.naacl-main.220.mp4"/>
     </paper>
     <paper id="221">
       <title>Features or Spurious Artifacts? Data-centric Baselines for Fair and Robust Hate Speech Detection</title>
@@ -3298,6 +3514,7 @@
       <doi>10.18653/v1/2022.naacl-main.221</doi>
       <pwccode url="https://github.com/dhfbk/hate-speech-artifacts" additional="false">dhfbk/hate-speech-artifacts</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hate-speech">Hate Speech</pwcdataset>
+      <video href="2022.naacl-main.221.mp4"/>
     </paper>
     <paper id="222">
       <title>Document-Level Event Argument Extraction by Leveraging Redundant Information and Closed Boundary Loss</title>
@@ -3308,6 +3525,7 @@
       <url hash="7dad8e6c">2022.naacl-main.222</url>
       <bibkey>zhou-mao-2022-document</bibkey>
       <doi>10.18653/v1/2022.naacl-main.222</doi>
+      <video href="2022.naacl-main.222.mp4"/>
     </paper>
     <paper id="223">
       <title>A Few Thousand Translations Go a Long Way! Leveraging Pre-trained Models for <fixed-case>A</fixed-case>frican News Translation</title>
@@ -3364,6 +3582,7 @@
       <pwccode url="https://github.com/masakhane-io/lafand-mt" additional="false">masakhane-io/lafand-mt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ccaligned">CCAligned</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mc4">mC4</pwcdataset>
+      <video href="2022.naacl-main.223.mp4"/>
     </paper>
     <paper id="224">
       <title>Should We Rely on Entity Mentions for Relation Extraction? Debiasing Relation Extraction with Counterfactual Analysis</title>
@@ -3383,6 +3602,7 @@
       <doi>10.18653/v1/2022.naacl-main.224</doi>
       <pwccode url="https://github.com/vanoracai/core" additional="false">vanoracai/core</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/re-tacred">Re-TACRED</pwcdataset>
+      <video href="2022.naacl-main.224.mp4"/>
     </paper>
     <paper id="225">
       <title>Analyzing Encoded Concepts in Transformer Language Models</title>
@@ -3399,6 +3619,7 @@
       <bibkey>sajjad-etal-2022-analyzing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.225</doi>
       <pwccode url="https://github.com/hsajjad/conceptx" additional="false">hsajjad/conceptx</pwccode>
+      <video href="2022.naacl-main.225.mp4"/>
     </paper>
     <paper id="226">
       <title>Boosted Dense Retriever</title>
@@ -3416,6 +3637,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/beir">BEIR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
+      <video href="2022.naacl-main.226.mp4"/>
     </paper>
     <paper id="227">
       <title><fixed-case>M</fixed-case>u<fixed-case>CGEC</fixed-case>: a Multi-Reference Multi-Source Evaluation Dataset for <fixed-case>C</fixed-case>hinese Grammatical Error Correction</title>
@@ -3434,6 +3656,7 @@
       <doi>10.18653/v1/2022.naacl-main.227</doi>
       <pwccode url="https://github.com/hillzhang1999/mucgec" additional="false">hillzhang1999/mucgec</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mucgec">MuCGEC</pwcdataset>
+      <video href="2022.naacl-main.227.mp4"/>
     </paper>
     <paper id="228">
       <title><fixed-case>N</fixed-case>eu<fixed-case>S</fixed-case>: Neutral Multi-News Summarization for Mitigating Framing Bias</title>
@@ -3449,6 +3672,7 @@
       <doi>10.18653/v1/2022.naacl-main.228</doi>
       <pwccode url="https://github.com/hltchkust/framing-bias-metric" additional="false">hltchkust/framing-bias-metric</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multi-news">Multi-News</pwcdataset>
+      <video href="2022.naacl-main.228.mp4"/>
     </paper>
     <paper id="229">
       <title>Enhance Incomplete Utterance Restoration by Joint Learning Token Extraction and Text Generation</title>
@@ -3463,6 +3687,7 @@
       <doi>10.18653/v1/2022.naacl-main.229</doi>
       <pwccode url="https://github.com/shumpei19/jet" additional="false">shumpei19/jet</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/canard">CANARD</pwcdataset>
+      <video href="2022.naacl-main.229.mp4"/>
     </paper>
     <paper id="230">
       <title>Efficient Constituency Tree based Encoding for Natural Language to Bash Translation</title>
@@ -3475,6 +3700,7 @@
       <doi>10.18653/v1/2022.naacl-main.230</doi>
       <pwccode url="https://github.com/shikhar-s/segmented-invocation-transformer" additional="false">shikhar-s/segmented-invocation-transformer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/nlc2cmd">NLC2CMD</pwcdataset>
+      <video href="2022.naacl-main.230.mp4"/>
     </paper>
     <paper id="231">
       <title>Privacy-Preserving Text Classification on <fixed-case>BERT</fixed-case> Embeddings with Homomorphic Encryption</title>
@@ -3489,6 +3715,7 @@
       <attachment type="software" hash="ef8b3925">2022.naacl-main.231.software.zip</attachment>
       <bibkey>lee-etal-2022-privacy</bibkey>
       <doi>10.18653/v1/2022.naacl-main.231</doi>
+      <video href="2022.naacl-main.231.mp4"/>
     </paper>
     <paper id="232">
       <title><fixed-case>ITA</fixed-case>: Image-Text Alignments for Multi-Modal Named Entity Recognition</title>
@@ -3506,6 +3733,7 @@
       <bibkey>wang-etal-2022-ita</bibkey>
       <doi>10.18653/v1/2022.naacl-main.232</doi>
       <pwccode url="https://github.com/alibaba-nlp/kb-ner" additional="false">alibaba-nlp/kb-ner</pwccode>
+      <video href="2022.naacl-main.232.mp4"/>
     </paper>
     <paper id="233">
       <title>A Dataset for N-ary Relation Extraction of Drug Combinations</title>
@@ -3524,6 +3752,7 @@
       <doi>10.18653/v1/2022.naacl-main.233</doi>
       <pwccode url="https://github.com/allenai/drug-combo-extraction" additional="false">allenai/drug-combo-extraction</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/blue">BLUE</pwcdataset>
+      <video href="2022.naacl-main.233.mp4"/>
     </paper>
     <paper id="234">
       <title>Curriculum: A Broad-Coverage Benchmark for Linguistic Phenomena in Natural Language Understanding</title>
@@ -3541,6 +3770,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/help">HELP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.234.mp4"/>
     </paper>
     <paper id="235">
       <title>Neural Language Taskonomy: Which <fixed-case>NLP</fixed-case> Tasks are the most Predictive of f<fixed-case>MRI</fixed-case> Brain Activity?</title>
@@ -3556,6 +3786,7 @@
       <attachment type="software" hash="5cfabadb">2022.naacl-main.235.software.zip</attachment>
       <bibkey>oota-etal-2022-neural</bibkey>
       <doi>10.18653/v1/2022.naacl-main.235</doi>
+      <video href="2022.naacl-main.235.mp4"/>
     </paper>
     <paper id="236">
       <title><fixed-case>F</fixed-case>act<fixed-case>G</fixed-case>raph: Evaluating Factuality in Summarization with Semantic Graph Representations</title>
@@ -3572,6 +3803,7 @@
       <doi>10.18653/v1/2022.naacl-main.236</doi>
       <pwccode url="https://github.com/amazon-research/fact-graph" additional="false">amazon-research/fact-graph</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
+      <video href="2022.naacl-main.236.mp4"/>
     </paper>
     <paper id="237">
       <title>Unsupervised Paraphrasability Prediction for Compound Nominalizations</title>
@@ -3583,6 +3815,7 @@
       <url hash="b5505126">2022.naacl-main.237</url>
       <bibkey>lee-etal-2022-unsupervised</bibkey>
       <doi>10.18653/v1/2022.naacl-main.237</doi>
+      <video href="2022.naacl-main.237.mp4"/>
     </paper>
     <paper id="238">
       <title>Global Entity Disambiguation with <fixed-case>BERT</fixed-case></title>
@@ -3599,6 +3832,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ace-2004">ACE 2004</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/aida-conll-yago">AIDA CoNLL-YAGO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/aquaint">AQUAINT</pwcdataset>
+      <video href="2022.naacl-main.238.mp4"/>
     </paper>
     <paper id="239">
       <title>Clues Before Answers: Generation-Enhanced Multiple-Choice <fixed-case>QA</fixed-case></title>
@@ -3616,6 +3850,7 @@
       <pwccode url="https://github.com/nju-websoft/genmc" additional="false">nju-websoft/genmc</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/commonsenseqa">CommonsenseQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qasc">QASC</pwcdataset>
+      <video href="2022.naacl-main.239.mp4"/>
     </paper>
     <paper id="240">
       <title>Towards Efficient <fixed-case>NLP</fixed-case>: A Standard Evaluation and A Strong Baseline</title>
@@ -3643,6 +3878,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
+      <video href="2022.naacl-main.240.mp4"/>
     </paper>
     <paper id="241">
       <title>Stylized Knowledge-Grounded Dialogue Generation via Disentangled Template Rewriting</title>
@@ -3661,6 +3897,7 @@
       <bibkey>sun-etal-2022-stylized</bibkey>
       <doi>10.18653/v1/2022.naacl-main.241</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.241.mp4"/>
     </paper>
     <paper id="242">
       <title><fixed-case>LUNA</fixed-case>: Learning Slot-Turn Alignment for Dialogue State Tracking</title>
@@ -3678,6 +3915,7 @@
       <doi>10.18653/v1/2022.naacl-main.242</doi>
       <pwccode url="https://github.com/nlper27149/luna-dst" additional="false">nlper27149/luna-dst</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
+      <video href="2022.naacl-main.242.mp4"/>
     </paper>
     <paper id="243">
       <title>Crossroads, Buildings and Neighborhoods: A Dataset for Fine-grained Location Recognition</title>
@@ -3691,6 +3929,7 @@
       <bibkey>chen-etal-2022-crossroads</bibkey>
       <doi>10.18653/v1/2022.naacl-main.243</doi>
       <pwccode url="https://github.com/brickee/harveyner" additional="false">brickee/harveyner</pwccode>
+      <video href="2022.naacl-main.243.mp4"/>
     </paper>
     <paper id="244">
       <title>Tricks for Training Sparse Translation Models</title>
@@ -3705,6 +3944,7 @@
       <url hash="1bc5ac55">2022.naacl-main.244</url>
       <bibkey>dua-etal-2022-tricks</bibkey>
       <doi>10.18653/v1/2022.naacl-main.244</doi>
+      <video href="2022.naacl-main.244.mp4"/>
     </paper>
     <paper id="245">
       <title>Persona-Guided Planning for Controlling the Protagonist’s Persona in Story Generation</title>
@@ -3720,6 +3960,7 @@
       <doi>10.18653/v1/2022.naacl-main.245</doi>
       <pwccode url="https://github.com/thu-coai/conper" additional="false">thu-coai/conper</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
+      <video href="2022.naacl-main.245.mp4"/>
     </paper>
     <paper id="246">
       <title><fixed-case>CHEF</fixed-case>: A Pilot <fixed-case>C</fixed-case>hinese Dataset for Evidence-Based Fact-Checking</title>
@@ -3737,6 +3978,7 @@
       <pwccode url="https://github.com/thu-bpm/chef" additional="false">thu-bpm/chef</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/x-fact">X-Fact</pwcdataset>
+      <video href="2022.naacl-main.246.mp4"/>
     </paper>
     <paper id="247">
       <title><fixed-case>VGNMN</fixed-case>: Video-grounded Neural Module Networks for Video-Grounded Dialogue Systems</title>
@@ -3749,6 +3991,7 @@
       <bibkey>le-etal-2022-vgnmn</bibkey>
       <doi>10.18653/v1/2022.naacl-main.247</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
+      <video href="2022.naacl-main.247.mp4"/>
     </paper>
     <paper id="248">
       <title>Multimodal Dialogue State Tracking</title>
@@ -3762,6 +4005,7 @@
       <doi>10.18653/v1/2022.naacl-main.248</doi>
       <pwccode url="https://github.com/henryhungle/mm_dst" additional="false">henryhungle/mm_dst</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cater">CATER</pwcdataset>
+      <video href="2022.naacl-main.248.mp4"/>
     </paper>
     <paper id="249">
       <title>On the Use of Bert for Automated Essay Scoring: Joint Learning of Multi-Scale Essay Representation</title>
@@ -3776,6 +4020,7 @@
       <doi>10.18653/v1/2022.naacl-main.249</doi>
       <pwccode url="https://github.com/lingochamp/multi-scale-bert-aes" additional="false">lingochamp/multi-scale-bert-aes</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/asap">ASAP</pwcdataset>
+      <video href="2022.naacl-main.249.mp4"/>
     </paper>
     <paper id="250">
       <title>Recognition of They/Them as Singular Personal Pronouns in Coreference Resolution</title>
@@ -3793,6 +4038,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogender-schemas">Winogender Schemas</pwcdataset>
+      <video href="2022.naacl-main.250.mp4"/>
     </paper>
     <paper id="251">
       <title><fixed-case>TWEETSPIN</fixed-case>: Fine-grained Propaganda Detection in Social Media Using Multi-View Representations</title>
@@ -3803,6 +4049,7 @@
       <url hash="8052df46">2022.naacl-main.251</url>
       <bibkey>vijayaraghavan-vosoughi-2022-tweetspin</bibkey>
       <doi>10.18653/v1/2022.naacl-main.251</doi>
+      <video href="2022.naacl-main.251.mp4"/>
     </paper>
     <paper id="252">
       <title><fixed-case>U</fixed-case>ser<fixed-case>I</fixed-case>dentifier: Implicit User Representations for Simple and Effective Personalized Sentiment Analysis</title>
@@ -3817,6 +4064,7 @@
       <url hash="ea99bd6b">2022.naacl-main.252</url>
       <bibkey>mireshghallah-etal-2022-useridentifier</bibkey>
       <doi>10.18653/v1/2022.naacl-main.252</doi>
+      <video href="2022.naacl-main.252.mp4"/>
     </paper>
     <paper id="253">
       <title>Improving Neural Models for Radiology Report Retrieval with Lexicon-based Automated Annotation</title>
@@ -3829,6 +4077,7 @@
       <bibkey>shi-etal-2022-improving</bibkey>
       <doi>10.18653/v1/2022.naacl-main.253</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
+      <video href="2022.naacl-main.253.mp4"/>
     </paper>
     <paper id="254">
       <title>Transparent Human Evaluation for Image Captioning</title>
@@ -3847,6 +4096,7 @@
       <pwccode url="https://github.com/jungokasai/thumb" additional="true">jungokasai/thumb</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
+      <video href="2022.naacl-main.254.mp4"/>
     </paper>
     <paper id="255">
       <title>Lifting the Curse of Multilinguality by Pre-training Modular Transformers</title>
@@ -3866,6 +4116,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
+      <video href="2022.naacl-main.255.mp4"/>
     </paper>
     <paper id="256">
       <title><fixed-case>D</fixed-case>oc<fixed-case>AMR</fixed-case>: Multi-Sentence <fixed-case>AMR</fixed-case> Representation and Evaluation</title>
@@ -3885,6 +4136,7 @@
       <bibkey>naseem-etal-2022-docamr</bibkey>
       <doi>10.18653/v1/2022.naacl-main.256</doi>
       <pwccode url="https://github.com/ibm/docamr" additional="false">ibm/docamr</pwccode>
+      <video href="2022.naacl-main.256.mp4"/>
     </paper>
     <paper id="257">
       <title>Learning to Transfer Prompts for Text Generation</title>
@@ -3901,6 +4153,7 @@
       <pwccode url="https://github.com/rucaibox/transfer-prompts-for-text-generation" additional="false">rucaibox/transfer-prompts-for-text-generation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
+      <video href="2022.naacl-main.257.mp4"/>
     </paper>
     <paper id="258">
       <title><fixed-case>E</fixed-case>lite<fixed-case>PLM</fixed-case>: An Empirical Study on General Language Ability Evaluation of Pretrained Language Models</title>
@@ -3928,6 +4181,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/swag">SWAG</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
+      <video href="2022.naacl-main.258.mp4"/>
     </paper>
     <paper id="259">
       <title>Bidimensional Leaderboards: Generate and Evaluate Language Hand in Hand</title>
@@ -3947,6 +4201,7 @@
       <pwccode url="https://github.com/jungokasai/billboard" additional="true">jungokasai/billboard</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2020">WMT 2020</pwcdataset>
+      <video href="2022.naacl-main.259.mp4"/>
     </paper>
     <paper id="260">
       <title>Improving In-Context Few-Shot Learning via Self-Supervised Training</title>
@@ -3967,6 +4222,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multirc">MultiRC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-instructions">Natural Instructions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
+      <video href="2022.naacl-main.260.mp4"/>
     </paper>
     <paper id="261">
       <title>Exposing the Limits of Video-Text Models through Contrast Sets</title>
@@ -3982,6 +4238,7 @@
       <bibkey>park-etal-2022-exposing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.261</doi>
       <pwccode url="https://github.com/jamespark3922/video-lang-contrast-set" additional="false">jamespark3922/video-lang-contrast-set</pwccode>
+      <video href="2022.naacl-main.261.mp4"/>
     </paper>
     <paper id="262">
       <title>Zero-shot Sonnet Generation with Discourse-level Planning and Aesthetics Features</title>
@@ -3993,6 +4250,7 @@
       <bibkey>tian-peng-2022-zero</bibkey>
       <doi>10.18653/v1/2022.naacl-main.262</doi>
       <pwccode url="https://github.com/pluslabnlp/sonnet-gen" additional="false">pluslabnlp/sonnet-gen</pwccode>
+      <video href="2022.naacl-main.262.mp4"/>
     </paper>
     <paper id="263">
       <title>Benchmarking Intersectional Biases in <fixed-case>NLP</fixed-case></title>
@@ -4008,6 +4266,7 @@
       <bibkey>lalor-etal-2022-benchmarking</bibkey>
       <doi>10.18653/v1/2022.naacl-main.263</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/psychometric-nlp">Psychometric NLP</pwcdataset>
+      <video href="2022.naacl-main.263.mp4"/>
     </paper>
     <paper id="264">
       <title>When is <fixed-case>BERT</fixed-case> Multilingual? Isolating Crucial Ingredients for Cross-lingual Transfer</title>
@@ -4021,6 +4280,7 @@
       <doi>10.18653/v1/2022.naacl-main.264</doi>
       <pwccode url="https://github.com/princeton-nlp/MultilingualAnalysis" additional="false">princeton-nlp/MultilingualAnalysis</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
+      <video href="2022.naacl-main.264.mp4"/>
     </paper>
     <paper id="265">
       <title>How Conservative are Language Models? Adapting to the Introduction of Gender-Neutral Pronouns</title>
@@ -4034,6 +4294,7 @@
       <doi>10.18653/v1/2022.naacl-main.265</doi>
       <pwccode url="https://github.com/stephaniebrandl/gender-neutral-pronouns" additional="false">stephaniebrandl/gender-neutral-pronouns</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
+      <video href="2022.naacl-main.265.mp4"/>
     </paper>
     <paper id="266">
       <title>Prompt Waywardness: The Curious Case of Discretized Interpretation of Continuous Prompts</title>
@@ -4057,6 +4318,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-instructions">Natural Instructions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.266.mp4"/>
     </paper>
     <paper id="267">
       <title>Contrastive Representation Learning for Cross-Document Coreference Resolution of Events and Entities</title>
@@ -4068,6 +4330,7 @@
       <bibkey>hsu-horwood-2022-contrastive</bibkey>
       <doi>10.18653/v1/2022.naacl-main.267</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/ecb">ECB+</pwcdataset>
+      <video href="2022.naacl-main.267.mp4"/>
     </paper>
     <paper id="268">
       <title>Learning the Ordering of Coordinate Compounds and Elaborate Expressions in <fixed-case>H</fixed-case>mong, <fixed-case>L</fixed-case>ahu, and <fixed-case>C</fixed-case>hinese</title>
@@ -4079,6 +4342,7 @@
       <url hash="c8b09308">2022.naacl-main.268</url>
       <bibkey>cui-etal-2022-learning</bibkey>
       <doi>10.18653/v1/2022.naacl-main.268</doi>
+      <video href="2022.naacl-main.268.mp4"/>
     </paper>
     <paper id="269">
       <title><fixed-case>FRUIT</fixed-case>: Faithfully Reflecting Updated Information in Text</title>
@@ -4092,6 +4356,7 @@
       <url hash="eb5e69df">2022.naacl-main.269</url>
       <bibkey>iv-etal-2022-fruit</bibkey>
       <doi>10.18653/v1/2022.naacl-main.269</doi>
+      <video href="2022.naacl-main.269.mp4"/>
     </paper>
     <paper id="270">
       <title><fixed-case>M</fixed-case>ulti2<fixed-case>WOZ</fixed-case>: A Robust Multilingual Dataset and Conversational Pretraining for Task-Oriented Dialog</title>
@@ -4109,6 +4374,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ccnet">CCNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
+      <video href="2022.naacl-main.270.mp4"/>
     </paper>
     <paper id="271">
       <title><fixed-case>C</fixed-case>hapter<fixed-case>B</fixed-case>reak: A Challenge Dataset for Long-Range Language Models</title>
@@ -4122,6 +4388,7 @@
       <doi>10.18653/v1/2022.naacl-main.271</doi>
       <pwccode url="https://github.com/simengsun/chapterbreak" additional="false">simengsun/chapterbreak</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/pg-19">PG-19</pwcdataset>
+      <video href="2022.naacl-main.271.mp4"/>
     </paper>
     <paper id="272">
       <title><fixed-case>C</fixed-case>ol<fixed-case>BERT</fixed-case>v2: Effective and Efficient Retrieval via Lightweight Late Interaction</title>
@@ -4143,6 +4410,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
+      <video href="2022.naacl-main.272.mp4"/>
     </paper>
     <paper id="273">
       <title>Quantifying Language Variation Acoustically with Few Resources</title>
@@ -4155,6 +4423,7 @@
       <doi>10.18653/v1/2022.naacl-main.273</doi>
       <pwccode url="https://github.com/bartelds/language-variation" additional="false">bartelds/language-variation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
+      <video href="2022.naacl-main.273.mp4"/>
     </paper>
     <paper id="274">
       <title>Adaptable Adapters</title>
@@ -4175,6 +4444,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.274.mp4"/>
     </paper>
     <paper id="275">
       <title>Models in the Loop: Aiding Crowdworkers with Generative Annotation Assistants</title>
@@ -4193,6 +4463,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/kilt">KILT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mrqa-2019">MRQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
+      <video href="2022.naacl-main.275.mp4"/>
     </paper>
     <paper id="276">
       <title><fixed-case>GMN</fixed-case>: Generative Multi-modal Network for Practical Document Information Extraction</title>
@@ -4211,6 +4482,7 @@
       <doi>10.18653/v1/2022.naacl-main.276</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/funsd">FUNSD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sroie">SROIE</pwcdataset>
+      <video href="2022.naacl-main.276.mp4"/>
     </paper>
     <paper id="277">
       <title>One Reference Is Not Enough: Diverse Distillation with Reference Selection for Non-Autoregressive Translation</title>
@@ -4223,6 +4495,7 @@
       <bibkey>shao-etal-2022-one</bibkey>
       <doi>10.18653/v1/2022.naacl-main.277</doi>
       <pwccode url="https://github.com/ictnlp/ddrs-nat" additional="false">ictnlp/ddrs-nat</pwccode>
+      <video href="2022.naacl-main.277.mp4"/>
     </paper>
     <paper id="278">
       <title>Can Rationalization Improve Robustness?</title>
@@ -4238,6 +4511,7 @@
       <pwccode url="https://github.com/princeton-nlp/rationale-robustness" additional="false">princeton-nlp/rationale-robustness</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multirc">MultiRC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
+      <video href="2022.naacl-main.278.mp4"/>
     </paper>
     <paper id="279">
       <title>On the Effectiveness of Sentence Encoding for Intent Detection Meta-Learning</title>
@@ -4254,6 +4528,7 @@
       <pwccode url="https://github.com/microsoft/KC" additional="false">microsoft/KC</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.279.mp4"/>
     </paper>
     <paper id="280">
       <title>A Computational Acquisition Model for Multimodal Word Categorization</title>
@@ -4270,6 +4545,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imagenet">ImageNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
+      <video href="2022.naacl-main.280.mp4"/>
     </paper>
     <paper id="281">
       <title>Residue-Based Natural Language Adversarial Attack Detection</title>
@@ -4283,6 +4559,7 @@
       <pwccode url="https://github.com/rainavyas/naacl-2022-residue-detector" additional="false">rainavyas/naacl-2022-residue-detector</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
+      <video href="2022.naacl-main.281.mp4"/>
     </paper>
     <paper id="282">
       <title>Does it Really Generalize Well on Unseen Data? Systematic Evaluation of Relational Triple Extraction Methods</title>
@@ -4296,6 +4573,7 @@
       <bibkey>lee-etal-2022-really</bibkey>
       <doi>10.18653/v1/2022.naacl-main.282</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
+      <video href="2022.naacl-main.282.mp4"/>
     </paper>
     <paper id="283">
       <title>From spoken dialogue to formal summary: An utterance rewriting for dialogue summarization</title>
@@ -4312,6 +4590,7 @@
       <attachment type="software" hash="86d40779">2022.naacl-main.283.software.zip</attachment>
       <bibkey>fang-etal-2022-spoken</bibkey>
       <doi>10.18653/v1/2022.naacl-main.283</doi>
+      <video href="2022.naacl-main.283.mp4"/>
     </paper>
     <paper id="284">
       <title><fixed-case>EASE</fixed-case>: Entity-Aware Contrastive Learning of Sentence Embedding</title>
@@ -4327,6 +4606,7 @@
       <doi>10.18653/v1/2022.naacl-main.284</doi>
       <pwccode url="https://github.com/studio-ousia/ease" additional="false">studio-ousia/ease</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mldoc">MLDoc</pwcdataset>
+      <video href="2022.naacl-main.284.mp4"/>
     </paper>
     <paper id="285">
       <title>Is Neural Topic Modelling Better than Clustering? An Empirical Study on Clustering with Contextual Embeddings for Topics</title>
@@ -4340,6 +4620,7 @@
       <bibkey>zhang-etal-2022-neural</bibkey>
       <doi>10.18653/v1/2022.naacl-main.285</doi>
       <pwccode url="https://github.com/hyintell/topicx" additional="false">hyintell/topicx</pwccode>
+      <video href="2022.naacl-main.285.mp4"/>
     </paper>
     <paper id="286">
       <title>Dynamic Multistep Reasoning based on Video Scene Graph for Video Question Answering</title>
@@ -4355,6 +4636,7 @@
       <url hash="607accf0">2022.naacl-main.286</url>
       <bibkey>mao-etal-2022-dynamic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.286</doi>
+      <video href="2022.naacl-main.286.mp4"/>
     </paper>
     <paper id="287">
       <title><fixed-case>TRUE</fixed-case>: Re-evaluating Factual Consistency Evaluation</title>
@@ -4402,6 +4684,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
+      <video href="2022.naacl-main.288.mp4"/>
     </paper>
     <paper id="289">
       <title><fixed-case>B</fixed-case>i-<fixed-case>S</fixed-case>im<fixed-case>C</fixed-case>ut: A Simple Strategy for Boosting Neural Machine Translation</title>
@@ -4416,6 +4699,7 @@
       <doi>10.18653/v1/2022.naacl-main.289</doi>
       <pwccode url="https://github.com/gpengzhi/Bi-SimCut" additional="false">gpengzhi/Bi-SimCut</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
+      <video href="2022.naacl-main.289.mp4"/>
     </paper>
     <paper id="290">
       <title>On Transferability of Prompt Tuning for Natural Language Processing</title>
@@ -4448,6 +4732,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.290.mp4"/>
     </paper>
     <paper id="291">
       <title><fixed-case>D</fixed-case>oc<fixed-case>EE</fixed-case>: A Large-Scale and Fine-grained Benchmark for Document-level Event Extraction</title>
@@ -4467,6 +4752,7 @@
       <doi>10.18653/v1/2022.naacl-main.291</doi>
       <pwccode url="https://github.com/tongmeihan1995/docee" additional="false">tongmeihan1995/docee</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikievents">WikiEvents</pwcdataset>
+      <video href="2022.naacl-main.291.mp4"/>
     </paper>
     <paper id="292">
       <title>Towards Debiasing Translation Artifacts</title>
@@ -4481,6 +4767,7 @@
       <doi>10.18653/v1/2022.naacl-main.292</doi>
       <pwccode url="https://github.com/koeldc/towards-debiasing-translation-artifacts" additional="false">koeldc/towards-debiasing-translation-artifacts</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.292.mp4"/>
     </paper>
     <paper id="293">
       <title><fixed-case>WECHSEL</fixed-case>: Effective initialization of subword embeddings for cross-lingual transfer of monolingual language models</title>
@@ -4493,6 +4780,7 @@
       <bibkey>minixhofer-etal-2022-wechsel</bibkey>
       <doi>10.18653/v1/2022.naacl-main.293</doi>
       <pwccode url="https://github.com/cpjku/wechsel" additional="false">cpjku/wechsel</pwccode>
+      <video href="2022.naacl-main.293.mp4"/>
     </paper>
     <paper id="294">
       <title>A New Concept of Knowledge based Question Answering (<fixed-case>KBQA</fixed-case>) System for Multi-hop Reasoning</title>
@@ -4504,6 +4792,7 @@
       <url hash="855acab0">2022.naacl-main.294</url>
       <bibkey>wang-etal-2022-new</bibkey>
       <doi>10.18653/v1/2022.naacl-main.294</doi>
+      <video href="2022.naacl-main.294.mp4"/>
     </paper>
     <paper id="295">
       <title>Bilingual Tabular Inference: A Case Study on Indic Languages</title>
@@ -4517,6 +4806,7 @@
       <bibkey>agarwal-etal-2022-bilingual</bibkey>
       <doi>10.18653/v1/2022.naacl-main.295</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/tabfact">TabFact</pwcdataset>
+      <video href="2022.naacl-main.295.mp4"/>
     </paper>
     <paper id="296">
       <title>Generative Biomedical Entity Linking via Knowledge Base-Guided Pre-training and Synonyms-Aware Fine-tuning</title>
@@ -4531,6 +4821,7 @@
       <pwccode url="https://github.com/yuanhy1997/genbioel" additional="false">yuanhy1997/genbioel</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bc5cdr">BC5CDR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cometa">COMETA</pwcdataset>
+      <video href="2022.naacl-main.296.mp4"/>
     </paper>
     <paper id="297">
       <title>Robust Self-Augmentation for Named Entity Recognition with Meta Reweighting</title>
@@ -4550,6 +4841,7 @@
       <pwccode url="https://github.com/LindgeW/MetaAug4NER" additional="false">LindgeW/MetaAug4NER</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/weibo-ner">Weibo NER</pwcdataset>
+      <video href="2022.naacl-main.297.mp4"/>
     </paper>
     <paper id="298">
       <title>Unsupervised Stem-based Cross-lingual Part-of-Speech Tagging for Morphologically Rich Low-Resource Languages</title>
@@ -4564,6 +4856,7 @@
       <url hash="5c178e09">2022.naacl-main.298</url>
       <bibkey>eskander-etal-2022-unsupervised</bibkey>
       <doi>10.18653/v1/2022.naacl-main.298</doi>
+      <video href="2022.naacl-main.298.mp4"/>
     </paper>
     <paper id="299">
       <title>Optimising Equal Opportunity Fairness in Model Training</title>
@@ -4578,6 +4871,7 @@
       <bibkey>shen-etal-2022-optimising</bibkey>
       <doi>10.18653/v1/2022.naacl-main.299</doi>
       <pwccode url="https://github.com/ailiaili/difference_mean_fair_models" additional="false">ailiaili/difference_mean_fair_models</pwccode>
+      <video href="2022.naacl-main.299.mp4"/>
     </paper>
     <paper id="300">
       <title>Leaner and Faster: Two-Stage Model Compression for Lightweight Text-Image Retrieval</title>
@@ -4591,6 +4885,7 @@
       <doi>10.18653/v1/2022.naacl-main.300</doi>
       <pwccode url="https://github.com/drsy/motis" additional="false">drsy/motis</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
+      <video href="2022.naacl-main.300.mp4"/>
     </paper>
     <paper id="301">
       <title>Joint Learning-based Heterogeneous Graph Attention Network for Timeline Summarization</title>
@@ -4604,6 +4899,7 @@
       <url hash="c6a7b2dd">2022.naacl-main.301</url>
       <bibkey>you-etal-2022-joint</bibkey>
       <doi>10.18653/v1/2022.naacl-main.301</doi>
+      <video href="2022.naacl-main.301.mp4"/>
     </paper>
     <paper id="302">
       <title><fixed-case>E</fixed-case>arly Rumor Detection Using Neural <fixed-case>H</fixed-case>awkes Process with a New Benchmark Dataset</title>
@@ -4615,6 +4911,7 @@
       <bibkey>zeng-gao-2022-early</bibkey>
       <doi>10.18653/v1/2022.naacl-main.302</doi>
       <pwccode url="https://github.com/znhy1024/heard" additional="false">znhy1024/heard</pwccode>
+      <video href="2022.naacl-main.302.mp4"/>
     </paper>
     <paper id="303">
       <title>Emp-<fixed-case>RFT</fixed-case>: Empathetic Response Generation via Recognizing Feature Transitions between Utterances</title>
@@ -4627,6 +4924,7 @@
       <url hash="830c14bb">2022.naacl-main.303</url>
       <bibkey>kim-etal-2022-emp</bibkey>
       <doi>10.18653/v1/2022.naacl-main.303</doi>
+      <video href="2022.naacl-main.303.mp4"/>
     </paper>
     <paper id="304">
       <title><fixed-case>KCD</fixed-case>: Knowledge Walks and Textual Cues Enhanced Political Perspective Detection in News Media</title>
@@ -4642,6 +4940,7 @@
       <bibkey>zhang-etal-2022-kcd</bibkey>
       <doi>10.18653/v1/2022.naacl-main.304</doi>
       <pwccode url="https://github.com/wenqian-zhang/kcd" additional="false">wenqian-zhang/kcd</pwccode>
+      <video href="2022.naacl-main.304.mp4"/>
     </paper>
     <paper id="305">
       <title>Collective Relevance Labeling for Passage Retrieval</title>
@@ -4656,6 +4955,7 @@
       <doi>10.18653/v1/2022.naacl-main.305</doi>
       <pwccode url="https://github.com/jihyukkim-nlp/CollectiveKD" additional="false">jihyukkim-nlp/CollectiveKD</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
+      <video href="2022.naacl-main.305.mp4"/>
     </paper>
     <paper id="306">
       <title><fixed-case>COGMEN</fixed-case>: <fixed-case>CO</fixed-case>ntextualized <fixed-case>GNN</fixed-case> based Multimodal Emotion recognitio<fixed-case>N</fixed-case></title>
@@ -4673,6 +4973,7 @@
       <pwccode url="https://github.com/exploration-lab/cogmen" additional="false">exploration-lab/cogmen</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cmu-mosei">CMU-MOSEI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
+      <video href="2022.naacl-main.306.mp4"/>
     </paper>
     <paper id="307">
       <title>Revisit Overconfidence for <fixed-case>OOD</fixed-case> Detection: Reassigned Contrastive Learning with Adaptive Class-dependent Threshold</title>
@@ -4693,6 +4994,7 @@
       <doi>10.18653/v1/2022.naacl-main.307</doi>
       <pwccode url="https://github.com/pris-nlp/naacl2022-reassigned_contrastive_learning_ood" additional="false">pris-nlp/naacl2022-reassigned_contrastive_learning_ood</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
+      <video href="2022.naacl-main.307.mp4"/>
     </paper>
     <paper id="308">
       <title><fixed-case>AISFG</fixed-case>: Abundant Information Slot Filling Generator</title>
@@ -4705,6 +5007,7 @@
       <url hash="0ea65e0c">2022.naacl-main.308</url>
       <bibkey>yan-etal-2022-aisfg</bibkey>
       <doi>10.18653/v1/2022.naacl-main.308</doi>
+      <video href="2022.naacl-main.308.mp4"/>
     </paper>
     <paper id="309">
       <title>Improving negation detection with negation-focused pre-training</title>
@@ -4717,6 +5020,7 @@
       <url hash="59410d4d">2022.naacl-main.309</url>
       <bibkey>truong-etal-2022-improving</bibkey>
       <doi>10.18653/v1/2022.naacl-main.309</doi>
+      <video href="2022.naacl-main.309.mp4"/>
     </paper>
     <paper id="310">
       <title>Practice Makes a Solver Perfect: Data Augmentation for Math Word Problem Solvers</title>
@@ -4732,6 +5036,7 @@
       <pwccode url="https://github.com/kevivk/mwp-augmentation" additional="false">kevivk/mwp-augmentation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mawps">MAWPS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/svamp">SVAMP</pwcdataset>
+      <video href="2022.naacl-main.310.mp4"/>
     </paper>
     <paper id="311">
       <title><fixed-case>D</fixed-case>iff<fixed-case>CSE</fixed-case>: Difference-based Contrastive Learning for Sentence Embeddings</title>
@@ -4758,6 +5063,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sts-benchmark">STS Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semantic-textual-similarity-2012-2016">Semantic Textual Similarity (2012 - 2016)</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
+      <video href="2022.naacl-main.311.mp4"/>
     </paper>
     <paper id="312">
       <title>Generative Cross-Domain Data Augmentation for Aspect and Opinion Co-Extraction</title>
@@ -4770,6 +5076,7 @@
       <bibkey>li-etal-2022-generative</bibkey>
       <doi>10.18653/v1/2022.naacl-main.312</doi>
       <pwccode url="https://github.com/nustm/gcdda" additional="false">nustm/gcdda</pwccode>
+      <video href="2022.naacl-main.312.mp4"/>
     </paper>
     <paper id="313">
       <title><fixed-case>P</fixed-case>ro<fixed-case>QA</fixed-case>: Structural Prompt-based Pre-training for Unified Question Answering</title>
@@ -4796,6 +5103,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/quoref">Quoref</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
+      <video href="2022.naacl-main.313.mp4"/>
     </paper>
     <paper id="314">
       <title>A Data Cartography based <fixed-case>M</fixed-case>ix<fixed-case>U</fixed-case>p for Pre-trained Language Models</title>
@@ -4811,6 +5119,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/swag">SWAG</pwcdataset>
+      <video href="2022.naacl-main.314.mp4"/>
     </paper>
     <paper id="315">
       <title>Grapheme-to-Phoneme Conversion for <fixed-case>T</fixed-case>hai using Neural Regression Models</title>
@@ -4821,6 +5130,7 @@
       <attachment type="software" hash="747f2671">2022.naacl-main.315.software.zip</attachment>
       <bibkey>yamasaki-2022-grapheme</bibkey>
       <doi>10.18653/v1/2022.naacl-main.315</doi>
+      <video href="2022.naacl-main.315.mp4"/>
     </paper>
     <paper id="316">
       <title>Generating Authentic Adversarial Examples beyond Meaning-preserving with Doubly Round-trip Translation</title>
@@ -4836,6 +5146,7 @@
       <url hash="a6dbbc13">2022.naacl-main.316</url>
       <bibkey>lai-etal-2022-generating</bibkey>
       <doi>10.18653/v1/2022.naacl-main.316</doi>
+      <video href="2022.naacl-main.316.mp4"/>
     </paper>
     <paper id="317">
       <title><fixed-case>TVS</fixed-case>how<fixed-case>G</fixed-case>uess: Character Comprehension in Stories as Speaker Guessing</title>
@@ -4852,6 +5163,7 @@
       <doi>10.18653/v1/2022.naacl-main.317</doi>
       <pwccode url="https://github.com/yisisang/tvshowguess" additional="false">yisisang/tvshowguess</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/narrativeqa">NarrativeQA</pwcdataset>
+      <video href="2022.naacl-main.317.mp4"/>
     </paper>
     <paper id="318">
       <title>Causal Distillation for Language Models</title>
@@ -4874,6 +5186,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
+      <video href="2022.naacl-main.318.mp4"/>
     </paper>
     <paper id="319">
       <title><fixed-case>FN</fixed-case>et: Mixing Tokens with <fixed-case>F</fixed-case>ourier Transforms</title>
@@ -4899,6 +5212,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sts-benchmark">STS Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
+      <video href="2022.naacl-main.319.mp4"/>
     </paper>
     <paper id="320">
       <title>Answer Consolidation: Formulation and Benchmarking</title>
@@ -4914,6 +5228,7 @@
       <doi>10.18653/v1/2022.naacl-main.320</doi>
       <pwccode url="https://github.com/amazon-research/question-answer-consolidation" additional="false">amazon-research/question-answer-consolidation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
+      <video href="2022.naacl-main.320.mp4"/>
     </paper>
     <paper id="321">
       <title>Informativeness and Invariance: Two Perspectives on Spurious Correlations in Natural Language</title>
@@ -4923,6 +5238,7 @@
       <url hash="a52cc6cf">2022.naacl-main.321</url>
       <bibkey>eisenstein-2022-informativeness</bibkey>
       <doi>10.18653/v1/2022.naacl-main.321</doi>
+      <video href="2022.naacl-main.321.mp4"/>
     </paper>
     <paper id="322">
       <title><fixed-case>FOAM</fixed-case>: A Follower-aware Speaker Model For Vision-and-Language Navigation</title>
@@ -4935,6 +5251,7 @@
       <doi>10.18653/v1/2022.naacl-main.322</doi>
       <pwccode url="https://github.com/pluslabnlp/follower_aware_speaker" additional="false">pluslabnlp/follower_aware_speaker</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/rxr">RxR</pwcdataset>
+      <video href="2022.naacl-main.322.mp4"/>
     </paper>
     <paper id="323">
       <title>Improving Compositional Generalization with Latent Structure and Data Augmentation</title>
@@ -4953,6 +5270,7 @@
       <pwccode url="https://github.com/google-research/language" additional="false">google-research/language</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/c4">C4</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
+      <video href="2022.naacl-main.323.mp4"/>
     </paper>
     <paper id="324">
       <title>Joint Extraction of Entities, Relations, and Events via Modeling Inter-Instance and Inter-Label Dependencies</title>
@@ -4965,6 +5283,7 @@
       <url hash="ead5ee4c">2022.naacl-main.324</url>
       <bibkey>nguyen-etal-2022-joint</bibkey>
       <doi>10.18653/v1/2022.naacl-main.324</doi>
+      <video href="2022.naacl-main.324.mp4"/>
     </paper>
     <paper id="325">
       <title>Linguistic Frameworks Go Toe-to-Toe at Neuro-Symbolic Language Modeling</title>
@@ -4979,6 +5298,7 @@
       <pwccode url="https://github.com/jakpra/linguisticstructurelm" additional="false">jakpra/linguisticstructurelm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
+      <video href="2022.naacl-main.325.mp4"/>
     </paper>
     <paper id="326">
       <title>Imagination-Augmented Natural Language Understanding</title>
@@ -4999,6 +5319,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/swag">SWAG</pwcdataset>
+      <video href="2022.naacl-main.326.mp4"/>
     </paper>
     <paper id="327">
       <title>What company do words keep? Revisiting the distributional semantics of <fixed-case>J</fixed-case>.<fixed-case>R</fixed-case>. Firth &amp; Zellig <fixed-case>H</fixed-case>arris</title>
@@ -5009,6 +5330,7 @@
       <url hash="48dcd0f5">2022.naacl-main.327</url>
       <bibkey>brunila-laviolette-2022-company</bibkey>
       <doi>10.18653/v1/2022.naacl-main.327</doi>
+      <video href="2022.naacl-main.327.mp4"/>
     </paper>
     <paper id="328">
       <title>Compositional Task-Oriented Parsing as Abstractive Question Answering</title>
@@ -5023,6 +5345,7 @@
       <doi>10.18653/v1/2022.naacl-main.328</doi>
       <pwccode url="https://github.com/amazon-research/semantic-parsing-as-abstractive-qa" additional="false">amazon-research/semantic-parsing-as-abstractive-qa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/topv2">TOPv2</pwcdataset>
+      <video href="2022.naacl-main.328.mp4"/>
     </paper>
     <paper id="329">
       <title>Learning Cross-Lingual <fixed-case>IR</fixed-case> from an <fixed-case>E</fixed-case>nglish Retriever</title>
@@ -5040,6 +5363,7 @@
       <pwccode url="https://github.com/primeqa/primeqa" additional="false">primeqa/primeqa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mkqa">MKQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
+      <video href="2022.naacl-main.329.mp4"/>
     </paper>
     <paper id="330">
       <title>Testing the Ability of Language Models to Interpret Figurative Language</title>
@@ -5056,6 +5380,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fig-qa">Fig-QA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/anli">ANLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
+      <video href="2022.naacl-main.330.mp4"/>
     </paper>
     <paper id="331">
       <title>Multi-Vector Models with Textual Guidance for Fine-Grained Scientific Document Similarity</title>
@@ -5068,6 +5393,7 @@
       <bibkey>mysore-etal-2022-multi</bibkey>
       <doi>10.18653/v1/2022.naacl-main.331</doi>
       <pwccode url="https://github.com/allenai/aspire" additional="false">allenai/aspire</pwccode>
+      <video href="2022.naacl-main.331.mp4"/>
     </paper>
     <paper id="332">
       <title><fixed-case>CHAI</fixed-case>: A <fixed-case>CH</fixed-case>atbot <fixed-case>AI</fixed-case> for Task-Oriented Dialogue with Offline Reinforcement Learning</title>
@@ -5100,6 +5426,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/clotho">Clotho</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/esc-50">ESC-50</pwcdataset>
+      <video href="2022.naacl-main.333.mp4"/>
     </paper>
     <paper id="334">
       <title><fixed-case>SURF</fixed-case>: Semantic-level Unsupervised Reward Function for Machine Translation</title>
@@ -5111,6 +5438,7 @@
       <bibkey>anuchitanukul-ive-2022-surf</bibkey>
       <doi>10.18653/v1/2022.naacl-main.334</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
+      <video href="2022.naacl-main.334.mp4"/>
     </paper>
     <paper id="335">
       <title>Disentangling Categorization in Multi-agent Emergent Communication</title>
@@ -5125,6 +5453,7 @@
       <doi>10.18653/v1/2022.naacl-main.335</doi>
       <pwccode url="https://github.com/fics/disentangling_categorization" additional="false">fics/disentangling_categorization</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mini-imagenet">mini-Imagenet</pwcdataset>
+      <video href="2022.naacl-main.335.mp4"/>
     </paper>
     <paper id="336">
       <title>Show, Don’t Tell: Demonstrations Outperform Descriptions for Schema-Guided Task-Oriented Dialogue</title>
@@ -5141,6 +5470,7 @@
       <doi>10.18653/v1/2022.naacl-main.336</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sgd">SGD</pwcdataset>
+      <video href="2022.naacl-main.336.mp4"/>
     </paper>
     <paper id="337">
       <title>Does Pre-training Induce Systematic Inference? How Masked Language Models Acquire Commonsense Knowledge</title>
@@ -5153,6 +5483,7 @@
       <attachment type="software" hash="05333834">2022.naacl-main.337.software.zip</attachment>
       <bibkey>porada-etal-2022-pre</bibkey>
       <doi>10.18653/v1/2022.naacl-main.337</doi>
+      <video href="2022.naacl-main.337.mp4"/>
     </paper>
     <paper id="338">
       <title>Using Paraphrases to Study Properties of Contextual Embeddings</title>
@@ -5164,6 +5495,7 @@
       <url hash="7d067c53">2022.naacl-main.338</url>
       <bibkey>burdick-etal-2022-using</bibkey>
       <doi>10.18653/v1/2022.naacl-main.338</doi>
+      <video href="2022.naacl-main.338.mp4"/>
     </paper>
     <paper id="339">
       <title>Measure and Improve Robustness in <fixed-case>NLP</fixed-case> Models: A Survey</title>
@@ -5176,6 +5508,7 @@
       <bibkey>wang-etal-2022-measure</bibkey>
       <doi>10.18653/v1/2022.naacl-main.339</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/anli">ANLI</pwcdataset>
+      <video href="2022.naacl-main.339.mp4"/>
     </paper>
     <paper id="340">
       <title>Learning to Generate Examples for Semantic Processing Tasks</title>
@@ -5189,6 +5522,7 @@
       <bibkey>croce-etal-2022-learning</bibkey>
       <doi>10.18653/v1/2022.naacl-main.340</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.340.mp4"/>
     </paper>
     <paper id="341">
       <title>Symbolic Knowledge Distillation: from General Language Models to Commonsense Models</title>
@@ -5206,6 +5540,7 @@
       <url hash="4e593252">2022.naacl-main.341</url>
       <bibkey>west-etal-2022-symbolic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.341</doi>
+      <video href="2022.naacl-main.341.mp4"/>
     </paper>
     <paper id="342">
       <title><fixed-case>G</fixed-case>en<fixed-case>IE</fixed-case>: Generative Information Extraction</title>
@@ -5221,6 +5556,7 @@
       <doi>10.18653/v1/2022.naacl-main.342</doi>
       <pwccode url="https://github.com/epfl-dlab/genie" additional="false">epfl-dlab/genie</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
+      <video href="2022.naacl-main.342.mp4"/>
     </paper>
     <paper id="343">
       <title>Entity Linking via Explicit Mention-Mention Coreference Modeling</title>
@@ -5236,6 +5572,7 @@
       <pwccode url="https://github.com/dhdhagar/arboEL" additional="false">dhdhagar/arboEL</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/medmentions">MedMentions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/zeshel">ZESHEL</pwcdataset>
+      <video href="2022.naacl-main.343.mp4"/>
     </paper>
     <paper id="344">
       <title>Massive-scale Decoding for Text Generation using Lattices</title>
@@ -5249,6 +5586,7 @@
       <doi>10.18653/v1/2022.naacl-main.344</doi>
       <pwccode url="https://github.com/jiacheng-xu/lattice-generation" additional="false">jiacheng-xu/lattice-generation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
+      <video href="2022.naacl-main.344.mp4"/>
     </paper>
     <paper id="345">
       <title>Disentangling Indirect Answers to Yes-No Questions in Real Conversations</title>
@@ -5268,6 +5606,7 @@
       <pwccode url="https://github.com/krishna-chaitanya-sanagavarapu/swda-ia" additional="false">krishna-chaitanya-sanagavarapu/swda-ia</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/boolq">BoolQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
+      <video href="2022.naacl-main.345.mp4"/>
     </paper>
     <paper id="346">
       <title>Quantifying Adaptability in Pre-trained Language Models with 500 Tasks</title>
@@ -5284,6 +5623,7 @@
       <doi>10.18653/v1/2022.naacl-main.346</doi>
       <pwccode url="https://github.com/facebookresearch/task_bench" additional="false">facebookresearch/task_bench</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
+      <video href="2022.naacl-main.346.mp4"/>
     </paper>
     <paper id="347">
       <title>Counterfactually Augmented Data and Unintended Bias: The Case of Sexism and Hate Speech Detection</title>
@@ -5297,6 +5637,7 @@
       <attachment type="software" hash="a6e23482">2022.naacl-main.347.software.zip</attachment>
       <bibkey>sen-etal-2022-counterfactually</bibkey>
       <doi>10.18653/v1/2022.naacl-main.347</doi>
+      <video href="2022.naacl-main.347.mp4"/>
     </paper>
     <paper id="348">
       <title>A Study of the Attention Abnormality in Trojaned <fixed-case>BERT</fixed-case>s</title>
@@ -5312,6 +5653,7 @@
       <pwccode url="https://github.com/weimin17/attention_abnormality_in_trojaned_berts" additional="false">weimin17/attention_abnormality_in_trojaned_berts</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.348.mp4"/>
     </paper>
     <paper id="349">
       <title><fixed-case>EP</fixed-case>i<fixed-case>DA</fixed-case>: An Easy Plug-in Data Augmentation Framework for High Performance Text Classification</title>
@@ -5329,6 +5671,7 @@
       <doi>10.18653/v1/2022.naacl-main.349</doi>
       <pwccode url="https://github.com/zhaominyiz/epida" additional="false">zhaominyiz/epida</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
+      <video href="2022.naacl-main.349.mp4"/>
     </paper>
     <paper id="350">
       <title>Partial-input baselines show that <fixed-case>NLI</fixed-case> models can ignore context, but they don’t.</title>
@@ -5341,6 +5684,7 @@
       <doi>10.18653/v1/2022.naacl-main.350</doi>
       <pwccode url="https://github.com/nehasrikn/context-editing" additional="false">nehasrikn/context-editing</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.350.mp4"/>
     </paper>
     <paper id="351">
       <title>Lifelong Pretraining: Continually Adapting Language Models to Emerging Corpora</title>
@@ -5359,6 +5703,7 @@
       <doi>10.18653/v1/2022.naacl-main.351</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
+      <video href="2022.naacl-main.351.mp4"/>
     </paper>
     <paper id="352">
       <title>Learning as Conversation: Dialogue Systems Reinforced for Information Acquisition</title>
@@ -5375,6 +5720,7 @@
       <doi>10.18653/v1/2022.naacl-main.352</doi>
       <pwccode url="https://github.com/ibm/reinforced-dialog-system-for-learning" additional="false">ibm/reinforced-dialog-system-for-learning</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.352.mp4"/>
     </paper>
     <paper id="353">
       <title>Dynamic Programming in Rank Space: Scaling Structured Inference with Low-Rank <fixed-case>HMM</fixed-case>s and <fixed-case>PCFG</fixed-case>s</title>
@@ -5388,6 +5734,7 @@
       <doi>10.18653/v1/2022.naacl-main.353</doi>
       <pwccode url="https://github.com/sustcsonglin/TN-PCFG" additional="true">sustcsonglin/TN-PCFG</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
+      <video href="2022.naacl-main.353.mp4"/>
     </paper>
     <paper id="354">
       <title>What Factors Should Paper-Reviewer Assignments Rely On? Community Perspectives on Issues and Ideals in Conference Peer-Review</title>
@@ -5399,6 +5746,7 @@
       <bibkey>thorn-jakobsen-rogers-2022-factors</bibkey>
       <doi>10.18653/v1/2022.naacl-main.354</doi>
       <pwccode url="https://github.com/terne/paper-reviewer-matching-surveys" additional="false">terne/paper-reviewer-matching-surveys</pwccode>
+      <video href="2022.naacl-main.354.mp4"/>
     </paper>
     <paper id="355">
       <title>Reducing Disambiguation Biases in <fixed-case>NMT</fixed-case> by Leveraging Explicit Word Sense Information</title>
@@ -5412,6 +5760,7 @@
       <attachment type="software" hash="dfbd348a">2022.naacl-main.355.software.zip</attachment>
       <bibkey>campolungo-etal-2022-reducing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.355</doi>
+      <video href="2022.naacl-main.355.mp4"/>
     </paper>
     <paper id="356">
       <title>Mining Clues from Incomplete Utterance: A Query-enhanced Network for Incomplete Utterance Rewriting</title>
@@ -5423,6 +5772,7 @@
       <url hash="75037155">2022.naacl-main.356</url>
       <bibkey>si-etal-2022-mining</bibkey>
       <doi>10.18653/v1/2022.naacl-main.356</doi>
+      <video href="2022.naacl-main.356.mp4"/>
     </paper>
     <paper id="357">
       <title>Domain-Oriented Prefix-Tuning: Towards Efficient and Generalizable Fine-tuning for Zero-Shot Dialogue Summarization</title>
@@ -5441,6 +5791,7 @@
       <doi>10.18653/v1/2022.naacl-main.357</doi>
       <pwccode url="https://github.com/Zeng-WH/DOP-Tuning" additional="false">Zeng-WH/DOP-Tuning</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
+      <video href="2022.naacl-main.357.mp4"/>
     </paper>
     <paper id="358">
       <title>Interactive Symbol Grounding with Complex Referential Expressions</title>
@@ -5452,6 +5803,7 @@
       <attachment type="software" hash="b081d068">2022.naacl-main.358.software.zip</attachment>
       <bibkey>rubavicius-lascarides-2022-interactive</bibkey>
       <doi>10.18653/v1/2022.naacl-main.358</doi>
+      <video href="2022.naacl-main.358.mp4"/>
     </paper>
     <paper id="359">
       <title>Generalized Quantifiers as a Source of Error in Multilingual <fixed-case>NLU</fixed-case> Benchmarks</title>
@@ -5488,6 +5840,7 @@
       <bibkey>malkin-etal-2022-balanced</bibkey>
       <doi>10.18653/v1/2022.naacl-main.361</doi>
       <pwccode url="https://github.com/slab-nlp/linguistic-blood-bank" additional="false">slab-nlp/linguistic-blood-bank</pwccode>
+      <video href="2022.naacl-main.361.mp4"/>
     </paper>
     <paper id="362">
       <title><fixed-case>SSEGCN</fixed-case>: Syntactic and Semantic Enhanced Graph Convolutional Network for Aspect-based Sentiment Analysis</title>
@@ -5500,6 +5853,7 @@
       <bibkey>zhang-etal-2022-ssegcn</bibkey>
       <doi>10.18653/v1/2022.naacl-main.362</doi>
       <pwccode url="https://github.com/zhangzheng1997/ssegcn-absa" additional="false">zhangzheng1997/ssegcn-absa</pwccode>
+      <video href="2022.naacl-main.362.mp4"/>
     </paper>
     <paper id="363">
       <title>Mitigating Toxic Degeneration with Empathetic Data: Exploring the Relationship Between Toxicity and Empathy</title>
@@ -5512,6 +5866,7 @@
       <url hash="a0a593d6">2022.naacl-main.363</url>
       <bibkey>lahnala-etal-2022-mitigating</bibkey>
       <doi>10.18653/v1/2022.naacl-main.363</doi>
+      <video href="2022.naacl-main.363.mp4"/>
     </paper>
     <paper id="364">
       <title><fixed-case>DUCK</fixed-case>: Rumour Detection on Social Media by Modelling User and Comment Propagation Networks</title>
@@ -5526,6 +5881,7 @@
       <doi>10.18653/v1/2022.naacl-main.364</doi>
       <pwccode url="https://github.com/ltian678/duck-code" additional="false">ltian678/duck-code</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coaid">CoAID</pwcdataset>
+      <video href="2022.naacl-main.364.mp4"/>
     </paper>
     <paper id="365">
       <title>Jam or Cream First? Modeling Ambiguity in Neural Machine Translation with <fixed-case>SCONES</fixed-case></title>
@@ -5536,6 +5892,7 @@
       <url hash="7fbf1ca1">2022.naacl-main.365</url>
       <bibkey>stahlberg-kumar-2022-jam</bibkey>
       <doi>10.18653/v1/2022.naacl-main.365</doi>
+      <video href="2022.naacl-main.365.mp4"/>
     </paper>
     <paper id="366">
       <title><fixed-case>S</fixed-case>kill<fixed-case>S</fixed-case>pan: Hard and Soft Skill Extraction from <fixed-case>E</fixed-case>nglish Job Postings</title>
@@ -5550,6 +5907,7 @@
       <doi>10.18653/v1/2022.naacl-main.366</doi>
       <pwccode url="https://github.com/Kaleidophon/deep-significance" additional="true">Kaleidophon/deep-significance</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/skillspan">SkillSpan</pwcdataset>
+      <video href="2022.naacl-main.366.mp4"/>
     </paper>
     <paper id="367">
       <title><fixed-case>RAAT</fixed-case>: Relation-Augmented Attention Transformer for Relation Modeling in Document-Level Event Extraction</title>
@@ -5562,6 +5920,7 @@
       <url hash="5a37bec8">2022.naacl-main.367</url>
       <bibkey>liang-etal-2022-raat</bibkey>
       <doi>10.18653/v1/2022.naacl-main.367</doi>
+      <video href="2022.naacl-main.367.mp4"/>
     </paper>
     <paper id="368">
       <title>A Double-Graph Based Framework for Frame Semantic Parsing</title>
@@ -5576,6 +5935,7 @@
       <doi>10.18653/v1/2022.naacl-main.368</doi>
       <pwccode url="https://github.com/pkunlp-icler/kid" additional="false">pkunlp-icler/kid</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
+      <video href="2022.naacl-main.368.mp4"/>
     </paper>
     <paper id="369">
       <title>An Enhanced Span-based Decomposition Method for Few-Shot Sequence Labeling</title>
@@ -5595,6 +5955,7 @@
       <pwccode url="https://github.com/wangpeiyi9979/esd" additional="false">wangpeiyi9979/esd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/few-nerd">Few-NERD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
+      <video href="2022.naacl-main.369.mp4"/>
     </paper>
     <paper id="370">
       <title>A Two-Stream <fixed-case>AMR</fixed-case>-enhanced Model for Document-level Event Argument Extraction</title>
@@ -5610,6 +5971,7 @@
       <bibkey>xu-etal-2022-two</bibkey>
       <doi>10.18653/v1/2022.naacl-main.370</doi>
       <pwccode url="https://github.com/pkunlp-icler/tsar" additional="false">pkunlp-icler/tsar</pwccode>
+      <video href="2022.naacl-main.370.mp4"/>
     </paper>
     <paper id="371">
       <title>Robust (Controlled) Table-to-Text Generation with Structure-Aware Equivariance Learning</title>
@@ -5624,6 +5986,7 @@
       <doi>10.18653/v1/2022.naacl-main.371</doi>
       <pwccode url="https://github.com/luka-group/lattice" additional="false">luka-group/lattice</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/totto">ToTTo</pwcdataset>
+      <video href="2022.naacl-main.371.mp4"/>
     </paper>
     <paper id="372">
       <title><fixed-case>J</fixed-case>oint<fixed-case>LK</fixed-case>: Joint Reasoning with Language Models and Knowledge Graphs for Commonsense Question Answering</title>
@@ -5640,6 +6003,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/commonsenseqa">CommonsenseQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/openbookqa">OpenBookQA</pwcdataset>
+      <video href="2022.naacl-main.372.mp4"/>
     </paper>
     <paper id="373">
       <title>Models In a Spelling Bee: Language Models Implicitly Learn the Character Composition of Tokens</title>
@@ -5651,6 +6015,7 @@
       <bibkey>itzhak-levy-2022-models</bibkey>
       <doi>10.18653/v1/2022.naacl-main.373</doi>
       <pwccode url="https://github.com/itay1itzhak/spellingbee" additional="false">itay1itzhak/spellingbee</pwccode>
+      <video href="2022.naacl-main.373.mp4"/>
     </paper>
     <paper id="374">
       <title>A Corpus for Understanding and Generating Moral Stories</title>
@@ -5666,6 +6031,7 @@
       <pwccode url="https://github.com/thu-coai/moralstory" additional="false">thu-coai/moralstory</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ethics-1">ETHICS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/moral-stories">Moral Stories</pwcdataset>
+      <video href="2022.naacl-main.374.mp4"/>
     </paper>
     <paper id="375">
       <title>Modeling Multi-Granularity Hierarchical Features for Relation Extraction</title>
@@ -5680,6 +6046,7 @@
       <doi>10.18653/v1/2022.naacl-main.375</doi>
       <pwccode url="https://github.com/xnliang98/sms" additional="false">xnliang98/sms</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2010-task-8">SemEval-2010 Task 8</pwcdataset>
+      <video href="2022.naacl-main.375.mp4"/>
     </paper>
     <paper id="376">
       <title>Cross-modal Contrastive Learning for Speech Translation</title>
@@ -5695,6 +6062,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
+      <video href="2022.naacl-main.376.mp4"/>
     </paper>
     <paper id="377">
       <title>Meet Your Favorite Character: Open-domain Chatbot Mimicking Fictional Characters with only a Few Utterances</title>
@@ -5712,6 +6080,7 @@
       <doi>10.18653/v1/2022.naacl-main.377</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/hla-chat">HLA-Chat</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/the-pile">The Pile</pwcdataset>
+      <video href="2022.naacl-main.377.mp4"/>
     </paper>
     <paper id="378">
       <title><fixed-case>D</fixed-case>ynamic<fixed-case>TOC</fixed-case>: Persona-based Table of Contents for Consumption of Long Documents</title>
@@ -5728,6 +6097,7 @@
       <bibkey>maheshwari-etal-2022-dynamictoc</bibkey>
       <doi>10.18653/v1/2022.naacl-main.378</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/eli5">ELI5</pwcdataset>
+      <video href="2022.naacl-main.378.mp4"/>
     </paper>
     <paper id="379">
       <title><fixed-case>KALA:</fixed-case> Knowledge-Augmented Language Model Adaptation</title>
@@ -5744,6 +6114,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ncbi-disease-1">NCBI Disease</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsqa">NewsQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
+      <video href="2022.naacl-main.379.mp4"/>
     </paper>
     <paper id="380">
       <title>On the Effect of Pretraining Corpora on In-context Learning by a Large-scale Language Model</title>
@@ -5764,6 +6135,7 @@
       <bibkey>shin-etal-2022-effect</bibkey>
       <doi>10.18653/v1/2022.naacl-main.380</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/korquad">KorQuAD</pwcdataset>
+      <video href="2022.naacl-main.380.mp4"/>
     </paper>
     <paper id="381">
       <title>Sketching as a Tool for Understanding and Accelerating Self-attention for Long Sequences</title>
@@ -5782,6 +6154,7 @@
       <pwccode url="https://github.com/pkuzengqi/skeinformer" additional="false">pkuzengqi/skeinformer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/lra">LRA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/listops">ListOps</pwcdataset>
+      <video href="2022.naacl-main.381.mp4"/>
     </paper>
     <paper id="382">
       <title>Partner Personas Generation for Dialogue Response Generation</title>
@@ -5795,6 +6168,7 @@
       <attachment type="software" hash="b87fdd7a">2022.naacl-main.382.software.zip</attachment>
       <bibkey>lu-etal-2022-partner</bibkey>
       <doi>10.18653/v1/2022.naacl-main.382</doi>
+      <video href="2022.naacl-main.382.mp4"/>
     </paper>
     <paper id="383">
       <title>Semantically Informed Slang Interpretation</title>
@@ -5807,6 +6181,7 @@
       <bibkey>sun-etal-2022-semantically</bibkey>
       <doi>10.18653/v1/2022.naacl-main.383</doi>
       <pwccode url="https://github.com/zhewei-sun/slanginterp" additional="false">zhewei-sun/slanginterp</pwccode>
+      <video href="2022.naacl-main.383.mp4"/>
     </paper>
     <paper id="384">
       <title>Dual-Channel Evidence Fusion for Fact Verification over Texts and Tables</title>
@@ -5821,6 +6196,7 @@
       <bibkey>hu-etal-2022-dual</bibkey>
       <doi>10.18653/v1/2022.naacl-main.384</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/feverous">FEVEROUS</pwcdataset>
+      <video href="2022.naacl-main.384.mp4"/>
     </paper>
     <paper id="385">
       <title><fixed-case>T</fixed-case>ree<fixed-case>M</fixed-case>ix: Compositional Constituency-based Data Augmentation for Natural Language Understanding</title>
@@ -5837,6 +6213,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
+      <video href="2022.naacl-main.385.mp4"/>
     </paper>
     <paper id="386">
       <title><fixed-case>S</fixed-case>yn2<fixed-case>V</fixed-case>ec: Synset Colexification Graphs for Lexical Semantic Similarity</title>
@@ -5850,6 +6227,7 @@
       <bibkey>harvill-etal-2022-syn2vec</bibkey>
       <doi>10.18653/v1/2022.naacl-main.386</doi>
       <pwccode url="https://github.com/jharvill23/syn2vec" additional="false">jharvill23/syn2vec</pwccode>
+      <video href="2022.naacl-main.386.mp4"/>
     </paper>
     <paper id="387">
       <title>On the Origin of Hallucinations in Conversational Models: Is it the Datasets or the Models?</title>
@@ -5865,6 +6243,7 @@
       <doi>10.18653/v1/2022.naacl-main.387</doi>
       <pwccode url="https://github.com/mcgill-nlp/faithdial" additional="false">mcgill-nlp/faithdial</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
+      <video href="2022.naacl-main.387.mp4"/>
     </paper>
     <paper id="388">
       <title>Is “My Favorite New Movie” My Favorite Movie? Probing the Understanding of Recursive Noun Phrases</title>
@@ -5881,6 +6260,7 @@
       <doi>10.18653/v1/2022.naacl-main.388</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.388.mp4"/>
     </paper>
     <paper id="389">
       <title>Original or Translated? A Causal Analysis of the Impact of Translationese on Machine Translation Performance</title>
@@ -5895,6 +6275,7 @@
       <bibkey>ni-etal-2022-original</bibkey>
       <doi>10.18653/v1/2022.naacl-main.389</doi>
       <pwccode url="https://github.com/edisonni-hku/causalmt" additional="false">edisonni-hku/causalmt</pwccode>
+      <video href="2022.naacl-main.389.mp4"/>
     </paper>
     <paper id="390">
       <title>Visual Commonsense in Pretrained Unimodal and Multimodal Models</title>
@@ -5910,6 +6291,7 @@
       <pwccode url="https://github.com/chenyuheidizhang/vl-commonsense" additional="false">chenyuheidizhang/vl-commonsense</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coda">CoDa</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
+      <video href="2022.naacl-main.390.mp4"/>
     </paper>
     <paper id="391">
       <title><fixed-case>Q</fixed-case>u<fixed-case>ALITY</fixed-case>: Question Answering with Long Input Texts, Yes!</title>
@@ -5932,6 +6314,7 @@
       <pwccode url="https://github.com/nyu-mll/quality" additional="true">nyu-mll/quality</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/narrativeqa">NarrativeQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
+      <video href="2022.naacl-main.391.mp4"/>
     </paper>
     <paper id="392">
       <title><fixed-case>ExSum</fixed-case>: <fixed-case>F</fixed-case>rom Local Explanations to Model Understanding</title>
@@ -5944,6 +6327,7 @@
       <bibkey>zhou-etal-2022-exsum</bibkey>
       <doi>10.18653/v1/2022.naacl-main.392</doi>
       <pwccode url="https://github.com/YilunZhou/ExSum" additional="false">YilunZhou/ExSum</pwccode>
+      <video href="2022.naacl-main.392.mp4"/>
     </paper>
     <paper id="393">
       <title>Maximum <fixed-case>B</fixed-case>ayes <fixed-case>S</fixed-case>match Ensemble Distillation for <fixed-case>AMR</fixed-case> Parsing</title>
@@ -5962,6 +6346,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bio">Bio</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ldc2017t10">LDC2017T10</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ldc2020t02">LDC2020T02</pwcdataset>
+      <video href="2022.naacl-main.393.mp4"/>
     </paper>
     <paper id="394">
       <title>When Does Syntax Mediate Neural Language Model Performance? Evidence from Dropout Probes</title>
@@ -5977,6 +6362,7 @@
       <doi>10.18653/v1/2022.naacl-main.394</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
+      <video href="2022.naacl-main.394.mp4"/>
     </paper>
     <paper id="395">
       <title>Modeling Task Interactions in Document-Level Joint Entity and Relation Extraction</title>
@@ -5990,6 +6376,7 @@
       <doi>10.18653/v1/2022.naacl-main.395</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/dwie">DWIE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
+      <video href="2022.naacl-main.395.mp4"/>
     </paper>
     <paper id="396">
       <title>Few-Shot Semantic Parsing with Language Models Trained on Code</title>
@@ -6000,6 +6387,7 @@
       <url hash="9a62e3e1">2022.naacl-main.396</url>
       <bibkey>shin-van-durme-2022-shot</bibkey>
       <doi>10.18653/v1/2022.naacl-main.396</doi>
+      <video href="2022.naacl-main.396.mp4"/>
     </paper>
     <paper id="397">
       <title><fixed-case>CORWA</fixed-case>: A Citation-Oriented Related Work Annotation Dataset</title>
@@ -6014,6 +6402,7 @@
       <doi>10.18653/v1/2022.naacl-main.397</doi>
       <pwccode url="https://github.com/jacklxc/corwa" additional="false">jacklxc/corwa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
+      <video href="2022.naacl-main.397.mp4"/>
     </paper>
     <paper id="398">
       <title>Overcoming Catastrophic Forgetting During Domain Adaptation of Seq2seq Language Generation</title>
@@ -6030,6 +6419,7 @@
       <url hash="e5409b1e">2022.naacl-main.398</url>
       <bibkey>li-etal-2022-overcoming</bibkey>
       <doi>10.18653/v1/2022.naacl-main.398</doi>
+      <video href="2022.naacl-main.398.mp4"/>
     </paper>
     <paper id="399">
       <title>Extreme <fixed-case>Z</fixed-case>ero-<fixed-case>S</fixed-case>hot Learning for Extreme Text Classification</title>
@@ -6044,6 +6434,7 @@
       <bibkey>xiong-etal-2022-extreme</bibkey>
       <doi>10.18653/v1/2022.naacl-main.399</doi>
       <pwccode url="https://github.com/amzn/pecos" additional="false">amzn/pecos</pwccode>
+      <video href="2022.naacl-main.399.mp4"/>
     </paper>
     <paper id="400">
       <title><fixed-case>C</fixed-case>onfli<fixed-case>BERT</fixed-case>: A Pre-trained Language Model for Political Conflict and Violence</title>
@@ -6062,6 +6453,7 @@
       <pwccode url="https://github.com/eventdata/conflibert" additional="false">eventdata/conflibert</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
+      <video href="2022.naacl-main.400.mp4"/>
     </paper>
     <paper id="401">
       <title>Automatic Multi-Label Prompting: Simple and Interpretable Few-Shot Classification</title>
@@ -6080,6 +6472,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-main.401.mp4"/>
     </paper>
     <paper id="402">
       <title>Few-shot Subgoal Planning with Language Models</title>
@@ -6094,6 +6487,7 @@
       <doi>10.18653/v1/2022.naacl-main.402</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/ai2-thor">AI2-THOR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/alfred">ALFRED</pwcdataset>
+      <video href="2022.naacl-main.402.mp4"/>
     </paper>
     <paper id="403">
       <title><fixed-case>IDPG</fixed-case>: An Instance-Dependent Prompt Generation Method</title>
@@ -6112,6 +6506,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mpqa-opinion-corpus">MPQA Opinion Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
+      <video href="2022.naacl-main.403.mp4"/>
     </paper>
     <paper id="404">
       <title>Embedding Hallucination for Few-shot Language Fine-tuning</title>
@@ -6126,6 +6521,7 @@
       <pwccode url="https://github.com/yiren-jian/embedhalluc" additional="false">yiren-jian/embedhalluc</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
+      <video href="2022.naacl-main.404.mp4"/>
     </paper>
     <paper id="405">
       <title>Cryptocurrency Bubble Detection: A New Stock Market Dataset, Financial Task &amp; Hyperbolic Models</title>
@@ -6142,6 +6538,7 @@
       <bibkey>sawhney-etal-2022-cryptocurrency</bibkey>
       <doi>10.18653/v1/2022.naacl-main.405</doi>
       <pwccode url="https://github.com/gtfintechlab/cryptobubbles-naacl" additional="false">gtfintechlab/cryptobubbles-naacl</pwccode>
+      <video href="2022.naacl-main.405.mp4"/>
     </paper>
     <paper id="406">
       <title>Nearest Neighbor Knowledge Distillation for Neural Machine Translation</title>
@@ -6154,6 +6551,7 @@
       <bibkey>yang-etal-2022-nearest</bibkey>
       <doi>10.18653/v1/2022.naacl-main.406</doi>
       <pwccode url="https://github.com/fadedcosine/knn-kd" additional="false">fadedcosine/knn-kd</pwccode>
+      <video href="2022.naacl-main.406.mp4"/>
     </paper>
     <paper id="407">
       <title><fixed-case>DEM</fixed-case>ix Layers: Disentangling Domains for Modular Language Modeling</title>
@@ -6170,6 +6568,7 @@
       <pwccode url="https://github.com/kernelmachine/demix" additional="true">kernelmachine/demix</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cord-19">CORD-19</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
+      <video href="2022.naacl-main.407.mp4"/>
     </paper>
     <paper id="408">
       <title>Contrastive Learning for Prompt-based Few-shot Language Learners</title>
@@ -6182,6 +6581,7 @@
       <bibkey>jian-etal-2022-contrastive</bibkey>
       <doi>10.18653/v1/2022.naacl-main.408</doi>
       <pwccode url="https://github.com/yiren-jian/lm-supcon" additional="false">yiren-jian/lm-supcon</pwccode>
+      <video href="2022.naacl-main.408.mp4"/>
     </paper>
     <paper id="409">
       <title>Cross-Lingual Event Detection via Optimized Adversarial Training</title>
@@ -6193,6 +6593,7 @@
       <url hash="0d9d4c94">2022.naacl-main.409</url>
       <bibkey>guzman-nateras-etal-2022-cross</bibkey>
       <doi>10.18653/v1/2022.naacl-main.409</doi>
+      <video href="2022.naacl-main.409.mp4"/>
     </paper>
     <paper id="410">
       <title>Identifying Implicitly Abusive Remarks about Identity Groups using a Linguistically Informed Approach</title>
@@ -6206,6 +6607,7 @@
       <doi>10.18653/v1/2022.naacl-main.410</doi>
       <pwccode url="https://github.com/miwieg/naacl2022_identity_groups" additional="false">miwieg/naacl2022_identity_groups</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
+      <video href="2022.naacl-main.410.mp4"/>
     </paper>
     <paper id="411">
       <title>Label Definitions Improve Semantic Role Labeling</title>
@@ -6219,6 +6621,7 @@
       <doi>10.18653/v1/2022.naacl-main.411</doi>
       <pwccode url="https://github.com/system-t/labelawaresrl" additional="false">system-t/labelawaresrl</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
+      <video href="2022.naacl-main.411.mp4"/>
     </paper>
     <paper id="412">
       <title>Shedding New Light on the Language of the Dark Web</title>
@@ -6233,6 +6636,7 @@
       <attachment type="software" hash="f4b2a47d">2022.naacl-main.412.software.zip</attachment>
       <bibkey>jin-etal-2022-shedding</bibkey>
       <doi>10.18653/v1/2022.naacl-main.412</doi>
+      <video href="2022.naacl-main.412.mp4"/>
     </paper>
     <paper id="413">
       <title>Conceptualizing Treatment Leakage in Text-based Causal Inference</title>
@@ -6244,6 +6648,7 @@
       <url hash="a692ea63">2022.naacl-main.413</url>
       <bibkey>daoud-etal-2022-conceptualizing</bibkey>
       <doi>10.18653/v1/2022.naacl-main.413</doi>
+      <video href="2022.naacl-main.413.mp4"/>
     </paper>
     <paper id="414">
       <title>Consistency Training with Virtual Adversarial Discrete Perturbation</title>
@@ -6262,6 +6667,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-main.414.mp4"/>
     </paper>
     <paper id="415">
       <title><fixed-case>CONFIT</fixed-case>: Toward Faithful Dialogue Summarization with Linguistically-Informed Contrastive Fine-tuning</title>
@@ -6281,6 +6687,7 @@
       <bibkey>tang-etal-2022-confit</bibkey>
       <doi>10.18653/v1/2022.naacl-main.415</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
+      <video href="2022.naacl-main.415.mp4"/>
     </paper>
     <paper id="416">
       <title><fixed-case>C</fixed-case>o<fixed-case>MPM</fixed-case>: Context Modeling with Speaker’s Pre-trained Memory Tracking for Emotion Recognition in Conversation</title>
@@ -6297,6 +6704,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/emorynlp">EmoryNLP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
+      <video href="2022.naacl-main.416.mp4"/>
     </paper>
     <paper id="417">
       <title>Investigating Crowdsourcing Protocols for Evaluating the Factual Consistency of Summaries</title>
@@ -6328,6 +6736,7 @@
       <pwccode url="https://github.com/kite99520/dialsummeval" additional="false">kite99520/dialsummeval</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/convosumm">ConvoSumm</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
+      <video href="2022.naacl-main.418.mp4"/>
     </paper>
     <paper id="419">
       <title>Hyperbolic Relevance Matching for Neural Keyphrase Extraction</title>
@@ -6341,6 +6750,7 @@
       <doi>10.18653/v1/2022.naacl-main.419</doi>
       <pwccode url="https://github.com/mysong7nlper/hypermatch" additional="false">mysong7nlper/hypermatch</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/kp20k">KP20k</pwcdataset>
+      <video href="2022.naacl-main.419.mp4"/>
     </paper>
     <paper id="420">
       <title>Template-free Prompt Tuning for Few-shot <fixed-case>NER</fixed-case></title>
@@ -6359,6 +6769,7 @@
       <doi>10.18653/v1/2022.naacl-main.420</doi>
       <pwccode url="https://github.com/rtmaww/EntLM" additional="false">rtmaww/EntLM</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
+      <video href="2022.naacl-main.420.mp4"/>
     </paper>
     <paper id="421">
       <title>Few-Shot Document-Level Relation Extraction</title>
@@ -6373,6 +6784,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fredo">FREDo</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
+      <video href="2022.naacl-main.421.mp4"/>
     </paper>
     <paper id="422">
       <title><fixed-case>L</fixed-case>a<fixed-case>M</fixed-case>emo: Language Modeling with Look-Ahead Memory</title>
@@ -6389,6 +6801,7 @@
       <pwccode url="https://github.com/thu-coai/lamemo" additional="false">thu-coai/lamemo</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
+      <video href="2022.naacl-main.422.mp4"/>
     </paper>
     <paper id="423">
       <title>Exploiting Inductive Bias in Transformers for Unsupervised Disentanglement of Syntax and Semantics with <fixed-case>VAE</fixed-case>s</title>
@@ -6401,6 +6814,7 @@
       <bibkey>felhi-etal-2022-exploiting</bibkey>
       <doi>10.18653/v1/2022.naacl-main.423</doi>
       <pwccode url="https://github.com/ghazi-f/qkvae" additional="false">ghazi-f/qkvae</pwccode>
+      <video href="2022.naacl-main.423.mp4"/>
     </paper>
     <paper id="424">
       <title>Neighbors Are Not Strangers: Improving Non-Autoregressive Translation under Low-Frequency Lexical Constraints</title>
@@ -6418,6 +6832,7 @@
       <bibkey>zeng-etal-2022-neighbors</bibkey>
       <doi>10.18653/v1/2022.naacl-main.424</doi>
       <pwccode url="https://github.com/sted-byte/act4nat" additional="false">sted-byte/act4nat</pwccode>
+      <video href="2022.naacl-main.424.mp4"/>
     </paper>
     <paper id="425">
       <title>What do Toothbrushes do in the Kitchen? How Transformers Think our World is Structured</title>
@@ -6428,6 +6843,7 @@
       <url hash="5e115295">2022.naacl-main.425</url>
       <bibkey>henlein-mehler-2022-toothbrushes</bibkey>
       <doi>10.18653/v1/2022.naacl-main.425</doi>
+      <video href="2022.naacl-main.425.mp4"/>
     </paper>
     <paper id="426">
       <title>Less is More: Learning to Refine Dialogue History for Personalized Dialogue Generation</title>
@@ -6441,6 +6857,7 @@
       <url hash="ad85b2c2">2022.naacl-main.426</url>
       <bibkey>zhong-etal-2022-less</bibkey>
       <doi>10.18653/v1/2022.naacl-main.426</doi>
+      <video href="2022.naacl-main.426.mp4"/>
     </paper>
     <paper id="427">
       <title>A Holistic Framework for Analyzing the <fixed-case>COVID</fixed-case>-19 Vaccine Debate</title>
@@ -6457,6 +6874,7 @@
       <bibkey>pacheco-etal-2022-holistic</bibkey>
       <doi>10.18653/v1/2022.naacl-main.427</doi>
       <pwccode url="https://gitlab.com/mlpacheco/covid-moral-foundations" additional="false">mlpacheco/covid-moral-foundations</pwccode>
+      <video href="2022.naacl-main.427.mp4"/>
     </paper>
     <paper id="428">
       <title>Learning to Win Lottery Tickets in <fixed-case>BERT</fixed-case> Transfer via Task-agnostic Mask Training</title>
@@ -6476,6 +6894,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
+      <video href="2022.naacl-main.428.mp4"/>
     </paper>
     <paper id="429">
       <title>You Don’t Know My Favorite Color: Preventing Dialogue Representations from Revealing Speakers’ Private Personas</title>
@@ -6489,6 +6908,7 @@
       <bibkey>li-etal-2022-dont</bibkey>
       <doi>10.18653/v1/2022.naacl-main.429</doi>
       <pwccode url="https://github.com/hkust-knowcomp/persona_leakage_and_defense_in_gpt-2" additional="false">hkust-knowcomp/persona_leakage_and_defense_in_gpt-2</pwccode>
+      <video href="2022.naacl-main.429.mp4"/>
     </paper>
     <paper id="430">
       <title>Explaining Dialogue Evaluation Metrics using Adversarial Behavioral Analysis</title>
@@ -6500,6 +6920,7 @@
       <bibkey>khalid-lee-2022-explaining</bibkey>
       <doi>10.18653/v1/2022.naacl-main.430</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
+      <video href="2022.naacl-main.430.mp4"/>
     </paper>
     <paper id="431">
       <title>Annotators with Attitudes: How Annotator Beliefs And Identities Bias Toxic Language Detection</title>
@@ -6514,6 +6935,7 @@
       <url hash="413b20ff">2022.naacl-main.431</url>
       <bibkey>sap-etal-2022-annotators</bibkey>
       <doi>10.18653/v1/2022.naacl-main.431</doi>
+      <video href="2022.naacl-main.431.mp4"/>
     </paper>
     <paper id="432">
       <title>Non-Autoregressive <fixed-case>C</fixed-case>hinese <fixed-case>ASR</fixed-case> Error Correction with Phonological Training</title>
@@ -6529,6 +6951,7 @@
       <bibkey>fang-etal-2022-non</bibkey>
       <doi>10.18653/v1/2022.naacl-main.432</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/aishell-1">AISHELL-1</pwcdataset>
+      <video href="2022.naacl-main.432.mp4"/>
     </paper>
     <paper id="433">
       <title>Hate Speech and Counter Speech Detection: Conversational Context Does Matter</title>
@@ -6541,6 +6964,7 @@
       <bibkey>yu-etal-2022-hate</bibkey>
       <doi>10.18653/v1/2022.naacl-main.433</doi>
       <pwccode url="https://github.com/xinchenyu/counter_context" additional="false">xinchenyu/counter_context</pwccode>
+      <video href="2022.naacl-main.433.mp4"/>
     </paper>
     <paper id="434">
       <title><fixed-case>DACSA</fixed-case>: A large-scale Dataset for Automatic summarization of <fixed-case>C</fixed-case>atalan and <fixed-case>S</fixed-case>panish newspaper Articles</title>
@@ -6555,6 +6979,7 @@
       <doi>10.18653/v1/2022.naacl-main.434</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/mlsum">MLSUM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsroom">NEWSROOM</pwcdataset>
+      <video href="2022.naacl-main.434.mp4"/>
     </paper>
     <paper id="435">
       <title>Time Waits for No One! Analysis and Challenges of Temporal Misalignment</title>
@@ -6570,6 +6995,7 @@
       <doi>10.18653/v1/2022.naacl-main.435</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/newsroom">NEWSROOM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
+      <video href="2022.naacl-main.435.mp4"/>
     </paper>
     <paper id="436">
       <title><fixed-case>MCSE</fixed-case>: <fixed-case>M</fixed-case>ultimodal Contrastive Learning of Sentence Embeddings</title>
@@ -6586,6 +7012,7 @@
       <pwccode url="https://github.com/uds-lsv/mcse" additional="false">uds-lsv/mcse</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
+      <video href="2022.naacl-main.436.mp4"/>
     </paper>
     <paper id="437">
       <title><fixed-case>H</fixed-case>i<fixed-case>URE</fixed-case>: Hierarchical Exemplar Contrastive Learning for Unsupervised Relation Extraction</title>
@@ -6602,6 +7029,7 @@
       <bibkey>liu-etal-2022-hiure</bibkey>
       <doi>10.18653/v1/2022.naacl-main.437</doi>
       <pwccode url="https://github.com/thu-bpm/hiure" additional="false">thu-bpm/hiure</pwccode>
+      <video href="2022.naacl-main.437.mp4"/>
     </paper>
     <paper id="438">
       <title>Diagnosing Vision-and-Language Navigation: What Really Matters</title>
@@ -6623,6 +7051,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/room-to-room">R2R</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rxr">RxR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/touchdown-dataset">Touchdown Dataset</pwcdataset>
+      <video href="2022.naacl-main.438.mp4"/>
     </paper>
     <paper id="439">
       <title>Aligning to Social Norms and Values in Interactive Narratives</title>
@@ -6638,6 +7067,7 @@
       <doi>10.18653/v1/2022.naacl-main.439</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/ethics-1">ETHICS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/jericho">Jericho</pwcdataset>
+      <video href="2022.naacl-main.439.mp4"/>
     </paper>
     <paper id="440">
       <title><fixed-case>MOVER</fixed-case>: Mask, Over-generate and Rank for Hyperbole Generation</title>
@@ -6649,6 +7079,7 @@
       <bibkey>zhang-wan-2022-mover</bibkey>
       <doi>10.18653/v1/2022.naacl-main.440</doi>
       <pwccode url="https://github.com/yunx-z/mover" additional="false">yunx-z/mover</pwccode>
+      <video href="2022.naacl-main.440.mp4"/>
     </paper>
     <paper id="441">
       <title>Embarrassingly Simple Performance Prediction for Abductive Natural Language Inference</title>
@@ -6662,6 +7093,7 @@
       <doi>10.18653/v1/2022.naacl-main.441</doi>
       <pwccode url="https://github.com/Vaibhavs10/anli-performance-prediction" additional="false">Vaibhavs10/anli-performance-prediction</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/art-dataset">ART Dataset</pwcdataset>
+      <video href="2022.naacl-main.441.mp4"/>
     </paper>
     <paper id="442">
       <title>Re-Examining System-Level Correlations of Automatic Summarization Evaluation Metrics</title>
@@ -6673,6 +7105,7 @@
       <url hash="05f47b57">2022.naacl-main.442</url>
       <bibkey>deutsch-etal-2022-examining</bibkey>
       <doi>10.18653/v1/2022.naacl-main.442</doi>
+      <video href="2022.naacl-main.442.mp4"/>
     </paper>
   </volume>
   <volume id="srw" ingest-date="2022-06-28">
@@ -6704,6 +7137,7 @@
       <bibkey>chakravarthy-etal-2022-systematicity</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.1</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
+      <video href="2022.naacl-srw.1.mp4"/>
     </paper>
     <paper id="2">
       <title>Grounding in social media: An approach to building a chit-chat dialogue model</title>
@@ -6716,6 +7150,7 @@
       <doi>10.18653/v1/2022.naacl-srw.2</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog-1">DailyDialog++</pwcdataset>
+      <video href="2022.naacl-srw.2.mp4"/>
     </paper>
     <paper id="3">
       <title><fixed-case>E</fixed-case>xtra<fixed-case>P</fixed-case>hrase: Efficient Data Augmentation for Abstractive Summarization</title>
@@ -6729,6 +7164,7 @@
       <bibkey>loem-etal-2022-extraphrase</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.3</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/sentence-compression">Sentence Compression</pwcdataset>
+      <video href="2022.naacl-srw.3.mp4"/>
     </paper>
     <paper id="4">
       <title>Regularized Training of Nearest Neighbor Language Models</title>
@@ -6741,6 +7177,7 @@
       <url hash="95d9852b">2022.naacl-srw.4</url>
       <bibkey>ton-etal-2022-regularized</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.4</doi>
+      <video href="2022.naacl-srw.4.mp4"/>
     </paper>
     <paper id="5">
       <title>“Again, Dozens of Refugees Drowned”: A Computational Study of Political Framing Evoked by Presuppositions</title>
@@ -6750,6 +7187,7 @@
       <url hash="df0caf23">2022.naacl-srw.5</url>
       <bibkey>yu-2022-dozens</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.5</doi>
+      <video href="2022.naacl-srw.5.mp4"/>
     </paper>
     <paper id="6">
       <title>Methods for Estimating and Improving Robustness of Language Models</title>
@@ -6759,6 +7197,7 @@
       <url hash="90567f54">2022.naacl-srw.6</url>
       <bibkey>stefanik-2022-methods</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.6</doi>
+      <video href="2022.naacl-srw.6.mp4"/>
     </paper>
     <paper id="7">
       <title>Retrieval-augmented Generation across Heterogeneous Knowledge</title>
@@ -6770,6 +7209,7 @@
       <doi>10.18653/v1/2022.naacl-srw.7</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/creak">CREAK</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
+      <video href="2022.naacl-srw.7.mp4"/>
     </paper>
     <paper id="8">
       <title>Neural Retriever and Go Beyond: A Thesis Proposal</title>
@@ -6780,6 +7220,7 @@
       <bibkey>luo-2022-neural</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.8</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/ok-vqa">OK-VQA</pwcdataset>
+      <video href="2022.naacl-srw.8.mp4"/>
     </paper>
     <paper id="9">
       <title>Improving Classification of Infrequent Cognitive Distortions: Domain-Specific Model vs. Data Augmentation</title>
@@ -6792,6 +7233,7 @@
       <url hash="0b5fac5c">2022.naacl-srw.9</url>
       <bibkey>ding-etal-2022-improving</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.9</doi>
+      <video href="2022.naacl-srw.9.mp4"/>
     </paper>
     <paper id="10">
       <title>Generate, Evaluate, and Select: A Dialogue System with a Response Evaluator for Diversity-Aware Response Generation</title>
@@ -6802,6 +7244,7 @@
       <url hash="652d78e4">2022.naacl-srw.10</url>
       <bibkey>sakaeda-kawahara-2022-generate</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.10</doi>
+      <video href="2022.naacl-srw.10.mp4"/>
     </paper>
     <paper id="11">
       <title>Impact of Training Instance Selection on Domain-Specific Entity Extraction using <fixed-case>BERT</fixed-case></title>
@@ -6816,6 +7259,7 @@
       <pwccode url="https://github.com/tugraz-isds/kd" additional="false">tugraz-isds/kd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bc5cdr">BC5CDR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
+      <video href="2022.naacl-srw.11.mp4"/>
     </paper>
     <paper id="12">
       <title>Analysing the Correlation between Lexical Ambiguity and Translation Quality in a Multimodal Setting using <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et</title>
@@ -6827,6 +7271,7 @@
       <url hash="af9ad37b">2022.naacl-srw.12</url>
       <bibkey>hatami-etal-2022-analysing</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.12</doi>
+      <video href="2022.naacl-srw.12.mp4"/>
     </paper>
     <paper id="13">
       <title>Building a Personalized Dialogue System with Prompt-Tuning</title>
@@ -6842,6 +7287,7 @@
       <bibkey>kasahara-etal-2022-building</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.13</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
+      <video href="2022.naacl-srw.13.mp4"/>
     </paper>
     <paper id="14">
       <title><fixed-case>MM</fixed-case>-<fixed-case>GATBT</fixed-case>: Enriching Multimodal Representation Using Graph Attention Network</title>
@@ -6854,6 +7300,7 @@
       <bibkey>seo-etal-2022-mm</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.14</doi>
       <pwccode url="https://github.com/sbseo/mm-gatbt" additional="false">sbseo/mm-gatbt</pwccode>
+      <video href="2022.naacl-srw.14.mp4"/>
     </paper>
     <paper id="15">
       <title>Simulating Feature Structures with Simple Types</title>
@@ -6863,6 +7310,7 @@
       <url hash="59c29c02">2022.naacl-srw.15</url>
       <bibkey>richard-2022-simulating</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.15</doi>
+      <video href="2022.naacl-srw.15.mp4"/>
     </paper>
     <paper id="16">
       <title>Dr. Livingstone, <fixed-case>I</fixed-case> presume? Polishing of foreign character identification in literary texts</title>
@@ -6874,6 +7322,7 @@
       <url hash="1f44c27e">2022.naacl-srw.16</url>
       <bibkey>konovalova-etal-2022-dr</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.16</doi>
+      <video href="2022.naacl-srw.16.mp4"/>
     </paper>
     <paper id="17">
       <title>Zuo Zhuan <fixed-case>A</fixed-case>ncient <fixed-case>C</fixed-case>hinese Dataset for Word Sense Disambiguation</title>
@@ -6886,6 +7335,7 @@
       <url hash="b4c635d0">2022.naacl-srw.17</url>
       <bibkey>pan-etal-2022-zuo</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.17</doi>
+      <video href="2022.naacl-srw.17.mp4"/>
     </paper>
     <paper id="18">
       <title><fixed-case>V</fixed-case>i<fixed-case>T</fixed-case>5: Pretrained Text-to-Text Transformer for <fixed-case>V</fixed-case>ietnamese Language Generation</title>
@@ -6903,6 +7353,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/phoner-covid19">PhoNER COVID19</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vnds">VNDS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikilingua">WikiLingua</pwcdataset>
+      <video href="2022.naacl-srw.18.mp4"/>
     </paper>
     <paper id="19">
       <title>Compositional Generalization in Grounded Language Learning via Induced Model Sparsity</title>
@@ -6914,6 +7365,7 @@
       <bibkey>spilsbury-ilin-2022-compositional</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.19</doi>
       <pwccode url="https://github.com/aalto-ai/sparse-compgen" additional="false">aalto-ai/sparse-compgen</pwccode>
+      <video href="2022.naacl-srw.19.mp4"/>
     </paper>
     <paper id="20">
       <title>How do people talk about images? A study on open-domain conversations with images.</title>
@@ -6926,6 +7378,7 @@
       <url hash="2e0bb714">2022.naacl-srw.20</url>
       <bibkey>chen-etal-2022-people</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.20</doi>
+      <video href="2022.naacl-srw.20.mp4"/>
     </paper>
     <paper id="21">
       <title>Text Style Transfer for Bias Mitigation using Masked Language Modeling</title>
@@ -6936,6 +7389,7 @@
       <url hash="125037de">2022.naacl-srw.21</url>
       <bibkey>tokpo-calders-2022-text</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.21</doi>
+      <video href="2022.naacl-srw.21.mp4"/>
     </paper>
     <paper id="22">
       <title>Differentially Private Instance Encoding against Privacy Attacks</title>
@@ -6948,6 +7402,7 @@
       <doi>10.18653/v1/2022.naacl-srw.22</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
+      <video href="2022.naacl-srw.22.mp4"/>
     </paper>
     <paper id="23">
       <title>A Simple Approach to Jointly Rank Passages and Select Relevant Sentences in the <fixed-case>OBQA</fixed-case> Context</title>
@@ -6960,6 +7415,7 @@
       <bibkey>luo-etal-2022-simple</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.23</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
+      <video href="2022.naacl-srw.23.mp4"/>
     </paper>
     <paper id="24">
       <title>Multimodal Modeling of Task-Mediated Confusion</title>
@@ -6973,6 +7429,7 @@
       <url hash="0e23f0f0">2022.naacl-srw.24</url>
       <bibkey>mince-etal-2022-multimodal</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.24</doi>
+      <video href="2022.naacl-srw.24.mp4"/>
     </paper>
     <paper id="25">
       <title>Probe-Less Probing of <fixed-case>BERT</fixed-case>’s Layer-Wise Linguistic Knowledge with Masked Word Prediction</title>
@@ -6983,6 +7440,7 @@
       <url hash="c5ffc658">2022.naacl-srw.25</url>
       <bibkey>aoyama-schneider-2022-probe</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.25</doi>
+      <video href="2022.naacl-srw.25.mp4"/>
     </paper>
     <paper id="26">
       <title>Multimodal large language models for inclusive collaboration learning tasks</title>
@@ -6992,6 +7450,7 @@
       <url hash="be160a18">2022.naacl-srw.26</url>
       <bibkey>lewis-2022-multimodal</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.26</doi>
+      <video href="2022.naacl-srw.26.mp4"/>
     </paper>
     <paper id="27">
       <title>Neural Networks in a Product of Hyperbolic Spaces</title>
@@ -7004,6 +7463,7 @@
       <bibkey>takeuchi-etal-2022-neural</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.27</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/pubmed">Pubmed</pwcdataset>
+      <video href="2022.naacl-srw.27.mp4"/>
     </paper>
     <paper id="28">
       <title>Explicit Use of Topicality in Dialogue Response Generation</title>
@@ -7016,6 +7476,7 @@
       <url hash="779bb697">2022.naacl-srw.28</url>
       <bibkey>yoshikoshi-etal-2022-explicit</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.28</doi>
+      <video href="2022.naacl-srw.28.mp4"/>
     </paper>
     <paper id="29">
       <title>Automating Human Evaluation of Dialogue Systems</title>
@@ -7025,6 +7486,7 @@
       <url hash="203aea07">2022.naacl-srw.29</url>
       <bibkey>a-2022-automating</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.29</doi>
+      <video href="2022.naacl-srw.29.mp4"/>
     </paper>
     <paper id="30">
       <title>Strong Heuristics for Named Entity Linking</title>
@@ -7040,6 +7502,7 @@
       <pwccode url="https://github.com/epfl-dlab/nelight" additional="false">epfl-dlab/nelight</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aida-conll-yago">AIDA CoNLL-YAGO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
+      <video href="2022.naacl-srw.30.mp4"/>
     </paper>
     <paper id="31">
       <title>Static and Dynamic Speaker Modeling based on Graph Neural Network for Emotion Recognition in Conversation</title>
@@ -7052,6 +7515,7 @@
       <bibkey>saxena-etal-2022-static</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.31</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
+      <video href="2022.naacl-srw.31.mp4"/>
     </paper>
     <paper id="32">
       <title>Few-shot fine-tuning <fixed-case>SOTA</fixed-case> summarization models for medical dialogues</title>
@@ -7063,6 +7527,7 @@
       <url hash="b58218c5">2022.naacl-srw.32</url>
       <bibkey>navarro-etal-2022-shot</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.32</doi>
+      <video href="2022.naacl-srw.32.mp4"/>
     </paper>
     <paper id="33">
       <title>Unifying Parsing and Tree-Structured Models for Generating Sentence Semantic Representations</title>
@@ -7075,6 +7540,7 @@
       <doi>10.18653/v1/2022.naacl-srw.33</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
+      <video href="2022.naacl-srw.33.mp4"/>
     </paper>
     <paper id="34">
       <title>Multiformer: A Head-Configurable Transformer-Based Model for Direct Speech Translation</title>
@@ -7087,6 +7553,7 @@
       <url hash="094b9633">2022.naacl-srw.34</url>
       <bibkey>sant-etal-2022-multiformer</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.34</doi>
+      <video href="2022.naacl-srw.34.mp4"/>
     </paper>
     <paper id="35">
       <title>Defending Compositionality in Emergent Languages</title>
@@ -7098,6 +7565,7 @@
       <bibkey>auersperger-pecina-2022-defending</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.35</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
+      <video href="2022.naacl-srw.35.mp4"/>
     </paper>
     <paper id="36">
       <title>Exploring the Effect of Dialect Mismatched Language Models in <fixed-case>T</fixed-case>elugu Automatic Speech Recognition</title>
@@ -7109,6 +7577,7 @@
       <url hash="12d93502">2022.naacl-srw.36</url>
       <bibkey>yadavalli-etal-2022-exploring</bibkey>
       <doi>10.18653/v1/2022.naacl-srw.36</doi>
+      <video href="2022.naacl-srw.36.mp4"/>
     </paper>
   </volume>
   <volume id="demo" ingest-date="2022-06-30">
@@ -7148,6 +7617,7 @@
       <pwccode url="https://github.com/facebookresearch/textlesslib" additional="false">facebookresearch/textlesslib</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/libri-light">Libri-Light</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
+      <video href="2022.naacl-demo.1.mp4"/>
     </paper>
     <paper id="2">
       <title>Web-based Annotation Interface for Derivational Morphology</title>
@@ -7157,6 +7627,7 @@
       <url hash="ee4421b1">2022.naacl-demo.2</url>
       <bibkey>kyjanek-2022-web</bibkey>
       <doi>10.18653/v1/2022.naacl-demo.2</doi>
+      <video href="2022.naacl-demo.2.mp4"/>
     </paper>
     <paper id="3">
       <title><fixed-case>T</fixed-case>urkish<fixed-case>D</fixed-case>elight<fixed-case>NLP</fixed-case>: A Neural <fixed-case>T</fixed-case>urkish <fixed-case>NLP</fixed-case> Toolkit</title>
@@ -7169,6 +7640,7 @@
       <bibkey>alecakir-etal-2022-turkishdelightnlp</bibkey>
       <doi>10.18653/v1/2022.naacl-demo.3</doi>
       <pwccode url="https://github.com/halecakir/turkish-delight-nlp-api" additional="false">halecakir/turkish-delight-nlp-api</pwccode>
+      <video href="2022.naacl-demo.3.mp4"/>
     </paper>
     <paper id="4">
       <title><fixed-case>ZS</fixed-case>4<fixed-case>IE</fixed-case>: A toolkit for Zero-Shot Information Extraction with simple Verbalizations</title>
@@ -7202,6 +7674,7 @@
       <url hash="1f51ce04">2022.naacl-demo.5</url>
       <bibkey>pichl-etal-2022-flowstorm</bibkey>
       <doi>10.18653/v1/2022.naacl-demo.5</doi>
+      <video href="2022.naacl-demo.5.mp4"/>
     </paper>
     <paper id="6">
       <title>Contrastive Explanations of Text Classifiers as a Service</title>
@@ -7215,6 +7688,7 @@
       <url hash="0d8a19ab">2022.naacl-demo.6</url>
       <bibkey>malandri-etal-2022-contrastive</bibkey>
       <doi>10.18653/v1/2022.naacl-demo.6</doi>
+      <video href="2022.naacl-demo.6.mp4"/>
     </paper>
     <paper id="7">
       <title><fixed-case>RESIN</fixed-case>-11: Schema-guided Event Prediction for 11 Newsworthy Scenarios</title>
@@ -7275,6 +7749,7 @@
       <bibkey>vacareanu-etal-2022-human</bibkey>
       <doi>10.18653/v1/2022.naacl-demo.8</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/tacred">TACRED</pwcdataset>
+      <video href="2022.naacl-demo.8.mp4"/>
     </paper>
     <paper id="9">
       <title><fixed-case>SETS</fixed-case>um: Summarization and Visualization of Student Evaluations of Teaching</title>
@@ -7289,6 +7764,7 @@
       <bibkey>hu-etal-2022-setsum</bibkey>
       <doi>10.18653/v1/2022.naacl-demo.9</doi>
       <pwccode url="https://github.com/evahuyn/setsum" additional="false">evahuyn/setsum</pwccode>
+      <video href="2022.naacl-demo.9.mp4"/>
     </paper>
     <paper id="10">
       <title>Towards Open-Domain Topic Classification</title>
@@ -7306,6 +7782,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
+      <video href="2022.naacl-demo.10.mp4"/>
     </paper>
     <paper id="11">
       <title><fixed-case>S</fixed-case>ent<fixed-case>S</fixed-case>pace: Large-Scale Benchmarking and Evaluation of Text using Cognitively Motivated Lexical, Syntactic, and Semantic Features</title>
@@ -7353,6 +7830,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/voxceleb1">VoxCeleb1</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/voxceleb2">VoxCeleb2</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wenetspeech">WenetSpeech</pwcdataset>
+      <video href="2022.naacl-demo.12.mp4"/>
     </paper>
     <paper id="13">
       <title><fixed-case>D</fixed-case>adma<fixed-case>T</fixed-case>ools: Natural Language Processing Toolkit for <fixed-case>P</fixed-case>ersian Language</title>
@@ -7367,6 +7845,7 @@
       <bibkey>etezadi-etal-2022-dadmatools</bibkey>
       <doi>10.18653/v1/2022.naacl-demo.13</doi>
       <pwccode url="https://github.com/dadmatech/dadmatools" additional="false">dadmatech/dadmatools</pwccode>
+      <video href="2022.naacl-demo.13.mp4"/>
     </paper>
     <paper id="14">
       <title><fixed-case>FAMIE</fixed-case>: A Fast Active Learning Framework for Multilingual Information Extraction</title>
@@ -7381,6 +7860,7 @@
       <doi>10.18653/v1/2022.naacl-demo.14</doi>
       <pwccode url="https://github.com/nlp-uoregon/famie" additional="false">nlp-uoregon/famie</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
+      <video href="2022.naacl-demo.14.mp4"/>
     </paper>
   </volume>
   <volume id="tutorials" ingest-date="2022-06-28">
@@ -7517,6 +7997,7 @@
       <url hash="98471458">2022.naacl-industry.1</url>
       <bibkey>kachuee-etal-2022-scalable</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.1</doi>
+      <video href="2022.naacl-industry.1.mp4"/>
     </paper>
     <paper id="2">
       <title><fixed-case>CREATER</fixed-case>: <fixed-case>CTR</fixed-case>-driven Advertising Text Generation with Controlled Pre-Training and Contrastive Fine-Tuning</title>
@@ -7530,6 +8011,7 @@
       <url hash="eea50163">2022.naacl-industry.2</url>
       <bibkey>wei-etal-2022-creater</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.2</doi>
+      <video href="2022.naacl-industry.2.mp4"/>
     </paper>
     <paper id="3">
       <title>Augmenting Poetry Composition with <fixed-case>V</fixed-case>erse by <fixed-case>V</fixed-case>erse</title>
@@ -7541,6 +8023,7 @@
       <url hash="2235db9a">2022.naacl-industry.3</url>
       <bibkey>uthus-etal-2022-augmenting</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.3</doi>
+      <video href="2022.naacl-industry.3.mp4"/>
     </paper>
     <paper id="4">
       <title><fixed-case>AB</fixed-case>/<fixed-case>BA</fixed-case> analysis: A framework for estimating keyword spotting recall improvement while maintaining audio privacy</title>
@@ -7553,6 +8036,7 @@
       <url hash="bdc84369">2022.naacl-industry.4</url>
       <bibkey>petegrosso-etal-2022-ab</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.4</doi>
+      <video href="2022.naacl-industry.4.mp4"/>
     </paper>
     <paper id="5">
       <title>Temporal Generalization for Spoken Language Understanding</title>
@@ -7565,6 +8049,7 @@
       <url hash="c34842ac">2022.naacl-industry.5</url>
       <bibkey>gaspers-etal-2022-temporal</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.5</doi>
+      <video href="2022.naacl-industry.5.mp4"/>
     </paper>
     <paper id="6">
       <title>An End-to-End Dialogue Summarization System for Sales Calls</title>
@@ -7583,6 +8068,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dialogsum">DialogSum</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
+      <video href="2022.naacl-industry.6.mp4"/>
     </paper>
     <paper id="7">
       <title>Controlled Data Generation via Insertion Operations for <fixed-case>NLU</fixed-case></title>
@@ -7597,6 +8083,7 @@
       <url hash="5a1d7102">2022.naacl-industry.7</url>
       <bibkey>kumar-etal-2022-controlled</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.7</doi>
+      <video href="2022.naacl-industry.7.mp4"/>
     </paper>
     <paper id="8">
       <title>Easy and Efficient Transformer: Scalable Inference Solution For Large <fixed-case>NLP</fixed-case> Model</title>
@@ -7615,6 +8102,7 @@
       <url hash="7d9a8de2">2022.naacl-industry.8</url>
       <bibkey>li-etal-2022-easy</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.8</doi>
+      <video href="2022.naacl-industry.8.mp4"/>
     </paper>
     <paper id="9">
       <title>Aspect-based Analysis of Advertising Appeals for Search Engine Advertising</title>
@@ -7629,6 +8117,7 @@
       <url hash="a2ec38f9">2022.naacl-industry.9</url>
       <bibkey>murakami-etal-2022-aspect</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.9</doi>
+      <video href="2022.naacl-industry.9.mp4"/>
     </paper>
     <paper id="10">
       <title>Self-supervised Product Title Rewrite for Product Listing Ads</title>
@@ -7644,6 +8133,7 @@
       <url hash="25eaf32a">2022.naacl-industry.10</url>
       <bibkey>zhao-etal-2022-self</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.10</doi>
+      <video href="2022.naacl-industry.10.mp4"/>
     </paper>
     <paper id="11">
       <title>Efficient Semi-supervised Consistency Training for Natural Language Understanding</title>
@@ -7654,6 +8144,7 @@
       <url hash="fac24315">2022.naacl-industry.11</url>
       <bibkey>leung-tan-2022-efficient</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.11</doi>
+      <video href="2022.naacl-industry.11.mp4"/>
     </paper>
     <paper id="12">
       <title>Distantly Supervised Aspect Clustering And Naming For <fixed-case>E</fixed-case>-Commerce Reviews</title>
@@ -7666,6 +8157,7 @@
       <url hash="a2eeb8cc">2022.naacl-industry.12</url>
       <bibkey>sircar-etal-2022-distantly</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.12</doi>
+      <video href="2022.naacl-industry.12.mp4"/>
     </paper>
     <paper id="13">
       <title>Local-to-global learning for iterative training of production <fixed-case>SLU</fixed-case> models on new features</title>
@@ -7676,6 +8168,7 @@
       <url hash="bce801a1">2022.naacl-industry.13</url>
       <bibkey>grishina-sorokin-2022-local</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.13</doi>
+      <video href="2022.naacl-industry.13.mp4"/>
     </paper>
     <paper id="14">
       <title><fixed-case>CULG</fixed-case>: Commercial Universal Language Generation</title>
@@ -7702,6 +8195,7 @@
       <bibkey>gueudre-jose-2022-constraining</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.15</doi>
       <pwccode url="https://github.com/amazon-research/fast_label" additional="false">amazon-research/fast_label</pwccode>
+      <video href="2022.naacl-industry.15.mp4"/>
     </paper>
     <paper id="16">
       <title>Explaining the Effectiveness of Multi-Task Learning for Efficient Knowledge Extraction from Spine <fixed-case>MRI</fixed-case> Reports</title>
@@ -7720,6 +8214,7 @@
       <url hash="d2eea078">2022.naacl-industry.16</url>
       <bibkey>sehanobish-etal-2022-explaining</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.16</doi>
+      <video href="2022.naacl-industry.16.mp4"/>
     </paper>
     <paper id="17">
       <title><fixed-case>FPI</fixed-case>: Failure Point Isolation in Large-scale Conversational Assistants</title>
@@ -7734,6 +8229,7 @@
       <url hash="7fee073e">2022.naacl-industry.17</url>
       <bibkey>khaziev-etal-2022-fpi</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.17</doi>
+      <video href="2022.naacl-industry.17.mp4"/>
     </paper>
     <paper id="18">
       <title>Asynchronous Convergence in Multi-Task Learning via Knowledge Distillation from Converged Tasks</title>
@@ -7751,6 +8247,7 @@
       <bibkey>lu-etal-2022-asynchronous</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.18</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
+      <video href="2022.naacl-industry.18.mp4"/>
     </paper>
     <paper id="19">
       <title>Augmenting Training Data for Massive Semantic Matching Models in Low-Traffic <fixed-case>E</fixed-case>-commerce Stores</title>
@@ -7766,6 +8263,7 @@
       <url hash="bf36d620">2022.naacl-industry.19</url>
       <bibkey>joshi-etal-2022-augmenting</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.19</doi>
+      <video href="2022.naacl-industry.19.mp4"/>
     </paper>
     <paper id="20">
       <title>Retrieval Based Response Letter Generation For a Customer Care Setting</title>
@@ -7777,6 +8275,7 @@
       <url hash="85819e7d">2022.naacl-industry.20</url>
       <bibkey>biswas-etal-2022-retrieval</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.20</doi>
+      <video href="2022.naacl-industry.20.mp4"/>
     </paper>
     <paper id="21">
       <title><fixed-case>M</fixed-case>edical Coding with Biomedical Transformer Ensembles and Zero/Few-shot Learning</title>
@@ -7792,6 +8291,7 @@
       <bibkey>ziletti-etal-2022-medical</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.21</doi>
       <pwccode url="https://github.com/bayer-group/xtars-naacl2022" additional="false">bayer-group/xtars-naacl2022</pwccode>
+      <video href="2022.naacl-industry.21.mp4"/>
     </paper>
     <paper id="22">
       <title>Knowledge extraction from aeronautical messages (<fixed-case>NOTAM</fixed-case>s) with self-supervised language models for aircraft pilots</title>
@@ -7804,6 +8304,7 @@
       <url hash="7367e44f">2022.naacl-industry.22</url>
       <bibkey>arnold-etal-2022-knowledge</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.22</doi>
+      <video href="2022.naacl-industry.22.mp4"/>
     </paper>
     <paper id="23">
       <title>Intent Discovery for Enterprise Virtual Assistants: Applications of Utterance Embedding and Clustering to Intent Mining</title>
@@ -7817,6 +8318,7 @@
       <url hash="eb8cf882">2022.naacl-industry.23</url>
       <bibkey>chen-etal-2022-intent</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.23</doi>
+      <video href="2022.naacl-industry.23.mp4"/>
     </paper>
     <paper id="24">
       <title><fixed-case>R</fixed-case>e<fixed-case>F</fixed-case>in<fixed-case>ED</fixed-case>: An Efficient Zero-shot-capable Approach to End-to-End Entity Linking</title>
@@ -7835,6 +8337,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/aida-conll-yago">AIDA CoNLL-YAGO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/aquaint">AQUAINT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ipm-nel">IPM NEL</pwcdataset>
+      <video href="2022.naacl-industry.24.mp4"/>
     </paper>
     <paper id="25">
       <title>Lightweight Transformers for Conversational <fixed-case>AI</fixed-case></title>
@@ -7849,6 +8352,7 @@
       <doi>10.18653/v1/2022.naacl-industry.25</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/c4">C4</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
+      <video href="2022.naacl-industry.25.mp4"/>
     </paper>
     <paper id="26">
       <title><fixed-case>NER-MQMRC</fixed-case>: <fixed-case>F</fixed-case>ormulating Named Entity Recognition as Multi Question Machine Reading Comprehension</title>
@@ -7861,6 +8365,7 @@
       <url hash="dcd352b4">2022.naacl-industry.26</url>
       <bibkey>shrimal-etal-2022-ner</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.26</doi>
+      <video href="2022.naacl-industry.26.mp4"/>
     </paper>
     <paper id="27">
       <title>What Do Users Care About? Detecting Actionable Insights from User Feedback</title>
@@ -7874,6 +8379,7 @@
       <bibkey>bhattacharjee-etal-2022-users</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.27</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/clinc150">CLINC150</pwcdataset>
+      <video href="2022.naacl-industry.27.mp4"/>
     </paper>
     <paper id="28">
       <title><fixed-case>CTM</fixed-case> - A Model for Large-Scale Multi-View Tweet Topic Classification</title>
@@ -7885,6 +8391,7 @@
       <url hash="70a239fb">2022.naacl-industry.28</url>
       <bibkey>kulkarni-etal-2022-ctm</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.28</doi>
+      <video href="2022.naacl-industry.28.mp4"/>
     </paper>
     <paper id="29">
       <title>Developing a Production System for <fixed-case>P</fixed-case>urpose of <fixed-case>C</fixed-case>all Detection in Business Phone Conversations</title>
@@ -7899,6 +8406,7 @@
       <url hash="1ce59f05">2022.naacl-industry.29</url>
       <bibkey>khasanova-etal-2022-developing</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.29</doi>
+      <video href="2022.naacl-industry.29.mp4"/>
     </paper>
     <paper id="30">
       <title>Adversarial Text Normalization</title>
@@ -7911,6 +8419,7 @@
       <bibkey>bitton-etal-2022-adversarial</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.30</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/anli">ANLI</pwcdataset>
+      <video href="2022.naacl-industry.30.mp4"/>
     </paper>
     <paper id="31">
       <title>Constraint-based Multi-hop Question Answering with Knowledge Graph</title>
@@ -7923,6 +8432,7 @@
       <bibkey>mitra-etal-2022-constraint</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.31</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/complexwebquestions">ComplexWebQuestions</pwcdataset>
+      <video href="2022.naacl-industry.31.mp4"/>
     </paper>
     <paper id="32">
       <title>Fast Bilingual Grapheme-To-Phoneme Conversion</title>
@@ -7936,6 +8446,7 @@
       <doi>10.18653/v1/2022.naacl-industry.32</doi>
       <revision id="1" href="2022.naacl-industry.32v1" hash="c9277315"/>
       <revision id="2" href="2022.naacl-industry.32v2" hash="bb1bdcea" date="2022-07-12">Changed wording, updated Figure 1 and corrected tables.</revision>
+      <video href="2022.naacl-industry.32.mp4"/>
     </paper>
     <paper id="33">
       <title>Knowledge Extraction From Texts Based on <fixed-case>W</fixed-case>ikidata</title>
@@ -7951,6 +8462,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/t-rex">T-REx</pwcdataset>
+      <video href="2022.naacl-industry.33.mp4"/>
     </paper>
     <paper id="34">
       <title><fixed-case>AIT-QA</fixed-case>: <fixed-case>Q</fixed-case>uestion Answering Dataset over Complex Tables in the Airline Industry</title>
@@ -7978,6 +8490,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/tat-qa">TAT-QA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitablequestions">WikiTableQuestions</pwcdataset>
+      <video href="2022.naacl-industry.34.mp4"/>
     </paper>
     <paper id="35">
       <title>Parameter-efficient Continual Learning Framework in Industrial Real-time Text Classification System</title>
@@ -7996,6 +8509,7 @@
       <url hash="53bc3d4b">2022.naacl-industry.35</url>
       <bibkey>zhu-etal-2022-parameter</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.35</doi>
+      <video href="2022.naacl-industry.35.mp4"/>
     </paper>
     <paper id="36">
       <title>Self-Aware Feedback-Based Self-Learning in Large-Scale Conversational <fixed-case>AI</fixed-case></title>
@@ -8009,6 +8523,7 @@
       <url hash="617ae801">2022.naacl-industry.36</url>
       <bibkey>ponnusamy-etal-2022-self</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.36</doi>
+      <video href="2022.naacl-industry.36.mp4"/>
     </paper>
     <paper id="37">
       <title>Fast and Light-Weight Answer Text Retrieval in Dialogue Systems</title>
@@ -8024,6 +8539,7 @@
       <doi>10.18653/v1/2022.naacl-industry.37</doi>
       <pwccode url="https://github.com/IBM/ColBERT-practical" additional="false">IBM/ColBERT-practical</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
+      <video href="2022.naacl-industry.37.mp4"/>
     </paper>
     <paper id="38">
       <title><fixed-case>BLINK</fixed-case> with <fixed-case>E</fixed-case>lasticsearch for Efficient Entity Linking in Business Conversations</title>
@@ -8039,6 +8555,7 @@
       <url hash="90745fc9">2022.naacl-industry.38</url>
       <bibkey>laskar-etal-2022-blink</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.38</doi>
+      <video href="2022.naacl-industry.38.mp4"/>
     </paper>
     <paper id="39">
       <title><fixed-case>Q</fixed-case>2<fixed-case>R</fixed-case>: A Query-to-Resolution System for Natural-Language Queries</title>
@@ -8050,6 +8567,7 @@
       <bibkey>lim-wynter-2022-q2r</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.39</doi>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
+      <video href="2022.naacl-industry.39.mp4"/>
     </paper>
     <paper id="40">
       <title><fixed-case>I</fixed-case>dentifying <fixed-case>C</fixed-case>orporate <fixed-case>C</fixed-case>redit <fixed-case>R</fixed-case>isk <fixed-case>S</fixed-case>entiments from <fixed-case>F</fixed-case>inancial <fixed-case>N</fixed-case>ews</title>
@@ -8064,6 +8582,7 @@
       <url hash="89ad57e3">2022.naacl-industry.40</url>
       <bibkey>ahbali-etal-2022-identifying</bibkey>
       <doi>10.18653/v1/2022.naacl-industry.40</doi>
+      <video href="2022.naacl-industry.40.mp4"/>
     </paper>
   </volume>
 </collection>


### PR DESCRIPTION
* Added videos for NAACL 2022.

I only pushed NAACL for now but I have also created (missing) video links for the following proceedings:
	modified:   data/xml/2014.lilt.xml
	modified:   data/xml/2020.cl.xml
	modified:   data/xml/2020.tacl.xml
	modified:   data/xml/2021.acl.xml
	modified:   data/xml/2021.blackboxnlp.xml
	modified:   data/xml/2021.calcs.xml
	modified:   data/xml/2021.case.xml
	modified:   data/xml/2021.cl.xml
	modified:   data/xml/2021.codi.xml
	modified:   data/xml/2021.conll.xml
	modified:   data/xml/2021.crac.xml
	modified:   data/xml/2021.dialdoc.xml
	modified:   data/xml/2021.eacl.xml
	modified:   data/xml/2021.econlp.xml
	modified:   data/xml/2021.emnlp.xml
	modified:   data/xml/2021.eval4nlp.xml
	modified:   data/xml/2021.fever.xml
	modified:   data/xml/2021.findings.xml
	modified:   data/xml/2021.gem.xml
	modified:   data/xml/2021.humeval.xml
	modified:   data/xml/2021.insights.xml
	modified:   data/xml/2021.iwpt.xml
	modified:   data/xml/2021.latechclfl.xml
	modified:   data/xml/2021.metanlp.xml
	modified:   data/xml/2021.mrl.xml
	modified:   data/xml/2021.mrqa.xml
	modified:   data/xml/2021.mwe.xml
	modified:   data/xml/2021.naacl.xml
	modified:   data/xml/2021.newsum.xml
	modified:   data/xml/2021.nlp4convai.xml
	modified:   data/xml/2021.nlpmc.xml
	modified:   data/xml/2021.privatenlp.xml
	modified:   data/xml/2021.repl4nlp.xml
	modified:   data/xml/2021.semeval.xml
	modified:   data/xml/2021.sigmorphon.xml
	modified:   data/xml/2021.splurobonlp.xml
	modified:   data/xml/2021.spnlp.xml
	modified:   data/xml/2021.sustainlp.xml
	modified:   data/xml/2021.tacl.xml
	modified:   data/xml/2021.unimplicit.xml
	modified:   data/xml/2021.wmt.xml
	modified:   data/xml/2021.wnut.xml
	modified:   data/xml/2021.woah.xml
	modified:   data/xml/2022.acl.xml
	modified:   data/xml/2022.bea.xml
	modified:   data/xml/2022.cl.xml
	modified:   data/xml/2022.clinicalnlp.xml
	modified:   data/xml/2022.clpsych.xml
	modified:   data/xml/2022.dadc.xml
	modified:   data/xml/2022.deeplo.xml
	modified:   data/xml/2022.dialdoc.xml
	modified:   data/xml/2022.distcurate.xml
	modified:   data/xml/2022.emoji.xml
	modified:   data/xml/2022.findings.xml
	modified:   data/xml/2022.gebnlp.xml
	modified:   data/xml/2022.hcinlp.xml
	modified:   data/xml/2022.mia.xml
	modified:   data/xml/2022.privatenlp.xml
	modified:   data/xml/2022.semeval.xml
	modified:   data/xml/2022.sigmorphon.xml
	modified:   data/xml/2022.sigtyp.xml
	modified:   data/xml/2022.socialnlp.xml
	modified:   data/xml/2022.suki.xml
	modified:   data/xml/2022.tacl.xml
	modified:   data/xml/2022.trustnlp.xml
	modified:   data/xml/2022.unimplicit.xml
	modified:   data/xml/2022.wnu.xml
	modified:   data/xml/2022.woah.xml
	modified:   data/xml/P14.xml
	modified:   data/xml/Q13.xml
	modified:   data/xml/Q14.xml
I will add these after some checks. Not sure if it is best to do everything in a single pull request. Let me know if I should create multiple requests. Adding these videos will partly solve the missing video issue #1984.