### PR TITLE
Author name correction ID: 2022.acl-long.243

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -3782,7 +3782,7 @@
       <title>Investigating Failures of Automatic Translation
 
 in the Case of Unambiguous Gender</title>
-      <author><first>Adi</first><last>Renduchintala</last></author>
+      <author><first>Adithya</first><last>Renduchintala</last></author>
       <author><first>Adina</first><last>Williams</last></author>
       <pages>3454-3469</pages>
       <abstract>Transformer-based models are the modern work horses for neural machine translation (NMT), reaching state of the art across several benchmarks. Despite their impressive accuracy, we observe a systemic and rudimentary class of errors made by current state-of-the-art NMT models with regards to translating from a language that doesn’t mark gender on nouns into others that do. We find that even when the surrounding context provides unambiguous evidence of the appropriate grammatical gender marking, no tested model was able to accurately gender occupation nouns systematically. We release an evaluation scheme and dataset for measuring the ability of NMT models to translate gender morphology correctly in unambiguous contexts across syntactically diverse sentences. Our dataset translates from an English source into 20 languages from several different language families. With the availability of this dataset, our hope is that the NMT community can iterate on solutions for this class of especially egregious errors.</abstract>


### PR DESCRIPTION
Fixed first author's name in this paper: [Investigating Failures of Automatic Translation in the Case of Unambiguous Gender](https://aclanthology.org/2022.acl-long.243.pdf)
Anthology ID: 2022.acl-long.243

First author name is now inline with PDF.
