### PR TITLE
Fix spelling in error in last name

### DIFF
--- a/data/xml/2022.dclrl.xml
+++ b/data/xml/2022.dclrl.xml
@@ -3,7 +3,7 @@
   <volume id="1" ingest-date="2022-09-21">
     <meta>
       <booktitle>Proceedings of the Workshop on Dataset Creation for Lower-Resourced Languages within the 13th Language Resources and Evaluation Conference</booktitle>
-      <editor><first>Jonne</first><last>S{\"a}lev{\"a}</last></editor>
+      <editor><first>Jonne</first><last>Sälevä</last></editor>
       <editor><first>Constantine</first><last>Lignos</last></editor>
       <publisher>European Language Resources Association</publisher>
       <address>Marseille, France</address>


### PR DESCRIPTION
Fixes spelling of my last name, Sälevä, as documented in #2201.

Ping @ConstantineLignos  🙂
