### PR TITLE
Remove duplicate videos for papers

### DIFF
--- a/data/xml/2020.challengehml.xml
+++ b/data/xml/2020.challengehml.xml
@@ -108,7 +108,6 @@
       <url hash="f8016049">2020.challengehml-1.7</url>
       <doi>10.18653/v1/2020.challengehml-1.7</doi>
       <video href="http://slideslive.com/38931265"/>
-      <video href="http://slideslive.com/38931265"/>
       <bibkey>okur-etal-2020-audio</bibkey>
     </paper>
     <paper id="8">

--- a/data/xml/2021.acl.xml
+++ b/data/xml/2021.acl.xml
@@ -33,7 +33,6 @@
       <bibkey>beck-etal-2021-investigating</bibkey>
       <video href="2021.acl-long.1.mp4"/>
       <pwccode url="https://github.com/UKPLab/acl2021-label-suggestions-german-covid19" additional="false">UKPLab/acl2021-label-suggestions-german-covid19</pwccode>
-      <video href="2021.acl-long.1.mp4"/>
     </paper>
     <paper id="2">
       <title><fixed-case>H</fixed-case>ow Did This Get Funded?! <fixed-case>A</fixed-case>utomatically Identifying Quirky Scientific Achievements</title>
@@ -47,7 +46,6 @@
       <bibkey>shani-etal-2021-get</bibkey>
       <video href="2021.acl-long.2.mp4"/>
       <pwccode url="https://github.com/nadavborenstein/Iggy" additional="false">nadavborenstein/Iggy</pwccode>
-      <video href="2021.acl-long.2.mp4"/>
     </paper>
     <paper id="3">
       <title>Engage the Public: Poll Question Generation for Social Media Posts</title>
@@ -64,7 +62,6 @@
       <bibkey>lu-etal-2021-engage</bibkey>
       <video href="2021.acl-long.3.mp4"/>
       <pwccode url="https://github.com/polyusmart/poll-question-generation" additional="false">polyusmart/poll-question-generation</pwccode>
-      <video href="2021.acl-long.3.mp4"/>
     </paper>
     <paper id="4">
       <title><fixed-case>H</fixed-case>ate<fixed-case>C</fixed-case>heck: Functional Tests for Hate Speech Detection Models</title>
@@ -81,7 +78,6 @@
       <bibkey>rottger-etal-2021-hatecheck</bibkey>
       <video href="2021.acl-long.4.mp4"/>
       <pwccode url="https://github.com/paul-rottger/hate-functional-tests" additional="true">paul-rottger/hate-functional-tests</pwccode>
-      <video href="2021.acl-long.4.mp4"/>
     </paper>
     <paper id="5">
       <title>Unified Dual-view Cognitive Model for Interpretable Claim Verification</title>
@@ -97,7 +93,6 @@
       <bibkey>wu-etal-2021-unified</bibkey>
       <video href="2021.acl-long.5.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
-      <video href="2021.acl-long.5.mp4"/>
     </paper>
     <paper id="6">
       <title><fixed-case>D</fixed-case>eep<fixed-case>R</fixed-case>apper: Neural Rap Generation with Rhyme and Rhythm Modeling</title>
@@ -116,7 +111,6 @@
       <bibkey>xue-etal-2021-deeprapper</bibkey>
       <video href="2021.acl-long.6.mp4"/>
       <pwccode url="https://github.com/microsoft/muzic/tree/main/deeprapper" additional="false">microsoft/muzic</pwccode>
-      <video href="2021.acl-long.6.mp4"/>
     </paper>
     <paper id="7">
       <title><fixed-case>PENS</fixed-case>: A Dataset and Generic Framework for Personalized News Headline Generation</title>
@@ -133,7 +127,6 @@
       <bibkey>ao-etal-2021-pens</bibkey>
       <video href="2021.acl-long.7.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mind">MIND</pwcdataset>
-      <video href="2021.acl-long.7.mp4"/>
     </paper>
     <paper id="8">
       <title>Enhancing Content Preservation in Text Style Transfer Using Reverse Attention and Conditional Layer Normalization</title>
@@ -148,7 +141,6 @@
       <bibkey>lee-etal-2021-enhancing</bibkey>
       <video href="2021.acl-long.8.mp4"/>
       <pwccode url="https://github.com/MovingKyu/RACoLN" additional="false">MovingKyu/RACoLN</pwccode>
-      <video href="2021.acl-long.8.mp4"/>
     </paper>
     <paper id="9">
       <title>Mention Flags (<fixed-case>MF</fixed-case>): Constraining Transformer-based Text Generators</title>
@@ -168,7 +160,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/commongen">CommonGen</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/nocaps">nocaps</pwcdataset>
-      <video href="2021.acl-long.9.mp4"/>
     </paper>
     <paper id="10">
       <title>Generalising Multilingual Concept-to-Text <fixed-case>NLG</fixed-case> with Language Agnostic Delexicalisation</title>
@@ -181,7 +172,6 @@
       <bibkey>zhou-lampouras-2021-generalising</bibkey>
       <video href="2021.acl-long.10.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/crosswoz">CrossWOZ</pwcdataset>
-      <video href="2021.acl-long.10.mp4"/>
     </paper>
     <paper id="11">
       <title>Conversations Are Not Flat: Modeling the Dynamic Information Flow across Dialogue Utterances</title>
@@ -199,7 +189,6 @@
       <pwccode url="https://github.com/ictnlp/DialoFlow" additional="false">ictnlp/DialoFlow</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fed">FED</pwcdataset>
-      <video href="2021.acl-long.11.mp4"/>
     </paper>
     <paper id="12">
       <title>Dual Slot Selector via Local Reliability Verification for Dialogue State Tracking</title>
@@ -214,7 +203,6 @@
       <bibkey>guo-etal-2021-dual</bibkey>
       <video href="2021.acl-long.12.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.acl-long.12.mp4"/>
     </paper>
     <paper id="13">
       <title>Transferable Dialogue Systems and User Simulators</title>
@@ -229,7 +217,6 @@
       <bibkey>tseng-etal-2021-transferable</bibkey>
       <video href="2021.acl-long.13.mp4"/>
       <pwccode url="https://github.com/andy194673/joust" additional="false">andy194673/joust</pwccode>
-      <video href="2021.acl-long.13.mp4"/>
     </paper>
     <paper id="14">
       <title><fixed-case>B</fixed-case>o<fixed-case>B</fixed-case>: <fixed-case>BERT</fixed-case> Over <fixed-case>BERT</fixed-case> for Training Persona-based Dialogue Models from Limited Personalized Data</title>
@@ -248,7 +235,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/convai2">ConvAI2</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/personaldialog">PersonalDialog</pwcdataset>
-      <video href="2021.acl-long.14.mp4"/>
     </paper>
     <paper id="15">
       <title><fixed-case>GL</fixed-case>-<fixed-case>GIN</fixed-case>: Fast and Accurate Non-Autoregressive Model for Joint Multiple Intent Detection and Slot Filling</title>
@@ -269,7 +255,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mixatis">MixATIS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mixsnips-1">MixSNIPs</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
-      <video href="2021.acl-long.15.mp4"/>
     </paper>
     <paper id="16">
       <title>Accelerating <fixed-case>BERT</fixed-case> Inference for Sequence Labeling via Early-Exit</title>
@@ -289,7 +274,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/clue">CLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.acl-long.16.mp4"/>
     </paper>
     <paper id="17">
       <title>Modularized Interaction Network for Named Entity Recognition</title>
@@ -309,7 +293,6 @@
       <video href="2021.acl-long.17.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
-      <video href="2021.acl-long.17.mp4"/>
     </paper>
     <paper id="18">
       <title>Capturing Event Argument Interaction via A Bi-Directional Entity-Level Recurrent Decoder</title>
@@ -324,7 +307,6 @@
       <url hash="b8171f2c">2021.acl-long.18</url>
       <doi>10.18653/v1/2021.acl-long.18</doi>
       <bibkey>xiangyu-etal-2021-capturing</bibkey>
-      <video href="2021.acl-long.18.mp4"/>
       <video href="2021.acl-long.18.mp4"/>
     </paper>
     <paper id="19">
@@ -343,7 +325,6 @@
       <video href="2021.acl-long.19.mp4"/>
       <pwccode url="https://github.com/Receiling/UniRE" additional="false">Receiling/UniRE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
-      <video href="2021.acl-long.19.mp4"/>
     </paper>
     <paper id="20">
       <title>Refining Sample Embeddings with Relation Prototypes to Enhance Continual Relation Extraction</title>
@@ -363,7 +344,6 @@
       <video href="2021.acl-long.20.mp4"/>
       <pwccode url="https://github.com/fd2014cl/rp-cre" additional="false">fd2014cl/rp-cre</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
-      <video href="2021.acl-long.20.mp4"/>
     </paper>
     <paper id="21">
       <title>Contrastive Learning for Many-to-many Multilingual Neural Machine Translation</title>
@@ -379,7 +359,6 @@
       <video href="2021.acl-long.21.mp4"/>
       <pwccode url="https://github.com/PANXiao1994/mCOLT" additional="true">PANXiao1994/mCOLT</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opus-100">OPUS-100</pwcdataset>
-      <video href="2021.acl-long.21.mp4"/>
     </paper>
     <paper id="22">
       <title>Understanding the Properties of Minimum <fixed-case>B</fixed-case>ayes Risk Decoding in Neural Machine Translation</title>
@@ -392,7 +371,6 @@
       <bibkey>muller-sennrich-2021-understanding</bibkey>
       <video href="2021.acl-long.22.mp4"/>
       <pwccode url="https://github.com/ZurichNLP/understanding-mbr" additional="false">ZurichNLP/understanding-mbr</pwccode>
-      <video href="2021.acl-long.22.mp4"/>
     </paper>
     <paper id="23">
       <title>Multi-Head Highly Parallelized <fixed-case>LSTM</fixed-case> Decoder for Neural Machine Translation</title>
@@ -407,7 +385,6 @@
       <doi>10.18653/v1/2021.acl-long.23</doi>
       <bibkey>xu-etal-2021-multi</bibkey>
       <video href="2021.acl-long.23.mp4"/>
-      <video href="2021.acl-long.23.mp4"/>
     </paper>
     <paper id="24">
       <title>A Bidirectional Transformer Based Alignment Model for Unsupervised Word Alignment</title>
@@ -418,7 +395,6 @@
       <url hash="214f1de7">2021.acl-long.24</url>
       <doi>10.18653/v1/2021.acl-long.24</doi>
       <bibkey>zhang-van-genabith-2021-bidirectional</bibkey>
-      <video href="2021.acl-long.24.mp4"/>
       <video href="2021.acl-long.24.mp4"/>
     </paper>
     <paper id="25">
@@ -434,7 +410,6 @@
       <bibkey>lin-etal-2021-learning</bibkey>
       <video href="2021.acl-long.25.mp4"/>
       <pwccode url="https://github.com/NLP-Playground/LaSS" additional="false">NLP-Playground/LaSS</pwccode>
-      <video href="2021.acl-long.25.mp4"/>
     </paper>
     <paper id="26">
       <title>Exploring the Efficacy of Automatically Generated Counterfactuals for Sentiment Analysis</title>
@@ -452,7 +427,6 @@
       <video href="2021.acl-long.26.mp4"/>
       <pwccode url="https://github.com/lijiazheng99/Counterfactuals-for-Sentiment-Analysis" additional="false">lijiazheng99/Counterfactuals-for-Sentiment-Analysis</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.acl-long.26.mp4"/>
     </paper>
     <paper id="27">
       <title>Bridge-Based Active Domain Adaptation for Aspect Term Extraction</title>
@@ -465,7 +439,6 @@
       <bibkey>chen-qian-2021-bridge</bibkey>
       <video href="2021.acl-long.27.mp4"/>
       <pwccode url="https://github.com/nlpwm-whu/bridge" additional="false">nlpwm-whu/bridge</pwccode>
-      <video href="2021.acl-long.27.mp4"/>
     </paper>
     <paper id="28">
       <title>Multimodal Sentiment Detection Based on Multi-channel Graph Neural Networks</title>
@@ -480,7 +453,6 @@
       <bibkey>yang-etal-2021-multimodal</bibkey>
       <video href="2021.acl-long.28.mp4"/>
       <pwccode url="https://github.com/yangxiaocui1215/mgnns" additional="false">yangxiaocui1215/mgnns</pwccode>
-      <video href="2021.acl-long.28.mp4"/>
     </paper>
     <paper id="29">
       <title>Aspect-Category-Opinion-Sentiment Quadruple Extraction with Implicit Aspects and Opinions</title>
@@ -496,7 +468,6 @@
       <pwccode url="https://github.com/nustm/acos" additional="false">nustm/acos</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/laptop-acos">Laptop-ACOS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/restaurant-acos">Restaurant-ACOS</pwcdataset>
-      <video href="2021.acl-long.29.mp4"/>
     </paper>
     <paper id="30">
       <title><fixed-case>PASS</fixed-case>: Perturb-and-Select Summarizer for Product Reviews</title>
@@ -507,7 +478,6 @@
       <url hash="006a0eaa">2021.acl-long.30</url>
       <doi>10.18653/v1/2021.acl-long.30</doi>
       <bibkey>oved-levy-2021-pass</bibkey>
-      <video href="2021.acl-long.30.mp4"/>
       <video href="2021.acl-long.30.mp4"/>
     </paper>
     <paper id="31">
@@ -525,7 +495,6 @@
       <doi>10.18653/v1/2021.acl-long.31</doi>
       <bibkey>jia-etal-2021-deep</bibkey>
       <video href="2021.acl-long.31.mp4"/>
-      <video href="2021.acl-long.31.mp4"/>
     </paper>
     <paper id="32">
       <title>Multi-<fixed-case>T</fixed-case>ime<fixed-case>L</fixed-case>ine Summarization (<fixed-case>MTLS</fixed-case>): Improving Timeline Summarization by Generating Multiple Summaries</title>
@@ -541,7 +510,6 @@
       <doi>10.18653/v1/2021.acl-long.32</doi>
       <bibkey>yu-etal-2021-multi</bibkey>
       <video href="2021.acl-long.32.mp4"/>
-      <video href="2021.acl-long.32.mp4"/>
     </paper>
     <paper id="33">
       <title>Self-Supervised Multimodal Opinion Summarization</title>
@@ -556,7 +524,6 @@
       <doi>10.18653/v1/2021.acl-long.33</doi>
       <bibkey>im-etal-2021-self</bibkey>
       <video href="2021.acl-long.33.mp4"/>
-      <video href="2021.acl-long.33.mp4"/>
     </paper>
     <paper id="34">
       <title>A Training-free and Reference-free Summarization Evaluation Metric via Centrality-weighted Relevance and Self-referenced Redundancy</title>
@@ -570,7 +537,6 @@
       <bibkey>chen-etal-2021-training</bibkey>
       <video href="2021.acl-long.34.mp4"/>
       <pwccode url="https://github.com/Chen-Wang-CUHK/Training-Free-and-Ref-Free-Summ-Evaluation" additional="false">Chen-Wang-CUHK/Training-Free-and-Ref-Free-Summ-Evaluation</pwccode>
-      <video href="2021.acl-long.34.mp4"/>
     </paper>
     <paper id="35">
       <title><fixed-case>DESCGEN</fixed-case>: A Distantly Supervised Datasetfor Generating Entity Descriptions</title>
@@ -586,7 +552,6 @@
       <pwccode url="https://github.com/swj0419/DESCGEN" additional="false">swj0419/DESCGEN</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/realnews">RealNews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisum">WikiSum</pwcdataset>
-      <video href="2021.acl-long.35.mp4"/>
     </paper>
     <paper id="36">
       <title>Introducing Orthogonal Constraint in Structural Probes</title>
@@ -600,7 +565,6 @@
       <video href="2021.acl-long.36.mp4"/>
       <pwccode url="https://github.com/Tom556/OrthogonalTransformerProbing" additional="false">Tom556/OrthogonalTransformerProbing</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/english-web-treebank">English Web Treebank</pwcdataset>
-      <video href="2021.acl-long.36.mp4"/>
     </paper>
     <paper id="37">
       <title>Hidden Killer: Invisible Textual Backdoor Attacks with Syntactic Trigger</title>
@@ -620,7 +584,6 @@
       <pwccode url="https://github.com/thunlp/HiddenKiller" additional="true">thunlp/HiddenKiller</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/olid">OLID</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.37.mp4"/>
     </paper>
     <paper id="38">
       <title>Examining the Inductive Bias of Neural Language Models with Artificial Languages</title>
@@ -633,7 +596,6 @@
       <bibkey>white-cotterell-2021-examining</bibkey>
       <video href="2021.acl-long.38.mp4"/>
       <pwccode url="https://github.com/rycolab/artificial-languages" additional="false">rycolab/artificial-languages</pwccode>
-      <video href="2021.acl-long.38.mp4"/>
     </paper>
     <paper id="39">
       <title>Explaining Contextualization in Language Models using Visual Analytics</title>
@@ -649,7 +611,6 @@
       <doi>10.18653/v1/2021.acl-long.39</doi>
       <bibkey>sevastjanova-etal-2021-explaining</bibkey>
       <video href="2021.acl-long.39.mp4"/>
-      <video href="2021.acl-long.39.mp4"/>
     </paper>
     <paper id="40">
       <title>Improving the Faithfulness of Attention-based Explanations with Task-specific Information for Text Classification</title>
@@ -664,7 +625,6 @@
       <video href="2021.acl-long.40.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.40.mp4"/>
     </paper>
     <paper id="41">
       <title>Generating Landmark Navigation Instructions from Maps as a Graph-to-Text Problem</title>
@@ -678,7 +638,6 @@
       <video href="2021.acl-long.41.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/map2seq">map2seq</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/talk-the-walk">Talk the Walk</pwcdataset>
-      <video href="2021.acl-long.41.mp4"/>
     </paper>
     <paper id="42">
       <title><fixed-case>E</fixed-case>2<fixed-case>E</fixed-case>-<fixed-case>VLP</fixed-case>: End-to-End Vision-Language Pre-training Enhanced by Visual Learning</title>
@@ -699,7 +658,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-long.42.mp4"/>
     </paper>
     <paper id="43">
       <title>Learning Relation Alignment for Calibrated Cross-modal Retrieval</title>
@@ -720,7 +678,6 @@
       <pwccode url="https://github.com/lancopku/IAIS" additional="false">lancopku/IAIS</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
-      <video href="2021.acl-long.43.mp4"/>
     </paper>
     <paper id="44">
       <title><fixed-case>KM</fixed-case>-<fixed-case>BART</fixed-case>: Knowledge Enhanced Multimodal <fixed-case>BART</fixed-case> for Visual Commonsense Generation</title>
@@ -743,7 +700,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptual-captions">Conceptual Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-long.44.mp4"/>
     </paper>
     <paper id="45">
       <title>Cascaded Head-colliding Attention</title>
@@ -760,7 +716,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.acl-long.45.mp4"/>
     </paper>
     <paper id="46">
       <title>Structural Knowledge Distillation: Tractably Distilling Information for Structured Predictor</title>
@@ -784,7 +739,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiann-1">WikiAnn</pwcdataset>
-      <video href="2021.acl-long.46.mp4"/>
     </paper>
     <paper id="47">
       <title>Parameter-efficient Multi-task Fine-tuning for Transformers via Shared Hypernetworks</title>
@@ -806,7 +760,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/paws">PAWS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.acl-long.47.mp4"/>
     </paper>
     <paper id="48">
       <title><fixed-case>COSY</fixed-case>: <fixed-case>CO</fixed-case>unterfactual <fixed-case>SY</fixed-case>ntax for Cross-Lingual Understanding</title>
@@ -824,7 +777,6 @@
       <pwccode url="https://github.com/pluviophileyu/cosy" additional="false">pluviophileyu/cosy</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mlqa">MLQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.acl-long.48.mp4"/>
     </paper>
     <paper id="49">
       <title><fixed-case>O</fixed-case>o<fixed-case>MM</fixed-case>ix: Out-of-manifold Regularization in Contextual Embedding Space for Text Classification</title>
@@ -839,7 +791,6 @@
       <bibkey>lee-etal-2021-oommix</bibkey>
       <video href="2021.acl-long.49.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
-      <video href="2021.acl-long.49.mp4"/>
     </paper>
     <paper id="50">
       <title>Understanding and Countering Stereotypes: A Computational Approach to the Stereotype Content Model</title>
@@ -853,7 +804,6 @@
       <bibkey>fraser-etal-2021-understanding</bibkey>
       <video href="2021.acl-long.50.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/stereoset">StereoSet</pwcdataset>
-      <video href="2021.acl-long.50.mp4"/>
     </paper>
     <paper id="51">
       <title>Structurizing Misinformation Stories via Rationalizing Fact-Checks</title>
@@ -865,7 +815,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="197a6b2b">2021.acl-long.51.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-long.51</doi>
       <bibkey>jiang-wilson-2021-structurizing</bibkey>
-      <video href="2021.acl-long.51.mp4"/>
       <video href="2021.acl-long.51.mp4"/>
     </paper>
     <paper id="52">
@@ -880,7 +829,6 @@
       <doi>10.18653/v1/2021.acl-long.52</doi>
       <bibkey>reddy-etal-2021-modeling</bibkey>
       <video href="2021.acl-long.52.mp4"/>
-      <video href="2021.acl-long.52.mp4"/>
     </paper>
     <paper id="53">
       <title>Breaking Down the Invisible Wall of Informal Fallacies in Online Discussions</title>
@@ -894,7 +842,6 @@
       <bibkey>sahai-etal-2021-breaking</bibkey>
       <video href="2021.acl-long.53.mp4"/>
       <pwccode url="https://github.com/sahaisaumya/informal_fallacies" additional="false">sahaisaumya/informal_fallacies</pwccode>
-      <video href="2021.acl-long.53.mp4"/>
     </paper>
     <paper id="54">
       <title><fixed-case>S</fixed-case>oc<fixed-case>A</fixed-case>o<fixed-case>G</fixed-case>: Incremental Graph Parsing for Social Relation Inference in Dialogues</title>
@@ -913,7 +860,6 @@
       <bibkey>qiu-etal-2021-socaog</bibkey>
       <video href="2021.acl-long.54.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/dialogre">DialogRE</pwcdataset>
-      <video href="2021.acl-long.54.mp4"/>
     </paper>
     <paper id="55">
       <title><fixed-case>T</fixed-case>icket<fixed-case>T</fixed-case>alk: Toward human-level performance with end-to-end, transaction-based dialog systems</title>
@@ -930,7 +876,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/tickettalk">TicketTalk</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/c4">C4</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/taskmaster-2">Taskmaster-2</pwcdataset>
-      <video href="2021.acl-long.55.mp4"/>
     </paper>
     <paper id="56">
       <title>Improving Dialog Systems for Negotiation with Personality Modeling</title>
@@ -944,7 +889,6 @@
       <bibkey>yang-etal-2021-improving</bibkey>
       <video href="2021.acl-long.56.mp4"/>
       <pwccode url="https://github.com/princeton-nlp/NegotiationToM" additional="false">princeton-nlp/NegotiationToM</pwccode>
-      <video href="2021.acl-long.56.mp4"/>
     </paper>
     <paper id="57">
       <title>Learning from Perturbations: Diverse and Informative Dialogue Generation with Inverse Adversarial Training</title>
@@ -959,7 +903,6 @@
       <video href="2021.acl-long.57.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
-      <video href="2021.acl-long.57.mp4"/>
     </paper>
     <paper id="58">
       <title>Increasing Faithfulness in Knowledge-Grounded Dialogue with Controllable Features</title>
@@ -974,7 +917,6 @@
       <bibkey>rashkin-etal-2021-increasing</bibkey>
       <video href="2021.acl-long.58.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
-      <video href="2021.acl-long.58.mp4"/>
     </paper>
     <paper id="59">
       <title><fixed-case>C</fixed-case>itation<fixed-case>IE</fixed-case>: Leveraging the Citation Graph for Scientific Information Extraction</title>
@@ -990,7 +932,6 @@
       <pwccode url="https://github.com/viswavi/ScigraphIE" additional="false">viswavi/ScigraphIE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scirex">SciREX</pwcdataset>
-      <video href="2021.acl-long.59.mp4"/>
     </paper>
     <paper id="60">
       <title>From Discourse to Narrative: Knowledge Projection for Event Relation Extraction</title>
@@ -1011,7 +952,6 @@
       <pwccode url="https://github.com/TangJiaLong/Knowledge-Projection-for-ERE" additional="false">TangJiaLong/Knowledge-Projection-for-ERE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
-      <video href="2021.acl-long.60.mp4"/>
     </paper>
     <paper id="61">
       <title><fixed-case>A</fixed-case>dv<fixed-case>P</fixed-case>icker: <fixed-case>E</fixed-case>ffectively <fixed-case>L</fixed-case>everaging <fixed-case>U</fixed-case>nlabeled <fixed-case>D</fixed-case>ata via <fixed-case>A</fixed-case>dversarial <fixed-case>D</fixed-case>iscriminator for <fixed-case>C</fixed-case>ross-<fixed-case>L</fixed-case>ingual <fixed-case>NER</fixed-case></title>
@@ -1029,7 +969,6 @@
       <pwccode url="https://github.com/microsoft/vert-papers/tree/master/papers/AdvPicker" additional="false">microsoft/vert-papers</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2002">CoNLL 2002</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
-      <video href="2021.acl-long.61.mp4"/>
     </paper>
     <paper id="62">
       <title>Compare to The Knowledge: Graph Neural Fake News Detection with External Knowledge</title>
@@ -1048,7 +987,6 @@
       <bibkey>hu-etal-2021-compare</bibkey>
       <video href="2021.acl-long.62.mp4"/>
       <pwccode url="https://github.com/ytc272098215/fakenewsdetection" additional="false">ytc272098215/fakenewsdetection</pwccode>
-      <video href="2021.acl-long.62.mp4"/>
     </paper>
     <paper id="63">
       <title>Discontinuous Named Entity Recognition as Maximal Clique Discovery</title>
@@ -1065,7 +1003,6 @@
       <bibkey>wang-etal-2021-discontinuous</bibkey>
       <video href="2021.acl-long.63.mp4"/>
       <pwccode url="https://github.com/131250208/infextraction" additional="false">131250208/infextraction</pwccode>
-      <video href="2021.acl-long.63.mp4"/>
     </paper>
     <paper id="64">
       <title><fixed-case>LNN</fixed-case>-<fixed-case>EL</fixed-case>: A Neuro-Symbolic Approach to Short-text Entity Linking</title>
@@ -1084,7 +1021,6 @@
       <bibkey>jiang-etal-2021-lnn</bibkey>
       <video href="2021.acl-long.64.mp4"/>
       <pwccode url="https://github.com/IBM/LNN" additional="false">IBM/LNN</pwccode>
-      <video href="2021.acl-long.64.mp4"/>
     </paper>
     <paper id="65">
       <title>Do Context-Aware Translation Models Pay the Right Attention?</title>
@@ -1101,7 +1037,6 @@
       <bibkey>yin-etal-2021-context</bibkey>
       <video href="2021.acl-long.65.mp4"/>
       <pwccode url="https://github.com/neulab/contextual-mt" additional="false">neulab/contextual-mt</pwccode>
-      <video href="2021.acl-long.65.mp4"/>
     </paper>
     <paper id="66">
       <title>Adapting High-resource <fixed-case>NMT</fixed-case> Models to Translate Low-resource Related Languages without Parallel Data</title>
@@ -1123,7 +1058,6 @@
       <pwccode url="https://github.com/wjko2/NMT-Adapt" additional="false">wjko2/NMT-Adapt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cc100">CC100</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flores">FLoRes</pwcdataset>
-      <video href="2021.acl-long.66.mp4"/>
     </paper>
     <paper id="67">
       <title>Bilingual Lexicon Induction via Unsupervised Bitext Construction and Word Alignment</title>
@@ -1138,7 +1072,6 @@
       <bibkey>shi-etal-2021-bilingual</bibkey>
       <video href="2021.acl-long.67.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wikimatrix">WikiMatrix</pwcdataset>
-      <video href="2021.acl-long.67.mp4"/>
     </paper>
     <paper id="68">
       <title>Multilingual Speech Translation from Efficient Finetuning of Pretrained Models</title>
@@ -1158,7 +1091,6 @@
       <bibkey>li-etal-2021-multilingual</bibkey>
       <video href="2021.acl-long.68.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/europarl-st">Europarl-ST</pwcdataset>
-      <video href="2021.acl-long.68.mp4"/>
     </paper>
     <paper id="69">
       <title>Learning Faithful Representations of Causal Graphs</title>
@@ -1169,7 +1101,6 @@
       <url hash="e221b59a">2021.acl-long.69</url>
       <doi>10.18653/v1/2021.acl-long.69</doi>
       <bibkey>balashankar-subramanian-2021-learning</bibkey>
-      <video href="2021.acl-long.69.mp4"/>
       <video href="2021.acl-long.69.mp4"/>
     </paper>
     <paper id="70">
@@ -1185,7 +1116,6 @@
       <pwccode url="https://github.com/lingo-mit/context-ablations" additional="false">lingo-mit/context-ablations</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.acl-long.70.mp4"/>
     </paper>
     <paper id="71">
       <title>Integrated Directional Gradients: Feature Interaction Attribution for Neural <fixed-case>NLP</fixed-case> Models</title>
@@ -1201,7 +1131,6 @@
       <pwccode url="https://github.com/parantapa/integrated-directional-gradients" additional="false">parantapa/integrated-directional-gradients</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.71.mp4"/>
     </paper>
     <paper id="72">
       <title><fixed-case>D</fixed-case>e<fixed-case>CLUTR</fixed-case>: Deep Contrastive Learning for Unsupervised Textual Representations</title>
@@ -1223,7 +1152,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.acl-long.72.mp4"/>
     </paper>
     <paper id="73">
       <title><fixed-case>XLPT</fixed-case>-<fixed-case>AMR</fixed-case>: Cross-Lingual Pre-Training via Multi-Task Learning for Zero-Shot <fixed-case>AMR</fixed-case> Parsing and Text Generation</title>
@@ -1237,7 +1165,6 @@
       <url hash="77ddc5d5">2021.acl-long.73</url>
       <doi>10.18653/v1/2021.acl-long.73</doi>
       <bibkey>xu-etal-2021-xlpt</bibkey>
-      <video href="2021.acl-long.73.mp4"/>
       <video href="2021.acl-long.73.mp4"/>
     </paper>
     <paper id="74">
@@ -1253,7 +1180,6 @@
       <pwccode url="https://github.com/jonathanherzig/span-based-sp" additional="false">jonathanherzig/span-based-sp</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/clevr">CLEVR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.acl-long.74.mp4"/>
     </paper>
     <paper id="75">
       <title>Compositional Generalization and Natural Language Variation: Can a Semantic Parsing Approach Handle Both?</title>
@@ -1270,7 +1196,6 @@
       <pwccode url="https://github.com/google-research/language/tree/master/language/nqg" additional="false">google-research/language</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cfq">CFQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.acl-long.75.mp4"/>
     </paper>
     <paper id="76">
       <title>A Targeted Assessment of Incremental Processing in Neural Language Models and Humans</title>
@@ -1284,7 +1209,6 @@
       <bibkey>wilcox-etal-2021-targeted</bibkey>
       <video href="2021.acl-long.76.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/billion-word-benchmark">Billion Word Benchmark</pwcdataset>
-      <video href="2021.acl-long.76.mp4"/>
     </paper>
     <paper id="77">
       <title>The Possible, the Plausible, and the Desirable: Event-Based Modality Detection for Language Processing</title>
@@ -1300,7 +1224,6 @@
       <bibkey>pyatkin-etal-2021-possible</bibkey>
       <video href="2021.acl-long.77.mp4"/>
       <pwccode url="https://github.com/OnlpLab/Modality-Corpus" additional="true">OnlpLab/Modality-Corpus</pwccode>
-      <video href="2021.acl-long.77.mp4"/>
     </paper>
     <paper id="78">
       <title>To <fixed-case>POS</fixed-case> Tag or Not to <fixed-case>POS</fixed-case> Tag: The Impact of <fixed-case>POS</fixed-case> Tags on Morphological Learning in Low-Resource Settings</title>
@@ -1312,7 +1235,6 @@
       <url hash="94c304e4">2021.acl-long.78</url>
       <doi>10.18653/v1/2021.acl-long.78</doi>
       <bibkey>moeller-etal-2021-pos</bibkey>
-      <video href="2021.acl-long.78.mp4"/>
       <video href="2021.acl-long.78.mp4"/>
     </paper>
     <paper id="79">
@@ -1328,7 +1250,6 @@
       <revision id="1" href="2021.acl-long.79v1" hash="432cee73"/>
       <revision id="2" href="2021.acl-long.79v2" hash="54b77a64" date="2021-10-07">Retracted.</revision>
       <retracted date="2021-10-07">An error occurred in the preprocessing of the pitch and intensity features that this model used. This error means that it can no longer be concluded that prosody is as helpful for finding sentence boundaries and parsing as asserted in this paper.</retracted>
-      <video href="2021.acl-long.79.mp4"/>
       <video href="2021.acl-long.79.mp4"/>
     </paper>
     <paper id="80">
@@ -1353,7 +1274,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/common-voice">Common Voice</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/europarl-st">Europarl-ST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
-      <video href="2021.acl-long.80.mp4"/>
     </paper>
     <paper id="81">
       <title>Stereotyping <fixed-case>N</fixed-case>orwegian Salmon: An Inventory of Pitfalls in Fairness Benchmark Datasets</title>
@@ -1371,7 +1291,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/crows-pairs">CrowS-Pairs</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/stereoset">StereoSet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
-      <video href="2021.acl-long.81.mp4"/>
     </paper>
     <paper id="82">
       <title>Robust Knowledge Graph Completion with Stacked Convolutions and a Student Re-Ranking Network</title>
@@ -1389,7 +1308,6 @@
       <pwccode url="https://github.com/justinlovelace/robust-kg-completion" additional="false">justinlovelace/robust-kg-completion</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/umls">UMLS</pwcdataset>
-      <video href="2021.acl-long.82.mp4"/>
     </paper>
     <paper id="83">
       <title>A <fixed-case>DQN</fixed-case>-based Approach to Finding Precise Evidences for Fact Verification</title>
@@ -1407,7 +1325,6 @@
       <video href="2021.acl-long.83.mp4"/>
       <pwccode url="https://github.com/sysulic/dqn-fv" additional="false">sysulic/dqn-fv</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
-      <video href="2021.acl-long.83.mp4"/>
     </paper>
     <paper id="84">
       <title>The Art of Abstention: Selective Prediction and Error Regularization for Natural Language Processing</title>
@@ -1427,7 +1344,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.84.mp4"/>
     </paper>
     <paper id="85">
       <title>Unsupervised Out-of-Domain Detection via Pre-trained Transformers</title>
@@ -1445,7 +1361,6 @@
       <pwccode url="https://github.com/rivercold/BERT-unsupervised-OOD" additional="false">rivercold/BERT-unsupervised-OOD</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.85.mp4"/>
     </paper>
     <paper id="86">
       <title><fixed-case>MATE</fixed-case>-<fixed-case>KD</fixed-case>: Masked Adversarial <fixed-case>TE</fixed-case>xt, a Companion to Knowledge Distillation</title>
@@ -1461,7 +1376,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paws">PAWS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.86.mp4"/>
     </paper>
     <paper id="87">
       <title>Selecting Informative Contexts Improves Language Model Fine-tuning</title>
@@ -1478,7 +1392,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.acl-long.87.mp4"/>
     </paper>
     <paper id="88">
       <title>Explainable Prediction of Text Complexity: The Missing Preliminaries for Text Simplification</title>
@@ -1494,7 +1407,6 @@
       <video href="2021.acl-long.88.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/newsela">Newsela</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikilarge">WikiLarge</pwcdataset>
-      <video href="2021.acl-long.88.mp4"/>
     </paper>
     <paper id="89">
       <title>Multi-Task Retrieval for Knowledge-Intensive Tasks</title>
@@ -1515,7 +1427,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/kilt">KILT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-long.89.mp4"/>
     </paper>
     <paper id="90">
       <title>When Do You Need Billions of Words of Pretraining Data?</title>
@@ -1535,7 +1446,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/copa">COPA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
-      <video href="2021.acl-long.90.mp4"/>
     </paper>
     <paper id="91">
       <title>Analyzing the Source and Target Contributions to Predictions in Neural Machine Translation</title>
@@ -1549,7 +1459,6 @@
       <bibkey>voita-etal-2021-analyzing</bibkey>
       <video href="2021.acl-long.91.mp4"/>
       <pwccode url="https://github.com/lena-voita/the-story-of-heads" additional="false">lena-voita/the-story-of-heads</pwccode>
-      <video href="2021.acl-long.91.mp4"/>
     </paper>
     <paper id="92">
       <title>Comparing Test Sets with Item Response Theory</title>
@@ -1588,7 +1497,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
-      <video href="2021.acl-long.92.mp4"/>
     </paper>
     <paper id="93">
       <title>Uncovering Constraint-Based Behavior in Neural Models via Targeted Fine-Tuning</title>
@@ -1601,7 +1509,6 @@
       <bibkey>davis-van-schijndel-2021-uncovering</bibkey>
       <video href="2021.acl-long.93.mp4"/>
       <pwccode url="https://github.com/forrestdavis/ImplicitCausality" additional="false">forrestdavis/ImplicitCausality</pwccode>
-      <video href="2021.acl-long.93.mp4"/>
     </paper>
     <paper id="94">
       <title>More Identifiable yet Equally Performant Transformers for Text Classification</title>
@@ -1620,7 +1527,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.94.mp4"/>
     </paper>
     <paper id="95">
       <title><fixed-case>A</fixed-case>ug<fixed-case>NLG</fixed-case>: Few-shot Natural Language Generation using Self-trained Data Augmentation</title>
@@ -1635,7 +1541,6 @@
       <bibkey>xu-etal-2021-augnlg</bibkey>
       <video href="2021.acl-long.95.mp4"/>
       <pwccode url="https://github.com/XinnuoXu/AugNLG" additional="false">XinnuoXu/AugNLG</pwccode>
-      <video href="2021.acl-long.95.mp4"/>
     </paper>
     <paper id="96">
       <title>Can vectors read minds better than experts? Comparing data augmentation strategies for the automated scoring of children’s mindreading ability</title>
@@ -1648,7 +1553,6 @@
       <url hash="95e14ae4">2021.acl-long.96</url>
       <doi>10.18653/v1/2021.acl-long.96</doi>
       <bibkey>kovatchev-etal-2021-vectors</bibkey>
-      <video href="2021.acl-long.96.mp4"/>
       <video href="2021.acl-long.96.mp4"/>
     </paper>
     <paper id="97">
@@ -1667,7 +1571,6 @@
       <video href="2021.acl-long.97.mp4"/>
       <pwccode url="https://github.com/zhangmozhi/mrs" additional="false">zhangmozhi/mrs</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mrs">MRS</pwcdataset>
-      <video href="2021.acl-long.97.mp4"/>
     </paper>
     <paper id="98">
       <title>What Ingredients Make for an Effective Crowdsourcing Protocol for Difficult <fixed-case>NLU</fixed-case> Data Collection Tasks?</title>
@@ -1687,7 +1590,6 @@
       <pwccode url="https://github.com/nyu-mll/crowdsourcing-protocol-comparison" additional="false">nyu-mll/crowdsourcing-protocol-comparison</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cosmosqa">CosmosQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
-      <video href="2021.acl-long.98.mp4"/>
     </paper>
     <paper id="99">
       <title>Align Voting Behavior with Public Statements for Legislator Representation Learning</title>
@@ -1704,7 +1606,6 @@
       <doi>10.18653/v1/2021.acl-long.99</doi>
       <bibkey>mou-etal-2021-align</bibkey>
       <video href="2021.acl-long.99.mp4"/>
-      <video href="2021.acl-long.99.mp4"/>
     </paper>
     <paper id="100">
       <title>Measure and Evaluation of Semantic Divergence across Two Languages</title>
@@ -1715,7 +1616,6 @@
       <url hash="f2fa2653">2021.acl-long.100</url>
       <doi>10.18653/v1/2021.acl-long.100</doi>
       <bibkey>montariol-allauzen-2021-measure</bibkey>
-      <video href="2021.acl-long.100.mp4"/>
       <video href="2021.acl-long.100.mp4"/>
     </paper>
     <paper id="101">
@@ -1734,7 +1634,6 @@
       <video href="2021.acl-long.101.mp4"/>
       <pwccode url="https://github.com/nlp-dke/NMTGMinor/tree/master/recipes/zero-shot" additional="false">nlp-dke/NMTGMinor</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/pmindia">PMIndia</pwcdataset>
-      <video href="2021.acl-long.101.mp4"/>
     </paper>
     <paper id="102">
       <title>Common Sense Beyond <fixed-case>E</fixed-case>nglish: Evaluating and Improving Multilingual Language Models for Commonsense Reasoning</title>
@@ -1756,7 +1655,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/lama">LAMA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/swag">SWAG</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.acl-long.102.mp4"/>
     </paper>
     <paper id="103">
       <title>Attention Calibration for Transformer in Neural Machine Translation</title>
@@ -1771,7 +1669,6 @@
       <doi>10.18653/v1/2021.acl-long.103</doi>
       <bibkey>lu-etal-2021-attention</bibkey>
       <video href="2021.acl-long.103.mp4"/>
-      <video href="2021.acl-long.103.mp4"/>
     </paper>
     <paper id="104">
       <title>Diverse Pretrained Context Encodings Improve Document Translation</title>
@@ -1783,7 +1680,6 @@
       <url hash="a379c6b3">2021.acl-long.104</url>
       <doi>10.18653/v1/2021.acl-long.104</doi>
       <bibkey>donato-etal-2021-diverse</bibkey>
-      <video href="2021.acl-long.104.mp4"/>
       <video href="2021.acl-long.104.mp4"/>
     </paper>
     <paper id="105">
@@ -1802,7 +1698,6 @@
       <bibkey>khemchandani-etal-2021-exploiting</bibkey>
       <video href="2021.acl-long.105.mp4"/>
       <pwccode url="https://github.com/yashkhem1/RelateLM" additional="false">yashkhem1/RelateLM</pwccode>
-      <video href="2021.acl-long.105.mp4"/>
     </paper>
     <paper id="106">
       <title>On Finding the K-best Non-projective Dependency Trees</title>
@@ -1816,7 +1711,6 @@
       <bibkey>zmigrod-etal-2021-finding</bibkey>
       <video href="2021.acl-long.106.mp4"/>
       <pwccode url="https://github.com/rycolab/spanningtrees" additional="false">rycolab/spanningtrees</pwccode>
-      <video href="2021.acl-long.106.mp4"/>
     </paper>
     <paper id="107">
       <title>Towards Argument Mining for Social Good: A Survey</title>
@@ -1830,7 +1724,6 @@
       <doi>10.18653/v1/2021.acl-long.107</doi>
       <bibkey>vecchi-etal-2021-towards</bibkey>
       <video href="2021.acl-long.107.mp4"/>
-      <video href="2021.acl-long.107.mp4"/>
     </paper>
     <paper id="108">
       <title><fixed-case>A</fixed-case>utomated Generation of Storytelling Vocabulary from Photographs for use in <fixed-case>AAC</fixed-case></title>
@@ -1843,7 +1736,6 @@
       <bibkey>fontana-de-vargas-moffatt-2021-automated</bibkey>
       <video href="2021.acl-long.108.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/vist">VIST</pwcdataset>
-      <video href="2021.acl-long.108.mp4"/>
     </paper>
     <paper id="109">
       <title><fixed-case>CLIP</fixed-case>: A Dataset for Extracting Action Items for Physicians from Hospital Discharge Notes</title>
@@ -1865,7 +1757,6 @@
       <pwccode url="https://github.com/asappresearch/clip" additional="false">asappresearch/clip</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/clip">CLIP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mimic-iii">MIMIC-III</pwcdataset>
-      <video href="2021.acl-long.109.mp4"/>
     </paper>
     <paper id="110">
       <title>Assessing Emoji Use in Modern Text Processing Tools</title>
@@ -1879,7 +1770,6 @@
       <revision id="1" href="2021.acl-long.110v1" hash="f04d6638"/>
       <revision id="2" href="2021.acl-long.110v2" hash="81ab714b" date="2021-08-12">Added missing subsections in section 6</revision>
       <video href="2021.acl-long.110.mp4"/>
-      <video href="2021.acl-long.110.mp4"/>
     </paper>
     <paper id="111">
       <title>Select, Extract and Generate: Neural Keyphrase Generation with Layer-wise Coverage Attention</title>
@@ -1892,7 +1782,6 @@
       <url hash="e0fd9d3d">2021.acl-long.111</url>
       <doi>10.18653/v1/2021.acl-long.111</doi>
       <bibkey>ahmad-etal-2021-select</bibkey>
-      <video href="2021.acl-long.111.mp4"/>
       <video href="2021.acl-long.111.mp4"/>
     </paper>
     <paper id="112">
@@ -1909,7 +1798,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paralex">Paralex</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quora-question-pairs">Quora Question Pairs</pwcdataset>
-      <video href="2021.acl-long.112.mp4"/>
     </paper>
     <paper id="113">
       <title><fixed-case>A</fixed-case>gg<fixed-case>G</fixed-case>en: Ordering and Aggregating while Generating</title>
@@ -1925,7 +1813,6 @@
       <video href="2021.acl-long.113.mp4"/>
       <pwccode url="https://github.com/XinnuoXu/AggGen" additional="false">XinnuoXu/AggGen</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.acl-long.113.mp4"/>
     </paper>
     <paper id="114">
       <title>Reflective Decoding: Beyond Unidirectional Generation with Off-the-Shelf Language Models</title>
@@ -1940,7 +1827,6 @@
       <url hash="9c6631ba">2021.acl-long.114</url>
       <doi>10.18653/v1/2021.acl-long.114</doi>
       <bibkey>west-etal-2021-reflective</bibkey>
-      <video href="2021.acl-long.114.mp4"/>
       <video href="2021.acl-long.114.mp4"/>
     </paper>
     <paper id="115">
@@ -1958,7 +1844,6 @@
       <video href="2021.acl-long.115.mp4"/>
       <pwccode url="https://github.com/titech-nlp/numeric-nlg" additional="false">titech-nlp/numeric-nlg</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/rotowire">RotoWire</pwcdataset>
-      <video href="2021.acl-long.115.mp4"/>
     </paper>
     <paper id="116">
       <title><fixed-case>BACO</fixed-case>: A Background Knowledge- and Content-Based Framework for Citing Sentence Generation</title>
@@ -1976,7 +1861,6 @@
       <doi>10.18653/v1/2021.acl-long.116</doi>
       <bibkey>ge-etal-2021-baco</bibkey>
       <video href="2021.acl-long.116.mp4"/>
-      <video href="2021.acl-long.116.mp4"/>
     </paper>
     <paper id="117">
       <title>Language Model as an Annotator: Exploring <fixed-case>D</fixed-case>ialo<fixed-case>GPT</fixed-case> for Dialogue Summarization</title>
@@ -1993,7 +1877,6 @@
       <video href="2021.acl-long.117.mp4"/>
       <pwccode url="https://github.com/xcfcode/PLM_annotator" additional="false">xcfcode/PLM_annotator</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.acl-long.117.mp4"/>
     </paper>
     <paper id="118">
       <title>Challenges in Information-Seeking <fixed-case>QA</fixed-case>: Unanswerable Questions and Paragraph Retrieval</title>
@@ -2008,7 +1891,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coqa">CoQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
-      <video href="2021.acl-long.118.mp4"/>
     </paper>
     <paper id="119">
       <title>A Gradually Soft Multi-Task and Data-Augmented Approach to Medical Question Understanding</title>
@@ -2028,7 +1910,6 @@
       <pwccode url="https://github.com/khalilmrini/medical-question-understanding" additional="false">khalilmrini/medical-question-understanding</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meqsum">MeQSum</pwcdataset>
-      <video href="2021.acl-long.119.mp4"/>
     </paper>
     <paper id="120">
       <title>Leveraging Type Descriptions for Zero-shot Named Entity Recognition and Classification</title>
@@ -2042,7 +1923,6 @@
       <bibkey>aly-etal-2021-leveraging</bibkey>
       <video href="2021.acl-long.120.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/medmentions">MedMentions</pwcdataset>
-      <video href="2021.acl-long.120.mp4"/>
     </paper>
     <paper id="121">
       <title><fixed-case>MECT</fixed-case>: <fixed-case>M</fixed-case>ulti-Metadata Embedding based Cross-Transformer for <fixed-case>C</fixed-case>hinese Named Entity Recognition</title>
@@ -2056,7 +1936,6 @@
       <bibkey>wu-etal-2021-mect</bibkey>
       <video href="2021.acl-long.121.mp4"/>
       <pwccode url="https://github.com/CoderMusou/MECT4CNER" additional="false">CoderMusou/MECT4CNER</pwccode>
-      <video href="2021.acl-long.121.mp4"/>
     </paper>
     <paper id="122">
       <title>Factuality Assessment as Modal Dependency Parsing</title>
@@ -2072,7 +1951,6 @@
       <bibkey>yao-etal-2021-factuality</bibkey>
       <video href="2021.acl-long.122.mp4"/>
       <pwccode url="https://github.com/jryao/modal_dependency" additional="false">jryao/modal_dependency</pwccode>
-      <video href="2021.acl-long.122.mp4"/>
     </paper>
     <paper id="123">
       <title>Directed Acyclic Graph Network for Conversational Emotion Recognition</title>
@@ -2091,7 +1969,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/emorynlp">EmoryNLP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
-      <video href="2021.acl-long.123.mp4"/>
     </paper>
     <paper id="124">
       <title>Improving Formality Style Transfer with Context-Aware Rule Injection</title>
@@ -2104,7 +1981,6 @@
       <bibkey>yao-yu-2021-improving</bibkey>
       <video href="2021.acl-long.124.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
-      <video href="2021.acl-long.124.mp4"/>
     </paper>
     <paper id="125">
       <title>Topic-Driven and Knowledge-Aware Transformer for Dialogue Emotion Detection</title>
@@ -2125,7 +2001,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/emorynlp">EmoryNLP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
-      <video href="2021.acl-long.125.mp4"/>
     </paper>
     <paper id="126">
       <title>Syntopical Graphs for Computational Argumentation Tasks</title>
@@ -2144,7 +2019,6 @@
       <doi>10.18653/v1/2021.acl-long.126</doi>
       <bibkey>barrow-etal-2021-syntopical</bibkey>
       <video href="2021.acl-long.126.mp4"/>
-      <video href="2021.acl-long.126.mp4"/>
     </paper>
     <paper id="127">
       <title>Stance Detection in <fixed-case>COVID</fixed-case>-19 Tweets</title>
@@ -2158,7 +2032,6 @@
       <url hash="0e4353d5">2021.acl-long.127</url>
       <doi>10.18653/v1/2021.acl-long.127</doi>
       <bibkey>glandt-etal-2021-stance</bibkey>
-      <video href="2021.acl-long.127.mp4"/>
       <video href="2021.acl-long.127.mp4"/>
     </paper>
     <paper id="128">
@@ -2176,7 +2049,6 @@
       <video href="2021.acl-long.128.mp4"/>
       <pwccode url="https://github.com/jasenchn/TARSA" additional="false">jasenchn/TARSA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
-      <video href="2021.acl-long.128.mp4"/>
     </paper>
     <paper id="129">
       <title>Changes in <fixed-case>E</fixed-case>uropean Solidarity Before and During <fixed-case>COVID</fixed-case>-19: Evidence from a Large Crowd- and Expert-Annotated <fixed-case>T</fixed-case>witter Dataset</title>
@@ -2191,7 +2063,6 @@
       <bibkey>ils-etal-2021-changes</bibkey>
       <video href="2021.acl-long.129.mp4"/>
       <pwccode url="https://github.com/lalashiwoya/socialsolidarityCOVID19" additional="false">lalashiwoya/socialsolidarityCOVID19</pwccode>
-      <video href="2021.acl-long.129.mp4"/>
     </paper>
     <paper id="130">
       <title>Measuring Conversational Uptake: A Case Study on Student-Teacher Interactions</title>
@@ -2209,7 +2080,6 @@
       <bibkey>demszky-etal-2021-measuring</bibkey>
       <video href="2021.acl-long.130.mp4"/>
       <pwccode url="https://github.com/ddemszky/conversational-uptake" additional="false">ddemszky/conversational-uptake</pwccode>
-      <video href="2021.acl-long.130.mp4"/>
     </paper>
     <paper id="131">
       <title>A Survey of Code-switching: Linguistic and Social Perspectives for Language Technologies</title>
@@ -2222,7 +2092,6 @@
       <url hash="39da2b13">2021.acl-long.131</url>
       <doi>10.18653/v1/2021.acl-long.131</doi>
       <bibkey>dogruoz-etal-2021-survey</bibkey>
-      <video href="2021.acl-long.131.mp4"/>
       <video href="2021.acl-long.131.mp4"/>
     </paper>
     <paper id="132">
@@ -2239,7 +2108,6 @@
       <bibkey>vidgen-etal-2021-learning</bibkey>
       <video href="2021.acl-long.132.mp4"/>
       <pwccode url="https://github.com/bvidgen/Dynamically-Generated-Hate-Speech-Dataset" additional="true">bvidgen/Dynamically-Generated-Hate-Speech-Dataset</pwccode>
-      <video href="2021.acl-long.132.mp4"/>
     </paper>
     <paper id="133">
       <title><fixed-case>I</fixed-case>nfo<fixed-case>S</fixed-case>urgeon: Cross-Media Fine-grained Information Consistency Checking for Fake News Detection</title>
@@ -2260,7 +2128,6 @@
       <video href="2021.acl-long.133.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/neuralnews">NeuralNews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/realnews">RealNews</pwcdataset>
-      <video href="2021.acl-long.133.mp4"/>
     </paper>
     <paper id="134">
       <title><fixed-case>I</fixed-case> like fish, especially dolphins: Addressing Contradictions in Dialogue Modeling</title>
@@ -2282,7 +2149,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
-      <video href="2021.acl-long.134.mp4"/>
     </paper>
     <paper id="135">
       <title>A Sequence-to-Sequence Approach to Dialogue State Tracking</title>
@@ -2301,7 +2167,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sgd">SGD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-oz">Wizard-of-Oz</pwcdataset>
-      <video href="2021.acl-long.135.mp4"/>
     </paper>
     <paper id="136">
       <title>Discovering Dialog Structure Graph for Coherent Dialog Generation</title>
@@ -2318,7 +2183,6 @@
       <bibkey>xu-etal-2021-discovering</bibkey>
       <video href="2021.acl-long.136.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/douban">Douban</pwcdataset>
-      <video href="2021.acl-long.136.mp4"/>
     </paper>
     <paper id="137">
       <title>Dialogue Response Selection with Hierarchical Curriculum Learning</title>
@@ -2341,7 +2205,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/douban">Douban</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/e-commerce-1">E-commerce</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rrs">RRS</pwcdataset>
-      <video href="2021.acl-long.137.mp4"/>
     </paper>
     <paper id="138">
       <title>A Joint Model for Dropped Pronoun Recovery and Conversational Discourse Parsing in <fixed-case>C</fixed-case>hinese Conversational Speech</title>
@@ -2360,7 +2223,6 @@
       <bibkey>yang-etal-2021-joint</bibkey>
       <video href="2021.acl-long.138.mp4"/>
       <pwccode url="https://github.com/ningningyang/DiscProReco" additional="false">ningningyang/DiscProReco</pwccode>
-      <video href="2021.acl-long.138.mp4"/>
     </paper>
     <paper id="139">
       <title>A Systematic Investigation of <fixed-case>KB</fixed-case>-Text Embedding Alignment at Scale</title>
@@ -2378,7 +2240,6 @@
       <bibkey>pahuja-etal-2021-systematic</bibkey>
       <video href="2021.acl-long.139.mp4"/>
       <pwccode url="https://github.com/dki-lab/joint-kb-text-embedding" additional="false">dki-lab/joint-kb-text-embedding</pwccode>
-      <video href="2021.acl-long.139.mp4"/>
     </paper>
     <paper id="140">
       <title>Named Entity Recognition with Small Strongly Labeled and Large Weakly Labeled Data</title>
@@ -2395,7 +2256,6 @@
       <video href="2021.acl-long.140.mp4"/>
       <pwccode url="https://github.com/amzn/amazon-weak-ner-needle" additional="false">amzn/amazon-weak-ner-needle</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ncbi-disease-1">NCBI Disease</pwcdataset>
-      <video href="2021.acl-long.140.mp4"/>
     </paper>
     <paper id="141">
       <title>Ultra-Fine Entity Typing with Weak Supervision from a Masked Language Model</title>
@@ -2411,7 +2271,6 @@
       <pwccode url="https://github.com/HKUST-KnowComp/MLMET" additional="false">HKUST-KnowComp/MLMET</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ontonotes-5-0">OntoNotes 5.0</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/open-entity-1">Open Entity</pwcdataset>
-      <video href="2021.acl-long.141.mp4"/>
     </paper>
     <paper id="142">
       <title>Improving Named Entity Recognition by External Context Retrieving and Cooperative Learning</title>
@@ -2435,7 +2294,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ncbi-disease-1">NCBI Disease</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2016-ner">WNUT 2016 NER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
-      <video href="2021.acl-long.142.mp4"/>
     </paper>
     <paper id="143">
       <title>Implicit Representations of Meaning in Neural Language Models</title>
@@ -2449,7 +2307,6 @@
       <bibkey>li-etal-2021-implicit</bibkey>
       <video href="2021.acl-long.143.mp4"/>
       <pwccode url="https://github.com/belindal/state-probes" additional="false">belindal/state-probes</pwccode>
-      <video href="2021.acl-long.143.mp4"/>
     </paper>
     <paper id="144">
       <title>Causal Analysis of Syntactic Agreement Mechanisms in Neural Language Models</title>
@@ -2466,7 +2323,6 @@
       <bibkey>finlayson-etal-2021-causal</bibkey>
       <video href="2021.acl-long.144.mp4"/>
       <pwccode url="https://github.com/mattf1n/lm-intervention" additional="false">mattf1n/lm-intervention</pwccode>
-      <video href="2021.acl-long.144.mp4"/>
     </paper>
     <paper id="145">
       <title>Bird’s Eye: Probing for Linguistic Graph Structures with a Simple Information-Theoretic Approach</title>
@@ -2481,7 +2337,6 @@
       <pwccode url="https://github.com/yifan-h/Graph_Probe-Birds_Eye" additional="false">yifan-h/Graph_Probe-Birds_Eye</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/amr-bank">AMR Bank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.acl-long.145.mp4"/>
     </paper>
     <paper id="146">
       <title>Knowledgeable or Educated Guess? Revisiting Language Models as Knowledge Bases</title>
@@ -2503,7 +2358,6 @@
       <pwccode url="https://github.com/c-box/LANKA" additional="false">c-box/LANKA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/commonsenseqa">CommonsenseQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/lama">LAMA</pwcdataset>
-      <video href="2021.acl-long.146.mp4"/>
     </paper>
     <paper id="147">
       <title>Poisoning Knowledge Graph Embeddings via Relation Inference Patterns</title>
@@ -2519,7 +2373,6 @@
       <video href="2021.acl-long.147.mp4"/>
       <pwccode url="https://github.com/perubhardwaj/inferenceattack" additional="false">perubhardwaj/inferenceattack</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
-      <video href="2021.acl-long.147.mp4"/>
     </paper>
     <paper id="148">
       <title>Bad Seeds: Evaluating Lexical Methods for Bias Measurement</title>
@@ -2533,7 +2386,6 @@
       <bibkey>antoniak-mimno-2021-bad</bibkey>
       <video href="2021.acl-long.148.mp4"/>
       <pwccode url="https://github.com/maria-antoniak/bad-seeds" additional="false">maria-antoniak/bad-seeds</pwccode>
-      <video href="2021.acl-long.148.mp4"/>
     </paper>
     <paper id="149">
       <title>A Survey of Race, Racism, and Anti-Racism in <fixed-case>NLP</fixed-case></title>
@@ -2548,7 +2400,6 @@
       <bibkey>field-etal-2021-survey</bibkey>
       <video href="2021.acl-long.149.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/hate-speech">Hate Speech</pwcdataset>
-      <video href="2021.acl-long.149.mp4"/>
     </paper>
     <paper id="150">
       <title>Intrinsic Bias Metrics Do Not Correlate with Application Bias</title>
@@ -2564,7 +2415,6 @@
       <bibkey>goldfarb-tarrant-etal-2021-intrinsic</bibkey>
       <video href="2021.acl-long.150.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
-      <video href="2021.acl-long.150.mp4"/>
     </paper>
     <paper id="151">
       <title><fixed-case>R</fixed-case>eddit<fixed-case>B</fixed-case>ias: A Real-World Resource for Bias Evaluation and Debiasing of Conversational Language Models</title>
@@ -2580,7 +2430,6 @@
       <video href="2021.acl-long.151.mp4"/>
       <pwccode url="https://github.com/umanlp/RedditBias" additional="false">umanlp/RedditBias</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.acl-long.151.mp4"/>
     </paper>
     <paper id="152">
       <title>Contributions of Transformer Attention Heads in Multi- and Cross-lingual Tasks</title>
@@ -2594,7 +2443,6 @@
       <url hash="7781f6e0">2021.acl-long.152</url>
       <doi>10.18653/v1/2021.acl-long.152</doi>
       <bibkey>ma-etal-2021-contributions</bibkey>
-      <video href="2021.acl-long.152.mp4"/>
       <video href="2021.acl-long.152.mp4"/>
     </paper>
     <paper id="153">
@@ -2610,7 +2458,6 @@
       <doi>10.18653/v1/2021.acl-long.153</doi>
       <bibkey>zhang-etal-2021-crafting</bibkey>
       <video href="2021.acl-long.153.mp4"/>
-      <video href="2021.acl-long.153.mp4"/>
     </paper>
     <paper id="154">
       <title><fixed-case>UXLA</fixed-case>: A Robust Unsupervised Data Augmentation Framework for Zero-Resource Cross-Lingual <fixed-case>NLP</fixed-case></title>
@@ -2625,7 +2472,6 @@
       <video href="2021.acl-long.154.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/paws-x">PAWS-X</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.acl-long.154.mp4"/>
     </paper>
     <paper id="155">
       <title>Glancing Transformer for Non-Autoregressive Neural Machine Translation</title>
@@ -2644,7 +2490,6 @@
       <bibkey>qian-etal-2021-glancing</bibkey>
       <video href="2021.acl-long.155.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
-      <video href="2021.acl-long.155.mp4"/>
     </paper>
     <paper id="156">
       <title>Hierarchical Context-aware Network for Dense Video Event Captioning</title>
@@ -2661,7 +2506,6 @@
       <pwccode url="https://github.com/kirkguo/hcn" additional="false">kirkguo/hcn</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/activitynet-captions">ActivityNet Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/youcook2">YouCook2</pwcdataset>
-      <video href="2021.acl-long.156.mp4"/>
     </paper>
     <paper id="157">
       <title>Control Image Captioning Spatially and Temporally</title>
@@ -2678,7 +2522,6 @@
       <bibkey>yan-etal-2021-control</bibkey>
       <video href="2021.acl-long.157.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/localized-narratives">Localized Narratives</pwcdataset>
-      <video href="2021.acl-long.157.mp4"/>
     </paper>
     <paper id="158">
       <title>Edited Media Understanding Frames: Reasoning About the Intent and Implications of Visual Misinformation</title>
@@ -2696,7 +2539,6 @@
       <bibkey>da-etal-2021-edited</bibkey>
       <video href="2021.acl-long.158.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptual-captions">Conceptual Captions</pwcdataset>
-      <video href="2021.acl-long.158.mp4"/>
     </paper>
     <paper id="159">
       <title><fixed-case>PIGL</fixed-case>e<fixed-case>T</fixed-case>: Language Grounding Through Neuro-Symbolic Interaction in a 3<fixed-case>D</fixed-case> World</title>
@@ -2715,7 +2557,6 @@
       <bibkey>zellers-etal-2021-piglet</bibkey>
       <video href="2021.acl-long.159.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/vcr">VCR</pwcdataset>
-      <video href="2021.acl-long.159.mp4"/>
     </paper>
     <paper id="160">
       <title>Modeling Fine-Grained Entity Types with Box Embeddings</title>
@@ -2732,7 +2573,6 @@
       <pwccode url="https://github.com/yasumasaonoe/Box4Types" additional="false">yasumasaonoe/Box4Types</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/figer">FIGER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/open-entity-1">Open Entity</pwcdataset>
-      <video href="2021.acl-long.160.mp4"/>
     </paper>
     <paper id="161">
       <title><fixed-case>C</fixed-case>hinese<fixed-case>BERT</fixed-case>: <fixed-case>C</fixed-case>hinese Pretraining Enhanced by Glyph and <fixed-case>P</fixed-case>inyin Information</title>
@@ -2755,7 +2595,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/clue">CLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cmrc">CMRC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cmrc-2018">CMRC 2018</pwcdataset>
-      <video href="2021.acl-long.161.mp4"/>
     </paper>
     <paper id="162">
       <title>Weight Distillation: Transferring the Knowledge in Neural Network Parameters</title>
@@ -2771,7 +2610,6 @@
       <url hash="cdb966d5">2021.acl-long.162</url>
       <doi>10.18653/v1/2021.acl-long.162</doi>
       <bibkey>lin-etal-2021-weight</bibkey>
-      <video href="2021.acl-long.162.mp4"/>
       <video href="2021.acl-long.162.mp4"/>
     </paper>
     <paper id="163">
@@ -2793,7 +2631,6 @@
       <video href="2021.acl-long.163.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/reclor">ReClor</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/spider-1">SPIDER</pwcdataset>
-      <video href="2021.acl-long.163.mp4"/>
     </paper>
     <paper id="164">
       <title><fixed-case>BERTAC</fixed-case>: Enhancing Transformer-based Language Models with Adversarially Pretrained Convolutional Neural Networks</title>
@@ -2813,7 +2650,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/quasar-1">QUASAR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quasar-t">QUASAR-T</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
-      <video href="2021.acl-long.164.mp4"/>
     </paper>
     <paper id="165">
       <title><fixed-case>COVID</fixed-case>-Fact: Fact Extraction and Verification of Real-World Claims on <fixed-case>COVID</fixed-case>-19 Pandemic</title>
@@ -2834,7 +2670,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multifc">MultiFC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scifact">SciFact</pwcdataset>
-      <video href="2021.acl-long.165.mp4"/>
     </paper>
     <paper id="166">
       <title>Explaining Relationships Between Scientific Documents</title>
@@ -2851,7 +2686,6 @@
       <bibkey>luu-etal-2021-explaining</bibkey>
       <video href="2021.acl-long.166.mp4"/>
       <pwccode url="https://github.com/kel-lu/scigen" additional="false">kel-lu/scigen</pwccode>
-      <video href="2021.acl-long.166.mp4"/>
     </paper>
     <paper id="167">
       <title><fixed-case>I</fixed-case>r<fixed-case>E</fixed-case>ne: Interpretable Energy Prediction for Transformers</title>
@@ -2868,7 +2702,6 @@
       <video href="2021.acl-long.167.mp4"/>
       <pwccode url="https://github.com/StonyBrookNLP/irene" additional="false">StonyBrookNLP/irene</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.167.mp4"/>
     </paper>
     <paper id="168">
       <title>Mitigating Bias in Session-based Cyberbullying Detection: A Non-Compromising Approach</title>
@@ -2884,7 +2717,6 @@
       <bibkey>cheng-etal-2021-mitigating</bibkey>
       <video href="2021.acl-long.168.mp4"/>
       <pwccode url="https://github.com/githublucheng/mitigatebiassessioncb" additional="false">githublucheng/mitigatebiassessioncb</pwccode>
-      <video href="2021.acl-long.168.mp4"/>
     </paper>
     <paper id="169">
       <title><fixed-case>P</fixed-case>lot<fixed-case>C</fixed-case>oder: Hierarchical Decoding for Synthesizing Visualization Code in Programmatic Context</title>
@@ -2900,7 +2732,6 @@
       <video href="2021.acl-long.169.mp4"/>
       <pwccode url="https://github.com/jungyhuk/plotcoder" additional="false">jungyhuk/plotcoder</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/juice">JuICe</pwcdataset>
-      <video href="2021.acl-long.169.mp4"/>
     </paper>
     <paper id="170">
       <title>Changing the World by Changing the Data</title>
@@ -2910,7 +2741,6 @@
       <url hash="b5c8228f">2021.acl-long.170</url>
       <doi>10.18653/v1/2021.acl-long.170</doi>
       <bibkey>rogers-2021-changing</bibkey>
-      <video href="2021.acl-long.170.mp4"/>
       <video href="2021.acl-long.170.mp4"/>
     </paper>
     <paper id="171">
@@ -2931,7 +2761,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.171.mp4"/>
     </paper>
     <paper id="172">
       <title>On the Effectiveness of Adapter-based Tuning for Pretrained Language Model Adaptation</title>
@@ -2952,7 +2781,6 @@
       <video href="2021.acl-long.172.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.172.mp4"/>
     </paper>
     <paper id="173">
       <title>Data Augmentation for Text Generation Without Any Augmented Data</title>
@@ -2964,7 +2792,6 @@
       <url hash="bfa9d7e3">2021.acl-long.173</url>
       <doi>10.18653/v1/2021.acl-long.173</doi>
       <bibkey>bi-etal-2021-data</bibkey>
-      <video href="2021.acl-long.173.mp4"/>
       <video href="2021.acl-long.173.mp4"/>
     </paper>
     <paper id="174">
@@ -2985,7 +2812,6 @@
       <bibkey>ou-etal-2021-integrating</bibkey>
       <video href="2021.acl-long.174.mp4"/>
       <pwccode url="https://github.com/J-zin/SNUH" additional="false">J-zin/SNUH</pwccode>
-      <video href="2021.acl-long.174.mp4"/>
     </paper>
     <paper id="175">
       <title><fixed-case>SMURF</fixed-case>: <fixed-case>S</fixed-case>e<fixed-case>M</fixed-case>antic and linguistic <fixed-case>U</fixed-case>nde<fixed-case>R</fixed-case>standing Fusion for Caption Evaluation via Typicality Analysis</title>
@@ -2999,7 +2825,6 @@
       <video href="2021.acl-long.175.mp4"/>
       <pwccode url="https://github.com/JoshuaFeinglass/SMURF" additional="false">JoshuaFeinglass/SMURF</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
-      <video href="2021.acl-long.175.mp4"/>
     </paper>
     <paper id="176">
       <title><fixed-case>K</fixed-case>aggle<fixed-case>DBQA</fixed-case>: Realistic Evaluation of Text-to-<fixed-case>SQL</fixed-case> Parsers</title>
@@ -3014,7 +2839,6 @@
       <video href="2021.acl-long.176.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/spider-1">SPIDER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
-      <video href="2021.acl-long.176.mp4"/>
     </paper>
     <paper id="177">
       <title><fixed-case>QASR</fixed-case>: <fixed-case>QCRI</fixed-case> Aljazeera Speech Resource A Large Scale Annotated <fixed-case>A</fixed-case>rabic Speech Corpus</title>
@@ -3029,7 +2853,6 @@
       <bibkey>mubarak-etal-2021-qasr</bibkey>
       <video href="2021.acl-long.177.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/voxceleb1">VoxCeleb1</pwcdataset>
-      <video href="2021.acl-long.177.mp4"/>
     </paper>
     <paper id="178">
       <title>An Empirical Study on Hyperparameter Optimization for Fine-Tuning Pre-trained Language Models</title>
@@ -3045,7 +2868,6 @@
       <pwccode url="https://github.com/microsoft/FLAML" additional="false">microsoft/FLAML</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.178.mp4"/>
     </paper>
     <paper id="179">
       <title>Better than Average: Paired Evaluation of <fixed-case>NLP</fixed-case> systems</title>
@@ -3060,7 +2882,6 @@
       <bibkey>peyrard-etal-2021-better</bibkey>
       <video href="2021.acl-long.179.mp4"/>
       <pwccode url="https://github.com/epfl-dlab/bt-eval" additional="false">epfl-dlab/bt-eval</pwccode>
-      <video href="2021.acl-long.179.mp4"/>
     </paper>
     <paper id="180">
       <title>Chase: A Large-Scale and Pragmatic <fixed-case>C</fixed-case>hinese Dataset for Cross-Database Context-Dependent Text-to-<fixed-case>SQL</fixed-case></title>
@@ -3081,7 +2902,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/csqa">CSQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sparc">SParC</pwcdataset>
-      <video href="2021.acl-long.180.mp4"/>
     </paper>
     <paper id="181">
       <title><fixed-case>CLINE</fixed-case>: Contrastive Learning with Semantic Negative Examples for Natural Language Understanding</title>
@@ -3100,7 +2920,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/perspectrum">Perspectrum</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-long.181.mp4"/>
     </paper>
     <paper id="182">
       <title>Tree-Structured Topic Modeling with Nonparametric Neural Variational Inference</title>
@@ -3116,7 +2935,6 @@
       <bibkey>chen-etal-2021-tree</bibkey>
       <video href="2021.acl-long.182.mp4"/>
       <pwccode url="https://github.com/hostnlp/ntsntm" additional="false">hostnlp/ntsntm</pwccode>
-      <video href="2021.acl-long.182.mp4"/>
     </paper>
     <paper id="183">
       <title><fixed-case>E</fixed-case>x<fixed-case>CAR</fixed-case>: Event Graph Knowledge Enhanced Explainable Causal Reasoning</title>
@@ -3132,7 +2950,6 @@
       <doi>10.18653/v1/2021.acl-long.183</doi>
       <bibkey>du-etal-2021-excar</bibkey>
       <video href="2021.acl-long.183.mp4"/>
-      <video href="2021.acl-long.183.mp4"/>
     </paper>
     <paper id="184">
       <title>Distributed Representations of Emotion Categories in Emotion Space</title>
@@ -3146,7 +2963,6 @@
       <video href="2021.acl-long.184.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/goemotions">GoEmotions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/isear">ISEAR</pwcdataset>
-      <video href="2021.acl-long.184.mp4"/>
     </paper>
     <paper id="185">
       <title>Style is <fixed-case>NOT</fixed-case> a single variable: Case Studies for Cross-Stylistic Language Understanding</title>
@@ -3165,7 +2981,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/pastel">PASTEL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sarc">SARC</pwcdataset>
-      <video href="2021.acl-long.185.mp4"/>
     </paper>
     <paper id="186">
       <title><fixed-case>D</fixed-case>yna<fixed-case>S</fixed-case>ent: A Dynamic Benchmark for Sentiment Analysis</title>
@@ -3186,7 +3001,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mpqa-opinion-corpus">MPQA Opinion Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.186.mp4"/>
     </paper>
     <paper id="187">
       <title>A Hierarchical <fixed-case>VAE</fixed-case> for Calibrating Attributes while Generating Text using Normalizing Flow</title>
@@ -3198,7 +3012,6 @@
       <url hash="e144166f">2021.acl-long.187</url>
       <doi>10.18653/v1/2021.acl-long.187</doi>
       <bibkey>samanta-etal-2021-hierarchical</bibkey>
-      <video href="2021.acl-long.187.mp4"/>
       <video href="2021.acl-long.187.mp4"/>
     </paper>
     <paper id="188">
@@ -3217,7 +3030,6 @@
       <pwccode url="https://github.com/yhcc/BARTABSA" additional="true">yhcc/BARTABSA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aste-data-v2">ASTE-Data-V2</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2014-task-4-sub-task-2">SemEval 2014 Task 4 Sub Task 2</pwcdataset>
-      <video href="2021.acl-long.188.mp4"/>
     </paper>
     <paper id="189">
       <title>Discovering Dialogue Slots with Weak Supervision</title>
@@ -3232,7 +3044,6 @@
       <video href="2021.acl-long.189.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.acl-long.189.mp4"/>
     </paper>
     <paper id="190">
       <title>Enhancing the generalization for Intent Classification and Out-of-Domain Detection in <fixed-case>SLU</fixed-case></title>
@@ -3247,7 +3058,6 @@
       <bibkey>shen-etal-2021-enhancing</bibkey>
       <video href="2021.acl-long.190.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
-      <video href="2021.acl-long.190.mp4"/>
     </paper>
     <paper id="191">
       <title><fixed-case>PROTAUGMENT</fixed-case>: Unsupervised diverse short-texts paraphrasing for intent detection meta-learning</title>
@@ -3263,7 +3073,6 @@
       <video href="2021.acl-long.191.mp4"/>
       <pwccode url="https://github.com/tdopierre/ProtAugment" additional="false">tdopierre/ProtAugment</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dialoglue">DialoGLUE</pwcdataset>
-      <video href="2021.acl-long.191.mp4"/>
     </paper>
     <paper id="192">
       <title>Robustness Testing of Language Understanding in Task-Oriented Dialog</title>
@@ -3283,7 +3092,6 @@
       <bibkey>liu-etal-2021-robustness</bibkey>
       <video href="2021.acl-long.192.mp4"/>
       <pwccode url="https://github.com/thu-coai/ConvLab-2" additional="true">thu-coai/ConvLab-2</pwccode>
-      <video href="2021.acl-long.192.mp4"/>
     </paper>
     <paper id="193">
       <title>Comprehensive Study: How the Context Information of Different Granularity Affects Dialogue State Tracking?</title>
@@ -3297,7 +3105,6 @@
       <bibkey>yang-etal-2021-comprehensive</bibkey>
       <video href="2021.acl-long.193.mp4"/>
       <pwccode url="https://github.com/yangpuhai/Granularity-in-DST" additional="false">yangpuhai/Granularity-in-DST</pwccode>
-      <video href="2021.acl-long.193.mp4"/>
     </paper>
     <paper id="194">
       <title><fixed-case>OTT</fixed-case>ers: One-turn Topic Transitions for Open-Domain Dialogue</title>
@@ -3315,7 +3122,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/otters">OTTers</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/topical-chat">Topical-Chat</pwcdataset>
-      <video href="2021.acl-long.194.mp4"/>
     </paper>
     <paper id="195">
       <title>Towards Robustness of Text-to-<fixed-case>SQL</fixed-case> Models against Synonym Substitution</title>
@@ -3333,7 +3139,6 @@
       <bibkey>gan-etal-2021-towards</bibkey>
       <video href="2021.acl-long.195.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
-      <video href="2021.acl-long.195.mp4"/>
     </paper>
     <paper id="196">
       <title><fixed-case>KACE</fixed-case>: Generating Knowledge Aware Contrastive Explanations for Natural Language Inference</title>
@@ -3354,7 +3159,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/e-snli">e-SNLI</pwcdataset>
-      <video href="2021.acl-long.196.mp4"/>
     </paper>
     <paper id="197">
       <title>Self-Guided Contrastive Learning for <fixed-case>BERT</fixed-case> Sentence Representations</title>
@@ -3370,7 +3174,6 @@
       <pwccode url="https://github.com/galsang/SG-BERT" additional="false">galsang/SG-BERT</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.acl-long.197.mp4"/>
     </paper>
     <paper id="198">
       <title><fixed-case>LGESQL</fixed-case>: Line Graph Enhanced Text-to-<fixed-case>SQL</fixed-case> Model with Mixed Local and Non-Local Relations</title>
@@ -3388,7 +3191,6 @@
       <video href="2021.acl-long.198.mp4"/>
       <pwccode url="https://github.com/rhythmcao/text2sql-lgesql" additional="false">rhythmcao/text2sql-lgesql</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/spider-1">SPIDER</pwcdataset>
-      <video href="2021.acl-long.198.mp4"/>
     </paper>
     <paper id="199">
       <title>Multi-stage Pre-training over Simplified Multimodal Pre-training Models</title>
@@ -3407,7 +3209,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/gqa">GQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
-      <video href="2021.acl-long.199.mp4"/>
     </paper>
     <paper id="200">
       <title>Beyond Sentence-Level End-to-End Speech Translation: Context Helps</title>
@@ -3423,7 +3224,6 @@
       <video href="2021.acl-long.200.mp4"/>
       <pwccode url="https://github.com/bzhangGo/zero" additional="false">bzhangGo/zero</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
-      <video href="2021.acl-long.200.mp4"/>
     </paper>
     <paper id="201">
       <title><fixed-case>L</fixed-case>ayout<fixed-case>LM</fixed-case>v2: Multi-modal Pre-training for Visually-rich Document Understanding</title>
@@ -3453,7 +3253,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/rvl-cdip">RVL-CDIP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sroie">SROIE</pwcdataset>
-      <video href="2021.acl-long.201.mp4"/>
     </paper>
     <paper id="202">
       <title><fixed-case>UNIMO</fixed-case>: Towards Unified-Modal Understanding and Generation via Cross-Modal Contrastive Learning</title>
@@ -3479,7 +3278,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snli-ve">SNLI-VE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
-      <video href="2021.acl-long.202.mp4"/>
     </paper>
     <paper id="203">
       <title>Missing Modality Imagination Network for Emotion Recognition with Uncertain Missing Modalities</title>
@@ -3494,7 +3292,6 @@
       <video href="2021.acl-long.203.mp4"/>
       <pwccode url="https://github.com/aim3-ruc/mmin" additional="false">aim3-ruc/mmin</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
-      <video href="2021.acl-long.203.mp4"/>
     </paper>
     <paper id="204">
       <title>Stacked Acoustic-and-Textual Encoding: Integrating the Pre-trained Models into Speech Translation Encoders</title>
@@ -3514,7 +3311,6 @@
       <video href="2021.acl-long.204.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
-      <video href="2021.acl-long.204.mp4"/>
     </paper>
     <paper id="205">
       <title>N-ary Constituent Tree Parsing with Recursive Semi-<fixed-case>M</fixed-case>arkov Model</title>
@@ -3530,7 +3326,6 @@
       <video href="2021.acl-long.205.mp4"/>
       <pwccode url="https://github.com/NP-NET-research/Recursive-Semi-Markov-Model" additional="false">NP-NET-research/Recursive-Semi-Markov-Model</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.acl-long.205.mp4"/>
     </paper>
     <paper id="206">
       <title>Automated Concatenation of Embeddings for Structured Prediction</title>
@@ -3553,7 +3348,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2014-task-4-sub-task-2">SemEval 2014 Task 4 Sub Task 2</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tweebank">Tweebank</pwcdataset>
-      <video href="2021.acl-long.206.mp4"/>
     </paper>
     <paper id="207">
       <title>Multi-View Cross-Lingual Structured Prediction with Minimum Supervision</title>
@@ -3570,7 +3364,6 @@
       <doi>10.18653/v1/2021.acl-long.207</doi>
       <bibkey>hu-etal-2021-multi</bibkey>
       <video href="2021.acl-long.207.mp4"/>
-      <video href="2021.acl-long.207.mp4"/>
     </paper>
     <paper id="208">
       <title>The Limitations of Limited Context for Constituency Parsing</title>
@@ -3581,7 +3374,6 @@
       <url hash="8cbe770c">2021.acl-long.208</url>
       <doi>10.18653/v1/2021.acl-long.208</doi>
       <bibkey>li-risteski-2021-limitations</bibkey>
-      <video href="2021.acl-long.208.mp4"/>
       <video href="2021.acl-long.208.mp4"/>
     </paper>
     <paper id="209">
@@ -3597,7 +3389,6 @@
       <video href="2021.acl-long.209.mp4"/>
       <pwccode url="https://github.com/sustcsonglin/TN-PCFG" additional="false">sustcsonglin/TN-PCFG</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.acl-long.209.mp4"/>
     </paper>
     <paper id="210">
       <title>Ruddit: <fixed-case>N</fixed-case>orms of Offensiveness for <fixed-case>E</fixed-case>nglish <fixed-case>R</fixed-case>eddit Comments</title>
@@ -3618,7 +3409,6 @@
       <pwccode url="https://github.com/hadarishav/Ruddit" additional="false">hadarishav/Ruddit</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ruddit">Ruddit</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/pushshift-reddit">Pushshift Reddit</pwcdataset>
-      <video href="2021.acl-long.210.mp4"/>
     </paper>
     <paper id="211">
       <title>Towards Quantifiable Dialogue Coherence Evaluation</title>
@@ -3636,7 +3426,6 @@
       <pwccode url="https://github.com/James-Yip/QuantiDCE" additional="false">James-Yip/QuantiDCE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/convai2">ConvAI2</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog-1">DailyDialog++</pwcdataset>
-      <video href="2021.acl-long.211.mp4"/>
     </paper>
     <paper id="212">
       <title>Assessing the Representations of Idiomaticity in Vector Models with a Noun Compound Dataset Labeled at Type and Token Levels</title>
@@ -3653,7 +3442,6 @@
       <video href="2021.acl-long.212.mp4"/>
       <pwccode url="https://github.com/marcospln/nctti" additional="false">marcospln/nctti</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/brwac">BRWAC</pwcdataset>
-      <video href="2021.acl-long.212.mp4"/>
     </paper>
     <paper id="213">
       <title>Factoring Statutory Reasoning as Language Understanding Challenges</title>
@@ -3667,7 +3455,6 @@
       <video href="2021.acl-long.213.mp4"/>
       <pwccode url="https://github.com/SgfdDttt/sara_v2" additional="false">SgfdDttt/sara_v2</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sara">SARA</pwcdataset>
-      <video href="2021.acl-long.213.mp4"/>
     </paper>
     <paper id="214">
       <title>Evaluating Evaluation Measures for Ordinal Classification and Ordinal Quantification</title>
@@ -3677,7 +3464,6 @@
       <url hash="b51a3ca6">2021.acl-long.214</url>
       <doi>10.18653/v1/2021.acl-long.214</doi>
       <bibkey>sakai-2021-evaluating</bibkey>
-      <video href="2021.acl-long.214.mp4"/>
       <video href="2021.acl-long.214.mp4"/>
     </paper>
     <paper id="215">
@@ -3698,7 +3484,6 @@
       <bibkey>yao-etal-2021-interpretable</bibkey>
       <video href="2021.acl-long.215.mp4"/>
       <pwccode url="https://github.com/THU-KEG/HIF-KAT" additional="false">THU-KEG/HIF-KAT</pwccode>
-      <video href="2021.acl-long.215.mp4"/>
     </paper>
     <paper id="216">
       <title>Locate and Label: A Two-stage Identifier for Nested Named Entity Recognition</title>
@@ -3721,7 +3506,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/genia">GENIA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/weibo-ner">Weibo NER</pwcdataset>
-      <video href="2021.acl-long.216.mp4"/>
     </paper>
     <paper id="217">
       <title><fixed-case>T</fixed-case>ext2<fixed-case>E</fixed-case>vent: Controllable Sequence-to-Structure Generation for End-to-end Event Extraction</title>
@@ -3741,7 +3525,6 @@
       <bibkey>lu-etal-2021-text2event</bibkey>
       <video href="2021.acl-long.217.mp4"/>
       <pwccode url="https://github.com/luyaojie/text2event" additional="false">luyaojie/text2event</pwccode>
-      <video href="2021.acl-long.217.mp4"/>
     </paper>
     <paper id="218">
       <title>A Large-Scale <fixed-case>C</fixed-case>hinese Multimodal <fixed-case>NER</fixed-case> Dataset with Speech Clues</title>
@@ -3759,7 +3542,6 @@
       <pwccode url="https://github.com/dianbowork/cnerta" additional="false">dianbowork/cnerta</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aishell-1">AISHELL-1</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/genia">GENIA</pwcdataset>
-      <video href="2021.acl-long.218.mp4"/>
     </paper>
     <paper id="219">
       <title>A Neural Transition-based Joint Model for Disease Named Entity Recognition and Normalization</title>
@@ -3772,7 +3554,6 @@
       <url hash="73898a3b">2021.acl-long.219</url>
       <doi>10.18653/v1/2021.acl-long.219</doi>
       <bibkey>ji-etal-2021-neural</bibkey>
-      <video href="2021.acl-long.219.mp4"/>
       <video href="2021.acl-long.219.mp4"/>
     </paper>
     <paper id="220">
@@ -3795,7 +3576,6 @@
       <video href="2021.acl-long.220.mp4"/>
       <pwccode url="https://github.com/231sm/Reasoning_In_EE" additional="false">231sm/Reasoning_In_EE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/maven">MAVEN</pwcdataset>
-      <video href="2021.acl-long.220.mp4"/>
     </paper>
     <paper id="221">
       <title>Self-Training Sampling with Monolingual Data Uncertainty for Neural Machine Translation</title>
@@ -3812,7 +3592,6 @@
       <bibkey>jiao-etal-2021-self</bibkey>
       <video href="2021.acl-long.221.mp4"/>
       <pwccode url="https://github.com/wxjiao/UncSamp" additional="false">wxjiao/UncSamp</pwccode>
-      <video href="2021.acl-long.221.mp4"/>
     </paper>
     <paper id="222">
       <title>Breaking the Corpus Bottleneck for Context-Aware Neural Machine Translation with Cross-Task Pre-training</title>
@@ -3829,7 +3608,6 @@
       <doi>10.18653/v1/2021.acl-long.222</doi>
       <bibkey>chen-etal-2021-breaking</bibkey>
       <video href="2021.acl-long.222.mp4"/>
-      <video href="2021.acl-long.222.mp4"/>
     </paper>
     <paper id="223">
       <title>Guiding Teacher Forcing with Seer Forcing for Neural Machine Translation</title>
@@ -3843,7 +3621,6 @@
       <url hash="270392c7">2021.acl-long.223</url>
       <doi>10.18653/v1/2021.acl-long.223</doi>
       <bibkey>feng-etal-2021-guiding</bibkey>
-      <video href="2021.acl-long.223.mp4"/>
       <video href="2021.acl-long.223.mp4"/>
     </paper>
     <paper id="224">
@@ -3861,7 +3638,6 @@
       <doi>10.18653/v1/2021.acl-long.224</doi>
       <bibkey>bentivogli-etal-2021-cascade</bibkey>
       <video href="2021.acl-long.224.mp4"/>
-      <video href="2021.acl-long.224.mp4"/>
     </paper>
     <paper id="225">
       <title>Unsupervised Neural Machine Translation for Low-Resource Domains via Meta-Learning</title>
@@ -3877,7 +3653,6 @@
       <url hash="f34cb3dd">2021.acl-long.225</url>
       <doi>10.18653/v1/2021.acl-long.225</doi>
       <bibkey>park-etal-2021-unsupervised</bibkey>
-      <video href="2021.acl-long.225.mp4"/>
       <video href="2021.acl-long.225.mp4"/>
     </paper>
     <paper id="226">
@@ -3896,7 +3671,6 @@
       <pwccode url="https://github.com/Mao-KU/lightweight-crosslingual-sent2vec" additional="false">Mao-KU/lightweight-crosslingual-sent2vec</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mldoc">MLDoc</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paracrawl">ParaCrawl</pwcdataset>
-      <video href="2021.acl-long.226.mp4"/>
     </paper>
     <paper id="227">
       <title><fixed-case>ERNIE</fixed-case>-<fixed-case>D</fixed-case>oc: A Retrospective Long-Document Modeling Transformer</title>
@@ -3937,7 +3711,6 @@
       <pwccode url="https://github.com/llyx97/Marginal-Utility-Diminishes" additional="false">llyx97/Marginal-Utility-Diminishes</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.228.mp4"/>
     </paper>
     <paper id="229">
       <title>Rational <fixed-case>LAMOL</fixed-case>: A Rationale-based Lifelong Learning Framework</title>
@@ -3955,7 +3728,6 @@
       <pwccode url="https://github.com/kanwatchara-k/r_lamol" additional="false">kanwatchara-k/r_lamol</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/boolq">BoolQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scifact">SciFact</pwcdataset>
-      <video href="2021.acl-long.229.mp4"/>
     </paper>
     <paper id="230">
       <title><fixed-case>E</fixed-case>ns<fixed-case>LM</fixed-case>: Ensemble Language Model for Data Diversity by Semantic Clustering</title>
@@ -3974,7 +3746,6 @@
       <pwccode url="https://github.com/bochengroup/enslm" additional="false">bochengroup/enslm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.acl-long.230.mp4"/>
     </paper>
     <paper id="231">
       <title><fixed-case>L</fixed-case>ee<fixed-case>BERT</fixed-case>: Learned Early Exit for <fixed-case>BERT</fixed-case> with cross-level optimization</title>
@@ -3987,7 +3758,6 @@
       <video href="2021.acl-long.231.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.231.mp4"/>
     </paper>
     <paper id="232">
       <title>Unsupervised Extractive Summarization-Based Representations for Accurate and Explainable Collaborative Filtering</title>
@@ -4000,7 +3770,6 @@
       <bibkey>pugoy-kao-2021-unsupervised</bibkey>
       <video href="2021.acl-long.232.mp4"/>
       <pwccode url="https://github.com/reinaldncku/escofilt" additional="false">reinaldncku/escofilt</pwccode>
-      <video href="2021.acl-long.232.mp4"/>
     </paper>
     <paper id="233">
       <title><fixed-case>PLOME</fixed-case>: Pre-training with Misspelled Knowledge for <fixed-case>C</fixed-case>hinese Spelling Correction</title>
@@ -4016,7 +3785,6 @@
       <bibkey>liu-etal-2021-plome</bibkey>
       <video href="2021.acl-long.233.mp4"/>
       <pwccode url="https://github.com/liushulinle/plome" additional="false">liushulinle/plome</pwccode>
-      <video href="2021.acl-long.233.mp4"/>
     </paper>
     <paper id="234">
       <title>Competence-based Multimodal Curriculum Learning for Medical Report Generation</title>
@@ -4031,7 +3799,6 @@
       <video href="2021.acl-long.234.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/chexpert">CheXpert</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imagenet">ImageNet</pwcdataset>
-      <video href="2021.acl-long.234.mp4"/>
     </paper>
     <paper id="235">
       <title>Learning Syntactic Dense Embedding with Correlation Graph for Automatic Readability Assessment</title>
@@ -4048,7 +3815,6 @@
       <bibkey>qiu-etal-2021-learning</bibkey>
       <video href="2021.acl-long.235.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/onestopenglish">OneStopEnglish</pwcdataset>
-      <video href="2021.acl-long.235.mp4"/>
     </paper>
     <paper id="236">
       <title>Meta-<fixed-case>KD</fixed-case>: A Meta Knowledge Distillation Framework for Language Model Compression across Domains</title>
@@ -4065,7 +3831,6 @@
       <bibkey>pan-etal-2021-meta</bibkey>
       <video href="2021.acl-long.236.mp4"/>
       <pwccode url="https://github.com/alibaba/EasyNLP" additional="false">alibaba/EasyNLP</pwccode>
-      <video href="2021.acl-long.236.mp4"/>
     </paper>
     <paper id="237">
       <title>A Semantic-based Method for Unsupervised Commonsense Question Answering</title>
@@ -4084,7 +3849,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/atomic">ATOMIC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/copa">COPA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.acl-long.237.mp4"/>
     </paper>
     <paper id="238">
       <title><fixed-case>E</fixed-case>xplanations for <fixed-case>C</fixed-case>ommonsense<fixed-case>QA</fixed-case>: <fixed-case>N</fixed-case>ew <fixed-case>D</fixed-case>ataset and <fixed-case>M</fixed-case>odels</title>
@@ -4107,7 +3871,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/openbookqa">OpenBookQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qasc">QASC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/worldtree">Worldtree</pwcdataset>
-      <video href="2021.acl-long.238.mp4"/>
     </paper>
     <paper id="239">
       <title>Few-Shot Question Answering by Pretraining Span Selection</title>
@@ -4131,7 +3894,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-long.239.mp4"/>
     </paper>
     <paper id="240">
       <title><fixed-case>U</fixed-case>nited<fixed-case>QA</fixed-case>: <fixed-case>A</fixed-case> Hybrid Approach for Open Domain Question Answering</title>
@@ -4149,7 +3911,6 @@
       <video href="2021.acl-long.240.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-long.240.mp4"/>
     </paper>
     <paper id="241">
       <title>Database reasoning over text</title>
@@ -4168,7 +3929,6 @@
       <pwccode url="https://github.com/facebookresearch/NeuralDB" additional="false">facebookresearch/NeuralDB</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikinldb">WikiNLDB</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/break">BREAK</pwcdataset>
-      <video href="2021.acl-long.241.mp4"/>
     </paper>
     <paper id="242">
       <title><fixed-case>O</fixed-case>nline <fixed-case>L</fixed-case>earning Meets <fixed-case>M</fixed-case>achine <fixed-case>T</fixed-case>ranslation Evaluation: Finding the Best Systems with the Least Human Effort</title>
@@ -4185,7 +3945,6 @@
       <bibkey>mendonca-etal-2021-online</bibkey>
       <video href="2021.acl-long.242.mp4"/>
       <pwccode url="https://github.com/vania-mendonca/MTOL" additional="false">vania-mendonca/MTOL</pwccode>
-      <video href="2021.acl-long.242.mp4"/>
     </paper>
     <paper id="243">
       <title>How Good is Your Tokenizer? On the Monolingual Performance of Multilingual Language Models</title>
@@ -4202,7 +3961,6 @@
       <video href="2021.acl-long.243.mp4"/>
       <pwccode url="https://github.com/Adapter-Hub/hgiyt" additional="false">Adapter-Hub/hgiyt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.acl-long.243.mp4"/>
     </paper>
     <paper id="244">
       <title>Evaluating morphological typology in zero-shot cross-lingual transfer</title>
@@ -4215,7 +3973,6 @@
       <doi>10.18653/v1/2021.acl-long.244</doi>
       <bibkey>martinez-garcia-etal-2021-evaluating</bibkey>
       <video href="2021.acl-long.244.mp4"/>
-      <video href="2021.acl-long.244.mp4"/>
     </paper>
     <paper id="245">
       <title>From Machine Translation to Code-Switching: Generating High-Quality Code-Switched Text</title>
@@ -4227,7 +3984,6 @@
       <url hash="84dcc3e6">2021.acl-long.245</url>
       <doi>10.18653/v1/2021.acl-long.245</doi>
       <bibkey>tarunesh-etal-2021-machine</bibkey>
-      <video href="2021.acl-long.245.mp4"/>
       <video href="2021.acl-long.245.mp4"/>
     </paper>
     <paper id="246">
@@ -4242,7 +3998,6 @@
       <url hash="5d6358ba">2021.acl-long.246</url>
       <doi>10.18653/v1/2021.acl-long.246</doi>
       <bibkey>he-etal-2021-fast</bibkey>
-      <video href="2021.acl-long.246.mp4"/>
       <video href="2021.acl-long.246.mp4"/>
     </paper>
     <paper id="247">
@@ -4261,7 +4016,6 @@
       <video href="2021.acl-long.247.mp4"/>
       <pwccode url="https://github.com/phze22/Online-Misogyny-in-Danish-Bajer" additional="false">phze22/Online-Misogyny-in-Danish-Bajer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bajer-danish-misogyny">bajer_danish_misogyny</pwcdataset>
-      <video href="2021.acl-long.247.mp4"/>
     </paper>
     <paper id="248">
       <title>Few-<fixed-case>NERD</fixed-case>: A Few-shot Named Entity Recognition Dataset</title>
@@ -4282,7 +4036,6 @@
       <pwccode url="https://github.com/thunlp/Few-NERD" additional="true">thunlp/Few-NERD</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/few-nerd">Few-NERD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
-      <video href="2021.acl-long.248.mp4"/>
     </paper>
     <paper id="249">
       <title><fixed-case>M</fixed-case>ulti<fixed-case>MET</fixed-case>: A Multimodal Dataset for Metaphor Understanding</title>
@@ -4296,7 +4049,6 @@
       <url hash="c0c0f938">2021.acl-long.249</url>
       <doi>10.18653/v1/2021.acl-long.249</doi>
       <bibkey>zhang-etal-2021-multimet</bibkey>
-      <video href="2021.acl-long.249.mp4"/>
       <video href="2021.acl-long.249.mp4"/>
     </paper>
     <paper id="250">
@@ -4314,7 +4066,6 @@
       <pwccode url="https://github.com/marcoguerini/CONAN" additional="false">marcoguerini/CONAN</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hate-speech">Hate Speech</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sbic">SBIC</pwcdataset>
-      <video href="2021.acl-long.250.mp4"/>
     </paper>
     <paper id="251">
       <title>Can Generative Pre-trained Language Models Serve As Knowledge Bases for Closed-book <fixed-case>QA</fixed-case>?</title>
@@ -4333,7 +4084,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestions">WebQuestions</pwcdataset>
-      <video href="2021.acl-long.251.mp4"/>
     </paper>
     <paper id="252">
       <title>Joint Models for Answer Verification in Question Answering Systems</title>
@@ -4350,7 +4100,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/trecqa">TrecQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiqa">WikiQA</pwcdataset>
-      <video href="2021.acl-long.252.mp4"/>
     </paper>
     <paper id="253">
       <title>Answering Ambiguous Questions through Generative Evidence Fusion and Round-Trip Prediction</title>
@@ -4372,7 +4121,6 @@
       <video href="2021.acl-long.253.mp4"/>
       <pwccode url="https://github.com/amzn/refuel-open-domain-qa" additional="false">amzn/refuel-open-domain-qa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.acl-long.253.mp4"/>
     </paper>
     <paper id="254">
       <title><fixed-case>TAT</fixed-case>-<fixed-case>QA</fixed-case>: A Question Answering Benchmark on a Hybrid of Tabular and Textual Content in Finance</title>
@@ -4392,7 +4140,6 @@
       <video href="2021.acl-long.254.mp4"/>
       <pwccode url="https://github.com/NExTplusplus/TAT-QA" additional="false">NExTplusplus/TAT-QA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/tat-qa">TAT-QA</pwcdataset>
-      <video href="2021.acl-long.254.mp4"/>
     </paper>
     <paper id="255">
       <title>Modeling Transitions of Focal Entities for Conversational Knowledge Base Question Answering</title>
@@ -4407,7 +4154,6 @@
       <pwccode url="https://github.com/lanyunshi/conversationalkbqa" additional="false">lanyunshi/conversationalkbqa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/csqa">CSQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/convquestions">ConvQuestions</pwcdataset>
-      <video href="2021.acl-long.255.mp4"/>
     </paper>
     <paper id="256">
       <title>Evidence-based Factual Error Correction</title>
@@ -4421,7 +4167,6 @@
       <video href="2021.acl-long.256.mp4"/>
       <pwccode url="https://github.com/j6mes/2021-acl-factual-error-correction" additional="false">j6mes/2021-acl-factual-error-correction</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
-      <video href="2021.acl-long.256.mp4"/>
     </paper>
     <paper id="257">
       <title>Probabilistic, Structure-Aware Algorithms for Improved Variety, Accuracy, and Coverage of <fixed-case>AMR</fixed-case> Alignments</title>
@@ -4434,7 +4179,6 @@
       <bibkey>blodgett-schneider-2021-probabilistic</bibkey>
       <video href="2021.acl-long.257.mp4"/>
       <pwccode url="https://github.com/ablodge/leamr" additional="false">ablodge/leamr</pwccode>
-      <video href="2021.acl-long.257.mp4"/>
     </paper>
     <paper id="258">
       <title>Meta-Learning to Compositionally Generalize</title>
@@ -4450,7 +4194,6 @@
       <video href="2021.acl-long.258.mp4"/>
       <pwccode url="https://github.com/berlino/tensor2struct-public" additional="false">berlino/tensor2struct-public</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.acl-long.258.mp4"/>
     </paper>
     <paper id="259">
       <title>Taming Pre-trained Language Models with N-gram Representations for Low-Resource Domain Adaptation</title>
@@ -4469,7 +4212,6 @@
       <pwccode url="https://github.com/shizhediao/t-dna" additional="false">shizhediao/t-dna</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.acl-long.259.mp4"/>
     </paper>
     <paper id="260">
       <title><fixed-case>ERICA</fixed-case>: Improving Entity and Relation Understanding for Pre-trained Language Models via Contrastive Learning</title>
@@ -4495,7 +4237,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2010-task-8">SemEval-2010 Task 8</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikihop">WikiHop</pwcdataset>
-      <video href="2021.acl-long.260.mp4"/>
     </paper>
     <paper id="261">
       <title>Position Bias Mitigation: A Knowledge-Aware Graph Model for Emotion Cause Extraction</title>
@@ -4511,7 +4252,6 @@
       <video href="2021.acl-long.261.mp4"/>
       <pwccode url="https://github.com/hanqi-qi/Position-Bias-Mitigation-in-Emotion-Cause-Analysis" additional="false">hanqi-qi/Position-Bias-Mitigation-in-Emotion-Cause-Analysis</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.acl-long.261.mp4"/>
     </paper>
     <paper id="262">
       <title>Every Bite Is an Experience: <fixed-case>K</fixed-case>ey <fixed-case>P</fixed-case>oint <fixed-case>A</fixed-case>nalysis of Business Reviews</title>
@@ -4526,7 +4266,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="320b7030">2021.acl-long.262.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-long.262</doi>
       <bibkey>bar-haim-etal-2021-every</bibkey>
-      <video href="2021.acl-long.262.mp4"/>
       <video href="2021.acl-long.262.mp4"/>
     </paper>
     <paper id="263">
@@ -4545,7 +4284,6 @@
       <pwccode url="https://github.com/jerbarnes/sentiment_graphs" additional="true">jerbarnes/sentiment_graphs</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mpqa-opinion-corpus">MPQA Opinion Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/norec-fine">NoReC_fine</pwcdataset>
-      <video href="2021.acl-long.263.mp4"/>
     </paper>
     <paper id="264">
       <title>Consistency Regularization for Cross-Lingual Fine-Tuning</title>
@@ -4572,7 +4310,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/tydiqa-goldp">TyDiQA-GoldP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.acl-long.264.mp4"/>
     </paper>
     <paper id="265">
       <title>Improving Pretrained Cross-Lingual Language Models via Self-Labeled Word Alignment</title>
@@ -4595,7 +4332,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.acl-long.265.mp4"/>
     </paper>
     <paper id="266">
       <title>Rejuvenating Low-Frequency Words: Making the Most of Parallel Data in Non-Autoregressive Translation</title>
@@ -4612,7 +4348,6 @@
       <bibkey>ding-etal-2021-rejuvenating</bibkey>
       <video href="2021.acl-long.266.mp4"/>
       <pwccode url="https://github.com/alphadl/rlfw-nat" additional="false">alphadl/rlfw-nat</pwccode>
-      <video href="2021.acl-long.266.mp4"/>
     </paper>
     <paper id="267">
       <title><fixed-case>G</fixed-case>-Transformer for Document-Level Machine Translation</title>
@@ -4628,7 +4363,6 @@
       <bibkey>bao-etal-2021-g</bibkey>
       <video href="2021.acl-long.267.mp4"/>
       <pwccode url="https://github.com/baoguangsheng/g-transformer" additional="false">baoguangsheng/g-transformer</pwccode>
-      <video href="2021.acl-long.267.mp4"/>
     </paper>
     <paper id="268">
       <title>Prevent the Language Model from being Overconfident in Neural Machine Translation</title>
@@ -4644,7 +4378,6 @@
       <bibkey>miao-etal-2021-prevent</bibkey>
       <video href="2021.acl-long.268.mp4"/>
       <pwccode url="https://github.com/Mlair77/nmt_adequacy" additional="false">Mlair77/nmt_adequacy</pwccode>
-      <video href="2021.acl-long.268.mp4"/>
     </paper>
     <paper id="269">
       <title>Towards Emotional Support Dialog Systems</title>
@@ -4663,7 +4396,6 @@
       <bibkey>liu-etal-2021-towards</bibkey>
       <video href="2021.acl-long.269.mp4"/>
       <pwccode url="https://github.com/thu-coai/Emotional-Support-Conversation" additional="false">thu-coai/Emotional-Support-Conversation</pwccode>
-      <video href="2021.acl-long.269.mp4"/>
     </paper>
     <paper id="270">
       <title>Novel Slot Detection: A Benchmark for Discovering Unknown Slot Types in the Task-Oriented Dialogue System</title>
@@ -4683,7 +4415,6 @@
       <pwccode url="https://github.com/ChestnutWYN/ACL2021-Novel-Slot-Detection" additional="false">ChestnutWYN/ACL2021-Novel-Slot-Detection</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
-      <video href="2021.acl-long.270.mp4"/>
     </paper>
     <paper id="271">
       <title><fixed-case>GTM</fixed-case>: A Generative Triple-wise Model for Conversational Question Generation</title>
@@ -4698,7 +4429,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="a16ffc41">2021.acl-long.271.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-long.271</doi>
       <bibkey>shen-etal-2021-gtm</bibkey>
-      <video href="2021.acl-long.271.mp4"/>
       <video href="2021.acl-long.271.mp4"/>
     </paper>
     <paper id="272">
@@ -4715,7 +4445,6 @@
       <video href="2021.acl-long.272.mp4"/>
       <pwccode url="https://github.com/lemon234071/AdaLabel" additional="false">lemon234071/AdaLabel</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
-      <video href="2021.acl-long.272.mp4"/>
     </paper>
     <paper id="273">
       <title>Out-of-Scope Intent Detection with Self-Supervision and Discriminative Training</title>
@@ -4732,7 +4461,6 @@
       <bibkey>zhan-etal-2021-scope</bibkey>
       <video href="2021.acl-long.273.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.acl-long.273.mp4"/>
     </paper>
     <paper id="274">
       <title>Document-level Event Extraction via Heterogeneous Graph-based Interaction Model with a Tracker</title>
@@ -4747,7 +4475,6 @@
       <bibkey>xu-etal-2021-document</bibkey>
       <video href="2021.acl-long.274.mp4"/>
       <pwccode url="https://github.com/RunxinXu/GIT" additional="true">RunxinXu/GIT</pwccode>
-      <video href="2021.acl-long.274.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/chfinann">ChFinAnn</pwcdataset>
     </paper>
     <paper id="275">
@@ -4766,7 +4493,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ace-2004">ACE 2004</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ace-2005">ACE 2005</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/genia">GENIA</pwcdataset>
-      <video href="2021.acl-long.275.mp4"/>
     </paper>
     <paper id="276">
       <title><fixed-case>L</fixed-case>earn<fixed-case>DA</fixed-case>: Learnable Knowledge-Guided Data Augmentation for Event Causality Identification</title>
@@ -4784,7 +4510,6 @@
       <bibkey>zuo-etal-2021-learnda</bibkey>
       <video href="2021.acl-long.276.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
-      <video href="2021.acl-long.276.mp4"/>
     </paper>
     <paper id="277">
       <title>Revisiting the Negative Data of Distantly Supervised Relation Extraction</title>
@@ -4803,7 +4528,6 @@
       <pwccode url="https://github.com/redreamality/RERE-relation-extraction" additional="false">redreamality/RERE-relation-extraction</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/nyt11-hrl">NYT11-HRL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.acl-long.277.mp4"/>
     </paper>
     <paper id="278">
       <title>Knowing the No-match: Entity Alignment with Dangling Cases</title>
@@ -4818,7 +4542,6 @@
       <video href="2021.acl-long.278.mp4"/>
       <pwccode url="https://github.com/nju-websoft/OpenEA" additional="false">nju-websoft/OpenEA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dbp2-0-zh-en">DBP2.0 zh-en</pwcdataset>
-      <video href="2021.acl-long.278.mp4"/>
     </paper>
     <paper id="279">
       <title>Superbizarre Is Not Superb: Derivational Morphology Improves <fixed-case>BERT</fixed-case>’s Interpretation of Complex Words</title>
@@ -4832,7 +4555,6 @@
       <bibkey>hofmann-etal-2021-superbizarre</bibkey>
       <video href="2021.acl-long.279.mp4"/>
       <pwccode url="https://github.com/valentinhofmann/superbizarre" additional="false">valentinhofmann/superbizarre</pwccode>
-      <video href="2021.acl-long.279.mp4"/>
     </paper>
     <paper id="280">
       <title><fixed-case>BERT</fixed-case> is to <fixed-case>NLP</fixed-case> what <fixed-case>A</fixed-case>lex<fixed-case>N</fixed-case>et is to <fixed-case>CV</fixed-case>: Can Pre-Trained Language Models Identify Analogies?</title>
@@ -4847,7 +4569,6 @@
       <bibkey>ushio-etal-2021-bert</bibkey>
       <video href="2021.acl-long.280.mp4"/>
       <pwccode url="https://github.com/asahi417/analogy-language-model" additional="false">asahi417/analogy-language-model</pwccode>
-      <video href="2021.acl-long.280.mp4"/>
     </paper>
     <paper id="281">
       <title>Exploring the Representation of Word Meanings in Context: <fixed-case>A</fixed-case> Case Study on Homonymy and Synonymy</title>
@@ -4860,7 +4581,6 @@
       <video href="2021.acl-long.281.mp4"/>
       <pwccode url="https://github.com/marcospln/homonymy_acl21" additional="false">marcospln/homonymy_acl21</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
-      <video href="2021.acl-long.281.mp4"/>
     </paper>
     <paper id="282">
       <title>Measuring Fine-Grained Domain Relevance of Terms: A Hierarchical Core-Fringe Approach</title>
@@ -4875,7 +4595,6 @@
       <bibkey>huang-etal-2021-measuring</bibkey>
       <video href="2021.acl-long.282.mp4"/>
       <pwccode url="https://github.com/jeffhj/domain-relevance" additional="false">jeffhj/domain-relevance</pwccode>
-      <video href="2021.acl-long.282.mp4"/>
     </paper>
     <paper id="283">
       <title><fixed-case>HERALD</fixed-case>: An Annotation Efficient Method to Detect User Disengagement in Social Conversations</title>
@@ -4890,7 +4609,6 @@
       <video href="2021.acl-long.283.mp4"/>
       <pwccode url="https://github.com/Weixin-Liang/HERALD" additional="false">Weixin-Liang/HERALD</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/convai2">ConvAI2</pwcdataset>
-      <video href="2021.acl-long.283.mp4"/>
     </paper>
     <paper id="284">
       <title>Value-Agnostic Conversational Semantic Parsing</title>
@@ -4911,7 +4629,6 @@
       <doi>10.18653/v1/2021.acl-long.284</doi>
       <bibkey>platanios-etal-2021-value</bibkey>
       <video href="2021.acl-long.284.mp4"/>
-      <video href="2021.acl-long.284.mp4"/>
     </paper>
     <paper id="285">
       <title><fixed-case>MPC</fixed-case>-<fixed-case>BERT</fixed-case>: A Pre-Trained Language Model for Multi-Party Conversation Understanding</title>
@@ -4928,7 +4645,6 @@
       <bibkey>gu-etal-2021-mpc</bibkey>
       <video href="2021.acl-long.285.mp4"/>
       <pwccode url="https://github.com/JasonForJoy/MPC-BERT" additional="false">JasonForJoy/MPC-BERT</pwccode>
-      <video href="2021.acl-long.285.mp4"/>
     </paper>
     <paper id="286">
       <title>Best of Both Worlds: Making High Accuracy Non-incremental Transformer-based Disfluency Detection Incremental</title>
@@ -4939,7 +4655,6 @@
       <url hash="3e323441">2021.acl-long.286</url>
       <doi>10.18653/v1/2021.acl-long.286</doi>
       <bibkey>rohanian-hough-2021-best</bibkey>
-      <video href="2021.acl-long.286.mp4"/>
       <video href="2021.acl-long.286.mp4"/>
     </paper>
     <paper id="287">
@@ -4955,7 +4670,6 @@
       <video href="2021.acl-long.287.mp4"/>
       <pwccode url="https://github.com/naver-ai/neuralwoz" additional="false">naver-ai/neuralwoz</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.acl-long.287.mp4"/>
     </paper>
     <paper id="288">
       <title><fixed-case>CDRNN</fixed-case>: Discovering Complex Dynamics in Human Language Processing</title>
@@ -4968,7 +4682,6 @@
       <video href="2021.acl-long.288.mp4"/>
       <pwccode url="https://github.com/coryshain/cdr" additional="false">coryshain/cdr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-stories">Natural Stories</pwcdataset>
-      <video href="2021.acl-long.288.mp4"/>
     </paper>
     <paper id="289">
       <title>Structural Guidance for Transformer Language Models</title>
@@ -4986,7 +4699,6 @@
       <video href="2021.acl-long.289.mp4"/>
       <pwccode url="https://github.com/IBM/transformers-struct-guidance" additional="false">IBM/transformers-struct-guidance</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/blimp">BLiMP</pwcdataset>
-      <video href="2021.acl-long.289.mp4"/>
     </paper>
     <paper id="290">
       <title>Surprisal Estimators for Human Reading Times Need Character Models</title>
@@ -5002,7 +4714,6 @@
       <pwccode url="https://github.com/byungdoh/acl21_semproc" additional="false">byungdoh/acl21_semproc</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-stories">Natural Stories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.acl-long.290.mp4"/>
     </paper>
     <paper id="291">
       <title><fixed-case>C</fixed-case>og<fixed-case>A</fixed-case>lign: Learning to Align Textual Neural Representations to Cognitive Language Processing Signals</title>
@@ -5016,7 +4727,6 @@
       <video href="2021.acl-long.291.mp4"/>
       <pwccode url="https://github.com/tjunlp-lab/CogAlign" additional="false">tjunlp-lab/CogAlign</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.291.mp4"/>
     </paper>
     <paper id="292">
       <title>Self-Attention Networks Can Process Bounded Hierarchical Languages</title>
@@ -5033,7 +4743,6 @@
       <pwccode url="https://github.com/princeton-nlp/dyck-transformer" additional="false">princeton-nlp/dyck-transformer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.acl-long.292.mp4"/>
     </paper>
     <paper id="293">
       <title><fixed-case>T</fixed-case>ext<fixed-case>SETTR</fixed-case>: Few-Shot Text Style Extraction and Tunable Targeted Restyling</title>
@@ -5049,7 +4758,6 @@
       <doi>10.18653/v1/2021.acl-long.293</doi>
       <bibkey>riley-etal-2021-textsettr</bibkey>
       <video href="2021.acl-long.293.mp4"/>
-      <video href="2021.acl-long.293.mp4"/>
     </paper>
     <paper id="294">
       <title><fixed-case>H</fixed-case>-Transformer-1<fixed-case>D</fixed-case>: Fast One-Dimensional Hierarchical Attention for Sequences</title>
@@ -5064,7 +4772,6 @@
       <pwccode url="" additional="true"/>
       <pwcdataset url="https://paperswithcode.com/dataset/billion-word-benchmark">Billion Word Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/lra">LRA</pwcdataset>
-      <video href="2021.acl-long.294.mp4"/>
     </paper>
     <paper id="295">
       <title>Making Pre-trained Language Models Better Few-shot Learners</title>
@@ -5086,7 +4793,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.295.mp4"/>
     </paper>
     <paper id="296">
       <title>A Sweet Rabbit Hole by <fixed-case>DARCY</fixed-case>: Using Honeypots to Detect Universal Trigger’s Adversarial Attacks</title>
@@ -5098,7 +4804,6 @@
       <url hash="afb97e01">2021.acl-long.296</url>
       <doi>10.18653/v1/2021.acl-long.296</doi>
       <bibkey>le-etal-2021-sweet</bibkey>
-      <video href="2021.acl-long.296.mp4"/>
       <video href="2021.acl-long.296.mp4"/>
     </paper>
     <paper id="297">
@@ -5115,7 +4820,6 @@
       <bibkey>wei-etal-2021-towards</bibkey>
       <video href="2021.acl-long.297.mp4"/>
       <pwccode url="https://github.com/weilingwei96/EBGCN" additional="false">weilingwei96/EBGCN</pwccode>
-      <video href="2021.acl-long.297.mp4"/>
     </paper>
     <paper id="298">
       <title>Label-Specific Dual Graph Neural Network for Multi-Label Text Classification</title>
@@ -5130,7 +4834,6 @@
       <bibkey>ma-etal-2021-label</bibkey>
       <video href="2021.acl-long.298.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/rcv1">RCV1</pwcdataset>
-      <video href="2021.acl-long.298.mp4"/>
     </paper>
     <paper id="299">
       <title><fixed-case>TAN</fixed-case>-<fixed-case>NTM</fixed-case>: <fixed-case>T</fixed-case>opic Attention Networks for Neural Topic Modeling</title>
@@ -5146,7 +4849,6 @@
       <bibkey>panwar-etal-2021-tan</bibkey>
       <video href="2021.acl-long.299.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
-      <video href="2021.acl-long.299.mp4"/>
     </paper>
     <paper id="300">
       <title>Cross-language Sentence Selection via Data Augmentation and Rationale Training</title>
@@ -5163,7 +4865,6 @@
       <doi>10.18653/v1/2021.acl-long.300</doi>
       <bibkey>chen-etal-2021-cross-language</bibkey>
       <video href="2021.acl-long.300.mp4"/>
-      <video href="2021.acl-long.300.mp4"/>
     </paper>
     <paper id="301">
       <title>A Neural Model for Joint Document and Snippet Ranking in Question Answering for Large Document Collections</title>
@@ -5179,7 +4880,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.301.mp4"/>
     </paper>
     <paper id="302">
       <title><fixed-case>W</fixed-case>-<fixed-case>RST</fixed-case>: Towards a Weighted <fixed-case>RST</fixed-case>-style Discourse Framework</title>
@@ -5193,7 +4893,6 @@
       <bibkey>huber-etal-2021-w</bibkey>
       <video href="2021.acl-long.302.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
-      <video href="2021.acl-long.302.mp4"/>
     </paper>
     <paper id="303">
       <title><fixed-case>ABCD</fixed-case>: A Graph Framework to Convert Complex Sentences to a Covering Set of Simple Sentences</title>
@@ -5207,7 +4906,6 @@
       <bibkey>gao-etal-2021-abcd</bibkey>
       <video href="2021.acl-long.303.mp4"/>
       <pwccode url="https://github.com/serenayj/ABCD-ACL2021" additional="true">serenayj/ABCD-ACL2021</pwccode>
-      <video href="2021.acl-long.303.mp4"/>
     </paper>
     <paper id="304">
       <title>Which Linguist Invented the Lightbulb? Presupposition Verification for Question-Answering</title>
@@ -5226,7 +4924,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.304.mp4"/>
     </paper>
     <paper id="305">
       <title>Adversarial Learning for Discourse Rhetorical Structure Parsing</title>
@@ -5240,7 +4937,6 @@
       <bibkey>zhang-etal-2021-adversarial</bibkey>
       <video href="2021.acl-long.305.mp4"/>
       <pwccode url="https://github.com/nlp-discourse-soochowu/gan_dp" additional="false">nlp-discourse-soochowu/gan_dp</pwccode>
-      <video href="2021.acl-long.305.mp4"/>
     </paper>
     <paper id="306">
       <title>Exploring Discourse Structures for Argument Impact Classification</title>
@@ -5255,7 +4951,6 @@
       <bibkey>liu-etal-2021-exploring-discourse</bibkey>
       <video href="2021.acl-long.306.mp4"/>
       <pwccode url="https://github.com/HKUST-KnowComp/DisCOC" additional="false">HKUST-KnowComp/DisCOC</pwccode>
-      <video href="2021.acl-long.306.mp4"/>
     </paper>
     <paper id="307">
       <title>Point, Disambiguate and Copy: Incorporating Bilingual Dictionaries for Neural Machine Translation</title>
@@ -5272,7 +4967,6 @@
       <url hash="f624a6bf">2021.acl-long.307</url>
       <doi>10.18653/v1/2021.acl-long.307</doi>
       <bibkey>zhang-etal-2021-point</bibkey>
-      <video href="2021.acl-long.307.mp4"/>
       <video href="2021.acl-long.307.mp4"/>
     </paper>
     <paper id="308">
@@ -5298,7 +4992,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.acl-long.308.mp4"/>
     </paper>
     <paper id="309">
       <title>A unified approach to sentence segmentation of punctuated text in many languages</title>
@@ -5313,7 +5006,6 @@
       <pwccode url="https://github.com/rewicks/ersatz" additional="false">rewicks/ersatz</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ccmatrix">CCMatrix</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikimatrix">WikiMatrix</pwcdataset>
-      <video href="2021.acl-long.309.mp4"/>
     </paper>
     <paper id="310">
       <title>Towards User-Driven Neural Machine Translation</title>
@@ -5332,7 +5024,6 @@
       <bibkey>lin-etal-2021-towards</bibkey>
       <video href="2021.acl-long.310.mp4"/>
       <pwccode url="https://github.com/DeepLearnXMU/User-Driven-NMT" additional="false">DeepLearnXMU/User-Driven-NMT</pwccode>
-      <video href="2021.acl-long.310.mp4"/>
     </paper>
     <paper id="311">
       <title>End-to-End Lexically Constrained Machine Translation for Morphologically Rich Languages</title>
@@ -5346,7 +5037,6 @@
       <doi>10.18653/v1/2021.acl-long.311</doi>
       <bibkey>jon-etal-2021-end</bibkey>
       <video href="2021.acl-long.311.mp4"/>
-      <video href="2021.acl-long.311.mp4"/>
     </paper>
     <paper id="312">
       <title>Handling Extreme Class Imbalance in Technical Logbook Datasets</title>
@@ -5359,7 +5049,6 @@
       <url hash="1dd6ec65">2021.acl-long.312</url>
       <doi>10.18653/v1/2021.acl-long.312</doi>
       <bibkey>akhbardeh-etal-2021-handling</bibkey>
-      <video href="2021.acl-long.312.mp4"/>
       <video href="2021.acl-long.312.mp4"/>
     </paper>
     <paper id="313">
@@ -5379,7 +5068,6 @@
       <video href="2021.acl-long.313.mp4"/>
       <pwccode url="https://github.com/Exploration-Lab/CJPE" additional="false">Exploration-Lab/CJPE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ildc">ILDC</pwcdataset>
-      <video href="2021.acl-long.313.mp4"/>
     </paper>
     <paper id="314">
       <title>Supporting Cognitive and Emotional Empathic Writing of Students</title>
@@ -5395,7 +5083,6 @@
       <bibkey>wambsganss-etal-2021-supporting</bibkey>
       <video href="2021.acl-long.314.mp4"/>
       <pwccode url="https://github.com/thiemowa/empathy_annotated_peer_reviews" additional="false">thiemowa/empathy_annotated_peer_reviews</pwccode>
-      <video href="2021.acl-long.314.mp4"/>
     </paper>
     <paper id="315">
       <title>Dual Reader-Parser on Hybrid Textual and Tabular Evidence for Open Domain Question Answering</title>
@@ -5436,7 +5123,6 @@
       <pwccode url="https://github.com/morningmoni/GAR" additional="false">morningmoni/GAR</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-long.316.mp4"/>
     </paper>
     <paper id="317">
       <title>Check It Again:Progressive Visual Question Answering via Visual Entailment</title>
@@ -5453,7 +5139,6 @@
       <video href="2021.acl-long.317.mp4"/>
       <pwccode url="https://github.com/PhoebusSi/SAR" additional="false">PhoebusSi/SAR</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-long.317.mp4"/>
     </paper>
     <paper id="318">
       <title>A Mutual Information Maximization Approach for the Spurious Solution Problem in Weakly Supervised Question Answering</title>
@@ -5473,7 +5158,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/quasar-t">QUASAR-T</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestions">WebQuestions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
-      <video href="2021.acl-long.318.mp4"/>
     </paper>
     <paper id="319">
       <title>Breaking Down Walls of Text: How Can <fixed-case>NLP</fixed-case> Benefit Consumer Privacy?</title>
@@ -5489,7 +5173,6 @@
       <bibkey>ravichander-etal-2021-breaking</bibkey>
       <video href="2021.acl-long.319.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/policyqa">PolicyQA</pwcdataset>
-      <video href="2021.acl-long.319.mp4"/>
     </paper>
     <paper id="320">
       <title>Supporting Land Reuse of Former Open Pit Mining Sites using Text Classification and Active Learning</title>
@@ -5509,7 +5192,6 @@
       <doi>10.18653/v1/2021.acl-long.320</doi>
       <bibkey>schroder-etal-2021-supporting</bibkey>
       <video href="2021.acl-long.320.mp4"/>
-      <video href="2021.acl-long.320.mp4"/>
     </paper>
     <paper id="321">
       <title>Reliability Testing for Natural Language Processing Systems</title>
@@ -5524,7 +5206,6 @@
       <url hash="83debd67">2021.acl-long.321</url>
       <doi>10.18653/v1/2021.acl-long.321</doi>
       <bibkey>tan-etal-2021-reliability</bibkey>
-      <video href="2021.acl-long.321.mp4"/>
       <video href="2021.acl-long.321.mp4"/>
     </paper>
     <paper id="322">
@@ -5546,7 +5227,6 @@
       <doi>10.18653/v1/2021.acl-long.322</doi>
       <bibkey>liang-etal-2021-learning</bibkey>
       <video href="2021.acl-long.322.mp4"/>
-      <video href="2021.acl-long.322.mp4"/>
     </paper>
     <paper id="323">
       <title>Anonymisation Models for Text Data: State of the art, Challenges and Future Directions</title>
@@ -5562,7 +5242,6 @@
       <bibkey>lison-etal-2021-anonymisation</bibkey>
       <video href="2021.acl-long.323.mp4"/>
       <pwccode url="https://github.com/ildikopilan/anonymisation_acl2021" additional="false">ildikopilan/anonymisation_acl2021</pwccode>
-      <video href="2021.acl-long.323.mp4"/>
     </paper>
     <paper id="324">
       <title>End-to-End <fixed-case>AMR</fixed-case> Coreference Resolution</title>
@@ -5577,7 +5256,6 @@
       <bibkey>fu-etal-2021-end</bibkey>
       <video href="2021.acl-long.324.mp4"/>
       <pwccode url="https://github.com/sean-blank/amrcoref" additional="false">sean-blank/amrcoref</pwccode>
-      <video href="2021.acl-long.324.mp4"/>
     </paper>
     <paper id="325">
       <title>How is <fixed-case>BERT</fixed-case> surprised? Layerwise detection of linguistic anomalies</title>
@@ -5594,7 +5272,6 @@
       <video href="2021.acl-long.325.mp4"/>
       <pwccode url="https://github.com/SPOClab-ca/layerwise-anomaly" additional="false">SPOClab-ca/layerwise-anomaly</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/blimp">BLiMP</pwcdataset>
-      <video href="2021.acl-long.325.mp4"/>
     </paper>
     <paper id="326">
       <title>Psycholinguistic Tripartite Graph Network for Personality Detection</title>
@@ -5609,7 +5286,6 @@
       <bibkey>yang-etal-2021-psycholinguistic</bibkey>
       <video href="2021.acl-long.326.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/pandora">PANDORA</pwcdataset>
-      <video href="2021.acl-long.326.mp4"/>
     </paper>
     <paper id="327">
       <title>Verb Metaphor Detection via Contextual Relation Learning</title>
@@ -5623,7 +5299,6 @@
       <url hash="ea346a68">2021.acl-long.327</url>
       <doi>10.18653/v1/2021.acl-long.327</doi>
       <bibkey>song-etal-2021-verb</bibkey>
-      <video href="2021.acl-long.327.mp4"/>
       <video href="2021.acl-long.327.mp4"/>
     </paper>
     <paper id="328">
@@ -5640,7 +5315,6 @@
       <bibkey>tang-etal-2021-improving</bibkey>
       <video href="2021.acl-long.328.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
-      <video href="2021.acl-long.328.mp4"/>
     </paper>
     <paper id="329">
       <title>Probing Toxic Content in Large Pre-Trained Language Models</title>
@@ -5657,7 +5331,6 @@
       <video href="2021.acl-long.329.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/atomic">ATOMIC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/hate-speech-and-offensive-language">Hate Speech and Offensive Language</pwcdataset>
-      <video href="2021.acl-long.329.mp4"/>
     </paper>
     <paper id="330">
       <title>Societal Biases in Language Generation: Progress and Challenges</title>
@@ -5672,7 +5345,6 @@
       <bibkey>sheng-etal-2021-societal</bibkey>
       <video href="2021.acl-long.330.mp4"/>
       <pwccode url="https://github.com/ewsheng/decoding-biases" additional="false">ewsheng/decoding-biases</pwccode>
-      <video href="2021.acl-long.330.mp4"/>
     </paper>
     <paper id="331">
       <title>Reservoir Transformers</title>
@@ -5690,7 +5362,6 @@
       <video href="2021.acl-long.331.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.331.mp4"/>
     </paper>
     <paper id="332">
       <title>Subsequence Based Deep Active Learning for Named Entity Recognition</title>
@@ -5704,7 +5375,6 @@
       <bibkey>radmard-etal-2021-subsequence</bibkey>
       <video href="2021.acl-long.332.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
-      <video href="2021.acl-long.332.mp4"/>
     </paper>
     <paper id="333">
       <title>Convolutions and Self-Attention: <fixed-case>R</fixed-case>e-interpreting Relative Positions in Pre-trained Language Models</title>
@@ -5722,7 +5392,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.333.mp4"/>
     </paper>
     <paper id="334">
       <title><fixed-case>B</fixed-case>inary<fixed-case>BERT</fixed-case>: Pushing the Limit of <fixed-case>BERT</fixed-case> Quantization</title>
@@ -5745,7 +5414,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.334.mp4"/>
     </paper>
     <paper id="335">
       <title>Are Pretrained Convolutions Better than Pretrained Transformers?</title>
@@ -5769,7 +5437,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.335.mp4"/>
     </paper>
     <paper id="336">
       <title><fixed-case>P</fixed-case>air<fixed-case>RE</fixed-case>: Knowledge Graph Embeddings via Paired Relation Vectors</title>
@@ -5786,7 +5453,6 @@
       <pwccode url="https://github.com/alipay/KnowledgeGraphEmbeddingsViaPairedRelationVectors_PairRE" additional="false">alipay/KnowledgeGraphEmbeddingsViaPairedRelationVectors_PairRE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ogb">OGB</pwcdataset>
-      <video href="2021.acl-long.336.mp4"/>
     </paper>
     <paper id="337">
       <title>Hierarchy-aware Label Semantics Matching Network for Hierarchical Text Classification</title>
@@ -5804,7 +5470,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/eurlex57k">EURLEX57K</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rcv1">RCV1</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/web-of-science-dataset">WOS</pwcdataset>
-      <video href="2021.acl-long.337.mp4"/>
     </paper>
     <paper id="338">
       <title><fixed-case>H</fixed-case>idden<fixed-case>C</fixed-case>ut: Simple Data Augmentation for Natural Language Understanding with Better Generalizability</title>
@@ -5822,7 +5487,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.338.mp4"/>
     </paper>
     <paper id="339">
       <title>Neural Stylistic Response Generation with Disentangled Latent Variables</title>
@@ -5837,7 +5501,6 @@
       <bibkey>zhu-etal-2021-neural</bibkey>
       <video href="2021.acl-long.339.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
-      <video href="2021.acl-long.339.mp4"/>
     </paper>
     <paper id="340">
       <title>Intent Classification and Slot Filling for Privacy Policies</title>
@@ -5855,7 +5518,6 @@
       <bibkey>ahmad-etal-2021-intent</bibkey>
       <video href="2021.acl-long.340.mp4"/>
       <pwccode url="https://github.com/wasiahmad/PolicyIE" additional="false">wasiahmad/PolicyIE</pwccode>
-      <video href="2021.acl-long.340.mp4"/>
     </paper>
     <paper id="341">
       <title><fixed-case>RADDLE</fixed-case>: An Evaluation Benchmark and Analysis Platform for Robust Task-oriented Dialog Systems</title>
@@ -5873,7 +5535,6 @@
       <video href="2021.acl-long.341.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.acl-long.341.mp4"/>
     </paper>
     <paper id="342">
       <title>Semantic Representation for Dialogue Modeling</title>
@@ -5890,7 +5551,6 @@
       <pwccode url="https://github.com/muyeby/AMR-Dialogue" additional="false">muyeby/AMR-Dialogue</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dialogre">DialogRE</pwcdataset>
-      <video href="2021.acl-long.342.mp4"/>
     </paper>
     <paper id="343">
       <title>A Pre-training Strategy for Zero-Resource Response Selection in Knowledge-Grounded Conversations</title>
@@ -5908,7 +5568,6 @@
       <video href="2021.acl-long.343.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cmu-dog">CMU DoG</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
-      <video href="2021.acl-long.343.mp4"/>
     </paper>
     <paper id="344">
       <title>Dependency-driven Relation Extraction with Attentive Graph Convolutional Networks</title>
@@ -5926,7 +5585,6 @@
       <video href="2021.acl-long.344.mp4"/>
       <pwccode url="https://github.com/cuhksz-nlp/re-agcn" additional="false">cuhksz-nlp/re-agcn</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2010-task-8">SemEval-2010 Task 8</pwcdataset>
-      <video href="2021.acl-long.344.mp4"/>
     </paper>
     <paper id="345">
       <title>Evaluating Entity Disambiguation and the Role of Popularity in Retrieval-Based <fixed-case>NLP</fixed-case></title>
@@ -5946,7 +5604,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/kilt">KILT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/t-rex">T-REx</pwcdataset>
-      <video href="2021.acl-long.345.mp4"/>
     </paper>
     <paper id="346">
       <title>Evaluation Examples are not Equally Informative: How should that change <fixed-case>NLP</fixed-case> Leaderboards?</title>
@@ -5965,7 +5622,6 @@
       <video href="2021.acl-long.346.mp4"/>
       <pwccode url="https://github.com/jplalor/py-irt" additional="false">jplalor/py-irt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.346.mp4"/>
     </paper>
     <paper id="347">
       <title>Claim Matching Beyond <fixed-case>E</fixed-case>nglish to Scale Global Fact-Checking</title>
@@ -5980,7 +5636,6 @@
       <bibkey>kazemi-etal-2021-claim</bibkey>
       <video href="2021.acl-long.347.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
-      <video href="2021.acl-long.347.mp4"/>
     </paper>
     <paper id="348">
       <title><fixed-case>S</fixed-case>em<fixed-case>F</fixed-case>ace: Pre-training Encoder and Decoder with a Semantic Interface for Neural Machine Translation</title>
@@ -5995,7 +5650,6 @@
       <url hash="36bca43e">2021.acl-long.348</url>
       <doi>10.18653/v1/2021.acl-long.348</doi>
       <bibkey>ren-etal-2021-semface</bibkey>
-      <video href="2021.acl-long.348.mp4"/>
       <video href="2021.acl-long.348.mp4"/>
     </paper>
     <paper id="349">
@@ -6013,7 +5667,6 @@
       <bibkey>bhattacharyya-etal-2021-energy</bibkey>
       <video href="2021.acl-long.349.mp4"/>
       <pwccode url="https://github.com/rooshenas/ebr_mt" additional="false">rooshenas/ebr_mt</pwccode>
-      <video href="2021.acl-long.349.mp4"/>
     </paper>
     <paper id="350">
       <title>Syntax-augmented Multilingual <fixed-case>BERT</fixed-case> for Cross-lingual Transfer</title>
@@ -6032,7 +5685,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/paws-x">PAWS-X</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.acl-long.350.mp4"/>
     </paper>
     <paper id="351">
       <title>How to Adapt Your Pretrained Multilingual Model to 1600 Languages</title>
@@ -6043,7 +5695,6 @@
       <url hash="0ec129c8">2021.acl-long.351</url>
       <doi>10.18653/v1/2021.acl-long.351</doi>
       <bibkey>ebrahimi-kann-2021-adapt</bibkey>
-      <video href="2021.acl-long.351.mp4"/>
       <video href="2021.acl-long.351.mp4"/>
     </paper>
     <paper id="352">
@@ -6062,7 +5713,6 @@
       <pwccode url="https://github.com/JiachengLi1995/TALLOR" additional="true">JiachengLi1995/TALLOR</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bc5cdr">BC5CDR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
-      <video href="2021.acl-long.352.mp4"/>
     </paper>
     <paper id="353">
       <title>Prefix-Tuning: Optimizing Continuous Prompts for Generation</title>
@@ -6076,7 +5726,6 @@
       <video href="2021.acl-long.353.mp4"/>
       <pwccode url="https://github.com/XiangLi1999/PrefixTuning" additional="true">XiangLi1999/PrefixTuning</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dart">DART</pwcdataset>
-      <video href="2021.acl-long.353.mp4"/>
     </paper>
     <paper id="354">
       <title><fixed-case>O</fixed-case>ne2<fixed-case>S</fixed-case>et: <fixed-case>G</fixed-case>enerating Diverse Keyphrases as a Set</title>
@@ -6093,7 +5742,6 @@
       <video href="2021.acl-long.354.mp4"/>
       <pwccode url="https://github.com/jiacheng-ye/kg_one2set" additional="false">jiacheng-ye/kg_one2set</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/kp20k">KP20k</pwcdataset>
-      <video href="2021.acl-long.354.mp4"/>
     </paper>
     <paper id="355">
       <title>Continuous Language Generative Flow</title>
@@ -6110,7 +5758,6 @@
       <pwccode url="https://github.com/zinengtang/continuousflownlg" additional="false">zinengtang/continuousflownlg</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/tvqa">TVQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tvqa-1">TVQA+</pwcdataset>
-      <video href="2021.acl-long.355.mp4"/>
     </paper>
     <paper id="356">
       <title><fixed-case>TWAG</fixed-case>: A Topic-Guided <fixed-case>W</fixed-case>ikipedia Abstract Generator</title>
@@ -6131,7 +5778,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wikicatsum">WikiCatSum</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisum">WikiSum</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikipedia-generation">Wikipedia Generation</pwcdataset>
-      <video href="2021.acl-long.356.mp4"/>
     </paper>
     <paper id="357">
       <title><fixed-case>F</fixed-case>orecast<fixed-case>QA</fixed-case>: A Question Answering Challenge for Event Forecasting with Temporal Text Data</title>
@@ -6150,7 +5796,6 @@
       <video href="2021.acl-long.357.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/forecastqa">ForecastQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
-      <video href="2021.acl-long.357.mp4"/>
     </paper>
     <paper id="358">
       <title>Recursive Tree-Structured Self-Attention for Answer Sentence Selection</title>
@@ -6165,7 +5810,6 @@
       <video href="2021.acl-long.358.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/asnq">ASNQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiqa">WikiQA</pwcdataset>
-      <video href="2021.acl-long.358.mp4"/>
     </paper>
     <paper id="359">
       <title>How Knowledge Graph and Attention Help? A Qualitative Analysis into Bag-level Relation Extraction</title>
@@ -6181,7 +5825,6 @@
       <video href="2021.acl-long.359.mp4"/>
       <pwccode url="https://github.com/zig-kwin-hu/how-KG-ATT-help" additional="false">zig-kwin-hu/how-KG-ATT-help</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
-      <video href="2021.acl-long.359.mp4"/>
     </paper>
     <paper id="360">
       <title>Trigger is Not Sufficient: Exploiting Frame-aware Knowledge for Implicit Event Argument Extraction</title>
@@ -6196,7 +5839,6 @@
       <url hash="1ba8ba11">2021.acl-long.360</url>
       <doi>10.18653/v1/2021.acl-long.360</doi>
       <bibkey>wei-etal-2021-trigger</bibkey>
-      <video href="2021.acl-long.360.mp4"/>
       <video href="2021.acl-long.360.mp4"/>
     </paper>
     <paper id="361">
@@ -6215,7 +5857,6 @@
       <revision id="2" href="2021.acl-long.361v2" hash="0b78b856" date="2021-08-17">Typo fixes in Abstract, clearer content in Related Work and Conclusion</revision>
       <video href="2021.acl-long.361.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/t-rex">T-REx</pwcdataset>
-      <video href="2021.acl-long.361.mp4"/>
     </paper>
     <paper id="362">
       <title><fixed-case>A</fixed-case>da<fixed-case>T</fixed-case>ag: Multi-Attribute Value Extraction from Product Profiles with Adaptive Decoding</title>
@@ -6231,7 +5872,6 @@
       <doi>10.18653/v1/2021.acl-long.362</doi>
       <bibkey>yan-etal-2021-adatag</bibkey>
       <video href="2021.acl-long.362.mp4"/>
-      <video href="2021.acl-long.362.mp4"/>
     </paper>
     <paper id="363">
       <title><fixed-case>C</fixed-case>o<fixed-case>RI</fixed-case>: Collective Relation Integration with Data Augmentation for Open Information Extraction</title>
@@ -6244,7 +5884,6 @@
       <url hash="25a7a172">2021.acl-long.363</url>
       <doi>10.18653/v1/2021.acl-long.363</doi>
       <bibkey>jiang-etal-2021-cori</bibkey>
-      <video href="2021.acl-long.363.mp4"/>
       <video href="2021.acl-long.363.mp4"/>
     </paper>
     <paper id="364">
@@ -6262,7 +5901,6 @@
       <pwccode url="https://github.com/rloganiv/streaming-cdc" additional="false">rloganiv/streaming-cdc</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/medmentions">MedMentions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/zeshel">ZESHEL</pwcdataset>
-      <video href="2021.acl-long.364.mp4"/>
     </paper>
     <paper id="365">
       <title>Search from History and Reason for Future: Two-stage Reasoning on Temporal Knowledge Graphs</title>
@@ -6280,7 +5918,6 @@
       <bibkey>li-etal-2021-search</bibkey>
       <video href="2021.acl-long.365.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/icews">ICEWS</pwcdataset>
-      <video href="2021.acl-long.365.mp4"/>
     </paper>
     <paper id="366">
       <title>Employing Argumentation Knowledge Graphs for Neural Argument Generation</title>
@@ -6296,7 +5933,6 @@
       <bibkey>al-khatib-etal-2021-employing</bibkey>
       <video href="2021.acl-long.366.mp4"/>
       <pwccode url="https://github.com/webis-de/ACL-21" additional="false">webis-de/ACL-21</pwccode>
-      <video href="2021.acl-long.366.mp4"/>
     </paper>
     <paper id="367">
       <title>Learning Span-Level Interactions for Aspect Sentiment Triplet Extraction</title>
@@ -6311,7 +5947,6 @@
       <video href="2021.acl-long.367.mp4"/>
       <pwccode url="https://github.com/chiayewken/Span-ASTE" additional="true">chiayewken/Span-ASTE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aste-data-v2">ASTE-Data-V2</pwcdataset>
-      <video href="2021.acl-long.367.mp4"/>
     </paper>
     <paper id="368">
       <title>On Compositional Generalization of Neural Machine Translation</title>
@@ -6329,7 +5964,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cfq">CFQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.acl-long.368.mp4"/>
     </paper>
     <paper id="369">
       <title>Mask-Align: Self-Supervised Neural Word Alignment</title>
@@ -6343,7 +5977,6 @@
       <bibkey>chen-etal-2021-mask</bibkey>
       <video href="2021.acl-long.369.mp4"/>
       <pwccode url="https://github.com/THUNLP-MT/Mask-Align" additional="false">THUNLP-MT/Mask-Align</pwccode>
-      <video href="2021.acl-long.369.mp4"/>
     </paper>
     <paper id="370">
       <title><fixed-case>GWLAN</fixed-case>: General Word-Level <fixed-case>A</fixed-case>utocompletio<fixed-case>N</fixed-case> for Computer-Aided Translation</title>
@@ -6356,7 +5989,6 @@
       <url hash="0c2a2aa1">2021.acl-long.370</url>
       <doi>10.18653/v1/2021.acl-long.370</doi>
       <bibkey>li-etal-2021-gwlan</bibkey>
-      <video href="2021.acl-long.370.mp4"/>
       <video href="2021.acl-long.370.mp4"/>
     </paper>
     <paper id="371">
@@ -6373,7 +6005,6 @@
       <video href="2021.acl-long.371.mp4"/>
       <pwccode url="https://github.com/zwkatgithub/DSCAU" additional="false">zwkatgithub/DSCAU</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
-      <video href="2021.acl-long.371.mp4"/>
     </paper>
     <paper id="372">
       <title>A Span-Based Model for Joint Overlapped and Discontinuous Named Entity Recognition</title>
@@ -6389,7 +6020,6 @@
       <video href="2021.acl-long.372.mp4"/>
       <pwccode url="https://github.com/foxlf823/sodner" additional="false">foxlf823/sodner</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/genia">GENIA</pwcdataset>
-      <video href="2021.acl-long.372.mp4"/>
     </paper>
     <paper id="373">
       <title><fixed-case>MLB</fixed-case>i<fixed-case>N</fixed-case>et: A Cross-Sentence Collective Event Detection Network</title>
@@ -6406,7 +6036,6 @@
       <video href="2021.acl-long.373.mp4"/>
       <pwccode url="https://github.com/zjunlp/DocED" additional="false">zjunlp/DocED</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ace-2005">ACE 2005</pwcdataset>
-      <video href="2021.acl-long.373.mp4"/>
     </paper>
     <paper id="374">
       <title>Exploiting Document Structures and Cluster Consistencies for Event Coreference Resolution</title>
@@ -6418,7 +6047,6 @@
       <url hash="16fc6c84">2021.acl-long.374</url>
       <doi>10.18653/v1/2021.acl-long.374</doi>
       <bibkey>minh-tran-etal-2021-exploiting</bibkey>
-      <video href="2021.acl-long.374.mp4"/>
       <video href="2021.acl-long.374.mp4"/>
     </paper>
     <paper id="375">
@@ -6434,7 +6062,6 @@
       <bibkey>tian-etal-2021-stereorel</bibkey>
       <video href="2021.acl-long.375.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.acl-long.375.mp4"/>
     </paper>
     <paper id="376">
       <title>Knowledge-Enriched Event Causality Identification via Latent Structure Induction Networks</title>
@@ -6453,7 +6080,6 @@
       <revision id="1" href="2021.acl-long.376v1" hash="2e648e90"/>
       <revision id="2" href="2021.acl-long.376v2" hash="d4e7b0af" date="2022-01-02">Updated results in Table 2 and Figure 3.</revision>
       <video href="2021.acl-long.376.mp4"/>
-      <video href="2021.acl-long.376.mp4"/>
     </paper>
     <paper id="377">
       <title>Turn the Combination Lock: Learnable Textual Backdoor Attacks via Word Substitution</title>
@@ -6471,7 +6097,6 @@
       <pwccode url="https://github.com/thunlp/BkdAtk-LWS" additional="false">thunlp/BkdAtk-LWS</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/olid">OLID</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.377.mp4"/>
     </paper>
     <paper id="378">
       <title>Parameter-Efficient Transfer Learning with Diff Pruning</title>
@@ -6488,7 +6113,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.378.mp4"/>
     </paper>
     <paper id="379">
       <title><fixed-case>R</fixed-case>2<fixed-case>D</fixed-case>2: Recursive Transformer based on Differentiable Tree for Interpretable Hierarchical Language Modeling</title>
@@ -6508,7 +6132,6 @@
       <pwccode url="https://github.com/alipay/StructuredLM_RTDT" additional="false">alipay/StructuredLM_RTDT</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.acl-long.379.mp4"/>
     </paper>
     <paper id="380">
       <title>Risk Minimization for Zero-shot Sequence Labeling</title>
@@ -6524,7 +6147,6 @@
       <url hash="5a70a1a1">2021.acl-long.380</url>
       <doi>10.18653/v1/2021.acl-long.380</doi>
       <bibkey>hu-etal-2021-risk</bibkey>
-      <video href="2021.acl-long.380.mp4"/>
       <video href="2021.acl-long.380.mp4"/>
     </paper>
     <paper id="381">
@@ -6550,7 +6172,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semantic-textual-similarity-2012-2016">Semantic Textual Similarity (2012 - 2016)</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.acl-long.381.mp4"/>
     </paper>
     <paper id="382">
       <title>Lexicon Learning for Few Shot Sequence Modeling</title>
@@ -6564,7 +6185,6 @@
       <video href="2021.acl-long.382.mp4"/>
       <pwccode url="https://github.com/ekinakyurek/lexical" additional="false">ekinakyurek/lexical</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.acl-long.382.mp4"/>
     </paper>
     <paper id="383">
       <title>Personalized Transformer for Explainable Recommendation</title>
@@ -6579,7 +6199,6 @@
       <video href="2021.acl-long.383.mp4"/>
       <pwccode url="https://github.com/lileipisces/PETER" additional="false">lileipisces/PETER</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/100doh">100DOH</pwcdataset>
-      <video href="2021.acl-long.383.mp4"/>
     </paper>
     <paper id="384">
       <title>Generating <fixed-case>SOAP</fixed-case> Notes from Doctor-Patient Conversations Using Modular Summarization Techniques</title>
@@ -6593,7 +6212,6 @@
       <doi>10.18653/v1/2021.acl-long.384</doi>
       <bibkey>krishna-etal-2021-generating</bibkey>
       <video href="2021.acl-long.384.mp4"/>
-      <video href="2021.acl-long.384.mp4"/>
     </paper>
     <paper id="385">
       <title>Tail-to-Tail Non-Autoregressive Sequence Prediction for <fixed-case>C</fixed-case>hinese Grammatical Error Correction</title>
@@ -6606,7 +6224,6 @@
       <bibkey>li-shi-2021-tail</bibkey>
       <video href="2021.acl-long.385.mp4"/>
       <pwccode url="https://github.com/lipiji/TtT" additional="false">lipiji/TtT</pwccode>
-      <video href="2021.acl-long.385.mp4"/>
     </paper>
     <paper id="386">
       <title>Early Detection of Sexual Predators in Chats</title>
@@ -6621,7 +6238,6 @@
       <video href="2021.acl-long.386.mp4"/>
       <pwccode url="https://gitlab.com/early-sexual-predator-detection/eSPD-lab" additional="false">early-sexual-predator-detection/eSPD-lab</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/panc">PANC</pwcdataset>
-      <video href="2021.acl-long.386.mp4"/>
     </paper>
     <paper id="387">
       <title>Writing by Memorizing: Hierarchical Retrieval-based Medical Report Generation</title>
@@ -6636,7 +6252,6 @@
       <bibkey>yang-etal-2021-writing</bibkey>
       <video href="2021.acl-long.387.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mimic-cxr">MIMIC-CXR</pwcdataset>
-      <video href="2021.acl-long.387.mp4"/>
     </paper>
     <paper id="388">
       <title>Concept-Based Label Embedding via Dynamic Routing for Hierarchical Text Classification</title>
@@ -6653,7 +6268,6 @@
       <bibkey>wang-etal-2021-concept</bibkey>
       <video href="2021.acl-long.388.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/web-of-science-dataset">WOS</pwcdataset>
-      <video href="2021.acl-long.388.mp4"/>
     </paper>
     <paper id="389">
       <title><fixed-case>V</fixed-case>isual<fixed-case>S</fixed-case>parta: An Embarrassingly Simple Approach to Large-scale Text-to-Image Search with Weighted Bag-of-words</title>
@@ -6669,7 +6283,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/coco-captions">COCO Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
-      <video href="2021.acl-long.389.mp4"/>
     </paper>
     <paper id="390">
       <title>Few-Shot Text Ranking with Meta Adapted Synthetic Weak Supervision</title>
@@ -6689,7 +6302,6 @@
       <video href="2021.acl-long.390.mp4"/>
       <pwccode url="https://github.com/thunlp/MetaAdaptRank" additional="false">thunlp/MetaAdaptRank</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
-      <video href="2021.acl-long.390.mp4"/>
     </paper>
     <paper id="391">
       <title>Semi-Supervised Text Classification with Balanced Deep Representation Distributions</title>
@@ -6703,7 +6315,6 @@
       <bibkey>li-etal-2021-semi-supervised</bibkey>
       <video href="2021.acl-long.391.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
-      <video href="2021.acl-long.391.mp4"/>
     </paper>
     <paper id="392">
       <title>Improving Document Representations by Generating Pseudo Query Embeddings for Dense Retrieval</title>
@@ -6720,7 +6331,6 @@
       <bibkey>tang-etal-2021-improving-document</bibkey>
       <video href="2021.acl-long.392.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
-      <video href="2021.acl-long.392.mp4"/>
     </paper>
     <paper id="393">
       <title><fixed-case>C</fixed-case>on<fixed-case>SERT</fixed-case>: A Contrastive Framework for Self-Supervised Sentence Representation Transfer</title>
@@ -6740,7 +6350,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.acl-long.393.mp4"/>
     </paper>
     <paper id="394">
       <title>Exploring Dynamic Selection of Branch Expansion Orders for Code Generation</title>
@@ -6760,7 +6369,6 @@
       <video href="2021.acl-long.394.mp4"/>
       <pwccode url="https://github.com/DeepLearnXMU/CG-RL" additional="false">DeepLearnXMU/CG-RL</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conala">CoNaLa</pwcdataset>
-      <video href="2021.acl-long.394.mp4"/>
     </paper>
     <paper id="395">
       <title><fixed-case>COINS</fixed-case>: Dynamically Generating <fixed-case>CO</fixed-case>ntextualized Inference Rules for Narrative Story Completion</title>
@@ -6776,7 +6384,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/atomic">ATOMIC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glucose">GLUCOSE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
-      <video href="2021.acl-long.395.mp4"/>
     </paper>
     <paper id="396">
       <title>Reasoning over Entity-Action-Location Graph for Procedural Text Understanding</title>
@@ -6793,7 +6400,6 @@
       <video href="2021.acl-long.396.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/propara">ProPara</pwcdataset>
-      <video href="2021.acl-long.396.mp4"/>
     </paper>
     <paper id="397">
       <title>From Paraphrasing to Semantic Parsing: Unsupervised Semantic Parsing via Synchronous Semantic Decoding</title>
@@ -6812,7 +6418,6 @@
       <doi>10.18653/v1/2021.acl-long.397</doi>
       <bibkey>wu-etal-2021-paraphrasing</bibkey>
       <video href="2021.acl-long.397.mp4"/>
-      <video href="2021.acl-long.397.mp4"/>
     </paper>
     <paper id="398">
       <title>Pre-training Universal Language Representation</title>
@@ -6830,7 +6435,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.398.mp4"/>
     </paper>
     <paper id="399">
       <title>Structural Pre-training for Dialogue Comprehension</title>
@@ -6845,7 +6449,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/douban">Douban</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/douban-conversation-corpus">Douban Conversation Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mutual">MuTual</pwcdataset>
-      <video href="2021.acl-long.399.mp4"/>
     </paper>
     <paper id="400">
       <title><fixed-case>A</fixed-case>uto<fixed-case>T</fixed-case>iny<fixed-case>BERT</fixed-case>: Automatic Hyper-parameter Optimization for Efficient Pre-trained Language Models</title>
@@ -6865,7 +6468,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.400.mp4"/>
     </paper>
     <paper id="401">
       <title>Data Augmentation with Adversarial Training for Cross-Lingual <fixed-case>NLI</fixed-case></title>
@@ -6879,7 +6481,6 @@
       <url hash="c1da9200">2021.acl-long.401</url>
       <doi>10.18653/v1/2021.acl-long.401</doi>
       <bibkey>dong-etal-2021-data</bibkey>
-      <video href="2021.acl-long.401.mp4"/>
       <video href="2021.acl-long.401.mp4"/>
     </paper>
     <paper id="402">
@@ -6900,7 +6501,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.acl-long.402.mp4"/>
     </paper>
     <paper id="403">
       <title>Learning Event Graph Knowledge for Abductive Reasoning</title>
@@ -6918,7 +6518,6 @@
       <pwccode url="https://github.com/sjcfr/ege-roberta" additional="false">sjcfr/ege-roberta</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/timetravel">TimeTravel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vist">VIST</pwcdataset>
-      <video href="2021.acl-long.403.mp4"/>
     </paper>
     <paper id="404">
       <title>A Cognitive Regularizer for Language Modeling</title>
@@ -6934,7 +6533,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wiki-40b">Wiki-40B</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.acl-long.404.mp4"/>
     </paper>
     <paper id="405">
       <title>Lower Perplexity is Not Always Human-Like</title>
@@ -6953,7 +6551,6 @@
       <revision id="2" href="2021.acl-long.405v2" hash="fae3db42" date="2022-01-24">Corrected data stats in Table 1 and updated metric psychometric predictive power.</revision>
       <video href="2021.acl-long.405.mp4"/>
       <pwccode url="https://github.com/kuribayashi4/surprisal_reading_time_en_ja" additional="false">kuribayashi4/surprisal_reading_time_en_ja</pwccode>
-      <video href="2021.acl-long.405.mp4"/>
     </paper>
     <paper id="406">
       <title>Word Sense Disambiguation: Towards Interactive Context Exploitation from Both Word and Sense Perspectives</title>
@@ -6967,7 +6564,6 @@
       <video href="2021.acl-long.406.mp4"/>
       <pwccode url="https://github.com/lwmlyy/sace" additional="false">lwmlyy/sace</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.acl-long.406.mp4"/>
     </paper>
     <paper id="407">
       <title>A Knowledge-Guided Framework for Frame Identification</title>
@@ -6985,7 +6581,6 @@
       <bibkey>su-etal-2021-knowledge</bibkey>
       <video href="2021.acl-long.407.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
-      <video href="2021.acl-long.407.mp4"/>
     </paper>
     <paper id="408">
       <title>Obtaining Better Static Word Embeddings Using Contextual Embedding Models</title>
@@ -7000,7 +6595,6 @@
       <pwccode url="https://github.com/epfml/X2Static" additional="false">epfml/X2Static</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mpqa-opinion-corpus">MPQA Opinion Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.408.mp4"/>
     </paper>
     <paper id="409">
       <title>Meta-Learning with Variational Semantic Memory for Word Sense Disambiguation</title>
@@ -7016,7 +6610,6 @@
       <bibkey>du-etal-2021-meta</bibkey>
       <video href="2021.acl-long.409.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.acl-long.409.mp4"/>
     </paper>
     <paper id="410">
       <title><fixed-case>L</fixed-case>ex<fixed-case>F</fixed-case>it: Lexical Fine-Tuning of Pretrained Language Models</title>
@@ -7029,7 +6622,6 @@
       <url hash="56326ae1">2021.acl-long.410</url>
       <doi>10.18653/v1/2021.acl-long.410</doi>
       <bibkey>vulic-etal-2021-lexfit</bibkey>
-      <video href="2021.acl-long.410.mp4"/>
       <video href="2021.acl-long.410.mp4"/>
     </paper>
     <paper id="411">
@@ -7048,7 +6640,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ljspeech">LJSpeech</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/places205">Places205</pwcdataset>
-      <video href="2021.acl-long.411.mp4"/>
     </paper>
     <paper id="412">
       <title><fixed-case>CTFN</fixed-case>: Hierarchical Learning for Multimodal Sentiment Analysis Using Coupled-Translation Fusion Network</title>
@@ -7066,7 +6657,6 @@
       <bibkey>tang-etal-2021-ctfn</bibkey>
       <video href="2021.acl-long.412.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
-      <video href="2021.acl-long.412.mp4"/>
     </paper>
     <paper id="413">
       <title>Positional Artefacts Propagate Through Masked Language Model Embeddings</title>
@@ -7082,7 +6672,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
-      <video href="2021.acl-long.413.mp4"/>
     </paper>
     <paper id="414">
       <title>Language Model Evaluation Beyond Perplexity</title>
@@ -7094,7 +6683,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="1adbbac1">2021.acl-long.414.OptionalSupplementaryMaterial.pdf</attachment>
       <doi>10.18653/v1/2021.acl-long.414</doi>
       <bibkey>meister-cotterell-2021-language</bibkey>
-      <video href="2021.acl-long.414.mp4"/>
       <video href="2021.acl-long.414.mp4"/>
     </paper>
     <paper id="415">
@@ -7113,7 +6701,6 @@
       <pwccode url="https://github.com/situsnow/l2e" additional="false">situsnow/l2e</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.415.mp4"/>
     </paper>
     <paper id="416">
       <title><fixed-case>S</fixed-case>tereo<fixed-case>S</fixed-case>et: Measuring stereotypical bias in pretrained language models</title>
@@ -7128,7 +6715,6 @@
       <video href="2021.acl-long.416.mp4"/>
       <pwccode url="https://github.com/moinnadeem/StereoSet" additional="true">moinnadeem/StereoSet</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/stereoset">StereoSet</pwcdataset>
-      <video href="2021.acl-long.416.mp4"/>
     </paper>
     <paper id="417">
       <title>Alignment Rationale for Natural Language Inference</title>
@@ -7146,7 +6732,6 @@
       <pwccode url="https://github.com/changmenseng/arec" additional="false">changmenseng/arec</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/e-snli">e-SNLI</pwcdataset>
-      <video href="2021.acl-long.417.mp4"/>
     </paper>
     <paper id="418">
       <title>Enabling Lightweight Fine-tuning for Pre-trained Language Model Compression based on Matrix Product Operators</title>
@@ -7165,7 +6750,6 @@
       <pwccode url="https://github.com/RUCAIBox/MPOP" additional="false">RUCAIBox/MPOP</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.418.mp4"/>
     </paper>
     <paper id="419">
       <title>On Sample Based Explanation Methods for <fixed-case>NLP</fixed-case>: Faithfulness, Efficiency and Semantic Evaluation</title>
@@ -7183,7 +6767,6 @@
       <bibkey>zhang-etal-2021-sample</bibkey>
       <video href="2021.acl-long.419.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mams">MAMS</pwcdataset>
-      <video href="2021.acl-long.419.mp4"/>
     </paper>
     <paper id="420">
       <title>Syntax-Enhanced Pre-trained Model</title>
@@ -7209,7 +6792,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/quasar-1">QUASAR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quasar-t">QUASAR-T</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
-      <video href="2021.acl-long.420.mp4"/>
     </paper>
     <paper id="421">
       <title>Matching Distributions between Model and Data: Cross-domain Knowledge Distillation for Unsupervised Domain Adaptation</title>
@@ -7223,7 +6805,6 @@
       <url hash="43f53db9">2021.acl-long.421</url>
       <doi>10.18653/v1/2021.acl-long.421</doi>
       <bibkey>zhang-etal-2021-matching</bibkey>
-      <video href="2021.acl-long.421.mp4"/>
       <video href="2021.acl-long.421.mp4"/>
     </paper>
     <paper id="422">
@@ -7240,7 +6821,6 @@
       <bibkey>qian-etal-2021-counterfactual</bibkey>
       <video href="2021.acl-long.422.mp4"/>
       <pwccode url="https://github.com/qianc62/corsair" additional="false">qianc62/corsair</pwccode>
-      <video href="2021.acl-long.422.mp4"/>
     </paper>
     <paper id="423">
       <title><fixed-case>H</fixed-case>ie<fixed-case>R</fixed-case>ec: Hierarchical User Interest Modeling for Personalized News Recommendation</title>
@@ -7258,7 +6838,6 @@
       <bibkey>qi-etal-2021-hierec</bibkey>
       <video href="2021.acl-long.423.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mind">MIND</pwcdataset>
-      <video href="2021.acl-long.423.mp4"/>
     </paper>
     <paper id="424">
       <title><fixed-case>PP</fixed-case>-Rec: News Recommendation with Personalized User Interest and Time-aware News Popularity</title>
@@ -7271,7 +6850,6 @@
       <url hash="6865cd3e">2021.acl-long.424</url>
       <doi>10.18653/v1/2021.acl-long.424</doi>
       <bibkey>qi-etal-2021-pp</bibkey>
-      <video href="2021.acl-long.424.mp4"/>
       <video href="2021.acl-long.424.mp4"/>
     </paper>
     <paper id="425">
@@ -7289,7 +6867,6 @@
       <video href="2021.acl-long.425.mp4"/>
       <pwccode url="https://github.com/ictmcg/mtm" additional="false">ictmcg/mtm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snopes">Snopes</pwcdataset>
-      <video href="2021.acl-long.425.mp4"/>
     </paper>
     <paper id="426">
       <title>Defense against Synonym Substitution-based Adversarial Attacks via <fixed-case>D</fixed-case>irichlet Neighborhood Ensemble</title>
@@ -7307,7 +6884,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-long.426.mp4"/>
     </paper>
     <paper id="427">
       <title>Shortformer: Better Language Modeling using Shorter Inputs</title>
@@ -7324,7 +6900,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.acl-long.427.mp4"/>
     </paper>
     <paper id="428">
       <title><fixed-case>B</fixed-case>andit<fixed-case>MTL</fixed-case>: Bandit-based Multi-task Learning for Text Classification</title>
@@ -7339,7 +6914,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="eb0a35fc">2021.acl-long.428.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-long.428</doi>
       <bibkey>mao-etal-2021-banditmtl</bibkey>
-      <video href="2021.acl-long.428.mp4"/>
       <video href="2021.acl-long.428.mp4"/>
     </paper>
     <paper id="429">
@@ -7361,7 +6935,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wn18">WN18</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wn18rr">WN18RR</pwcdataset>
-      <video href="2021.acl-long.429.mp4"/>
     </paper>
     <paper id="430">
       <title>De-Confounded Variational Encoder-Decoder for Logical Table-to-Text Generation</title>
@@ -7375,7 +6948,6 @@
       <url hash="3917ac37">2021.acl-long.430</url>
       <doi>10.18653/v1/2021.acl-long.430</doi>
       <bibkey>chen-etal-2021-de</bibkey>
-      <video href="2021.acl-long.430.mp4"/>
       <video href="2021.acl-long.430.mp4"/>
     </paper>
     <paper id="431">
@@ -7393,7 +6965,6 @@
       <video href="2021.acl-long.431.mp4"/>
       <pwccode url="https://github.com/lancopku/sos" additional="false">lancopku/sos</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.acl-long.431.mp4"/>
     </paper>
     <paper id="432">
       <title>Crowdsourcing Learning as Domain Adaptation: <fixed-case>A</fixed-case> Case Study on Named Entity Recognition</title>
@@ -7410,7 +6981,6 @@
       <video href="2021.acl-long.432.mp4"/>
       <pwccode url="https://github.com/izhx/CLasDA" additional="false">izhx/CLasDA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
-      <video href="2021.acl-long.432.mp4"/>
     </paper>
     <paper id="433">
       <title>Exploring Distantly-Labeled Rationales in Neural Network Models</title>
@@ -7425,7 +6995,6 @@
       <bibkey>huang-etal-2021-exploring</bibkey>
       <video href="2021.acl-long.433.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.433.mp4"/>
     </paper>
     <paper id="434">
       <title>Learning to Perturb Word Embeddings for Out-of-distribution <fixed-case>QA</fixed-case></title>
@@ -7442,7 +7011,6 @@
       <pwccode url="https://github.com/seanie12/SWEP" additional="false">seanie12/SWEP</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bioasq">BioASQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.434.mp4"/>
     </paper>
     <paper id="435">
       <title>Maria: A Visual Experience Powered Conversational Agent</title>
@@ -7464,7 +7032,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/reddit-conversation-corpus">Reddit Conversation Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
-      <video href="2021.acl-long.435.mp4"/>
     </paper>
     <paper id="436">
       <title>A Human-machine Collaborative Framework for Evaluating Malevolence in Dialogues</title>
@@ -7478,7 +7045,6 @@
       <bibkey>zhang-etal-2021-human</bibkey>
       <video href="2021.acl-long.436.mp4"/>
       <pwccode url="https://github.com/repozhang/case_hmceval" additional="false">repozhang/case_hmceval</pwccode>
-      <video href="2021.acl-long.436.mp4"/>
     </paper>
     <paper id="437">
       <title>Generating Relevant and Coherent Dialogue Responses using Self-Separated Conditional Variational <fixed-case>A</fixed-case>uto<fixed-case>E</fixed-case>ncoders</title>
@@ -7494,7 +7060,6 @@
       <bibkey>sun-etal-2021-generating</bibkey>
       <video href="2021.acl-long.437.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
-      <video href="2021.acl-long.437.mp4"/>
     </paper>
     <paper id="438">
       <title>Learning to Ask Conversational Questions by Optimizing <fixed-case>L</fixed-case>evenshtein Distance</title>
@@ -7512,7 +7077,6 @@
       <video href="2021.acl-long.438.mp4"/>
       <pwccode url="https://github.com/LZKSKY/CaSE_RISE" additional="false">LZKSKY/CaSE_RISE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/canard">CANARD</pwcdataset>
-      <video href="2021.acl-long.438.mp4"/>
     </paper>
     <paper id="439">
       <title><fixed-case>DVD</fixed-case>: A Diagnostic Dataset for Multi-step Reasoning in Video Grounded Dialogue</title>
@@ -7532,7 +7096,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cater">CATER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/clevr">CLEVR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/shapes-1">SHAPES</pwcdataset>
-      <video href="2021.acl-long.439.mp4"/>
     </paper>
     <paper id="440">
       <title><fixed-case>MMGCN</fixed-case>: Multimodal Fusion via Deep Graph Convolution Network for Emotion Recognition in Conversation</title>
@@ -7549,7 +7112,6 @@
       <pwccode url="https://github.com/hujingwen6666/MMGCN" additional="false">hujingwen6666/MMGCN</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
-      <video href="2021.acl-long.440.mp4"/>
     </paper>
     <paper id="441">
       <title><fixed-case>D</fixed-case>yna<fixed-case>E</fixed-case>val: Unifying Turn and Dialogue Level Evaluation</title>
@@ -7571,7 +7133,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/empatheticdialogues">EmpatheticDialogues</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fed">FED</pwcdataset>
-      <video href="2021.acl-long.441.mp4"/>
     </paper>
     <paper id="442">
       <title><fixed-case>C</fixed-case>o<fixed-case>SQA</fixed-case>: 20,000+ Web Queries for Code Search and Question Answering</title>
@@ -7594,7 +7155,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/codesearchnet">CodeSearchNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/codexglue">CodeXGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/staqc">StaQC</pwcdataset>
-      <video href="2021.acl-long.442.mp4"/>
     </paper>
     <paper id="443">
       <title>Rewriter-Evaluator Architecture for Neural Machine Translation</title>
@@ -7623,7 +7183,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bmeld">BMELD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/taskmaster-1">Taskmaster-1</pwcdataset>
-      <video href="2021.acl-long.444.mp4"/>
     </paper>
     <paper id="445">
       <title>Importance-based Neuron Allocation for Multilingual Neural Machine Translation</title>
@@ -7638,7 +7197,6 @@
       <bibkey>xie-etal-2021-importance</bibkey>
       <video href="2021.acl-long.445.mp4"/>
       <pwccode url="https://github.com/ictnlp/NA-MNMT" additional="false">ictnlp/NA-MNMT</pwccode>
-      <video href="2021.acl-long.445.mp4"/>
     </paper>
     <paper id="446">
       <title>Transfer Learning for Sequence Generation: from Single-source to Multi-source</title>
@@ -7653,7 +7211,6 @@
       <bibkey>huang-etal-2021-transfer</bibkey>
       <video href="2021.acl-long.446.mp4"/>
       <pwccode url="https://github.com/THUNLP-MT/TRICE" additional="false">THUNLP-MT/TRICE</pwccode>
-      <video href="2021.acl-long.446.mp4"/>
     </paper>
     <paper id="447">
       <title>A Closer Look at Few-Shot Crosslingual Transfer: The Choice of Shots Matters</title>
@@ -7672,7 +7229,6 @@
       <video href="2021.acl-long.447.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mldoc">MLDoc</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paws-x">PAWS-X</pwcdataset>
-      <video href="2021.acl-long.447.mp4"/>
     </paper>
     <paper id="448">
       <title>Coreference Reasoning in Machine Reading Comprehension</title>
@@ -7690,7 +7246,6 @@
       <pwccode url="https://github.com/UKPLab/coref-reasoning-in-qa" additional="false">UKPLab/coref-reasoning-in-qa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/quoref">Quoref</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.448.mp4"/>
     </paper>
     <paper id="449">
       <title>Adapting Unsupervised Syntactic Parsing Methodology for Discourse Dependency Parsing</title>
@@ -7703,7 +7258,6 @@
       <url hash="7ea4ff42">2021.acl-long.449</url>
       <doi>10.18653/v1/2021.acl-long.449</doi>
       <bibkey>zhang-etal-2021-adapting</bibkey>
-      <video href="2021.acl-long.449.mp4"/>
       <video href="2021.acl-long.449.mp4"/>
     </paper>
     <paper id="450">
@@ -7719,7 +7273,6 @@
       <bibkey>nguyen-etal-2021-conditional</bibkey>
       <video href="2021.acl-long.450.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.acl-long.450.mp4"/>
     </paper>
     <paper id="451">
       <title>A Unified Generative Framework for Various <fixed-case>NER</fixed-case> Subtasks</title>
@@ -7741,7 +7294,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/genia">GENIA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ontonotes-5-0">OntoNotes 5.0</pwcdataset>
-      <video href="2021.acl-long.451.mp4"/>
     </paper>
     <paper id="452">
       <title>An In-depth Study on Internal Structure of <fixed-case>C</fixed-case>hinese Words</title>
@@ -7760,7 +7312,6 @@
       <bibkey>gong-etal-2021-depth</bibkey>
       <video href="2021.acl-long.452.mp4"/>
       <pwccode url="https://github.com/SUDA-LA/wist" additional="false">SUDA-LA/wist</pwccode>
-      <video href="2021.acl-long.452.mp4"/>
     </paper>
     <paper id="453">
       <title><fixed-case>M</fixed-case>ul<fixed-case>DA</fixed-case>: A Multilingual Data Augmentation Framework for Low-Resource Cross-Lingual <fixed-case>NER</fixed-case></title>
@@ -7775,7 +7326,6 @@
       <url hash="ef47527c">2021.acl-long.453</url>
       <doi>10.18653/v1/2021.acl-long.453</doi>
       <bibkey>liu-etal-2021-mulda</bibkey>
-      <video href="2021.acl-long.453.mp4"/>
       <video href="2021.acl-long.453.mp4"/>
     </paper>
     <paper id="454">
@@ -7796,7 +7346,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/resume-ner">Resume NER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/weibo-ner">Weibo NER</pwcdataset>
-      <video href="2021.acl-long.454.mp4"/>
     </paper>
     <paper id="455">
       <title>Math Word Problem Solving with Explicit Numerical Values</title>
@@ -7813,7 +7362,6 @@
       <video href="2021.acl-long.455.mp4"/>
       <pwccode url="https://github.com/qinzhuowu/nums2t" additional="false">qinzhuowu/nums2t</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/math23k">Math23K</pwcdataset>
-      <video href="2021.acl-long.455.mp4"/>
     </paper>
     <paper id="456">
       <title>Neural-Symbolic Solver for Math Word Problems with Auxiliary Tasks</title>
@@ -7830,7 +7378,6 @@
       <video href="2021.acl-long.456.mp4"/>
       <pwccode url="https://github.com/QinJinghui/NS-Solver" additional="false">QinJinghui/NS-Solver</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/math23k">Math23K</pwcdataset>
-      <video href="2021.acl-long.456.mp4"/>
     </paper>
     <paper id="457">
       <title><fixed-case>SM</fixed-case>ed<fixed-case>BERT</fixed-case>: A Knowledge-Enhanced Pre-trained Language Model with Structured Semantics for Medical Text Mining</title>
@@ -7847,7 +7394,6 @@
       <bibkey>zhang-etal-2021-smedbert</bibkey>
       <video href="2021.acl-long.457.mp4"/>
       <pwccode url="https://github.com/matnlp/smedbert" additional="true">matnlp/smedbert</pwccode>
-      <video href="2021.acl-long.457.mp4"/>
     </paper>
     <paper id="458">
       <title>What is Your Article Based On? Inferring Fine-grained Provenance</title>
@@ -7859,7 +7405,6 @@
       <url hash="2b607c0f">2021.acl-long.458</url>
       <doi>10.18653/v1/2021.acl-long.458</doi>
       <bibkey>zhang-etal-2021-article</bibkey>
-      <video href="2021.acl-long.458.mp4"/>
       <video href="2021.acl-long.458.mp4"/>
     </paper>
     <paper id="459">
@@ -7876,7 +7421,6 @@
       <video href="2021.acl-long.459.mp4"/>
       <pwccode url="https://github.com/zhjohnchan/R2GenCMN" additional="false">zhjohnchan/R2GenCMN</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/chexpert">CheXpert</pwcdataset>
-      <video href="2021.acl-long.459.mp4"/>
     </paper>
     <paper id="460">
       <title>Controversy and Conformity: from Generalized to Personalized Aggressiveness Detection</title>
@@ -7894,7 +7438,6 @@
       <doi>10.18653/v1/2021.acl-long.460</doi>
       <bibkey>kanclerz-etal-2021-controversy</bibkey>
       <video href="2021.acl-long.460.mp4"/>
-      <video href="2021.acl-long.460.mp4"/>
     </paper>
     <paper id="461">
       <title>Multi-perspective Coherent Reasoning for Helpfulness Prediction of Multimodal Reviews</title>
@@ -7909,7 +7452,6 @@
       <bibkey>liu-etal-2021-multi-perspective</bibkey>
       <video href="2021.acl-long.461.mp4"/>
       <pwccode url="https://github.com/jhliu17/mcr" additional="false">jhliu17/mcr</pwccode>
-      <video href="2021.acl-long.461.mp4"/>
     </paper>
     <paper id="462">
       <title>Instantaneous Grammatical Error Correction with Shallow Aggressive Decoding</title>
@@ -7924,7 +7466,6 @@
       <bibkey>sun-etal-2021-instantaneous</bibkey>
       <video href="2021.acl-long.462.mp4"/>
       <pwccode url="https://github.com/AutoTemp/Shallow-Aggressive-Decoding" additional="false">AutoTemp/Shallow-Aggressive-Decoding</pwccode>
-      <video href="2021.acl-long.462.mp4"/>
     </paper>
     <paper id="463">
       <title>Automatic <fixed-case>ICD</fixed-case> Coding via Interactive Shared Representation Networks with Self-distillation Mechanism</title>
@@ -7958,7 +7499,6 @@
       <doi>10.18653/v1/2021.acl-long.464</doi>
       <bibkey>huang-etal-2021-phmospell</bibkey>
       <video href="2021.acl-long.464.mp4"/>
-      <video href="2021.acl-long.464.mp4"/>
     </paper>
     <paper id="465">
       <title>Guiding the Growth: Difficulty-Controllable Question Generation through Step-by-Step Rewriting</title>
@@ -7976,7 +7516,6 @@
       <bibkey>cheng-etal-2021-guiding</bibkey>
       <video href="2021.acl-long.465.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
-      <video href="2021.acl-long.465.mp4"/>
     </paper>
     <paper id="466">
       <title>Improving Encoder by Auxiliary Supervision Tasks for Table-to-Text Generation</title>
@@ -7992,7 +7531,6 @@
       <video href="2021.acl-long.466.mp4"/>
       <pwccode url="https://github.com/liang8qi/data2textwithauxiliarysupervision" additional="false">liang8qi/data2textwithauxiliarysupervision</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/rotowire">RotoWire</pwcdataset>
-      <video href="2021.acl-long.466.mp4"/>
     </paper>
     <paper id="467">
       <title><fixed-case>POS</fixed-case>-<fixed-case>C</fixed-case>onstrained <fixed-case>P</fixed-case>arallel <fixed-case>D</fixed-case>ecoding for <fixed-case>N</fixed-case>on-autoregressive <fixed-case>G</fixed-case>eneration</title>
@@ -8010,7 +7548,6 @@
       <pwccode url="https://github.com/yangkexin/pospd" additional="false">yangkexin/pospd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glge">GLGE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
-      <video href="2021.acl-long.467.mp4"/>
     </paper>
     <paper id="468">
       <title>Bridging Subword Gaps in Pretrain-Finetune Paradigm for Natural Language Generation</title>
@@ -8029,7 +7566,6 @@
       <bibkey>liu-etal-2021-bridging</bibkey>
       <video href="2021.acl-long.468.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.468.mp4"/>
     </paper>
     <paper id="469">
       <title><fixed-case>TGEA</fixed-case>: An Error-Annotated Dataset and Benchmark Tasks for <fixed-case>T</fixed-case>ext<fixed-case>G</fixed-case>eneration from Pretrained Language Models</title>
@@ -8052,7 +7588,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/piqa">PIQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
-      <video href="2021.acl-long.469.mp4"/>
     </paper>
     <paper id="470">
       <title>Long-Span Summarization via Local Attention and Content Selection</title>
@@ -8066,7 +7601,6 @@
       <video href="2021.acl-long.470.mp4"/>
       <pwccode url="https://github.com/potsawee/longsum0" additional="false">potsawee/longsum0</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
-      <video href="2021.acl-long.470.mp4"/>
     </paper>
     <paper id="471">
       <title><fixed-case>R</fixed-case>ep<fixed-case>S</fixed-case>um: Unsupervised Dialogue Summarization based on Replacement Strategy</title>
@@ -8081,7 +7615,6 @@
       <url hash="bc390988">2021.acl-long.471</url>
       <doi>10.18653/v1/2021.acl-long.471</doi>
       <bibkey>fu-etal-2021-repsum</bibkey>
-      <video href="2021.acl-long.471.mp4"/>
       <video href="2021.acl-long.471.mp4"/>
     </paper>
     <paper id="472">
@@ -8102,7 +7635,6 @@
       <video href="2021.acl-long.472.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/bigpatent">BigPatent</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisum">WikiSum</pwcdataset>
-      <video href="2021.acl-long.472.mp4"/>
     </paper>
     <paper id="473">
       <title>Capturing Relations between Scientific Papers: An Abstractive Model for Related Work Section Generation</title>
@@ -8121,7 +7653,6 @@
       <video href="2021.acl-long.473.mp4"/>
       <pwccode url="https://github.com/iriscxy/relatedworkgeneration" additional="false">iriscxy/relatedworkgeneration</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
-      <video href="2021.acl-long.473.mp4"/>
     </paper>
     <paper id="474">
       <title>Focus Attention: Promoting Faithfulness and Diversity in Summarization</title>
@@ -8136,7 +7667,6 @@
       <doi>10.18653/v1/2021.acl-long.474</doi>
       <bibkey>aralikatte-etal-2021-focus</bibkey>
       <video href="2021.acl-long.474.mp4"/>
-      <video href="2021.acl-long.474.mp4"/>
     </paper>
     <paper id="475">
       <title>Generating Query Focused Summaries from Query-Free Resources</title>
@@ -8150,7 +7680,6 @@
       <video href="2021.acl-long.475.mp4"/>
       <pwccode url="https://github.com/yumoxu/marge" additional="false">yumoxu/marge</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multi-news">Multi-News</pwcdataset>
-      <video href="2021.acl-long.475.mp4"/>
     </paper>
     <paper id="476">
       <title>Robustifying Multi-hop <fixed-case>QA</fixed-case> through Pseudo-Evidentiality Training</title>
@@ -8165,7 +7694,6 @@
       <bibkey>lee-etal-2021-robustifying</bibkey>
       <video href="2021.acl-long.476.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
-      <video href="2021.acl-long.476.mp4"/>
     </paper>
     <paper id="477">
       <title>x<fixed-case>M</fixed-case>o<fixed-case>C</fixed-case>o: Cross Momentum Contrastive Learning for Open-Domain Question Answering</title>
@@ -8184,7 +7712,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestions">WebQuestions</pwcdataset>
-      <video href="2021.acl-long.477.mp4"/>
     </paper>
     <paper id="478">
       <title>Learn to Resolve Conversational Dependency: A Consistency Training Framework for Conversational Question Answering</title>
@@ -8202,7 +7729,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/canard">CANARD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/coqa">CoQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quac">QuAC</pwcdataset>
-      <video href="2021.acl-long.478.mp4"/>
     </paper>
     <paper id="479">
       <title><fixed-case>P</fixed-case>hoto<fixed-case>C</fixed-case>hat: A Human-Human Dialogue Dataset With Photo Sharing Behavior For Joint Image-Text Modeling</title>
@@ -8220,7 +7746,6 @@
       <video href="2021.acl-long.479.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-long.479.mp4"/>
     </paper>
     <paper id="480">
       <title>Good for Misconceived Reasons: An Empirical Revisiting on the Need for Visual Context in Multimodal Machine Translation</title>
@@ -8236,7 +7761,6 @@
       <bibkey>wu-etal-2021-good</bibkey>
       <video href="2021.acl-long.480.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/vatex">VATEX</pwcdataset>
-      <video href="2021.acl-long.480.mp4"/>
     </paper>
     <paper id="481">
       <title>Attend What You Need: Motion-Appearance Synergistic Networks for Video Question Answering</title>
@@ -8252,7 +7776,6 @@
       <video href="2021.acl-long.481.mp4"/>
       <pwccode url="https://github.com/ahjeongseo/MASN-pytorch" additional="false">ahjeongseo/MASN-pytorch</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-long.481.mp4"/>
     </paper>
     <paper id="482">
       <title><fixed-case>BERT</fixed-case>ifying the Hidden <fixed-case>M</fixed-case>arkov Model for Multi-Source Weakly Supervised Named Entity Recognition</title>
@@ -8271,7 +7794,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bc5cdr">BC5CDR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ncbi-disease-1">NCBI Disease</pwcdataset>
-      <video href="2021.acl-long.482.mp4"/>
     </paper>
     <paper id="483">
       <title><fixed-case>CIL</fixed-case>: Contrastive Instance Learning Framework for Distantly Supervised Relation Extraction</title>
@@ -8288,7 +7810,6 @@
       <bibkey>chen-etal-2021-cil</bibkey>
       <video href="2021.acl-long.483.mp4"/>
       <pwccode url="https://github.com/antct/cil" additional="false">antct/cil</pwccode>
-      <video href="2021.acl-long.483.mp4"/>
     </paper>
     <paper id="484">
       <title><fixed-case>SENT</fixed-case>: <fixed-case>S</fixed-case>entence-level Distant Relation Extraction via Negative Training</title>
@@ -8305,7 +7826,6 @@
       <bibkey>ma-etal-2021-sent</bibkey>
       <video href="2021.acl-long.484.mp4"/>
       <pwccode url="https://github.com/rtmaww/SENT" additional="false">rtmaww/SENT</pwccode>
-      <video href="2021.acl-long.484.mp4"/>
     </paper>
     <paper id="485">
       <title>An End-to-End Progressive Multi-Task Learning Framework for Medical Named Entity Recognition and Normalization</title>
@@ -8321,7 +7841,6 @@
       <video href="2021.acl-long.485.mp4"/>
       <pwccode url="https://github.com/zhoubaohang/e2emern" additional="false">zhoubaohang/e2emern</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bc5cdr">BC5CDR</pwcdataset>
-      <video href="2021.acl-long.485.mp4"/>
     </paper>
     <paper id="486">
       <title><fixed-case>PRGC</fixed-case>: Potential Relation and Global Correspondence Based Joint Relational Triple Extraction</title>
@@ -8344,7 +7863,6 @@
       <video href="2021.acl-long.486.mp4"/>
       <pwccode url="https://github.com/hy-struggle/PRGC" additional="false">hy-struggle/PRGC</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.acl-long.486.mp4"/>
     </paper>
     <paper id="487">
       <title>Learning from Miscellaneous Other-Class Words for Few-shot Named Entity Recognition</title>
@@ -8363,7 +7881,6 @@
       <video href="2021.acl-long.487.mp4"/>
       <pwccode url="https://github.com/shuaiwa16/OtherClassNER" additional="false">shuaiwa16/OtherClassNER</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cluener2020">CLUENER2020</pwcdataset>
-      <video href="2021.acl-long.487.mp4"/>
     </paper>
     <paper id="488">
       <title>Joint Biomedical Entity and Relation Extraction with Knowledge-Enhanced Collective Inference</title>
@@ -8378,7 +7895,6 @@
       <bibkey>lai-etal-2021-joint</bibkey>
       <video href="2021.acl-long.488.mp4"/>
       <pwccode url="https://github.com/laituan245/bio_relex" additional="false">laituan245/bio_relex</pwccode>
-      <video href="2021.acl-long.488.mp4"/>
     </paper>
     <paper id="489">
       <title>Fine-grained Information Extraction from Biomedical Literature based on Knowledge-enriched <fixed-case>A</fixed-case>bstract <fixed-case>M</fixed-case>eaning <fixed-case>R</fixed-case>epresentation</title>
@@ -8395,7 +7911,6 @@
       <bibkey>zhang-etal-2021-fine</bibkey>
       <video href="2021.acl-long.489.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/bio">Bio</pwcdataset>
-      <video href="2021.acl-long.489.mp4"/>
     </paper>
     <paper id="490">
       <title>Unleash <fixed-case>GPT</fixed-case>-2 Power for Event Detection</title>
@@ -8408,7 +7923,6 @@
       <url hash="ba13cce4">2021.acl-long.490</url>
       <doi>10.18653/v1/2021.acl-long.490</doi>
       <bibkey>pouran-ben-veyseh-etal-2021-unleash</bibkey>
-      <video href="2021.acl-long.490.mp4"/>
       <video href="2021.acl-long.490.mp4"/>
     </paper>
     <paper id="491">
@@ -8431,7 +7945,6 @@
       <pwccode url="https://github.com/THU-KEG/CLEVE" additional="false">THU-KEG/CLEVE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/maven">MAVEN</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/new-york-times-annotated-corpus">New York Times Annotated Corpus</pwcdataset>
-      <video href="2021.acl-long.491.mp4"/>
     </paper>
     <paper id="492">
       <title>Document-level Event Extraction via Parallel Prediction Networks</title>
@@ -8449,7 +7962,6 @@
       <video href="2021.acl-long.492.mp4"/>
       <pwccode url="https://github.com/hangyang-nlp/de-ppn" additional="true">hangyang-nlp/de-ppn</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/chfinann">ChFinAnn</pwcdataset>
-      <video href="2021.acl-long.492.mp4"/>
     </paper>
     <paper id="493">
       <title><fixed-case>S</fixed-case>tructural<fixed-case>LM</fixed-case>: Structural Pre-training for Form Understanding</title>
@@ -8470,7 +7982,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/docvqa">DocVQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/funsd">FUNSD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rvl-cdip">RVL-CDIP</pwcdataset>
-      <video href="2021.acl-long.493.mp4"/>
     </paper>
     <paper id="494">
       <title>Dual Graph Convolutional Networks for Aspect-based Sentiment Analysis</title>
@@ -8487,7 +7998,6 @@
       <bibkey>li-etal-2021-dual-graph</bibkey>
       <video href="2021.acl-long.494.mp4"/>
       <pwccode url="https://github.com/ccchenhao997/dualgcn-absa" additional="false">ccchenhao997/dualgcn-absa</pwccode>
-      <video href="2021.acl-long.494.mp4"/>
     </paper>
     <paper id="495">
       <title>Multi-Label Few-Shot Learning for Aspect Category Detection</title>
@@ -8506,7 +8016,6 @@
       <doi>10.18653/v1/2021.acl-long.495</doi>
       <bibkey>hu-etal-2021-multi-label</bibkey>
       <video href="2021.acl-long.495.mp4"/>
-      <video href="2021.acl-long.495.mp4"/>
     </paper>
     <paper id="496">
       <title>Argument Pair Extraction via Attention-guided Multi-Layer Multi-Cross Encoding</title>
@@ -8522,7 +8031,6 @@
       <video href="2021.acl-long.496.mp4"/>
       <pwccode url="https://github.com/tianyuterry/mlmc" additional="false">tianyuterry/mlmc</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/rr">RR</pwcdataset>
-      <video href="2021.acl-long.496.mp4"/>
     </paper>
     <paper id="497">
       <title>A Neural Transition-based Model for Argumentation Mining</title>
@@ -8539,7 +8047,6 @@
       <bibkey>bao-etal-2021-neural</bibkey>
       <video href="2021.acl-long.497.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cdcp">CDCP</pwcdataset>
-      <video href="2021.acl-long.497.mp4"/>
     </paper>
     <paper id="498">
       <title>Keep It Simple: Unsupervised Simplification of Multi-Paragraph Text</title>
@@ -8556,7 +8063,6 @@
       <pwccode url="https://github.com/tingofurro/keep_it_simple" additional="false">tingofurro/keep_it_simple</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/newsela">Newsela</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikilarge">WikiLarge</pwcdataset>
-      <video href="2021.acl-long.498.mp4"/>
     </paper>
     <paper id="499">
       <title>Long Text Generation by Modeling Sentence-Level and Discourse-Level Coherence</title>
@@ -8576,7 +8082,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
-      <video href="2021.acl-long.499.mp4"/>
     </paper>
     <paper id="500">
       <title><fixed-case>O</fixed-case>pen<fixed-case>MEVA</fixed-case>: A Benchmark for Evaluating Open-ended Story Generation Metrics</title>
@@ -8598,7 +8103,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/openmeva">OpenMEVA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
-      <video href="2021.acl-long.500.mp4"/>
     </paper>
     <paper id="501">
       <title><fixed-case>DYPLOC</fixed-case>: Dynamic Planning of Content Using Mixed Language Models for Text Generation</title>
@@ -8612,7 +8116,6 @@
       <bibkey>hua-etal-2021-dyploc</bibkey>
       <video href="2021.acl-long.501.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.acl-long.501.mp4"/>
     </paper>
     <paper id="502">
       <title>Controllable Open-ended Question Generation with A New Question Type Ontology</title>
@@ -8627,7 +8130,6 @@
       <pwccode url="https://github.com/ShuyangCao/open-ended_question_ontology" additional="false">ShuyangCao/open-ended_question_ontology</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.502.mp4"/>
     </paper>
     <paper id="503">
       <title><fixed-case>BERTG</fixed-case>en: Multi-task Generation through <fixed-case>BERT</fixed-case></title>
@@ -8642,7 +8144,6 @@
       <bibkey>mitzalis-etal-2021-bertgen</bibkey>
       <video href="2021.acl-long.503.mp4"/>
       <pwccode url="https://github.com/ImperialNLP/BertGen" additional="false">ImperialNLP/BertGen</pwccode>
-      <video href="2021.acl-long.503.mp4"/>
     </paper>
     <paper id="504">
       <title>Selective Knowledge Distillation for Neural Machine Translation</title>
@@ -8657,7 +8158,6 @@
       <bibkey>wang-etal-2021-selective</bibkey>
       <video href="2021.acl-long.504.mp4"/>
       <pwccode url="https://github.com/LeslieOverfitting/selective_distillation" additional="false">LeslieOverfitting/selective_distillation</pwccode>
-      <video href="2021.acl-long.504.mp4"/>
     </paper>
     <paper id="505">
       <title>Measuring and Increasing Context Usage in Context-Aware Machine Translation</title>
@@ -8672,7 +8172,6 @@
       <bibkey>fernandes-etal-2021-measuring</bibkey>
       <video href="2021.acl-long.505.mp4"/>
       <pwccode url="https://github.com/neulab/contextual-mt" additional="false">neulab/contextual-mt</pwccode>
-      <video href="2021.acl-long.505.mp4"/>
     </paper>
     <paper id="506">
       <title>Beyond Offline Mapping: Learning Cross-lingual Word Embeddings through Context Anchoring</title>
@@ -8688,7 +8187,6 @@
       <bibkey>ormazabal-etal-2021-beyond</bibkey>
       <video href="2021.acl-long.506.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.acl-long.506.mp4"/>
     </paper>
     <paper id="507">
       <title><fixed-case>CCM</fixed-case>atrix: Mining Billions of High-Quality Parallel Sentences on the Web</title>
@@ -8708,7 +8206,6 @@
       <pwccode url="https://github.com/facebookresearch/LASER" additional="true">facebookresearch/LASER</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ccmatrix">CCMatrix</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ccnet">CCNet</pwcdataset>
-      <video href="2021.acl-long.507.mp4"/>
     </paper>
     <paper id="508">
       <title>Length-Adaptive Transformer: Train Once with Length Drop, Use Anytime with Search</title>
@@ -8723,7 +8220,6 @@
       <pwccode url="https://github.com/clovaai/length-adaptive-transformer" additional="false">clovaai/length-adaptive-transformer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.508.mp4"/>
     </paper>
     <paper id="509">
       <title><fixed-case>G</fixed-case>host<fixed-case>BERT</fixed-case>: Generate More Features with Cheap Operations for <fixed-case>BERT</fixed-case></title>
@@ -8741,7 +8237,6 @@
       <video href="2021.acl-long.509.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-long.509.mp4"/>
     </paper>
     <paper id="510">
       <title>Super Tickets in Pre-Trained Language Models: From Model Compression to Improving Generalization</title>
@@ -8767,7 +8262,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.510.mp4"/>
     </paper>
     <paper id="511">
       <title>A Novel Estimator of Mutual Information for Learning to Disentangle Textual Representations</title>
@@ -8780,7 +8274,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="cc20cbe0">2021.acl-long.511.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-long.511</doi>
       <bibkey>colombo-etal-2021-novel</bibkey>
-      <video href="2021.acl-long.511.mp4"/>
       <video href="2021.acl-long.511.mp4"/>
     </paper>
     <paper id="512">
@@ -8795,7 +8288,6 @@
       <bibkey>meister-etal-2021-determinantal</bibkey>
       <video href="2021.acl-long.512.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
-      <video href="2021.acl-long.512.mp4"/>
     </paper>
     <paper id="513">
       <title>Multi-hop Graph Convolutional Network with High-order Chebyshev Approximation for Text Reasoning</title>
@@ -8812,7 +8304,6 @@
       <video href="2021.acl-long.513.mp4"/>
       <pwccode url="https://github.com/MathIsAll/HDGCN-pytorch" additional="false">MathIsAll/HDGCN-pytorch</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-long.513.mp4"/>
     </paper>
     <paper id="514">
       <title>Accelerating Text Communication via Abbreviated Sentence Input</title>
@@ -8828,7 +8319,6 @@
       <video href="2021.acl-long.514.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.acl-long.514.mp4"/>
     </paper>
     <paper id="515">
       <title>Regression Bugs Are In Your Model! Measuring, Reducing and Analyzing Regressions In <fixed-case>NLP</fixed-case> Model Updates</title>
@@ -8847,7 +8337,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.515.mp4"/>
     </paper>
     <paper id="516">
       <title>Detecting Propaganda Techniques in Memes</title>
@@ -8868,7 +8357,6 @@
       <pwccode url="https://github.com/di-dimitrov/propaganda-techniques-in-memes" additional="false">di-dimitrov/propaganda-techniques-in-memes</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/hateful-memes">Hateful Memes</pwcdataset>
-      <video href="2021.acl-long.516.mp4"/>
     </paper>
     <paper id="517">
       <title>On the Efficacy of Adversarial Data Collection for Question Answering: Results from a Large-Scale Randomized Study</title>
@@ -8892,7 +8380,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-long.517.mp4"/>
     </paper>
     <paper id="518">
       <title>Learning Dense Representations of Phrases at Scale</title>
@@ -8912,7 +8399,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/t-rex">T-REx</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestions">WebQuestions</pwcdataset>
-      <video href="2021.acl-long.518.mp4"/>
     </paper>
     <paper id="519">
       <title>End-to-End Training of Neural Retrievers for Open-Domain Question Answering</title>
@@ -8932,7 +8418,6 @@
       <pwccode url="https://github.com/NVIDIA/Megatron-LM" additional="true">NVIDIA/Megatron-LM</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-long.519.mp4"/>
     </paper>
     <paper id="520">
       <title>Question Answering Over Temporal Knowledge Graphs</title>
@@ -8950,7 +8435,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/complexwebquestions">ComplexWebQuestions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/metaqa">MetaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/simplequestions">SimpleQuestions</pwcdataset>
-      <video href="2021.acl-long.520.mp4"/>
     </paper>
     <paper id="521">
       <title>Language Model Augmented Relevance Score</title>
@@ -8965,7 +8449,6 @@
       <video href="2021.acl-long.521.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mocha">MOCHA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsroom">NEWSROOM</pwcdataset>
-      <video href="2021.acl-long.521.mp4"/>
     </paper>
     <paper id="522">
       <title><fixed-case>DE</fixed-case>xperts: Decoding-Time Controlled Text Generation with Experts and Anti-Experts</title>
@@ -8986,7 +8469,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/openwebtext">OpenWebText</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.acl-long.522.mp4"/>
     </paper>
     <paper id="523">
       <title>Polyjuice: Generating Counterfactuals for Explaining, Evaluating, and Improving Models</title>
@@ -9004,7 +8486,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-long.523.mp4"/>
     </paper>
     <paper id="524">
       <title>Metaphor Generation with Conceptual Mappings</title>
@@ -9021,7 +8502,6 @@
       <video href="2021.acl-long.524.mp4"/>
       <pwccode url="https://github.com/UKPLab/acl2021-metaphor-generation-conceptual" additional="false">UKPLab/acl2021-metaphor-generation-conceptual</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
-      <video href="2021.acl-long.524.mp4"/>
     </paper>
     <paper id="525">
       <title>Learning Latent Structures for Cross Action Phrase Relations in Wet Lab Protocols</title>
@@ -9037,7 +8517,6 @@
       <bibkey>kulkarni-etal-2021-learning</bibkey>
       <video href="2021.acl-long.525.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-20-task-1-extracting-entities-and">WNUT 2020</pwcdataset>
-      <video href="2021.acl-long.525.mp4"/>
     </paper>
     <paper id="526">
       <title>Multimodal Multi-Speaker Merger &amp; Acquisition Financial Modeling: A New Task, Dataset, and Neural Baselines</title>
@@ -9051,7 +8530,6 @@
       <url hash="4d447793">2021.acl-long.526</url>
       <doi>10.18653/v1/2021.acl-long.526</doi>
       <bibkey>sawhney-etal-2021-multimodal</bibkey>
-      <video href="2021.acl-long.526.mp4"/>
       <video href="2021.acl-long.526.mp4"/>
     </paper>
     <paper id="527">
@@ -9067,7 +8545,6 @@
       <bibkey>albo-jamara-etal-2021-mid</bibkey>
       <video href="2021.acl-long.527.mp4"/>
       <pwccode url="https://github.com/nicoherbig/mmpe" additional="false">nicoherbig/mmpe</pwccode>
-      <video href="2021.acl-long.527.mp4"/>
     </paper>
     <paper id="528">
       <title><fixed-case>I</fixed-case>nter-<fixed-case>GPS</fixed-case>: Interpretable Geometry Problem Solving with Formal Language and Symbolic Reasoning</title>
@@ -9088,7 +8565,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/geometry3k">Geometry3K</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/geos">GeoS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/pgdp5k">PGDP5K</pwcdataset>
-      <video href="2021.acl-long.528.mp4"/>
     </paper>
     <paper id="529">
       <title>Joint Verification and Reranking for Open Fact Checking Over Tables</title>
@@ -9105,7 +8581,6 @@
       <bibkey>schlichtkrull-etal-2021-joint</bibkey>
       <video href="2021.acl-long.529.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/tabfact">TabFact</pwcdataset>
-      <video href="2021.acl-long.529.mp4"/>
     </paper>
     <paper id="530">
       <title>Evaluation of Thematic Coherence in Microblogs</title>
@@ -9121,7 +8596,6 @@
       <bibkey>bilal-etal-2021-evaluation</bibkey>
       <video href="2021.acl-long.530.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/covid-19-election">COVID-19 &amp; Election</pwcdataset>
-      <video href="2021.acl-long.530.mp4"/>
     </paper>
     <paper id="531">
       <title>Neural semi-<fixed-case>M</fixed-case>arkov <fixed-case>CRF</fixed-case> for Monolingual Word Alignment</title>
@@ -9143,7 +8617,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sick">SICK</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiqa">WikiQA</pwcdataset>
-      <video href="2021.acl-long.531.mp4"/>
     </paper>
     <paper id="532">
       <title>Privacy at Scale: Introducing the <fixed-case>P</fixed-case>riva<fixed-case>S</fixed-case>eer Corpus of Web Privacy Policies</title>
@@ -9155,7 +8628,6 @@
       <url hash="a2706646">2021.acl-long.532</url>
       <doi>10.18653/v1/2021.acl-long.532</doi>
       <bibkey>srinath-etal-2021-privacy</bibkey>
-      <video href="2021.acl-long.532.mp4"/>
       <video href="2021.acl-long.532.mp4"/>
     </paper>
     <paper id="533">
@@ -9169,7 +8641,6 @@
       <bibkey>wei-jia-2021-statistical</bibkey>
       <video href="2021.acl-long.533.mp4"/>
       <pwccode url="https://github.com/johntzwei/metric-statistical-advantage" additional="false">johntzwei/metric-statistical-advantage</pwccode>
-      <video href="2021.acl-long.533.mp4"/>
     </paper>
     <paper id="534">
       <title>Are Missing Links Predictable? An Inferential Benchmark for Knowledge Graph Completion</title>
@@ -9189,7 +8660,6 @@
       <pwccode url="https://github.com/TaoMiner/inferwiki" additional="false">TaoMiner/inferwiki</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/inferwiki">InferWiki</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
-      <video href="2021.acl-long.534.mp4"/>
     </paper>
     <paper id="535">
       <title><fixed-case>C</fixed-case>onvo<fixed-case>S</fixed-case>umm: Conversation Summarization Benchmark and Improved Abstractive Summarization with Argument Mining</title>
@@ -9211,7 +8681,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cqasumm">CQASUMM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.acl-long.535.mp4"/>
     </paper>
     <paper id="536">
       <title>Improving Factual Consistency of Abstractive Summarization via Question Answering</title>
@@ -9232,7 +8701,6 @@
       <bibkey>nan-etal-2021-improving</bibkey>
       <video href="2021.acl-long.536.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
-      <video href="2021.acl-long.536.mp4"/>
     </paper>
     <paper id="537">
       <title><fixed-case>E</fixed-case>mail<fixed-case>S</fixed-case>um: Abstractive Email Thread Summarization</title>
@@ -9250,7 +8718,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/emailsum">EmailSum</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/crd3">CRD3</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.acl-long.537.mp4"/>
     </paper>
     <paper id="538">
       <title>Cross-Lingual Abstractive Summarization with Limited Parallel Resources</title>
@@ -9265,7 +8732,6 @@
       <video href="2021.acl-long.538.mp4"/>
       <pwccode url="https://github.com/WoodenWhite/MCLAS" additional="false">WoodenWhite/MCLAS</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ncls">NCLS</pwcdataset>
-      <video href="2021.acl-long.538.mp4"/>
     </paper>
     <paper id="539">
       <title>Dissecting Generation Modes for Abstractive Summarization Models via Ablation and Attribution</title>
@@ -9280,7 +8746,6 @@
       <pwccode url="https://github.com/jiacheng-xu/sum-interpret" additional="false">jiacheng-xu/sum-interpret</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/c4">C4</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.acl-long.539.mp4"/>
     </paper>
     <paper id="540">
       <title>Learning Prototypical Functions for Physical Artifacts</title>
@@ -9295,7 +8760,6 @@
       <pwccode url="https://github.com/tyjiangu/physical_artifacts_function" additional="false">tyjiangu/physical_artifacts_function</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
-      <video href="2021.acl-long.540.mp4"/>
     </paper>
     <paper id="541">
       <title>Verb Knowledge Injection for Multilingual Event Processing</title>
@@ -9312,7 +8776,6 @@
       <video href="2021.acl-long.541.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/maven">MAVEN</pwcdataset>
-      <video href="2021.acl-long.541.mp4"/>
     </paper>
     <paper id="542">
       <title>Dynamic Contextualized Word Embeddings</title>
@@ -9327,7 +8790,6 @@
       <video href="2021.acl-long.542.mp4"/>
       <pwccode url="https://github.com/valentinhofmann/dcwe" additional="false">valentinhofmann/dcwe</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ciao">Ciao</pwcdataset>
-      <video href="2021.acl-long.542.mp4"/>
     </paper>
     <paper id="543">
       <title>Lexical Semantic Change Discovery</title>
@@ -9343,7 +8805,6 @@
       <bibkey>kurtyigit-etal-2021-lexical</bibkey>
       <video href="2021.acl-long.543.mp4"/>
       <pwccode url="https://github.com/seinan9/LSCDiscovery" additional="false">seinan9/LSCDiscovery</pwccode>
-      <video href="2021.acl-long.543.mp4"/>
     </paper>
     <paper id="544">
       <title>The <fixed-case>R</fixed-case>-<fixed-case>U</fixed-case>-A-Robot Dataset: Helping Avoid Chatbot Deception by Detecting User Questions About Human or Non-Human Identity</title>
@@ -9357,7 +8818,6 @@
       <bibkey>gros-etal-2021-r</bibkey>
       <video href="2021.acl-long.544.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ethics-1">ETHICS</pwcdataset>
-      <video href="2021.acl-long.544.mp4"/>
     </paper>
     <paper id="545">
       <title>Using Meta-Knowledge Mined from Identifiers to Improve Intent Recognition in Conversational Systems</title>
@@ -9378,7 +8838,6 @@
       <doi>10.18653/v1/2021.acl-long.545</doi>
       <bibkey>pinhanez-etal-2021-using</bibkey>
       <video href="2021.acl-long.545.mp4"/>
-      <video href="2021.acl-long.545.mp4"/>
     </paper>
     <paper id="546">
       <title>Space Efficient Context Encoding for Non-Task-Oriented Dialogue Generation with Graph Attention Transformer</title>
@@ -9394,7 +8853,6 @@
       <video href="2021.acl-long.546.mp4"/>
       <pwccode url="https://github.com/fabiangal/space-efficient-context-encoding-acl21" additional="false">fabiangal/space-efficient-context-encoding-acl21</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opendialkg">OpenDialKG</pwcdataset>
-      <video href="2021.acl-long.546.mp4"/>
     </paper>
     <paper id="547">
       <title><fixed-case>D</fixed-case>ialogue<fixed-case>CRN</fixed-case>: Contextual Reasoning Networks for Emotion Recognition in Conversations</title>
@@ -9412,7 +8870,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semaine">SEMAINE</pwcdataset>
-      <video href="2021.acl-long.547.mp4"/>
     </paper>
     <paper id="548">
       <title>Cross-replication Reliability - An Empirical Approach to Interpreting Inter-rater Reliability</title>
@@ -9426,7 +8883,6 @@
       <bibkey>wong-etal-2021-cross</bibkey>
       <video href="2021.acl-long.548.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/imagenet">ImageNet</pwcdataset>
-      <video href="2021.acl-long.548.mp4"/>
     </paper>
     <paper id="549">
       <title><fixed-case>TIMEDIAL</fixed-case>: Temporal Commonsense Reasoning in Dialog</title>
@@ -9446,7 +8902,6 @@
       <pwccode url="https://github.com/google-research-datasets/timedial" additional="false">google-research-datasets/timedial</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/timedial">TimeDial</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
-      <video href="2021.acl-long.549.mp4"/>
     </paper>
     <paper id="550">
       <title><fixed-case>RAW</fixed-case>-<fixed-case>C</fixed-case>: Relatedness of Ambiguous Words in Context (A New Lexical Resource for <fixed-case>E</fixed-case>nglish)</title>
@@ -9459,7 +8914,6 @@
       <bibkey>trott-bergen-2021-raw</bibkey>
       <video href="2021.acl-long.550.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/raw-c">RAW-C</pwcdataset>
-      <video href="2021.acl-long.550.mp4"/>
     </paper>
     <paper id="551">
       <title><fixed-case>ARBERT</fixed-case> &amp; <fixed-case>MARBERT</fixed-case>: Deep Bidirectional Transformers for <fixed-case>A</fixed-case>rabic</title>
@@ -9479,7 +8933,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/labr">LABR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/decanlp">decaNLP</pwcdataset>
-      <video href="2021.acl-long.551.mp4"/>
     </paper>
     <paper id="552">
       <title>Improving Paraphrase Detection with the Adversarial Paraphrasing Task</title>
@@ -9498,7 +8951,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/paws">PAWS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.acl-long.552.mp4"/>
     </paper>
     <paper id="553">
       <title><fixed-case>ADEPT</fixed-case>: An Adjective-Dependent Plausibility Task</title>
@@ -9517,7 +8969,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-long.553.mp4"/>
     </paper>
     <paper id="554">
       <title><fixed-case>R</fixed-case>ead<fixed-case>O</fixed-case>nce Transformers: Reusable Representations of Text for Transformers</title>
@@ -9533,7 +8984,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/narrativeqa">NarrativeQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-long.554.mp4"/>
     </paper>
     <paper id="555">
       <title>Conditional Generation of Temporally-ordered Event Sequences</title>
@@ -9547,7 +8997,6 @@
       <bibkey>lin-etal-2021-conditional</bibkey>
       <video href="2021.acl-long.555.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mc-taco">MC-TACO</pwcdataset>
-      <video href="2021.acl-long.555.mp4"/>
     </paper>
     <paper id="556">
       <title>Hate Speech Detection Based on Sentiment Knowledge Sharing</title>
@@ -9566,7 +9015,6 @@
       <bibkey>zhou-etal-2021-hate</bibkey>
       <video href="2021.acl-long.556.mp4"/>
       <pwccode url="https://github.com/1783696285/sks" additional="false">1783696285/sks</pwccode>
-      <video href="2021.acl-long.556.mp4"/>
     </paper>
     <paper id="557">
       <title>Transition-based Bubble Parsing: Improvements on Coordination Structure Prediction</title>
@@ -9582,7 +9030,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/genia">GENIA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.acl-long.557.mp4"/>
     </paper>
     <paper id="558">
       <title><fixed-case>S</fixed-case>pan<fixed-case>NER</fixed-case>: Named Entity Re-/Recognition as Span Prediction</title>
@@ -9599,7 +9046,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2002">CoNLL 2002</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2016-ner">WNUT 2016 NER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
-      <video href="2021.acl-long.558.mp4"/>
     </paper>
     <paper id="559">
       <title><fixed-case>S</fixed-case>truct<fixed-case>F</fixed-case>ormer: Joint Unsupervised Induction of Dependency and Constituency Structure from Masked Language Modeling</title>
@@ -9616,7 +9062,6 @@
       <bibkey>shen-etal-2021-structformer</bibkey>
       <video href="2021.acl-long.559.mp4"/>
       <pwccode url="https://github.com/google-research/google-research/tree/master/structformer" additional="false">google-research/google-research</pwccode>
-      <video href="2021.acl-long.559.mp4"/>
     </paper>
     <paper id="560">
       <title>Language Embeddings for Typology and Cross-lingual Transfer Learning</title>
@@ -9631,7 +9076,6 @@
       <video href="2021.acl-long.560.mp4"/>
       <pwccode url="https://github.com/DianDYu/language_embeddings" additional="false">DianDYu/language_embeddings</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.acl-long.560.mp4"/>
     </paper>
     <paper id="561">
       <title>Can Sequence-to-Sequence Models Crack Substitution Ciphers?</title>
@@ -9642,7 +9086,6 @@
       <url hash="e7f38674">2021.acl-long.561</url>
       <doi>10.18653/v1/2021.acl-long.561</doi>
       <bibkey>aldarrab-may-2021-sequence</bibkey>
-      <video href="2021.acl-long.561.mp4"/>
       <video href="2021.acl-long.561.mp4"/>
     </paper>
     <paper id="562">
@@ -9657,7 +9100,6 @@
       <video href="2021.acl-long.562.mp4"/>
       <pwccode url="https://github.com/awslabs/sockeye" additional="true">awslabs/sockeye</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikimatrix">WikiMatrix</pwcdataset>
-      <video href="2021.acl-long.562.mp4"/>
     </paper>
     <paper id="563">
       <title>Discriminative Reranking for Neural Machine Translation</title>
@@ -9669,7 +9111,6 @@
       <url hash="f35ede19">2021.acl-long.563</url>
       <doi>10.18653/v1/2021.acl-long.563</doi>
       <bibkey>lee-etal-2021-discriminative</bibkey>
-      <video href="2021.acl-long.563.mp4"/>
       <video href="2021.acl-long.563.mp4"/>
     </paper>
     <paper id="564">
@@ -9689,7 +9130,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/gqa">GQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-long.564.mp4"/>
     </paper>
     <paper id="565">
       <title>All That’s ‘Human’ Is Not Gold: Evaluating Human Evaluation of Generated Text</title>
@@ -9707,7 +9147,6 @@
       <doi>10.18653/v1/2021.acl-long.565</doi>
       <bibkey>clark-etal-2021-thats</bibkey>
       <video href="2021.acl-long.565.mp4"/>
-      <video href="2021.acl-long.565.mp4"/>
     </paper>
     <paper id="566">
       <title>Scientific Credibility of Machine Translation Research: A Meta-Evaluation of 769 Papers</title>
@@ -9723,7 +9162,6 @@
       <bibkey>marie-etal-2021-scientific</bibkey>
       <video href="2021.acl-long.566.mp4"/>
       <pwccode url="https://github.com/benjamin-marie/meta_evaluation_mt" additional="true">benjamin-marie/meta_evaluation_mt</pwccode>
-      <video href="2021.acl-long.566.mp4"/>
     </paper>
     <paper id="567">
       <title>Neural Machine Translation with Monolingual Translation Memory</title>
@@ -9778,7 +9216,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ocnli">OCNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-long.569.mp4"/>
     </paper>
     <paper id="570">
       <title>Including Signed Languages in Natural Language Processing</title>
@@ -9793,7 +9230,6 @@
       <award>Best Theme Paper</award>
       <doi>10.18653/v1/2021.acl-long.570</doi>
       <bibkey>yin-etal-2021-including</bibkey>
-      <video href="2021.acl-long.570.mp4"/>
       <video href="2021.acl-long.570.mp4"/>
     </paper>
     <paper id="571">
@@ -9811,7 +9247,6 @@
       <bibkey>xu-etal-2021-vocabulary</bibkey>
       <video href="2021.acl-long.571.mp4"/>
       <pwccode url="https://github.com/Jingjing-NLP/VOLT" additional="false">Jingjing-NLP/VOLT</pwccode>
-      <video href="2021.acl-long.571.mp4"/>
     </paper>
   </volume>
   <volume id="short" ingest-date="2021-07-25">
@@ -9841,7 +9276,6 @@
       <doi>10.18653/v1/2021.acl-short.1</doi>
       <bibkey>sweed-shahaf-2021-catchphrase</bibkey>
       <video href="2021.acl-short.1.mp4"/>
-      <video href="2021.acl-short.1.mp4"/>
     </paper>
     <paper id="2">
       <title>On Training Instance Selection for Few-Shot Neural Text Generation</title>
@@ -9856,7 +9290,6 @@
       <bibkey>chang-etal-2021-training</bibkey>
       <video href="2021.acl-short.2.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-short.2.mp4"/>
     </paper>
     <paper id="3">
       <title>Coreference Resolution without Span Representations</title>
@@ -9872,7 +9305,6 @@
       <pwccode url="https://github.com/yuvalkirstain/s2e-coref" additional="false">yuvalkirstain/s2e-coref</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2012-1">CoNLL-2012</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/gap-coreference-dataset">GAP Coreference Dataset</pwcdataset>
-      <video href="2021.acl-short.3.mp4"/>
     </paper>
     <paper id="4">
       <title>Enhancing Entity Boundary Detection for Better <fixed-case>C</fixed-case>hinese Named Entity Recognition</title>
@@ -9885,7 +9317,6 @@
       <bibkey>chen-kong-2021-enhancing</bibkey>
       <video href="2021.acl-short.4.mp4"/>
       <pwccode url="https://github.com/cchen-reese/Boundary-Enhanced-NER" additional="false">cchen-reese/Boundary-Enhanced-NER</pwccode>
-      <video href="2021.acl-short.4.mp4"/>
     </paper>
     <paper id="5">
       <title>Difficulty-Aware Machine Translation Evaluation</title>
@@ -9900,7 +9331,6 @@
       <bibkey>zhan-etal-2021-difficulty</bibkey>
       <video href="2021.acl-short.5.mp4"/>
       <pwccode url="https://github.com/NLP2CT/Difficulty-Aware-MT-Evaluation" additional="false">NLP2CT/Difficulty-Aware-MT-Evaluation</pwccode>
-      <video href="2021.acl-short.5.mp4"/>
     </paper>
     <paper id="6">
       <title>Uncertainty and Surprisal Jointly Deliver the Punchline: Exploiting Incongruity-Based Features for Humor Recognition</title>
@@ -9913,7 +9343,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="7ce19773">2021.acl-short.6.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-short.6</doi>
       <bibkey>xie-etal-2021-uncertainty</bibkey>
-      <video href="2021.acl-short.6.mp4"/>
       <video href="2021.acl-short.6.mp4"/>
     </paper>
     <paper id="7">
@@ -9930,7 +9359,6 @@
       <bibkey>nangi-etal-2021-counterfactuals</bibkey>
       <video href="2021.acl-short.7.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
-      <video href="2021.acl-short.7.mp4"/>
     </paper>
     <paper id="8">
       <title>Attention Flows are Shapley Value Explanations</title>
@@ -9941,7 +9369,6 @@
       <url hash="8e5cd30b">2021.acl-short.8</url>
       <doi>10.18653/v1/2021.acl-short.8</doi>
       <bibkey>ethayarajh-jurafsky-2021-attention</bibkey>
-      <video href="2021.acl-short.8.mp4"/>
       <video href="2021.acl-short.8.mp4"/>
     </paper>
     <paper id="9">
@@ -9955,7 +9382,6 @@
       <bibkey>liu-wan-2021-video</bibkey>
       <video href="2021.acl-short.9.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/activitynet-captions">ActivityNet Captions</pwcdataset>
-      <video href="2021.acl-short.9.mp4"/>
     </paper>
     <paper id="10">
       <title>Are <fixed-case>VQA</fixed-case> Systems <fixed-case>RAD</fixed-case>? <fixed-case>M</fixed-case>easuring Robustness to Augmented Data with Focused Interventions</title>
@@ -9971,7 +9397,6 @@
       <video href="2021.acl-short.10.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/visdial">VisDial</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-short.10.mp4"/>
     </paper>
     <paper id="11">
       <title>How Helpful is Inverse Reinforcement Learning for Table-to-Text Generation?</title>
@@ -9987,7 +9412,6 @@
       <bibkey>ghosh-etal-2021-helpful</bibkey>
       <video href="2021.acl-short.11.mp4"/>
       <pwccode url="https://github.com/issacqzh/irl_table2text" additional="false">issacqzh/irl_table2text</pwccode>
-      <video href="2021.acl-short.11.mp4"/>
     </paper>
     <paper id="12">
       <title>Automatic Fake News Detection: Are Models Learning to Reason?</title>
@@ -10001,7 +9425,6 @@
       <bibkey>hansen-etal-2021-automatic</bibkey>
       <video href="2021.acl-short.12.mp4"/>
       <pwccode url="https://github.com/casperhansen/fake-news-reasoning" additional="false">casperhansen/fake-news-reasoning</pwccode>
-      <video href="2021.acl-short.12.mp4"/>
     </paper>
     <paper id="13">
       <title><fixed-case>S</fixed-case>aying <fixed-case>N</fixed-case>o is <fixed-case>A</fixed-case>n <fixed-case>A</fixed-case>rt: <fixed-case>C</fixed-case>ontextualized <fixed-case>F</fixed-case>allback <fixed-case>R</fixed-case>esponses for <fixed-case>U</fixed-case>nanswerable <fixed-case>D</fixed-case>ialogue <fixed-case>Q</fixed-case>ueries</title>
@@ -10016,7 +9439,6 @@
       <bibkey>shrivastava-etal-2021-saying</bibkey>
       <video href="2021.acl-short.13.mp4"/>
       <pwccode url="https://github.com/kaustubhdhole/natural-dont-know" additional="false">kaustubhdhole/natural-dont-know</pwccode>
-      <video href="2021.acl-short.13.mp4"/>
     </paper>
     <paper id="14">
       <title>N-Best <fixed-case>ASR</fixed-case> Transformer: Enhancing <fixed-case>SLU</fixed-case> Performance using Multiple <fixed-case>ASR</fixed-case> Hypotheses</title>
@@ -10032,7 +9454,6 @@
       <bibkey>ganesan-etal-2021-n</bibkey>
       <video href="2021.acl-short.14.mp4"/>
       <pwccode url="https://github.com/Vernacular-ai/N-Best-ASR-Transformer" additional="false">Vernacular-ai/N-Best-ASR-Transformer</pwccode>
-      <video href="2021.acl-short.14.mp4"/>
     </paper>
     <paper id="15">
       <title>Gender bias amplification during Speed-Quality optimization in Neural Machine Translation</title>
@@ -10048,7 +9469,6 @@
       <doi>10.18653/v1/2021.acl-short.15</doi>
       <bibkey>renduchintala-etal-2021-gender</bibkey>
       <video href="2021.acl-short.15.mp4"/>
-      <video href="2021.acl-short.15.mp4"/>
     </paper>
     <paper id="16">
       <title>Machine Translation into Low-resource Language Varieties</title>
@@ -10063,7 +9483,6 @@
       <bibkey>kumar-etal-2021-machine</bibkey>
       <video href="2021.acl-short.16.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wikimatrix">WikiMatrix</pwcdataset>
-      <video href="2021.acl-short.16.mp4"/>
     </paper>
     <paper id="17">
       <title>Is Sparse Attention more Interpretable?</title>
@@ -10077,7 +9496,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="31a397f4">2021.acl-short.17.OptionalSupplementaryMaterial.png</attachment>
       <doi>10.18653/v1/2021.acl-short.17</doi>
       <bibkey>meister-etal-2021-sparse</bibkey>
-      <video href="2021.acl-short.17.mp4"/>
       <video href="2021.acl-short.17.mp4"/>
     </paper>
     <paper id="18">
@@ -10093,7 +9511,6 @@
       <pwccode url="https://github.com/ulmewennberg/tisa" additional="false">ulmewennberg/tisa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.acl-short.18.mp4"/>
     </paper>
     <paper id="19">
       <title>Relative Importance in Sentence Processing</title>
@@ -10107,7 +9524,6 @@
       <bibkey>hollenstein-beinborn-2021-relative</bibkey>
       <video href="2021.acl-short.19.mp4"/>
       <pwccode url="https://github.com/beinborn/relative_importance" additional="false">beinborn/relative_importance</pwccode>
-      <video href="2021.acl-short.19.mp4"/>
     </paper>
     <paper id="20">
       <title>Doing Good or Doing Right? Exploring the Weakness of Commonsense Causal Reasoning Models</title>
@@ -10123,7 +9539,6 @@
       <pwccode url="https://github.com/badbadcode/weakCOPA" additional="false">badbadcode/weakCOPA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bcopa-ce">BCOPA-CE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/copa">COPA</pwcdataset>
-      <video href="2021.acl-short.20.mp4"/>
     </paper>
     <paper id="21">
       <title><fixed-case>AND</fixed-case> does not mean <fixed-case>OR</fixed-case>: Using Formal Languages to Study Language Models’ Representations</title>
@@ -10135,7 +9550,6 @@
       <url hash="7b6e7d8a">2021.acl-short.21</url>
       <doi>10.18653/v1/2021.acl-short.21</doi>
       <bibkey>traylor-etal-2021-mean</bibkey>
-      <video href="2021.acl-short.21.mp4"/>
       <video href="2021.acl-short.21.mp4"/>
     </paper>
     <paper id="22">
@@ -10151,7 +9565,6 @@
       <video href="2021.acl-short.22.mp4"/>
       <pwccode url="https://github.com/nitishgupta/allennlp-semparse" additional="false">nitishgupta/allennlp-semparse</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/nlvr">NLVR</pwcdataset>
-      <video href="2021.acl-short.22.mp4"/>
     </paper>
     <paper id="23">
       <title>An Improved Model for Voicing Silent Speech</title>
@@ -10164,7 +9577,6 @@
       <bibkey>gaddy-klein-2021-improved</bibkey>
       <video href="2021.acl-short.23.mp4"/>
       <pwccode url="https://github.com/dgaddy/silent_speech" additional="false">dgaddy/silent_speech</pwccode>
-      <video href="2021.acl-short.23.mp4"/>
     </paper>
     <paper id="24">
       <title>What’s in the Box? An Analysis of Undesirable Content in the <fixed-case>C</fixed-case>ommon <fixed-case>C</fixed-case>rawl Corpus</title>
@@ -10175,7 +9587,6 @@
       <url hash="62dd27b9">2021.acl-short.24</url>
       <doi>10.18653/v1/2021.acl-short.24</doi>
       <bibkey>luccioni-viviano-2021-whats</bibkey>
-      <video href="2021.acl-short.24.mp4"/>
       <video href="2021.acl-short.24.mp4"/>
     </paper>
     <paper id="25">
@@ -10188,7 +9599,6 @@
       <url hash="4e7e52ac">2021.acl-short.25</url>
       <doi>10.18653/v1/2021.acl-short.25</doi>
       <bibkey>obamuyide-etal-2021-continual</bibkey>
-      <video href="2021.acl-short.25.mp4"/>
       <video href="2021.acl-short.25.mp4"/>
     </paper>
     <paper id="26">
@@ -10204,7 +9614,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="f658f59f">2021.acl-short.26.OptionalSupplementaryMaterial.pdf</attachment>
       <doi>10.18653/v1/2021.acl-short.26</doi>
       <bibkey>shang-etal-2021-span</bibkey>
-      <video href="2021.acl-short.26.mp4"/>
       <video href="2021.acl-short.26.mp4"/>
     </paper>
     <paper id="27">
@@ -10224,7 +9633,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-short.27.mp4"/>
     </paper>
     <paper id="28">
       <title><fixed-case>W</fixed-case>iki<fixed-case>S</fixed-case>um: Coherent Summarization Dataset for Efficient Human-Evaluation</title>
@@ -10241,7 +9649,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bigpatent">BigPatent</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikihow">WikiHow</pwcdataset>
-      <video href="2021.acl-short.28.mp4"/>
     </paper>
     <paper id="29">
       <title><fixed-case>UMIC</fixed-case>: An Unreferenced Metric for Image Captioning via Contrastive Learning</title>
@@ -10258,7 +9665,6 @@
       <bibkey>lee-etal-2021-umic</bibkey>
       <video href="2021.acl-short.29.mp4"/>
       <pwccode url="https://github.com/hwanheelee1993/UMIC" additional="false">hwanheelee1993/UMIC</pwccode>
-      <video href="2021.acl-short.29.mp4"/>
     </paper>
     <paper id="30">
       <title>Anchor-based Bilingual Word Embeddings for Low-Resource Languages</title>
@@ -10270,7 +9676,6 @@
       <url hash="835dd543">2021.acl-short.30</url>
       <doi>10.18653/v1/2021.acl-short.30</doi>
       <bibkey>eder-etal-2021-anchor</bibkey>
-      <video href="2021.acl-short.30.mp4"/>
       <video href="2021.acl-short.30.mp4"/>
     </paper>
     <paper id="31">
@@ -10288,7 +9693,6 @@
       <doi>10.18653/v1/2021.acl-short.31</doi>
       <bibkey>yang-etal-2021-multilingual</bibkey>
       <video href="2021.acl-short.31.mp4"/>
-      <video href="2021.acl-short.31.mp4"/>
     </paper>
     <paper id="32">
       <title>Higher-order Derivatives of Weighted Finite-state Machines</title>
@@ -10300,7 +9704,6 @@
       <url hash="778aed74">2021.acl-short.32</url>
       <doi>10.18653/v1/2021.acl-short.32</doi>
       <bibkey>zmigrod-etal-2021-higher</bibkey>
-      <video href="2021.acl-short.32.mp4"/>
       <video href="2021.acl-short.32.mp4"/>
     </paper>
     <paper id="33">
@@ -10317,7 +9720,6 @@
       <video href="2021.acl-short.33.mp4"/>
       <pwccode url="https://github.com/shwetanlp/CHQ-Summ" additional="false">shwetanlp/CHQ-Summ</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/matinf">MATINF</pwcdataset>
-      <video href="2021.acl-short.33.mp4"/>
     </paper>
     <paper id="34">
       <title>A Semantics-aware Transformer Model of Relation Linking for Knowledge Base Question Answering</title>
@@ -10336,7 +9738,6 @@
       <doi>10.18653/v1/2021.acl-short.34</doi>
       <bibkey>naseem-etal-2021-semantics</bibkey>
       <video href="2021.acl-short.34.mp4"/>
-      <video href="2021.acl-short.34.mp4"/>
     </paper>
     <paper id="35">
       <title>Neural Retrieval for Question Answering with Cross-Attention Supervised Data Augmentation</title>
@@ -10353,7 +9754,6 @@
       <video href="2021.acl-short.35.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/reqa">ReQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-short.35.mp4"/>
     </paper>
     <paper id="36">
       <title>Enhancing Descriptive Image Captioning with Natural Language Inference</title>
@@ -10369,7 +9769,6 @@
       <pwccode url="https://github.com/gitsamshi/nli-image-caption" additional="false">gitsamshi/nli-image-caption</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-short.36.mp4"/>
     </paper>
     <paper id="37">
       <title><fixed-case>MOLEMAN</fixed-case>: Mention-Only Linking of Entities with a Mention Annotation Network</title>
@@ -10386,7 +9785,6 @@
       <bibkey>fitzgerald-etal-2021-moleman</bibkey>
       <video href="2021.acl-short.37.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mewsli-9">Mewsli-9</pwcdataset>
-      <video href="2021.acl-short.37.mp4"/>
     </paper>
     <paper id="38">
       <title>e<fixed-case>MLM</fixed-case>: A New Pre-training Objective for Emotion Related Tasks</title>
@@ -10402,7 +9800,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/goemotions">GoEmotions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-short.38.mp4"/>
     </paper>
     <paper id="39">
       <title>On Positivity Bias in Negative Reviews</title>
@@ -10418,7 +9815,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/peerread">PeerRead</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-short.39.mp4"/>
     </paper>
     <paper id="40">
       <title><fixed-case>PRAL</fixed-case>: A Tailored Pre-Training Model for Task-Oriented Dialog Generation</title>
@@ -10432,7 +9828,6 @@
       <url hash="c6933eed">2021.acl-short.40</url>
       <doi>10.18653/v1/2021.acl-short.40</doi>
       <bibkey>gu-etal-2021-pral</bibkey>
-      <video href="2021.acl-short.40.mp4"/>
       <video href="2021.acl-short.40.mp4"/>
     </paper>
     <paper id="41">
@@ -10452,7 +9847,6 @@
       <bibkey>lee-etal-2021-rope</bibkey>
       <video href="2021.acl-short.41.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/funsd">FUNSD</pwcdataset>
-      <video href="2021.acl-short.41.mp4"/>
     </paper>
     <paper id="42">
       <title>Zero-shot Event Extraction via Transfer Learning: <fixed-case>C</fixed-case>hallenges and Insights</title>
@@ -10469,7 +9863,6 @@
       <video href="2021.acl-short.42.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qamr">QAMR</pwcdataset>
-      <video href="2021.acl-short.42.mp4"/>
     </paper>
     <paper id="43">
       <title>Using Adversarial Attacks to Reveal the Statistical Bias in Machine Reading Comprehension Models</title>
@@ -10483,7 +9876,6 @@
       <bibkey>lin-etal-2021-using</bibkey>
       <video href="2021.acl-short.43.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
-      <video href="2021.acl-short.43.mp4"/>
     </paper>
     <paper id="44">
       <title>Quantifying and Avoiding Unfair Qualification Labour in Crowdsourcing</title>
@@ -10494,7 +9886,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="286d23db">2021.acl-short.44.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-short.44</doi>
       <bibkey>kummerfeld-2021-quantifying</bibkey>
-      <video href="2021.acl-short.44.mp4"/>
       <video href="2021.acl-short.44.mp4"/>
     </paper>
     <paper id="45">
@@ -10509,7 +9900,6 @@
       <bibkey>sun-peng-2021-men</bibkey>
       <video href="2021.acl-short.45.mp4"/>
       <pwccode url="https://github.com/PlusLabNLP/ee-wiki-bias" additional="false">PlusLabNLP/ee-wiki-bias</pwccode>
-      <video href="2021.acl-short.45.mp4"/>
     </paper>
     <paper id="46">
       <title>Modeling Task-Aware <fixed-case>MIMO</fixed-case> Cardinality for Efficient Multilingual Neural Machine Translation</title>
@@ -10524,7 +9914,6 @@
       <bibkey>xu-etal-2021-modeling</bibkey>
       <video href="2021.acl-short.46.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/opus-100">OPUS-100</pwcdataset>
-      <video href="2021.acl-short.46.mp4"/>
     </paper>
     <paper id="47">
       <title>Adaptive Nearest Neighbor Machine Translation</title>
@@ -10542,7 +9931,6 @@
       <bibkey>zheng-etal-2021-adaptive</bibkey>
       <video href="2021.acl-short.47.mp4"/>
       <pwccode url="https://github.com/zhengxxn/adaptive-knn-mt" additional="true">zhengxxn/adaptive-knn-mt</pwccode>
-      <video href="2021.acl-short.47.mp4"/>
     </paper>
     <paper id="48">
       <title>On Orthogonality Constraints for Transformers</title>
@@ -10562,7 +9950,6 @@
       <bibkey>zhang-etal-2021-orthogonality</bibkey>
       <video href="2021.acl-short.48.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
-      <video href="2021.acl-short.48.mp4"/>
     </paper>
     <paper id="49">
       <title>Measuring and Improving <fixed-case>BERT</fixed-case>’s Mathematical Abilities by Predicting the Order of Reasoning.</title>
@@ -10577,7 +9964,6 @@
       <bibkey>piekos-etal-2021-measuring</bibkey>
       <video href="2021.acl-short.49.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/aqua-rat">AQUA-RAT</pwcdataset>
-      <video href="2021.acl-short.49.mp4"/>
     </paper>
     <paper id="50">
       <title>Happy Dance, Slow Clap: <fixed-case>Using</fixed-case> Reaction <fixed-case>GIFs</fixed-case> to Predict Induced Affect on <fixed-case>Twitter</fixed-case></title>
@@ -10591,7 +9977,6 @@
       <bibkey>shmueli-etal-2021-happy</bibkey>
       <video href="2021.acl-short.50.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/reactiongif">ReactionGIF</pwcdataset>
-      <video href="2021.acl-short.50.mp4"/>
     </paper>
     <paper id="51">
       <title>Exploring Listwise Evidence Reasoning with T5 for Fact Verification</title>
@@ -10606,7 +9991,6 @@
       <bibkey>jiang-etal-2021-exploring-listwise</bibkey>
       <video href="2021.acl-short.51.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
-      <video href="2021.acl-short.51.mp4"/>
     </paper>
     <paper id="52">
       <title><fixed-case>D</fixed-case>ef<fixed-case>S</fixed-case>ent: Sentence Embeddings using Definition Sentences</title>
@@ -10621,7 +10005,6 @@
       <video href="2021.acl-short.52.mp4"/>
       <pwccode url="https://github.com/hppRC/defsent" additional="false">hppRC/defsent</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.acl-short.52.mp4"/>
     </paper>
     <paper id="53">
       <title>Discrete Cosine Transform as Universal Sentence Encoder</title>
@@ -10632,7 +10015,6 @@
       <url hash="b3776fff">2021.acl-short.53</url>
       <doi>10.18653/v1/2021.acl-short.53</doi>
       <bibkey>almarwani-diab-2021-discrete</bibkey>
-      <video href="2021.acl-short.53.mp4"/>
       <video href="2021.acl-short.53.mp4"/>
     </paper>
     <paper id="54">
@@ -10647,7 +10029,6 @@
       <bibkey>mirza-etal-2021-alignarr</bibkey>
       <video href="2021.acl-short.54.mp4"/>
       <pwccode url="https://github.com/paramitamirza/alignarr" additional="false">paramitamirza/alignarr</pwccode>
-      <video href="2021.acl-short.54.mp4"/>
     </paper>
     <paper id="55">
       <title>An Exploratory Analysis of Multilingual Word-Level Quality Estimation with Cross-Lingual Transformers</title>
@@ -10662,7 +10043,6 @@
       <bibkey>ranasinghe-etal-2021-exploratory</bibkey>
       <video href="2021.acl-short.55.mp4"/>
       <pwccode url="https://github.com/tharindudr/transQuest" additional="false">tharindudr/transQuest</pwccode>
-      <video href="2021.acl-short.55.mp4"/>
     </paper>
     <paper id="56">
       <title>Exploration and Exploitation: Two Ways to Improve <fixed-case>C</fixed-case>hinese Spelling Correction Models</title>
@@ -10678,7 +10058,6 @@
       <bibkey>li-etal-2021-exploration</bibkey>
       <video href="2021.acl-short.56.mp4"/>
       <pwccode url="https://github.com/FDChongli/TwoWaysToImproveCSC" additional="false">FDChongli/TwoWaysToImproveCSC</pwccode>
-      <video href="2021.acl-short.56.mp4"/>
     </paper>
     <paper id="57">
       <title>Training Adaptive Computation for Open-Domain Question Answering with Computational Constraints</title>
@@ -10695,7 +10074,6 @@
       <pwccode url="https://github.com/uclnlp/APE" additional="false">uclnlp/APE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-short.57.mp4"/>
     </paper>
     <paper id="58">
       <title>An Empirical Study on Adversarial Attack on <fixed-case>NMT</fixed-case>: Languages and Positions Matter</title>
@@ -10706,7 +10084,6 @@
       <url hash="3e9fbe24">2021.acl-short.58</url>
       <doi>10.18653/v1/2021.acl-short.58</doi>
       <bibkey>zeng-xiong-2021-empirical</bibkey>
-      <video href="2021.acl-short.58.mp4"/>
       <video href="2021.acl-short.58.mp4"/>
     </paper>
     <paper id="59">
@@ -10725,7 +10102,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/gap-coreference-dataset">GAP Coreference Dataset</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/gum">GUM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikicoref">WikiCoref</pwcdataset>
-      <video href="2021.acl-short.59.mp4"/>
     </paper>
     <paper id="60">
       <title>In Factuality: Efficient Integration of Relevant Facts for Visual Question Answering</title>
@@ -10740,7 +10116,6 @@
       <bibkey>vickers-etal-2021-factuality</bibkey>
       <video href="2021.acl-short.60.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-short.60.mp4"/>
     </paper>
     <paper id="61">
       <title>Zero-shot Fact Verification by Claim Generation</title>
@@ -10759,7 +10134,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qa2d">QA2D</pwcdataset>
-      <video href="2021.acl-short.61.mp4"/>
     </paper>
     <paper id="62">
       <title>Thank you <fixed-case>BART</fixed-case>! Rewarding Pre-Trained Models Improves Formality Style Transfer</title>
@@ -10774,7 +10148,6 @@
       <video href="2021.acl-short.62.mp4"/>
       <pwccode url="https://github.com/laihuiyuan/Pre-trained-formality-transfer" additional="false">laihuiyuan/Pre-trained-formality-transfer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
-      <video href="2021.acl-short.62.mp4"/>
     </paper>
     <paper id="63">
       <title>Deep Context- and Relation-Aware Learning for Aspect-based Sentiment Analysis</title>
@@ -10790,7 +10163,6 @@
       <url hash="dccca1b6">2021.acl-short.63</url>
       <doi>10.18653/v1/2021.acl-short.63</doi>
       <bibkey>oh-etal-2021-deep</bibkey>
-      <video href="2021.acl-short.63.mp4"/>
       <video href="2021.acl-short.63.mp4"/>
     </paper>
     <paper id="64">
@@ -10808,7 +10180,6 @@
       <video href="2021.acl-short.64.mp4"/>
       <pwccode url="https://github.com/IsakZhang/Generative-ABSA" additional="false">IsakZhang/Generative-ABSA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aste-data-v2">ASTE-Data-V2</pwcdataset>
-      <video href="2021.acl-short.64.mp4"/>
     </paper>
     <paper id="65">
       <title>Bilingual Mutual Information Based Adaptive Training for Neural Machine Translation</title>
@@ -10826,7 +10197,6 @@
       <bibkey>xu-etal-2021-bilingual</bibkey>
       <video href="2021.acl-short.65.mp4"/>
       <pwccode url="https://github.com/xydaytoy/BMI-NMT" additional="false">xydaytoy/BMI-NMT</pwccode>
-      <video href="2021.acl-short.65.mp4"/>
     </paper>
     <paper id="66">
       <title>Continual Learning for Task-oriented Dialogue System with Iterative Network Pruning, Expanding and Masking</title>
@@ -10843,7 +10213,6 @@
       <bibkey>geng-etal-2021-continual</bibkey>
       <video href="2021.acl-short.66.mp4"/>
       <pwccode url="https://github.com/siat-nlp/TPEM" additional="false">siat-nlp/TPEM</pwccode>
-      <video href="2021.acl-short.66.mp4"/>
     </paper>
     <paper id="67">
       <title><fixed-case>TIMERS</fixed-case>: Document-level Temporal Relation Extraction</title>
@@ -10859,7 +10228,6 @@
       <doi>10.18653/v1/2021.acl-short.67</doi>
       <bibkey>mathur-etal-2021-timers</bibkey>
       <video href="2021.acl-short.67.mp4"/>
-      <video href="2021.acl-short.67.mp4"/>
     </paper>
     <paper id="68">
       <title>Improving <fixed-case>A</fixed-case>rabic Diacritization with Regularized Decoding and Adversarial Training</title>
@@ -10874,7 +10242,6 @@
       <bibkey>qin-etal-2021-improving</bibkey>
       <video href="2021.acl-short.68.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/arabic-text-diacritization">Arabic Text Diacritization</pwcdataset>
-      <video href="2021.acl-short.68.mp4"/>
     </paper>
     <paper id="69">
       <title>When is Char Better Than Subword: A Systematic Study of Segmentation Algorithms for Neural Machine Translation</title>
@@ -10888,7 +10255,6 @@
       <url hash="0dd4c302">2021.acl-short.69</url>
       <doi>10.18653/v1/2021.acl-short.69</doi>
       <bibkey>li-etal-2021-char</bibkey>
-      <video href="2021.acl-short.69.mp4"/>
       <video href="2021.acl-short.69.mp4"/>
     </paper>
     <paper id="70">
@@ -10906,7 +10272,6 @@
       <bibkey>zhang-etal-2021-text</bibkey>
       <video href="2021.acl-short.70.mp4"/>
       <pwccode url="https://github.com/manlp-suda/mcws" additional="false">manlp-suda/mcws</pwccode>
-      <video href="2021.acl-short.70.mp4"/>
     </paper>
     <paper id="71">
       <title>A Mixture-of-Experts Model for Antonym-Synonym Discrimination</title>
@@ -10920,7 +10285,6 @@
       <bibkey>xie-zeng-2021-mixture</bibkey>
       <video href="2021.acl-short.71.mp4"/>
       <pwccode url="https://github.com/zengnan1997/moe-asd" additional="false">zengnan1997/moe-asd</pwccode>
-      <video href="2021.acl-short.71.mp4"/>
     </paper>
     <paper id="72">
       <title>Learning Domain-Specialised Representations for Cross-Lingual Biomedical Entity Linking</title>
@@ -10936,7 +10300,6 @@
       <video href="2021.acl-short.72.mp4"/>
       <pwccode url="https://github.com/cambridgeltl/sapbert" additional="false">cambridgeltl/sapbert</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/xl-bel">XL-BEL</pwcdataset>
-      <video href="2021.acl-short.72.mp4"/>
     </paper>
     <paper id="73">
       <title>A Cluster-based Approach for Improving Isotropy in Contextual Embedding Space</title>
@@ -10956,7 +10319,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sts-2014">STS 2014</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
-      <video href="2021.acl-short.73.mp4"/>
     </paper>
     <paper id="74">
       <title>Unsupervised Enrichment of Persona-grounded Dialog with Background Stories</title>
@@ -10971,7 +10333,6 @@
       <bibkey>majumder-etal-2021-unsupervised</bibkey>
       <video href="2021.acl-short.74.mp4"/>
       <pwccode url="https://github.com/majumderb/pabst" additional="false">majumderb/pabst</pwccode>
-      <video href="2021.acl-short.74.mp4"/>
     </paper>
     <paper id="75">
       <title>Beyond Laurel/Yanny: An Autoencoder-Enabled Search for Polyperceivable Audio</title>
@@ -10984,7 +10345,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="98d3ba90">2021.acl-short.75.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-short.75</doi>
       <bibkey>chandra-etal-2021-beyond</bibkey>
-      <video href="2021.acl-short.75.mp4"/>
       <video href="2021.acl-short.75.mp4"/>
     </paper>
     <paper id="76">
@@ -10999,7 +10359,6 @@
       <doi>10.18653/v1/2021.acl-short.76</doi>
       <bibkey>koupaee-etal-2021-dont</bibkey>
       <video href="2021.acl-short.76.mp4"/>
-      <video href="2021.acl-short.76.mp4"/>
     </paper>
     <paper id="77">
       <title>The Curse of Dense Low-Dimensional Information Retrieval for Large Index Sizes</title>
@@ -11013,7 +10372,6 @@
       <video href="2021.acl-short.77.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.acl-short.77.mp4"/>
     </paper>
     <paper id="78">
       <title>Cross-lingual Text Classification with Heterogeneous Graph Neural Network</title>
@@ -11030,7 +10388,6 @@
       <video href="2021.acl-short.78.mp4"/>
       <pwccode url="https://github.com/TencentGameMate/gnn_cross_lingual" additional="false">TencentGameMate/gnn_cross_lingual</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/xglue">XGLUE</pwcdataset>
-      <video href="2021.acl-short.78.mp4"/>
     </paper>
     <paper id="79">
       <title>Towards more equitable question answering systems: How much more data do you need?</title>
@@ -11048,7 +10405,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mlqa">MLQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
-      <video href="2021.acl-short.79.mp4"/>
     </paper>
     <paper id="80">
       <title>Embedding Time Differences in Context-sensitive Neural Networks for Learning Time to Event</title>
@@ -11060,7 +10416,6 @@
       <url hash="9f79e0fd">2021.acl-short.80</url>
       <doi>10.18653/v1/2021.acl-short.80</doi>
       <bibkey>dehghani-etal-2021-embedding</bibkey>
-      <video href="2021.acl-short.80.mp4"/>
       <video href="2021.acl-short.80.mp4"/>
     </paper>
     <paper id="81">
@@ -11076,7 +10431,6 @@
       <bibkey>kim-etal-2021-improving</bibkey>
       <video href="2021.acl-short.81.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cfq">CFQ</pwcdataset>
-      <video href="2021.acl-short.81.mp4"/>
     </paper>
     <paper id="82">
       <title>Learning to Generate Task-Specific Adapters from Task Description</title>
@@ -11094,7 +10448,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/newsqa">NewsQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/zest">ZEST</pwcdataset>
-      <video href="2021.acl-short.82.mp4"/>
     </paper>
     <paper id="83">
       <title><fixed-case>QA</fixed-case>-Driven Zero-shot Slot Filling with Weak Supervision Pretraining</title>
@@ -11111,7 +10464,6 @@
       <bibkey>du-etal-2021-qa</bibkey>
       <video href="2021.acl-short.83.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
-      <video href="2021.acl-short.83.mp4"/>
     </paper>
     <paper id="84">
       <title>Domain-Adaptive Pretraining Methods for Dialogue Understanding</title>
@@ -11128,7 +10480,6 @@
       <bibkey>wu-etal-2021-domain</bibkey>
       <video href="2021.acl-short.84.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/crosswoz">CrossWOZ</pwcdataset>
-      <video href="2021.acl-short.84.mp4"/>
     </paper>
     <paper id="85">
       <title>Targeting the Benchmark: On Methodology in Current Natural Language Processing Research</title>
@@ -11140,7 +10491,6 @@
       <bibkey>schlangen-2021-targeting</bibkey>
       <video href="2021.acl-short.85.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-short.85.mp4"/>
     </paper>
     <paper id="86">
       <title><fixed-case>X</fixed-case>-Fact: A New Benchmark Dataset for Multilingual Fact Checking</title>
@@ -11154,7 +10504,6 @@
       <video href="2021.acl-short.86.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/x-fact">X-Fact</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multifc">MultiFC</pwcdataset>
-      <video href="2021.acl-short.86.mp4"/>
     </paper>
     <paper id="87">
       <title>nm<fixed-case>T</fixed-case>5 - Is parallel data still relevant for pre-training massively multilingual language models?</title>
@@ -11172,7 +10521,6 @@
       <video href="2021.acl-short.87.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/opus-100">OPUS-100</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mc4">mC4</pwcdataset>
-      <video href="2021.acl-short.87.mp4"/>
     </paper>
     <paper id="88">
       <title>Question Generation for Adaptive Education</title>
@@ -11185,7 +10533,6 @@
       <bibkey>srivastava-goodman-2021-question</bibkey>
       <video href="2021.acl-short.88.mp4"/>
       <pwccode url="https://github.com/meghabyte/acl2021-education" additional="false">meghabyte/acl2021-education</pwccode>
-      <video href="2021.acl-short.88.mp4"/>
     </paper>
     <paper id="89">
       <title>A Simple Recipe for Multilingual Grammatical Error Correction</title>
@@ -11206,7 +10553,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2014-shared-task-grammatical-error">CoNLL-2014 Shared Task: Grammatical Error Correction</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fce">FCE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mc4">mC4</pwcdataset>
-      <video href="2021.acl-short.89.mp4"/>
     </paper>
     <paper id="90">
       <title>Towards Visual Question Answering on Pathology Images</title>
@@ -11225,7 +10571,6 @@
       <video href="2021.acl-short.90.mp4"/>
       <pwccode url="https://github.com/UCSD-AI4H/PathVQA" additional="false">UCSD-AI4H/PathVQA</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.acl-short.90.mp4"/>
     </paper>
     <paper id="91">
       <title>Efficient Text-based Reinforcement Learning by Jointly Leveraging State and Commonsense Graph Representations</title>
@@ -11242,7 +10587,6 @@
       <bibkey>murugesan-etal-2021-efficient</bibkey>
       <video href="2021.acl-short.91.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.acl-short.91.mp4"/>
     </paper>
     <paper id="92">
       <title>m<fixed-case>TVR</fixed-case>: Multilingual Moment Retrieval in Videos</title>
@@ -11258,7 +10602,6 @@
       <pwccode url="https://github.com/jayleicn/mTVRetrieval" additional="false">jayleicn/mTVRetrieval</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mtvr">mTVR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tvr">TVR</pwcdataset>
-      <video href="2021.acl-short.92.mp4"/>
     </paper>
     <paper id="93">
       <title>Explicitly Capturing Relations between Entity Mentions via Graph Neural Networks for Domain-specific Named Entity Recognition</title>
@@ -11273,7 +10616,6 @@
       <bibkey>chen-etal-2021-explicitly</bibkey>
       <video href="2021.acl-short.93.mp4"/>
       <pwccode url="https://github.com/brickee/enrel-g" additional="false">brickee/enrel-g</pwccode>
-      <video href="2021.acl-short.93.mp4"/>
     </paper>
     <paper id="94">
       <title>Improving Lexically Constrained Neural Machine Translation with Source-Conditioned Masked Span Prediction</title>
@@ -11287,7 +10629,6 @@
       <bibkey>lee-etal-2021-improving</bibkey>
       <video href="2021.acl-short.94.mp4"/>
       <pwccode url="https://github.com/wns823/NMT_SSP" additional="false">wns823/NMT_SSP</pwccode>
-      <video href="2021.acl-short.94.mp4"/>
     </paper>
     <paper id="95">
       <title>Quotation Recommendation and Interpretation Based on Transformation from Queries to Quotations</title>
@@ -11301,7 +10642,6 @@
       <bibkey>wang-etal-2021-quotation</bibkey>
       <video href="2021.acl-short.95.mp4"/>
       <pwccode url="https://github.com/Lingzhi-WANG/Quotation-Recommendation" additional="false">Lingzhi-WANG/Quotation-Recommendation</pwccode>
-      <video href="2021.acl-short.95.mp4"/>
     </paper>
     <paper id="96">
       <title>Pre-training is a Hot Topic: Contextualized Document Embeddings Improve Topic Coherence</title>
@@ -11316,7 +10656,6 @@
       <video href="2021.acl-short.96.mp4"/>
       <pwccode url="https://github.com/MilaNLProc/contextualized-topic-models" additional="true">MilaNLProc/contextualized-topic-models</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/20-newsgroups">20 Newsgroups</pwcdataset>
-      <video href="2021.acl-short.96.mp4"/>
     </paper>
     <paper id="97">
       <title>Input Representations for Parsing Discourse Representation Structures: Comparing <fixed-case>E</fixed-case>nglish with <fixed-case>C</fixed-case>hinese</title>
@@ -11331,7 +10670,6 @@
       <bibkey>wang-etal-2021-input</bibkey>
       <video href="2021.acl-short.97.mp4"/>
       <pwccode url="https://github.com/wangchunliu/chinese-drs-parsing" additional="false">wangchunliu/chinese-drs-parsing</pwccode>
-      <video href="2021.acl-short.97.mp4"/>
     </paper>
     <paper id="98">
       <title>Code Generation from Natural Language with Less Prior Knowledge and More Monolingual Data</title>
@@ -11347,7 +10685,6 @@
       <pwccode url="https://github.com/borealisai/code-gen-tae" additional="false">borealisai/code-gen-tae</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conala">CoNaLa</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
-      <video href="2021.acl-short.98.mp4"/>
     </paper>
     <paper id="99">
       <title>Issues with Entailment-based Zero-shot Text Classification</title>
@@ -11370,7 +10707,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.acl-short.99.mp4"/>
     </paper>
     <paper id="100">
       <title>Neural-Symbolic Commonsense Reasoner with Relation Predictors</title>
@@ -11386,7 +10722,6 @@
       <bibkey>moghimifar-etal-2021-neural</bibkey>
       <video href="2021.acl-short.100.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.acl-short.100.mp4"/>
     </paper>
     <paper id="101">
       <title>What Motivates You? Benchmarking Automatic Detection of Basic Needs from Short Posts</title>
@@ -11399,7 +10734,6 @@
       <url hash="163f9a91">2021.acl-short.101</url>
       <doi>10.18653/v1/2021.acl-short.101</doi>
       <bibkey>stajner-etal-2021-motivates</bibkey>
-      <video href="2021.acl-short.101.mp4"/>
       <video href="2021.acl-short.101.mp4"/>
     </paper>
     <paper id="102">
@@ -11414,7 +10748,6 @@
       <bibkey>yamada-etal-2021-semantic</bibkey>
       <video href="2021.acl-short.102.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
-      <video href="2021.acl-short.102.mp4"/>
     </paper>
     <paper id="103">
       <title>Lightweight Adapter Tuning for Multilingual Speech Translation</title>
@@ -11432,7 +10765,6 @@
       <video href="2021.acl-short.103.mp4"/>
       <pwccode url="https://github.com/formiel/fairseq/blob/master/examples/speech_to_text/docs/adapters.md" additional="false">formiel/fairseq</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
-      <video href="2021.acl-short.103.mp4"/>
     </paper>
     <paper id="104">
       <title>Parameter Selection: Why We Should Pay More Attention to It</title>
@@ -11447,7 +10779,6 @@
       <bibkey>liu-etal-2021-parameter</bibkey>
       <video href="2021.acl-short.104.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mimic-iii">MIMIC-III</pwcdataset>
-      <video href="2021.acl-short.104.mp4"/>
     </paper>
     <paper id="105">
       <title>Distinct Label Representations for Few-Shot Text Classification</title>
@@ -11463,7 +10794,6 @@
       <video href="2021.acl-short.105.mp4"/>
       <pwccode url="https://github.com/21335732529sky/difference_extractor" additional="false">21335732529sky/difference_extractor</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
-      <video href="2021.acl-short.105.mp4"/>
     </paper>
     <paper id="106">
       <title>Learning to Solve <fixed-case>NLP</fixed-case> Tasks in an Incremental Number of Languages</title>
@@ -11478,7 +10808,6 @@
       <bibkey>castellucci-etal-2021-learning</bibkey>
       <video href="2021.acl-short.106.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/paws-x">PAWS-X</pwcdataset>
-      <video href="2021.acl-short.106.mp4"/>
     </paper>
     <paper id="107">
       <title>Hi-Transformer: Hierarchical Interactive Transformer for Efficient and Effective Long Document Modeling</title>
@@ -11493,7 +10822,6 @@
       <bibkey>wu-etal-2021-hi</bibkey>
       <video href="2021.acl-short.107.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mind">MIND</pwcdataset>
-      <video href="2021.acl-short.107.mp4"/>
     </paper>
     <paper id="108">
       <title>Robust Transfer Learning with Pretrained Language Models through Adapters</title>
@@ -11507,7 +10835,6 @@
       <bibkey>han-etal-2021-robust</bibkey>
       <video href="2021.acl-short.108.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.acl-short.108.mp4"/>
     </paper>
     <paper id="109">
       <title>Embracing Ambiguity: <fixed-case>S</fixed-case>hifting the Training Target of <fixed-case>NLI</fixed-case> Models</title>
@@ -11526,7 +10853,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-short.109.mp4"/>
     </paper>
     <paper id="110">
       <title>Modeling Discriminative Representations for Out-of-Domain Detection with Supervised Contrastive Learning</title>
@@ -11545,7 +10871,6 @@
       <bibkey>zeng-etal-2021-modeling</bibkey>
       <video href="2021.acl-short.110.mp4"/>
       <pwccode url="https://github.com/parZival27/supervised-contrastive-learning-for-out-of-domain-detection" additional="false">parZival27/supervised-contrastive-learning-for-out-of-domain-detection</pwccode>
-      <video href="2021.acl-short.110.mp4"/>
     </paper>
     <paper id="111">
       <title>Preview, Attend and Review: Schema-Aware Curriculum Learning for Multi-Domain Dialogue State Tracking</title>
@@ -11562,7 +10887,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="c5f904e4">2021.acl-short.111.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-short.111</doi>
       <bibkey>dai-etal-2021-preview</bibkey>
-      <video href="2021.acl-short.111.mp4"/>
       <video href="2021.acl-short.111.mp4"/>
     </paper>
     <paper id="112">
@@ -11590,7 +10914,6 @@
       <bibkey>zhou-etal-2021-generation</bibkey>
       <video href="2021.acl-short.112.mp4"/>
       <pwccode url="https://github.com/UCSD-AI4H/COVID-Dialogue" additional="false">UCSD-AI4H/COVID-Dialogue</pwccode>
-      <video href="2021.acl-short.112.mp4"/>
     </paper>
     <paper id="113">
       <title>Constructing Multi-Modal Dialogue Dataset by Replacing Text with Semantically Relevant Images</title>
@@ -11606,7 +10929,6 @@
       <bibkey>lee-etal-2021-constructing</bibkey>
       <video href="2021.acl-short.113.mp4"/>
       <pwccode url="https://github.com/shh1574/multi-modal-dialogue-dataset" additional="false">shh1574/multi-modal-dialogue-dataset</pwccode>
-      <video href="2021.acl-short.113.mp4"/>
     </paper>
     <paper id="114">
       <title>Exposing the limits of Zero-shot Cross-lingual Hate Speech Detection</title>
@@ -11616,7 +10938,6 @@
       <url hash="01f5c0c8">2021.acl-short.114</url>
       <doi>10.18653/v1/2021.acl-short.114</doi>
       <bibkey>nozza-2021-exposing</bibkey>
-      <video href="2021.acl-short.114.mp4"/>
       <video href="2021.acl-short.114.mp4"/>
     </paper>
     <paper id="115">
@@ -11630,7 +10951,6 @@
       <doi>10.18653/v1/2021.acl-short.115</doi>
       <bibkey>jauregi-unanue-etal-2021-berttune</bibkey>
       <video href="2021.acl-short.115.mp4"/>
-      <video href="2021.acl-short.115.mp4"/>
     </paper>
     <paper id="116">
       <title>Entity Enhancement for Implicit Discourse Relation Classification in the Biomedical Domain</title>
@@ -11641,7 +10961,6 @@
       <url hash="1531228b">2021.acl-short.116</url>
       <doi>10.18653/v1/2021.acl-short.116</doi>
       <bibkey>shi-demberg-2021-entity</bibkey>
-      <video href="2021.acl-short.116.mp4"/>
       <video href="2021.acl-short.116.mp4"/>
     </paper>
     <paper id="117">
@@ -11661,7 +10980,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
-      <video href="2021.acl-short.117.mp4"/>
     </paper>
     <paper id="118">
       <title>Addressing Semantic Drift in Generative Question Answering with Auxiliary Extraction</title>
@@ -11677,7 +10995,6 @@
       <bibkey>li-etal-2021-addressing-semantic</bibkey>
       <video href="2021.acl-short.118.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
-      <video href="2021.acl-short.118.mp4"/>
     </paper>
     <paper id="119">
       <title>Demoting the Lead Bias in News Summarization via Alternating Adversarial Learning</title>
@@ -11689,7 +11006,6 @@
       <url hash="ddfe075e">2021.acl-short.119</url>
       <doi>10.18653/v1/2021.acl-short.119</doi>
       <bibkey>xing-etal-2021-demoting</bibkey>
-      <video href="2021.acl-short.119.mp4"/>
       <video href="2021.acl-short.119.mp4"/>
     </paper>
     <paper id="120">
@@ -11708,7 +11024,6 @@
       <video href="2021.acl-short.120.mp4"/>
       <pwccode url="https://github.com/baidu/DuReader" additional="false">baidu/DuReader</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dureader">DuReader</pwcdataset>
-      <video href="2021.acl-short.120.mp4"/>
     </paper>
     <paper id="121">
       <title>Sequence to General Tree: Knowledge-Guided Geometry Word Problem Solving</title>
@@ -11723,7 +11038,6 @@
       <bibkey>tsai-etal-2021-sequence</bibkey>
       <video href="2021.acl-short.121.mp4"/>
       <pwccode url="https://github.com/doublebite/Sequence-to-General-tree" additional="false">doublebite/Sequence-to-General-tree</pwccode>
-      <video href="2021.acl-short.121.mp4"/>
     </paper>
     <paper id="122">
       <title>Multi-Scale Progressive Attention Network for Video Question Answering</title>
@@ -11738,7 +11052,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="370d2120">2021.acl-short.122.OptionalSupplementaryMaterial.zip</attachment>
       <doi>10.18653/v1/2021.acl-short.122</doi>
       <bibkey>guo-etal-2021-multi</bibkey>
-      <video href="2021.acl-short.122.mp4"/>
       <video href="2021.acl-short.122.mp4"/>
     </paper>
     <paper id="123">
@@ -11756,7 +11069,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tqa">TQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.acl-short.123.mp4"/>
     </paper>
     <paper id="124">
       <title>Entity Concept-enhanced Few-shot Relation Extraction</title>
@@ -11773,7 +11085,6 @@
       <video href="2021.acl-short.124.mp4"/>
       <pwccode url="https://github.com/LittleGuoKe/ConceptFERE" additional="false">LittleGuoKe/ConceptFERE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
-      <video href="2021.acl-short.124.mp4"/>
     </paper>
     <paper id="125">
       <title>Improving Model Generalization: A <fixed-case>C</fixed-case>hinese Named Entity Recognition Case Study</title>
@@ -11784,7 +11095,6 @@
       <url hash="2b2c3ecf">2021.acl-short.125</url>
       <doi>10.18653/v1/2021.acl-short.125</doi>
       <bibkey>liang-leung-2021-improving</bibkey>
-      <video href="2021.acl-short.125.mp4"/>
       <video href="2021.acl-short.125.mp4"/>
     </paper>
     <paper id="126">
@@ -11802,7 +11112,6 @@
       <bibkey>huang-etal-2021-three</bibkey>
       <video href="2021.acl-short.126.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
-      <video href="2021.acl-short.126.mp4"/>
     </paper>
     <paper id="127">
       <title>Unsupervised Cross-Domain Prerequisite Chain Learning using Variational Graph Autoencoders</title>
@@ -11819,7 +11128,6 @@
       <bibkey>li-etal-2021-unsupervised-cross</bibkey>
       <video href="2021.acl-short.127.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/lecturebank">LectureBank</pwcdataset>
-      <video href="2021.acl-short.127.mp4"/>
     </paper>
     <paper id="128">
       <title>Attentive Multiview Text Representation for Differential Diagnosis</title>
@@ -11832,7 +11140,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="d0a67f2c">2021.acl-short.128.OptionalSupplementaryMaterial.pdf</attachment>
       <doi>10.18653/v1/2021.acl-short.128</doi>
       <bibkey>amiri-etal-2021-attentive</bibkey>
-      <video href="2021.acl-short.128.mp4"/>
       <video href="2021.acl-short.128.mp4"/>
     </paper>
     <paper id="129">
@@ -11850,7 +11157,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mimic-iii">MIMIC-III</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.acl-short.129.mp4"/>
     </paper>
     <paper id="130">
       <title>Towards a more Robust Evaluation for Conversational Question Answering</title>
@@ -11865,7 +11171,6 @@
       <video href="2021.acl-short.130.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coqa">CoQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-short.130.mp4"/>
     </paper>
     <paper id="131">
       <title><fixed-case>VAULT</fixed-case>: <fixed-case>VA</fixed-case>riable Unified Long Text Representation for Machine Reading Comprehension</title>
@@ -11883,7 +11188,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/techqa">TechQA</pwcdataset>
-      <video href="2021.acl-short.131.mp4"/>
     </paper>
     <paper id="132">
       <title>Avoiding Overlap in Data Augmentation for <fixed-case>AMR</fixed-case>-to-Text Generation</title>
@@ -11894,7 +11198,6 @@
       <url hash="ac9829b7">2021.acl-short.132</url>
       <doi>10.18653/v1/2021.acl-short.132</doi>
       <bibkey>du-flanigan-2021-avoiding</bibkey>
-      <video href="2021.acl-short.132.mp4"/>
       <video href="2021.acl-short.132.mp4"/>
     </paper>
     <paper id="133">
@@ -11909,7 +11212,6 @@
       <bibkey>yang-etal-2021-weakly</bibkey>
       <video href="2021.acl-short.133.mp4"/>
       <pwccode url="https://github.com/yangalan123/WM-SRA" additional="false">yangalan123/WM-SRA</pwccode>
-      <video href="2021.acl-short.133.mp4"/>
     </paper>
     <paper id="134">
       <title>Can Transformer Models Measure Coherence In Text: Re-Thinking the Shuffle Test</title>
@@ -11924,7 +11226,6 @@
       <bibkey>laban-etal-2021-transformer</bibkey>
       <video href="2021.acl-short.134.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/billsum">BillSum</pwcdataset>
-      <video href="2021.acl-short.134.mp4"/>
     </paper>
     <paper id="135">
       <title><fixed-case>S</fixed-case>im<fixed-case>CLS</fixed-case>: A Simple Framework for Contrastive Learning of Abstractive Summarization</title>
@@ -11939,7 +11240,6 @@
       <pwccode url="https://github.com/yixinL7/SimCLS" additional="true">yixinL7/SimCLS</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xsum">XSum</pwcdataset>
-      <video href="2021.acl-short.135.mp4"/>
     </paper>
     <paper id="136">
       <title><fixed-case>S</fixed-case>a<fixed-case>R</fixed-case>o<fixed-case>C</fixed-case>o: Detecting Satire in a Novel <fixed-case>R</fixed-case>omanian Corpus of News Articles</title>
@@ -11954,7 +11254,6 @@
       <video href="2021.acl-short.136.mp4"/>
       <pwccode url="https://github.com/MihaelaGaman/SaRoCo" additional="false">MihaelaGaman/SaRoCo</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/saroco">SaRoCo</pwcdataset>
-      <video href="2021.acl-short.136.mp4"/>
     </paper>
     <paper id="137">
       <title>Bringing Structure into Summaries: a Faceted Summarization Dataset for Long Scientific Documents</title>
@@ -11973,7 +11272,6 @@
       <video href="2021.acl-short.137.mp4"/>
       <pwccode url="https://github.com/hfthair/emerald_crawler" additional="false">hfthair/emerald_crawler</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/facetsum">FacetSum</pwcdataset>
-      <video href="2021.acl-short.137.mp4"/>
     </paper>
     <paper id="138">
       <title><fixed-case>R</fixed-case>eplicating and Extending “<fixed-case>B</fixed-case>ecause Their Treebanks Leak”: <fixed-case>G</fixed-case>raph Isomorphism, Covariants, and Parser Performance</title>
@@ -11987,7 +11285,6 @@
       <doi>10.18653/v1/2021.acl-short.138</doi>
       <bibkey>anderson-etal-2021-replicating</bibkey>
       <video href="2021.acl-short.138.mp4"/>
-      <video href="2021.acl-short.138.mp4"/>
     </paper>
     <paper id="139">
       <title>Don’t Rule Out Monolingual Speakers: <fixed-case>A</fixed-case> Method For Crowdsourcing Machine Translation Data</title>
@@ -11999,7 +11296,6 @@
       <url hash="7c5f0ac2">2021.acl-short.139</url>
       <doi>10.18653/v1/2021.acl-short.139</doi>
       <bibkey>bhatnagar-etal-2021-dont</bibkey>
-      <video href="2021.acl-short.139.mp4"/>
       <video href="2021.acl-short.139.mp4"/>
     </paper>
   </volume>
@@ -12033,7 +11329,6 @@
       <doi>10.18653/v1/2021.acl-srw.1</doi>
       <bibkey>tokarchuk-etal-2021-investigation</bibkey>
       <video href="2021.acl-srw.1.mp4"/>
-      <video href="2021.acl-srw.1.mp4"/>
     </paper>
     <paper id="2">
       <title>Stage-wise Fine-tuning for Graph-to-Text Generation</title>
@@ -12051,7 +11346,6 @@
       <video href="2021.acl-srw.2.mp4"/>
       <pwccode url="https://github.com/EagleW/Stage-wise-Fine-tuning" additional="false">EagleW/Stage-wise-Fine-tuning</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.acl-srw.2.mp4"/>
     </paper>
     <paper id="3">
       <title>Transformer-Based Direct Hidden <fixed-case>M</fixed-case>arkov Model for Machine Translation</title>
@@ -12065,7 +11359,6 @@
       <doi>10.18653/v1/2021.acl-srw.3</doi>
       <bibkey>wang-etal-2021-transformer</bibkey>
       <video href="2021.acl-srw.3.mp4"/>
-      <video href="2021.acl-srw.3.mp4"/>
     </paper>
     <paper id="4">
       <title><fixed-case>A</fixed-case>uto<fixed-case>RC</fixed-case>: Improving <fixed-case>BERT</fixed-case> Based Relation Classification Models via Architecture Search</title>
@@ -12075,7 +11368,6 @@
       <url hash="b0e03efa">2021.acl-srw.4</url>
       <doi>10.18653/v1/2021.acl-srw.4</doi>
       <bibkey>zhu-2021-autorc</bibkey>
-      <video href="2021.acl-srw.4.mp4"/>
       <video href="2021.acl-srw.4.mp4"/>
     </paper>
     <paper id="5">
@@ -12094,7 +11386,6 @@
       <bibkey>bansal-etal-2021-low</bibkey>
       <video href="2021.acl-srw.5.mp4"/>
       <pwccode url="https://github.com/cdli-gh/Semi-Supervised-NMT-for-Sumerian-English" additional="true">cdli-gh/Semi-Supervised-NMT-for-Sumerian-English</pwccode>
-      <video href="2021.acl-srw.5.mp4"/>
     </paper>
     <paper id="6">
       <title>On the Relationship between <fixed-case>Z</fixed-case>ipf’s Law of Abbreviation and Interfering Noise in Emergent Languages</title>
@@ -12105,7 +11396,6 @@
       <url hash="c91df52c">2021.acl-srw.6</url>
       <doi>10.18653/v1/2021.acl-srw.6</doi>
       <bibkey>ueda-washio-2021-relationship</bibkey>
-      <video href="2021.acl-srw.6.mp4"/>
       <video href="2021.acl-srw.6.mp4"/>
     </paper>
     <paper id="7">
@@ -12129,7 +11419,6 @@
       <video href="2021.acl-srw.7.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.acl-srw.7.mp4"/>
     </paper>
     <paper id="8">
       <title>Attending Self-Attention: A Case Study of Visually Grounded Supervision in Vision-and-Language Transformers</title>
@@ -12146,7 +11435,6 @@
       <bibkey>samaran-etal-2021-attending</bibkey>
       <video href="2021.acl-srw.8.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptual-captions">Conceptual Captions</pwcdataset>
-      <video href="2021.acl-srw.8.mp4"/>
     </paper>
     <paper id="9">
       <title>Video-guided Machine Translation with Spatial Hierarchical Attention Network</title>
@@ -12182,7 +11470,6 @@
       <video href="2021.acl-srw.11.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/guesswhat">GuessWhat?!</pwcdataset>
-      <video href="2021.acl-srw.11.mp4"/>
     </paper>
     <paper id="12">
       <title>How do different factors Impact the Inter-language Similarity? A Case Study on <fixed-case>I</fixed-case>ndian languages</title>
@@ -12195,7 +11482,6 @@
       <url hash="399139e3">2021.acl-srw.12</url>
       <doi>10.18653/v1/2021.acl-srw.12</doi>
       <bibkey>kumar-etal-2021-different</bibkey>
-      <video href="2021.acl-srw.12.mp4"/>
       <video href="2021.acl-srw.12.mp4"/>
     </paper>
     <paper id="13">
@@ -12210,7 +11496,6 @@
       <doi>10.18653/v1/2021.acl-srw.13</doi>
       <bibkey>antypas-etal-2021-covid</bibkey>
       <video href="2021.acl-srw.13.mp4"/>
-      <video href="2021.acl-srw.13.mp4"/>
     </paper>
     <paper id="14">
       <title>Situation-Based Multiparticipant Chat Summarization: a Concept, an Exploration-Annotation Tool and an Example Collection</title>
@@ -12224,7 +11509,6 @@
       <bibkey>smirnova-etal-2021-situation</bibkey>
       <video href="2021.acl-srw.14.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/tweebank">Tweebank</pwcdataset>
-      <video href="2021.acl-srw.14.mp4"/>
     </paper>
     <paper id="15">
       <title>Modeling Text using the Continuous Space Topic Model with Pre-Trained Word Embeddings</title>
@@ -12257,7 +11541,6 @@
       <video href="2021.acl-srw.16.mp4"/>
       <pwccode url="https://github.com/rsvp-ai/semantic_unwritten" additional="false">rsvp-ai/semantic_unwritten</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
-      <video href="2021.acl-srw.16.mp4"/>
     </paper>
     <paper id="17">
       <title>Data Augmentation with Unsupervised Machine Translation Improves the Structural Similarity of Cross-lingual Word Embeddings</title>
@@ -12272,7 +11555,6 @@
       <video href="2021.acl-srw.17.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mldoc">MLDoc</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.acl-srw.17.mp4"/>
     </paper>
     <paper id="18">
       <title>Joint Detection and Coreference Resolution of Entities and Events with Document-level Context Aggregation</title>
@@ -12283,7 +11565,6 @@
       <url hash="e5b78005">2021.acl-srw.18</url>
       <doi>10.18653/v1/2021.acl-srw.18</doi>
       <bibkey>kriman-ji-2021-joint</bibkey>
-      <video href="2021.acl-srw.18.mp4"/>
       <video href="2021.acl-srw.18.mp4"/>
     </paper>
     <paper id="19">
@@ -12298,7 +11579,6 @@
       <doi>10.18653/v1/2021.acl-srw.19</doi>
       <bibkey>singh-etal-2021-hold</bibkey>
       <video href="2021.acl-srw.19.mp4"/>
-      <video href="2021.acl-srw.19.mp4"/>
     </paper>
     <paper id="20">
       <title>Observing the Learning Curve of <fixed-case>NMT</fixed-case> Systems With Regard to Linguistic Phenomena</title>
@@ -12310,7 +11590,6 @@
       <url hash="68c2fc64">2021.acl-srw.20</url>
       <doi>10.18653/v1/2021.acl-srw.20</doi>
       <bibkey>stadler-etal-2021-observing</bibkey>
-      <video href="2021.acl-srw.20.mp4"/>
       <video href="2021.acl-srw.20.mp4"/>
     </paper>
     <paper id="21">
@@ -12328,7 +11607,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsqa">NewsQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-srw.21.mp4"/>
     </paper>
     <paper id="22">
       <title>Tools Impact on the Quality of Annotations for Chat Untangling</title>
@@ -12340,7 +11618,6 @@
       <url hash="ba46e78b">2021.acl-srw.22</url>
       <doi>10.18653/v1/2021.acl-srw.22</doi>
       <bibkey>cerezo-etal-2021-tools</bibkey>
-      <video href="2021.acl-srw.22.mp4"/>
       <video href="2021.acl-srw.22.mp4"/>
     </paper>
     <paper id="23">
@@ -12379,7 +11656,6 @@
       <bibkey>ficsor-berend-2021-changing</bibkey>
       <video href="2021.acl-srw.25.mp4"/>
       <pwccode url="https://github.com/ficstamas/word_embedding_interpretability" additional="false">ficstamas/word_embedding_interpretability</pwccode>
-      <video href="2021.acl-srw.25.mp4"/>
     </paper>
     <paper id="26">
       <title>Personal Bias in Prediction of Emotions Elicited by Textual Opinions</title>
@@ -12408,7 +11684,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cmrc">CMRC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cmrc-2018">CMRC 2018</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/chid">ChID</pwcdataset>
-      <video href="2021.acl-srw.27.mp4"/>
     </paper>
     <paper id="28">
       <title><fixed-case>CMTA</fixed-case>: <fixed-case>COVID</fixed-case>-19 Misinformation Multilingual Analysis on <fixed-case>T</fixed-case>witter</title>
@@ -12421,7 +11696,6 @@
       <url hash="151800fd">2021.acl-srw.28</url>
       <doi>10.18653/v1/2021.acl-srw.28</doi>
       <bibkey>pranesh-etal-2021-cmta</bibkey>
-      <video href="2021.acl-srw.28.mp4"/>
       <video href="2021.acl-srw.28.mp4"/>
     </paper>
     <paper id="29">
@@ -12436,7 +11710,6 @@
       <url hash="4bd1ed95">2021.acl-srw.29</url>
       <doi>10.18653/v1/2021.acl-srw.29</doi>
       <bibkey>yang-etal-2021-predicting</bibkey>
-      <video href="2021.acl-srw.29.mp4"/>
       <video href="2021.acl-srw.29.mp4"/>
     </paper>
     <paper id="30">
@@ -12453,7 +11726,6 @@
       <video href="2021.acl-srw.30.mp4"/>
       <pwccode url="https://github.com/vgupta123/sumpubmed" additional="false">vgupta123/sumpubmed</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
-      <video href="2021.acl-srw.30.mp4"/>
     </paper>
     <paper id="31">
       <title>A Case Study of Analysis of Construals in Language on Social Media Surrounding a Crisis Event</title>
@@ -12468,7 +11740,6 @@
       <doi>10.18653/v1/2021.acl-srw.31</doi>
       <bibkey>aboufoul-etal-2021-case</bibkey>
       <video href="2021.acl-srw.31.mp4"/>
-      <video href="2021.acl-srw.31.mp4"/>
     </paper>
     <paper id="32">
       <title>Cross-lingual Evidence Improves Monolingual Fake News Detection</title>
@@ -12481,7 +11752,6 @@
       <bibkey>dementieva-panchenko-2021-cross</bibkey>
       <video href="2021.acl-srw.32.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/nela-gt-2018">NELA-GT-2018</pwcdataset>
-      <video href="2021.acl-srw.32.mp4"/>
     </paper>
     <paper id="33">
       <title>Neural Machine Translation with Synchronous Latent Phrase Structure</title>
@@ -12494,7 +11764,6 @@
       <bibkey>harada-watanabe-2021-neural</bibkey>
       <video href="2021.acl-srw.33.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/aspec">ASPEC</pwcdataset>
-      <video href="2021.acl-srw.33.mp4"/>
     </paper>
     <paper id="34">
       <title>Zero Pronouns Identification based on Span prediction</title>
@@ -12507,7 +11776,6 @@
       <attachment type="OptionalSupplementaryMaterial" hash="e4158e28">2021.acl-srw.34.OptionalSupplementaryMaterial.pdf</attachment>
       <doi>10.18653/v1/2021.acl-srw.34</doi>
       <bibkey>iwata-etal-2021-zero</bibkey>
-      <video href="2021.acl-srw.34.mp4"/>
       <video href="2021.acl-srw.34.mp4"/>
     </paper>
     <paper id="35">
@@ -12523,7 +11791,6 @@
       <bibkey>vazquez-etal-2021-differences</bibkey>
       <video href="2021.acl-srw.35.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
-      <video href="2021.acl-srw.35.mp4"/>
     </paper>
     <paper id="36">
       <title>Synchronous Syntactic Attention for Transformer Neural Machine Translation</title>
@@ -12592,7 +11859,6 @@
       <bibkey>lee-etal-2021-intellicat</bibkey>
       <video href="2021.acl-demo.2.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2020">WMT 2020</pwcdataset>
-      <video href="2021.acl-demo.2.mp4"/>
     </paper>
     <paper id="3">
       <title>The <fixed-case>C</fixed-case>lassical <fixed-case>L</fixed-case>anguage <fixed-case>T</fixed-case>oolkit: <fixed-case>A</fixed-case>n <fixed-case>NLP</fixed-case> Framework for Pre-Modern Languages</title>
@@ -12609,7 +11875,6 @@
       <bibkey>johnson-etal-2021-classical</bibkey>
       <video href="2021.acl-demo.3.mp4"/>
       <pwccode url="https://github.com/cltk/cltk" additional="false">cltk/cltk</pwccode>
-      <video href="2021.acl-demo.3.mp4"/>
     </paper>
     <paper id="4">
       <title><fixed-case>T</fixed-case>ext<fixed-case>B</fixed-case>ox: A Unified, Modularized, and Extensible Framework for Text Generation</title>
@@ -12632,7 +11897,6 @@
       <pwccode url="https://github.com/RUCAIBox/TextBox" additional="false">RUCAIBox/TextBox</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.acl-demo.4.mp4"/>
     </paper>
     <paper id="5">
       <title>Inside <fixed-case>ASCENT</fixed-case>: Exploring a Deep Commonsense Knowledge Base and its Usage in Question Answering</title>
@@ -12650,7 +11914,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quasimodo">Quasimodo</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webchild">WebChild</pwcdataset>
-      <video href="2021.acl-demo.5.mp4"/>
     </paper>
     <paper id="6">
       <title><fixed-case>S</fixed-case>ci<fixed-case>C</fixed-case>oncept<fixed-case>M</fixed-case>iner: A system for large-scale scientific concept discovery</title>
@@ -12666,7 +11929,6 @@
       <bibkey>shen-etal-2021-sciconceptminer</bibkey>
       <video href="2021.acl-demo.6.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/microsoft-academic-graph">Microsoft Academic Graph</pwcdataset>
-      <video href="2021.acl-demo.6.mp4"/>
     </paper>
     <paper id="7">
       <title><fixed-case>N</fixed-case>eur<fixed-case>ST</fixed-case>: Neural Speech Translation Toolkit</title>
@@ -12697,7 +11959,6 @@
       <doi>10.18653/v1/2021.acl-demo.8</doi>
       <bibkey>imanigooghari-etal-2021-parcoure</bibkey>
       <video href="2021.acl-demo.8.mp4"/>
-      <video href="2021.acl-demo.8.mp4"/>
     </paper>
     <paper id="9">
       <title><fixed-case>MT</fixed-case>-<fixed-case>T</fixed-case>elescope: <fixed-case>A</fixed-case>n interactive platform for contrastive evaluation of <fixed-case>MT</fixed-case> systems</title>
@@ -12711,7 +11972,6 @@
       <url hash="e1a613d0">2021.acl-demo.9</url>
       <doi>10.18653/v1/2021.acl-demo.9</doi>
       <bibkey>rei-etal-2021-mt</bibkey>
-      <video href="2021.acl-demo.9.mp4"/>
       <video href="2021.acl-demo.9.mp4"/>
     </paper>
     <paper id="10">
@@ -12728,7 +11988,6 @@
       <url hash="39802230">2021.acl-demo.10</url>
       <doi>10.18653/v1/2021.acl-demo.10</doi>
       <bibkey>lertvittayakumjorn-etal-2021-supporting</bibkey>
-      <video href="2021.acl-demo.10.mp4"/>
       <video href="2021.acl-demo.10.mp4"/>
     </paper>
     <paper id="11">
@@ -12760,7 +12019,6 @@
       <bibkey>geng-etal-2021-fasthan</bibkey>
       <video href="2021.acl-demo.12.mp4"/>
       <pwccode url="https://github.com/fastnlp/fastHan" additional="false">fastnlp/fastHan</pwccode>
-      <video href="2021.acl-demo.12.mp4"/>
     </paper>
     <paper id="13">
       <title>Erase and Rewind: Manual Correction of <fixed-case>NLP</fixed-case> Output through a Web Interface</title>
@@ -12772,7 +12030,6 @@
       <url hash="56d94550">2021.acl-demo.13</url>
       <doi>10.18653/v1/2021.acl-demo.13</doi>
       <bibkey>frasnelli-etal-2021-erase</bibkey>
-      <video href="2021.acl-demo.13.mp4"/>
       <video href="2021.acl-demo.13.mp4"/>
     </paper>
     <paper id="14">
@@ -12794,7 +12051,6 @@
       <video href="2021.acl-demo.14.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semantic-scholar">Semantic Scholar</pwcdataset>
-      <video href="2021.acl-demo.14.mp4"/>
     </paper>
     <paper id="15">
       <title>Trafilatura: <fixed-case>A</fixed-case> Web Scraping Library and Command-Line Tool for Text Discovery and Extraction</title>
@@ -12806,7 +12062,6 @@
       <bibkey>barbaresi-2021-trafilatura</bibkey>
       <video href="2021.acl-demo.15.mp4"/>
       <pwccode url="https://github.com/adbar/trafilatura" additional="false">adbar/trafilatura</pwccode>
-      <video href="2021.acl-demo.15.mp4"/>
     </paper>
     <paper id="16">
       <title>Dodrio: Exploring Transformer Models with Interactive Visualization</title>
@@ -12823,7 +12078,6 @@
       <pwccode url="https://github.com/poloclub/dodrio" additional="false">poloclub/dodrio</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.acl-demo.16.mp4"/>
     </paper>
     <paper id="17">
       <title><fixed-case>REM</fixed-case>: Efficient Semi-Automated Real-Time Moderation of Online Forums</title>
@@ -12835,7 +12089,6 @@
       <url hash="f06524a0">2021.acl-demo.17</url>
       <doi>10.18653/v1/2021.acl-demo.17</doi>
       <bibkey>andersen-etal-2021-rem</bibkey>
-      <video href="2021.acl-demo.17.mp4"/>
       <video href="2021.acl-demo.17.mp4"/>
     </paper>
     <paper id="18">
@@ -12852,7 +12105,6 @@
       <video href="2021.acl-demo.18.mp4"/>
       <pwccode url="https://github.com/robustness-gym/summvis" additional="false">robustness-gym/summvis</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/newsroom">NEWSROOM</pwcdataset>
-      <video href="2021.acl-demo.18.mp4"/>
     </paper>
     <paper id="19">
       <title>A Graphical Interface for Curating Schemas</title>
@@ -12866,7 +12118,6 @@
       <url hash="badb8b53">2021.acl-demo.19</url>
       <doi>10.18653/v1/2021.acl-demo.19</doi>
       <bibkey>mishra-etal-2021-graphical</bibkey>
-      <video href="2021.acl-demo.19.mp4"/>
       <video href="2021.acl-demo.19.mp4"/>
     </paper>
     <paper id="20">
@@ -12885,7 +12136,6 @@
       <video href="2021.acl-demo.20.mp4"/>
       <pwccode url="https://github.com/thuiar/textoir" additional="true">thuiar/textoir</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
-      <video href="2021.acl-demo.20.mp4"/>
     </paper>
     <paper id="21">
       <title><fixed-case>K</fixed-case>ui<fixed-case>L</fixed-case>ei<fixed-case>X</fixed-case>i: a <fixed-case>C</fixed-case>hinese Open-Ended Text Adventure Game</title>
@@ -12931,7 +12181,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/durecdial">DuRecDial</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/redial">ReDial</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tg-redial">TG-ReDial</pwcdataset>
-      <video href="2021.acl-demo.22.mp4"/>
     </paper>
     <paper id="23">
       <title>Does My Representation Capture <fixed-case>X</fixed-case>? Probe-Ably</title>
@@ -12962,7 +12211,6 @@
       <video href="2021.acl-demo.24.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitablequestions">WikiTableQuestions</pwcdataset>
-      <video href="2021.acl-demo.24.mp4"/>
     </paper>
     <paper id="25">
       <title>Neural Extractive Search</title>
@@ -12974,7 +12222,6 @@
       <url hash="944f9803">2021.acl-demo.25</url>
       <doi>10.18653/v1/2021.acl-demo.25</doi>
       <bibkey>ravfogel-etal-2021-neural</bibkey>
-      <video href="2021.acl-demo.25.mp4"/>
       <video href="2021.acl-demo.25.mp4"/>
     </paper>
     <paper id="26">
@@ -13057,7 +12304,6 @@
       <doi>10.18653/v1/2021.acl-demo.29</doi>
       <bibkey>gong-etal-2021-iflyea</bibkey>
       <video href="2021.acl-demo.29.mp4"/>
-      <video href="2021.acl-demo.29.mp4"/>
     </paper>
     <paper id="30">
       <title>Ecco: An Open Source Library for the Explainability of Transformer Language Models</title>
@@ -13070,7 +12316,6 @@
       <video href="2021.acl-demo.30.mp4"/>
       <pwccode url="https://github.com/jalammar/ecco" additional="false">jalammar/ecco</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/11k-hands">11k Hands</pwcdataset>
-      <video href="2021.acl-demo.30.mp4"/>
     </paper>
     <paper id="31">
       <title><fixed-case>PAWLS</fixed-case>: <fixed-case>PDF</fixed-case> Annotation With Labels and Structure</title>
@@ -13086,7 +12331,6 @@
       <pwccode url="https://github.com/allenai/pawls" additional="false">allenai/pawls</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docbank">DocBank</pwcdataset>
-      <video href="2021.acl-demo.31.mp4"/>
     </paper>
     <paper id="32">
       <title><fixed-case>T</fixed-case>wee<fixed-case>NLP</fixed-case>: A <fixed-case>T</fixed-case>witter Exploration Portal for Natural Language Processing</title>
@@ -13098,7 +12342,6 @@
       <url hash="1e0c0a3f">2021.acl-demo.32</url>
       <doi>10.18653/v1/2021.acl-demo.32</doi>
       <bibkey>shah-etal-2021-tweenlp</bibkey>
-      <video href="2021.acl-demo.32.mp4"/>
       <video href="2021.acl-demo.32.mp4"/>
     </paper>
     <paper id="33">
@@ -13113,7 +12356,6 @@
       <bibkey>zhang-etal-2021-chrentranslate</bibkey>
       <video href="2021.acl-demo.33.mp4"/>
       <pwccode url="https://github.com/ZhangShiyue/ChrEn" additional="true">ZhangShiyue/ChrEn</pwccode>
-      <video href="2021.acl-demo.33.mp4"/>
     </paper>
     <paper id="34">
       <title><fixed-case>E</fixed-case>xplaina<fixed-case>B</fixed-case>oard: An Explainable Leaderboard for <fixed-case>NLP</fixed-case></title>
@@ -13135,7 +12377,6 @@
       <video href="2021.acl-demo.34.mp4"/>
       <pwccode url="https://github.com/neulab/ExplainaBoard" additional="false">neulab/ExplainaBoard</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
-      <video href="2021.acl-demo.34.mp4"/>
     </paper>
     <paper id="35">
       <title>Exploring Word Usage Change with Continuously Evolving Embeddings</title>
@@ -13147,7 +12388,6 @@
       <bibkey>horn-2021-exploring</bibkey>
       <video href="2021.acl-demo.35.mp4"/>
       <pwccode url="https://github.com/cod3licious/evolvemb" additional="false">cod3licious/evolvemb</pwccode>
-      <video href="2021.acl-demo.35.mp4"/>
     </paper>
     <paper id="36">
       <title><fixed-case>TURING</fixed-case>: an Accurate and Interpretable Multi-Hypothesis Cross-Domain Natural Language Database Interface</title>
@@ -13168,7 +12408,6 @@
       <bibkey>xu-etal-2021-turing</bibkey>
       <video href="2021.acl-demo.36.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/spider-1">SPIDER</pwcdataset>
-      <video href="2021.acl-demo.36.mp4"/>
     </paper>
     <paper id="37">
       <title>Many-to-<fixed-case>E</fixed-case>nglish Machine Translation Tools, Data, and Pretrained Models</title>
@@ -13184,7 +12423,6 @@
       <video href="2021.acl-demo.37.mp4"/>
       <pwccode url="https://github.com/thammegowda/006-many-to-eng" additional="true">thammegowda/006-many-to-eng</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opus-100">OPUS-100</pwcdataset>
-      <video href="2021.acl-demo.37.mp4"/>
     </paper>
     <paper id="38">
       <title><fixed-case>LEGOE</fixed-case>val: An Open-Source Toolkit for Dialogue System Evaluation via Crowdsourcing</title>
@@ -13200,7 +12438,6 @@
       <bibkey>li-etal-2021-legoeval</bibkey>
       <video href="2021.acl-demo.38.mp4"/>
       <pwccode url="https://github.com/yooli23/LEGOEval" additional="false">yooli23/LEGOEval</pwccode>
-      <video href="2021.acl-demo.38.mp4"/>
     </paper>
     <paper id="39">
       <title><fixed-case>R</fixed-case>e<fixed-case>T</fixed-case>ra<fixed-case>C</fixed-case>k: A Flexible and Efficient Framework for Knowledge Base Question Answering</title>
@@ -13219,7 +12456,6 @@
       <pwccode url="https://github.com/microsoft/KC/tree/main/papers/ReTraCk" additional="false">microsoft/KC</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/grailqa">GrailQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestionssp">WebQuestionsSP</pwcdataset>
-      <video href="2021.acl-demo.39.mp4"/>
     </paper>
     <paper id="40">
       <title>skweak: Weak Supervision Made Easy for <fixed-case>NLP</fixed-case></title>
@@ -13280,7 +12516,6 @@
       <video href="2021.acl-demo.41.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.acl-demo.41.mp4"/>
     </paper>
     <paper id="42">
       <title>Stretch-<fixed-case>VST</fixed-case>: Getting Flexible With Visual Stories</title>
@@ -13296,7 +12531,6 @@
       <bibkey>hsu-etal-2021-stretch</bibkey>
       <video href="2021.acl-demo.42.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/vist">VIST</pwcdataset>
-      <video href="2021.acl-demo.42.mp4"/>
     </paper>
     <paper id="43">
       <title><fixed-case>O</fixed-case>pen<fixed-case>A</fixed-case>ttack: An Open-source Textual Adversarial Attack Toolkit</title>

--- a/data/xml/2021.emnlp.xml
+++ b/data/xml/2021.emnlp.xml
@@ -28,7 +28,6 @@
       <bibkey>song-etal-2021-alignart</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.1</doi>
       <video href="2021.emnlp-main.1.mp4"/>
-      <video href="2021.emnlp-main.1.mp4"/>
     </paper>
     <paper id="2">
       <title>Zero-Shot Cross-Lingual Transfer of Neural Machine Translation with Multilingual Pretrained Encoders</title>
@@ -47,7 +46,6 @@
       <doi>10.18653/v1/2021.emnlp-main.2</doi>
       <video href="2021.emnlp-main.2.mp4"/>
       <pwccode url="https://github.com/ghchen18/emnlp2021-sixt" additional="false">ghchen18/emnlp2021-sixt</pwccode>
-      <video href="2021.emnlp-main.2.mp4"/>
     </paper>
     <paper id="3">
       <title><fixed-case>ERNIE</fixed-case>-<fixed-case>M</fixed-case>: Enhanced Multilingual Representation by Aligning Cross-lingual Semantics with Monolingual Corpora</title>
@@ -67,7 +65,6 @@
       <pwccode url="https://github.com/PaddlePaddle/ERNIE" additional="true">PaddlePaddle/ERNIE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mlqa">MLQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xtreme">XTREME</pwcdataset>
-      <video href="2021.emnlp-main.3.mp4"/>
     </paper>
     <paper id="4">
       <title>Cross Attention Augmented Transducer Networks for Simultaneous Translation</title>
@@ -83,7 +80,6 @@
       <doi>10.18653/v1/2021.emnlp-main.4</doi>
       <video href="2021.emnlp-main.4.mp4"/>
       <pwccode url="https://github.com/danliu2/caat" additional="false">danliu2/caat</pwccode>
-      <video href="2021.emnlp-main.4.mp4"/>
     </paper>
     <paper id="5">
       <title>Translating Headers of Tabular Data: A Pilot Study of Schema Translation</title>
@@ -98,7 +94,6 @@
       <doi>10.18653/v1/2021.emnlp-main.5</doi>
       <video href="2021.emnlp-main.5.mp4"/>
       <pwccode url="https://github.com/microsoft/ContextualSP" additional="false">microsoft/ContextualSP</pwccode>
-      <video href="2021.emnlp-main.5.mp4"/>
     </paper>
     <paper id="6">
       <title>Towards Making the Most of Dialogue Characteristics for Neural Chat Translation</title>
@@ -117,7 +112,6 @@
       <video href="2021.emnlp-main.6.mp4"/>
       <pwccode url="https://github.com/xl2248/csa-nct" additional="false">xl2248/csa-nct</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bmeld">BMELD</pwcdataset>
-      <video href="2021.emnlp-main.6.mp4"/>
     </paper>
     <paper id="7">
       <title>Low-Resource Dialogue Summarization with Domain-Agnostic Multi-Source Pretraining</title>
@@ -137,7 +131,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/reddit-conversation-corpus">Reddit Conversation Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.emnlp-main.7.mp4"/>
     </paper>
     <paper id="8">
       <title>Controllable Neural Dialogue Summarization with Personal Named Entity Planning</title>
@@ -150,7 +143,6 @@
       <doi>10.18653/v1/2021.emnlp-main.8</doi>
       <video href="2021.emnlp-main.8.mp4"/>
       <pwccode url="https://github.com/seq-to-mind/planning_dial_summ" additional="false">seq-to-mind/planning_dial_summ</pwccode>
-      <video href="2021.emnlp-main.8.mp4"/>
     </paper>
     <paper id="9">
       <title>Fine-grained Factual Consistency Assessment for Abstractive Summarization Models</title>
@@ -165,7 +157,6 @@
       <video href="2021.emnlp-main.9.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-main.9.mp4"/>
     </paper>
     <paper id="10">
       <title>Decision-Focused Summarization</title>
@@ -178,7 +169,6 @@
       <doi>10.18653/v1/2021.emnlp-main.10</doi>
       <video href="2021.emnlp-main.10.mp4"/>
       <pwccode url="https://github.com/chicagohai/decsum" additional="false">chicagohai/decsum</pwccode>
-      <video href="2021.emnlp-main.10.mp4"/>
     </paper>
     <paper id="11">
       <title>Multiplex Graph Neural Network for Extractive Text Summarization</title>
@@ -193,7 +183,6 @@
       <bibkey>jing-etal-2021-multiplex</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.11</doi>
       <video href="2021.emnlp-main.11.mp4"/>
-      <video href="2021.emnlp-main.11.mp4"/>
     </paper>
     <paper id="12">
       <title>A Thorough Evaluation of Task-Specific Pretraining for Summarization</title>
@@ -205,7 +194,6 @@
       <url hash="5082584d">2021.emnlp-main.12</url>
       <bibkey>rothe-etal-2021-thorough</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.12</doi>
-      <video href="2021.emnlp-main.12.mp4"/>
       <video href="2021.emnlp-main.12.mp4"/>
     </paper>
     <paper id="13">
@@ -224,7 +212,6 @@
       <doi>10.18653/v1/2021.emnlp-main.13</doi>
       <video href="2021.emnlp-main.13.mp4"/>
       <pwccode url="https://github.com/yeliu918/hetformer" additional="false">yeliu918/hetformer</pwccode>
-      <video href="2021.emnlp-main.13.mp4"/>
     </paper>
     <paper id="14">
       <title>Unsupervised Keyphrase Extraction by Jointly Modeling Local and Global Context</title>
@@ -239,7 +226,6 @@
       <doi>10.18653/v1/2021.emnlp-main.14</doi>
       <video href="2021.emnlp-main.14.mp4"/>
       <pwccode url="https://github.com/xnliang98/uke_ccrank" additional="false">xnliang98/uke_ccrank</pwccode>
-      <video href="2021.emnlp-main.14.mp4"/>
     </paper>
     <paper id="15">
       <title>Distantly Supervised Relation Extraction using Multi-Layer Revision Network and Confidence-based Multi-Instance Learning</title>
@@ -252,7 +238,6 @@
       <url hash="38c85344">2021.emnlp-main.15</url>
       <bibkey>lin-etal-2021-distantly</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.15</doi>
-      <video href="2021.emnlp-main.15.mp4"/>
       <video href="2021.emnlp-main.15.mp4"/>
     </paper>
     <paper id="16">
@@ -270,7 +255,6 @@
       <pwccode url="https://github.com/qshi95/lergv" additional="false">qshi95/lergv</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tabfact">TabFact</pwcdataset>
-      <video href="2021.emnlp-main.16.mp4"/>
     </paper>
     <paper id="17">
       <title>A Partition Filter Network for Joint Entity and Relation Extraction</title>
@@ -290,7 +274,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ace-2005">ACE 2005</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.emnlp-main.17.mp4"/>
     </paper>
     <paper id="18">
       <title><fixed-case>TEBNER</fixed-case>: Domain Specific Named Entity Recognition with Type Expanded Boundary-aware Network</title>
@@ -309,7 +292,6 @@
       <video href="2021.emnlp-main.18.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/bc5cdr">BC5CDR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ncbi-disease-1">NCBI Disease</pwcdataset>
-      <video href="2021.emnlp-main.18.mp4"/>
     </paper>
     <paper id="19">
       <title>Beta Distribution Guided Aspect-aware Graph for Aspect Category Sentiment Analysis with Affective Knowledge</title>
@@ -330,7 +312,6 @@
       <video href="2021.emnlp-main.19.mp4"/>
       <pwccode url="https://github.com/binliang-nlp/aagcn-acsa" additional="true">binliang-nlp/aagcn-acsa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.emnlp-main.19.mp4"/>
     </paper>
     <paper id="20">
       <title><fixed-case>DILBERT</fixed-case>: Customized Pre-Training for Domain Adaptation with Category Shift, with an Application to Aspect Extraction</title>
@@ -345,7 +326,6 @@
       <video href="2021.emnlp-main.20.mp4"/>
       <pwccode url="https://github.com/tonylekhtman/dilbert" additional="false">tonylekhtman/dilbert</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mams">MAMS</pwcdataset>
-      <video href="2021.emnlp-main.20.mp4"/>
     </paper>
     <paper id="21">
       <title>Improving Multimodal fusion via Mutual Dependency Maximisation</title>
@@ -360,7 +340,6 @@
       <doi>10.18653/v1/2021.emnlp-main.21</doi>
       <video href="2021.emnlp-main.21.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cmu-mosei">CMU-MOSEI</pwcdataset>
-      <video href="2021.emnlp-main.21.mp4"/>
     </paper>
     <paper id="22">
       <title>Learning Implicit Sentiment in Aspect-based Sentiment Analysis with Supervised Contrastive Pre-Training</title>
@@ -377,7 +356,6 @@
       <video href="2021.emnlp-main.22.mp4"/>
       <pwccode url="https://github.com/tribleave/scapt-absa" additional="false">tribleave/scapt-absa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mams">MAMS</pwcdataset>
-      <video href="2021.emnlp-main.22.mp4"/>
     </paper>
     <paper id="23">
       <title>Progressive Self-Training with Discriminator for Aspect Term Extraction</title>
@@ -391,7 +369,6 @@
       <url hash="9ceb2642">2021.emnlp-main.23</url>
       <bibkey>wang-etal-2021-progressive</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.23</doi>
-      <video href="2021.emnlp-main.23.mp4"/>
       <video href="2021.emnlp-main.23.mp4"/>
     </paper>
     <paper id="24">
@@ -407,7 +384,6 @@
       <video href="2021.emnlp-main.24.mp4"/>
       <pwccode url="https://github.com/nustm/rcda" additional="false">nustm/rcda</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.24.mp4"/>
     </paper>
     <paper id="25">
       <title>Idiosyncratic but not Arbitrary: Learning Idiolects in Online Registers Reveals Distinctive yet Consistent Individual Styles</title>
@@ -420,7 +396,6 @@
       <doi>10.18653/v1/2021.emnlp-main.25</doi>
       <video href="2021.emnlp-main.25.mp4"/>
       <pwccode url="https://github.com/lingjzhu/idiolect" additional="false">lingjzhu/idiolect</pwccode>
-      <video href="2021.emnlp-main.25.mp4"/>
     </paper>
     <paper id="26">
       <title>Narrative Theory for Computational Narrative Understanding</title>
@@ -432,7 +407,6 @@
       <url hash="05dacdfe">2021.emnlp-main.26</url>
       <bibkey>piper-etal-2021-narrative</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.26</doi>
-      <video href="2021.emnlp-main.26.mp4"/>
       <video href="2021.emnlp-main.26.mp4"/>
     </paper>
     <paper id="27">
@@ -451,7 +425,6 @@
       <bibkey>joseph-etal-2021-mis</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.27</doi>
       <video href="2021.emnlp-main.27.mp4"/>
-      <video href="2021.emnlp-main.27.mp4"/>
     </paper>
     <paper id="28">
       <title>How Does Counterfactually Augmented Data Impact Models for Social Computing Constructs?</title>
@@ -467,7 +440,6 @@
       <doi>10.18653/v1/2021.emnlp-main.28</doi>
       <video href="2021.emnlp-main.28.mp4"/>
       <pwccode url="https://github.com/gesiscss/socialcad" additional="false">gesiscss/socialcad</pwccode>
-      <video href="2021.emnlp-main.28.mp4"/>
     </paper>
     <paper id="29">
       <title>Latent Hatred: A Benchmark for Understanding Implicit Hate Speech</title>
@@ -489,7 +461,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/hate-speech">Hate Speech</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.emnlp-main.29.mp4"/>
     </paper>
     <paper id="30">
       <title>Distilling Linguistic Context for Language Model Compression</title>
@@ -506,7 +477,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.30.mp4"/>
     </paper>
     <paper id="31">
       <title>Dynamic Knowledge Distillation for Pre-trained Language Models</title>
@@ -528,7 +498,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.31.mp4"/>
     </paper>
     <paper id="32">
       <title>Few-Shot Text Generation with Natural Language Instructions</title>
@@ -542,7 +511,6 @@
       <video href="2021.emnlp-main.32.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/aeslc">AESLC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/reddit-tifu">Reddit TIFU</pwcdataset>
-      <video href="2021.emnlp-main.32.mp4"/>
     </paper>
     <paper id="33">
       <title><fixed-case>SOM</fixed-case>-<fixed-case>NCSCM</fixed-case> : An Efficient Neural <fixed-case>C</fixed-case>hinese Sentence Compression Model Enhanced with Self-Organizing Map</title>
@@ -557,7 +525,6 @@
       <url hash="91eb6552">2021.emnlp-main.33</url>
       <bibkey>zi-etal-2021-som</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.33</doi>
-      <video href="2021.emnlp-main.33.mp4"/>
       <video href="2021.emnlp-main.33.mp4"/>
     </paper>
     <paper id="34">
@@ -576,7 +543,6 @@
       <pwccode url="https://github.com/miulab/fastmtl" additional="false">miulab/fastmtl</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.emnlp-main.34.mp4"/>
     </paper>
     <paper id="35">
       <title><fixed-case>GOLD</fixed-case>: Improving Out-of-Scope Detection in Dialogues using Data Augmentation</title>
@@ -591,7 +557,6 @@
       <pwccode url="https://github.com/asappresearch/gold" additional="false">asappresearch/gold</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/rostd">ROSTD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/star">STAR</pwcdataset>
-      <video href="2021.emnlp-main.35.mp4"/>
     </paper>
     <paper id="36">
       <title>Graph Based Network with Contextualized Representations of Turns in Dialogue</title>
@@ -608,7 +573,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/dialogre">DialogRE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/emorynlp">EmoryNLP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
-      <video href="2021.emnlp-main.36.mp4"/>
     </paper>
     <paper id="37">
       <title>Automatically Exposing Problems with Neural Dialog Models</title>
@@ -621,7 +585,6 @@
       <doi>10.18653/v1/2021.emnlp-main.37</doi>
       <video href="2021.emnlp-main.37.mp4"/>
       <pwccode url="https://github.com/diandyu/trigger" additional="false">diandyu/trigger</pwccode>
-      <video href="2021.emnlp-main.37.mp4"/>
     </paper>
     <paper id="38">
       <title><fixed-case>E</fixed-case>vent Coreference Data (Almost) for Free: <fixed-case>M</fixed-case>ining Hyperlinks from Online News</title>
@@ -635,7 +598,6 @@
       <video href="2021.emnlp-main.38.mp4"/>
       <pwccode url="https://github.com/ukplab/emnlp2021-hypercoref-cdcr" additional="false">ukplab/emnlp2021-hypercoref-cdcr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ecb">ECB+</pwcdataset>
-      <video href="2021.emnlp-main.38.mp4"/>
     </paper>
     <paper id="39">
       <title>Inducing Stereotypical Character Roles from Plot Structure</title>
@@ -647,7 +609,6 @@
       <url hash="6d207d87">2021.emnlp-main.39</url>
       <bibkey>jahan-etal-2021-inducing</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.39</doi>
-      <video href="2021.emnlp-main.39.mp4"/>
       <video href="2021.emnlp-main.39.mp4"/>
     </paper>
     <paper id="40">
@@ -661,7 +622,6 @@
       <url hash="7f80349e">2021.emnlp-main.40</url>
       <bibkey>spangher-etal-2021-multitask</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.40</doi>
-      <video href="2021.emnlp-main.40.mp4"/>
       <video href="2021.emnlp-main.40.mp4"/>
     </paper>
     <paper id="41">
@@ -678,7 +638,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/openwebtext">OpenWebText</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.emnlp-main.41.mp4"/>
     </paper>
     <paper id="42">
       <title>Mitigating Language-Dependent Ethnic Bias in <fixed-case>BERT</fixed-case></title>
@@ -692,7 +651,6 @@
       <video href="2021.emnlp-main.42.mp4"/>
       <pwccode url="https://github.com/jaimeenahn/ethnic_bias" additional="false">jaimeenahn/ethnic_bias</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.42.mp4"/>
     </paper>
     <paper id="43">
       <title>Adversarial Scrubbing of Demographic Information for Text Classification</title>
@@ -710,7 +668,6 @@
       <doi>10.18653/v1/2021.emnlp-main.43</doi>
       <video href="2021.emnlp-main.43.mp4"/>
       <pwccode url="https://github.com/brcsomnath/adversarial-scrubber" additional="false">brcsomnath/adversarial-scrubber</pwccode>
-      <video href="2021.emnlp-main.43.mp4"/>
     </paper>
     <paper id="44">
       <title>Open-domain clarification question generation without question examples</title>
@@ -727,7 +684,6 @@
       <video href="2021.emnlp-main.44.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/shapeworld">ShapeWorld</pwcdataset>
-      <video href="2021.emnlp-main.44.mp4"/>
     </paper>
     <paper id="45">
       <title>Improving Sequence-to-Sequence Pre-training via Sequence Span Rewriting</title>
@@ -743,7 +699,6 @@
       <doi>10.18653/v1/2021.emnlp-main.45</doi>
       <video href="2021.emnlp-main.45.mp4"/>
       <pwccode url="https://github.com/michaelzhouwang/sequence_span_rewriting" additional="false">michaelzhouwang/sequence_span_rewriting</pwccode>
-      <video href="2021.emnlp-main.45.mp4"/>
     </paper>
     <paper id="46">
       <title><fixed-case>C</fixed-case>oarse2<fixed-case>F</fixed-case>ine: Fine-grained Text Classification on Coarsely-grained Annotated Data</title>
@@ -755,7 +710,6 @@
       <url hash="2294e7ba">2021.emnlp-main.46</url>
       <bibkey>mekala-etal-2021-coarse2fine</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.46</doi>
-      <video href="2021.emnlp-main.46.mp4"/>
       <video href="2021.emnlp-main.46.mp4"/>
     </paper>
     <paper id="47">
@@ -771,7 +725,6 @@
       <video href="2021.emnlp-main.47.mp4"/>
       <pwccode url="https://github.com/cnedwards/text2mol" additional="false">cnedwards/text2mol</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/chebi-20">ChEBI-20</pwcdataset>
-      <video href="2021.emnlp-main.47.mp4"/>
     </paper>
     <paper id="48">
       <title>Classification of hierarchical text using geometric deep learning: the case of clinical trials corpus</title>
@@ -787,7 +740,6 @@
       <doi>10.18653/v1/2021.emnlp-main.48</doi>
       <video href="2021.emnlp-main.48.mp4"/>
       <pwccode url="https://github.com/sssohrab/ct-classification-graphs" additional="false">sssohrab/ct-classification-graphs</pwccode>
-      <video href="2021.emnlp-main.48.mp4"/>
     </paper>
     <paper id="49">
       <title>The Devil is in the Detail: Simple Tricks Improve Systematic Generalization of Transformers</title>
@@ -804,7 +756,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cfq">CFQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mathematics">Mathematics Dataset</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.emnlp-main.49.mp4"/>
     </paper>
     <paper id="50">
       <title>Artificial Text Detection via Examining the Topology of Attention Maps</title>
@@ -828,7 +779,6 @@
       <pwccode url="https://github.com/danchern97/tda4atd" additional="false">danchern97/tda4atd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/realnews">RealNews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.emnlp-main.50.mp4"/>
     </paper>
     <paper id="51">
       <title>Active Learning by Acquiring Contrastive Examples</title>
@@ -848,7 +798,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.51.mp4"/>
     </paper>
     <paper id="52">
       <title>Conditional <fixed-case>P</fixed-case>oisson Stochastic Beams</title>
@@ -861,7 +810,6 @@
       <url hash="8ed3e952">2021.emnlp-main.52</url>
       <bibkey>meister-etal-2021-conditional</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.52</doi>
-      <video href="2021.emnlp-main.52.mp4"/>
       <video href="2021.emnlp-main.52.mp4"/>
     </paper>
     <paper id="53">
@@ -885,7 +833,6 @@
       <doi>10.18653/v1/2021.emnlp-main.53</doi>
       <video href="2021.emnlp-main.53.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/viggo">ViGGO</pwcdataset>
-      <video href="2021.emnlp-main.53.mp4"/>
     </paper>
     <paper id="54">
       <title>Moral Stories: Situated Reasoning about Norms, Intents, Actions, and their Consequences</title>
@@ -903,7 +850,6 @@
       <video href="2021.emnlp-main.54.mp4"/>
       <pwccode url="https://github.com/demelin/moral_stories" additional="false">demelin/moral_stories</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/moral-stories">Moral Stories</pwcdataset>
-      <video href="2021.emnlp-main.54.mp4"/>
     </paper>
     <paper id="55">
       <title>Truth-Conditional Captions for Time Series Data</title>
@@ -916,7 +862,6 @@
       <doi>10.18653/v1/2021.emnlp-main.55</doi>
       <video href="2021.emnlp-main.55.mp4"/>
       <pwccode url="https://github.com/harsh19/truce" additional="false">harsh19/truce</pwccode>
-      <video href="2021.emnlp-main.55.mp4"/>
     </paper>
     <paper id="56">
       <title>Injecting Entity Types into Entity-Guided Text Generation</title>
@@ -931,7 +876,6 @@
       <doi>10.18653/v1/2021.emnlp-main.56</doi>
       <video href="2021.emnlp-main.56.mp4"/>
       <pwccode url="https://github.com/wyu97/InjType" additional="true">wyu97/InjType</pwccode>
-      <video href="2021.emnlp-main.56.mp4"/>
     </paper>
     <paper id="57">
       <title>Smelting Gold and Silver for Improved Multilingual <fixed-case>AMR</fixed-case>-to-<fixed-case>T</fixed-case>ext Generation</title>
@@ -946,7 +890,6 @@
       <doi>10.18653/v1/2021.emnlp-main.57</doi>
       <video href="2021.emnlp-main.57.mp4"/>
       <pwccode url="https://github.com/ukplab/m-amr2text" additional="false">ukplab/m-amr2text</pwccode>
-      <video href="2021.emnlp-main.57.mp4"/>
     </paper>
     <paper id="58">
       <title>Learning Compact Metrics for <fixed-case>MT</fixed-case></title>
@@ -966,7 +909,6 @@
       <pwccode url="https://github.com/google-research/bleurt" additional="false">google-research/bleurt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/c4">C4</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mc4">mC4</pwcdataset>
-      <video href="2021.emnlp-main.58.mp4"/>
     </paper>
     <paper id="59">
       <title>The Impact of Positional Encodings on Multilingual Compression</title>
@@ -980,7 +922,6 @@
       <video href="2021.emnlp-main.59.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.59.mp4"/>
     </paper>
     <paper id="60">
       <title>Disentangling Representations of Text by Masking Transformers</title>
@@ -994,7 +935,6 @@
       <doi>10.18653/v1/2021.emnlp-main.60</doi>
       <video href="2021.emnlp-main.60.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.60.mp4"/>
     </paper>
     <paper id="61">
       <title>Exploring the Role of <fixed-case>BERT</fixed-case> Token Representations to Explain Sentence Probing Results</title>
@@ -1008,7 +948,6 @@
       <doi>10.18653/v1/2021.emnlp-main.61</doi>
       <video href="2021.emnlp-main.61.mp4"/>
       <pwccode url="https://github.com/hmohebbi/explain-probing-results" additional="false">hmohebbi/explain-probing-results</pwccode>
-      <video href="2021.emnlp-main.61.mp4"/>
     </paper>
     <paper id="62">
       <title>Do Long-Range Language Models Actually Use Long-Range Context?</title>
@@ -1023,7 +962,6 @@
       <doi>10.18653/v1/2021.emnlp-main.62</doi>
       <video href="2021.emnlp-main.62.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/pg-19">PG-19</pwcdataset>
-      <video href="2021.emnlp-main.62.mp4"/>
     </paper>
     <paper id="63">
       <title><fixed-case>T</fixed-case>he <fixed-case>W</fixed-case>orld of an <fixed-case>O</fixed-case>ctopus: <fixed-case>H</fixed-case>ow <fixed-case>R</fixed-case>eporting <fixed-case>B</fixed-case>ias <fixed-case>I</fixed-case>nfluences a <fixed-case>L</fixed-case>anguage <fixed-case>M</fixed-case>odel’s <fixed-case>P</fixed-case>erception of <fixed-case>C</fixed-case>olor</title>
@@ -1053,7 +991,6 @@
       <video href="2021.emnlp-main.64.mp4"/>
       <pwccode url="https://github.com/dheerajrajagopal/SelfExplain" additional="true">dheerajrajagopal/SelfExplain</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.64.mp4"/>
     </paper>
     <paper id="65">
       <title>Memory and Knowledge Augmented Language Models for Inferring Salience in Long-Form Stories</title>
@@ -1067,7 +1004,6 @@
       <video href="2021.emnlp-main.65.mp4"/>
       <pwccode url="https://github.com/dwlmt/story-fragments" additional="false">dwlmt/story-fragments</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/shmoop-corpus">Shmoop Corpus</pwcdataset>
-      <video href="2021.emnlp-main.65.mp4"/>
     </paper>
     <paper id="66">
       <title>Semantic Novelty Detection in Natural Language Descriptions</title>
@@ -1087,7 +1023,6 @@
       <pwccode url="https://github.com/nianzuma/semantic-novelty-detection-in-natural-language-descriptions" additional="false">nianzuma/semantic-novelty-detection-in-natural-language-descriptions</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
-      <video href="2021.emnlp-main.66.mp4"/>
     </paper>
     <paper id="67">
       <title>Jump-Starting Item Parameters for Adaptive Language Tests</title>
@@ -1102,7 +1037,6 @@
       <url hash="9f922ac6">2021.emnlp-main.67</url>
       <bibkey>mccarthy-etal-2021-jump</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.67</doi>
-      <video href="2021.emnlp-main.67.mp4"/>
       <video href="2021.emnlp-main.67.mp4"/>
     </paper>
     <paper id="68">
@@ -1124,7 +1058,6 @@
       <bibkey>tang-etal-2021-voice</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.68</doi>
       <video href="2021.emnlp-main.68.mp4"/>
-      <video href="2021.emnlp-main.68.mp4"/>
     </paper>
     <paper id="69">
       <title><fixed-case>C</fixed-case>o<fixed-case>PHE</fixed-case>: A Count-Preserving Hierarchical Evaluation Metric in Large-Scale Multi-Label Text Classification</title>
@@ -1139,7 +1072,6 @@
       <doi>10.18653/v1/2021.emnlp-main.69</doi>
       <video href="2021.emnlp-main.69.mp4"/>
       <pwccode url="https://github.com/modr00cka/cophe" additional="false">modr00cka/cophe</pwccode>
-      <video href="2021.emnlp-main.69.mp4"/>
     </paper>
     <paper id="70">
       <title>Learning Universal Authorship Representations</title>
@@ -1156,7 +1088,6 @@
       <bibkey>rivera-soto-etal-2021-learning</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.70</doi>
       <video href="2021.emnlp-main.70.mp4"/>
-      <video href="2021.emnlp-main.70.mp4"/>
     </paper>
     <paper id="71">
       <title>Predicting emergent linguistic compositions through time: Syntactic frame extension via multimodal chaining</title>
@@ -1171,7 +1102,6 @@
       <pwccode url="https://github.com/jadeleiyu/frame_extension" additional="false">jadeleiyu/frame_extension</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imagenet">ImageNet</pwcdataset>
-      <video href="2021.emnlp-main.71.mp4"/>
     </paper>
     <paper id="72">
       <title>Frequency Effects on Syntactic Rule Learning in Transformers</title>
@@ -1186,7 +1116,6 @@
       <doi>10.18653/v1/2021.emnlp-main.72</doi>
       <video href="2021.emnlp-main.72.mp4"/>
       <pwccode url="https://github.com/google-research/language" additional="false">google-research/language</pwccode>
-      <video href="2021.emnlp-main.72.mp4"/>
     </paper>
     <paper id="73">
       <title>A surprisal–duration trade-off across and within the world’s languages</title>
@@ -1223,7 +1152,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-stories">Natural Stories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.74.mp4"/>
     </paper>
     <paper id="75">
       <title>Condenser: a Pre-training Architecture for Dense Retrieval</title>
@@ -1239,7 +1167,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.75.mp4"/>
     </paper>
     <paper id="76">
       <title>Monitoring geometrical properties of word embeddings for detecting the emergence of new topics.</title>
@@ -1253,7 +1180,6 @@
       <url hash="fc15f8ce">2021.emnlp-main.76</url>
       <bibkey>christophe-etal-2021-monitoring</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.76</doi>
-      <video href="2021.emnlp-main.76.mp4"/>
       <video href="2021.emnlp-main.76.mp4"/>
     </paper>
     <paper id="77">
@@ -1270,7 +1196,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/canard">CANARD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/orconvqa">ORConvQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quac">QuAC</pwcdataset>
-      <video href="2021.emnlp-main.77.mp4"/>
     </paper>
     <paper id="78">
       <title>Ultra-High Dimensional Sparse Representations with Binarization for Efficient Text Retrieval</title>
@@ -1289,7 +1214,6 @@
       <doi>10.18653/v1/2021.emnlp-main.78</doi>
       <video href="2021.emnlp-main.78.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
-      <video href="2021.emnlp-main.78.mp4"/>
     </paper>
     <paper id="79">
       <title><fixed-case>IR</fixed-case> like a <fixed-case>SIR</fixed-case>: <fixed-case>S</fixed-case>ense-enhanced <fixed-case>I</fixed-case>nformation <fixed-case>R</fixed-case>etrieval for <fixed-case>M</fixed-case>ultiple <fixed-case>L</fixed-case>anguages</title>
@@ -1306,7 +1230,6 @@
       <doi>10.18653/v1/2021.emnlp-main.79</doi>
       <video href="2021.emnlp-main.79.mp4"/>
       <pwccode url="https://github.com/sapienzanlp/sir" additional="false">sapienzanlp/sir</pwccode>
-      <video href="2021.emnlp-main.79.mp4"/>
     </paper>
     <paper id="80">
       <title>Neural Attention-Aware Hierarchical Topic Model</title>
@@ -1320,7 +1243,6 @@
       <url hash="07933aa6">2021.emnlp-main.80</url>
       <bibkey>jin-etal-2021-neural</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.80</doi>
-      <video href="2021.emnlp-main.80.mp4"/>
       <video href="2021.emnlp-main.80.mp4"/>
     </paper>
     <paper id="81">
@@ -1336,7 +1258,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/lama">LAMA</pwcdataset>
-      <video href="2021.emnlp-main.81.mp4"/>
     </paper>
     <paper id="82">
       <title>Certified Robustness to Programmable Transformations in <fixed-case>LSTM</fixed-case>s</title>
@@ -1369,7 +1290,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/kelm">KELM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tekgen">TekGen</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.emnlp-main.83.mp4"/>
     </paper>
     <paper id="84">
       <title>Contrastive Out-of-Distribution Detection for Pretrained Transformers</title>
@@ -1386,7 +1306,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2016">WMT 2016</pwcdataset>
-      <video href="2021.emnlp-main.84.mp4"/>
     </paper>
     <paper id="85">
       <title><fixed-case>M</fixed-case>ind<fixed-case>C</fixed-case>raft: Theory of Mind Modeling for Situated Dialogue in Collaborative Tasks</title>
@@ -1400,7 +1319,6 @@
       <doi>10.18653/v1/2021.emnlp-main.85</doi>
       <video href="2021.emnlp-main.85.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mindcraft">MindCraft</pwcdataset>
-      <video href="2021.emnlp-main.85.mp4"/>
     </paper>
     <paper id="86">
       <title>Detecting Speaker Personas from Conversational Texts</title>
@@ -1418,7 +1336,6 @@
       <video href="2021.emnlp-main.86.mp4"/>
       <pwccode url="https://github.com/jasonforjoy/spd" additional="false">jasonforjoy/spd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/pmpc">PMPC</pwcdataset>
-      <video href="2021.emnlp-main.86.mp4"/>
     </paper>
     <paper id="87">
       <title>Cross-lingual Intermediate Fine-tuning improves Dialogue State Tracking</title>
@@ -1433,7 +1350,6 @@
       <video href="2021.emnlp-main.87.mp4"/>
       <pwccode url="https://github.com/nikitacs16/xlift_dst" additional="false">nikitacs16/xlift_dst</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
-      <video href="2021.emnlp-main.87.mp4"/>
     </paper>
     <paper id="88">
       <title><fixed-case>ConvFiT:</fixed-case> <fixed-case>C</fixed-case>onversational Fine-Tuning of Pretrained Language Models</title>
@@ -1454,8 +1370,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/clinc150">CLINC150</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/reddit-corpus">Reddit Corpus</pwcdataset>
-      <video href="2021.emnlp-main.88.mp4"/>
-      <video href="2021.emnlp-main.88.mp4"/>
     </paper>
     <paper id="89">
       <title>We’ve had this conversation before: A Novel Approach to Measuring Dialog Similarity</title>
@@ -1487,7 +1401,6 @@
       <pwccode url="https://github.com/pkhdipraja/towards-incremental-transformers" additional="false">pkhdipraja/towards-incremental-transformers</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
-      <video href="2021.emnlp-main.90.mp4"/>
     </paper>
     <paper id="91">
       <title>Feedback Attribution for Counterfactual Bandit Learning in Multi-Domain Spoken Language Understanding</title>
@@ -1500,7 +1413,6 @@
       <doi>10.18653/v1/2021.emnlp-main.91</doi>
       <video href="2021.emnlp-main.91.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
-      <video href="2021.emnlp-main.91.mp4"/>
     </paper>
     <paper id="92">
       <title>Label Verbalization and Entailment for Effective Zero and Few-Shot Relation Extraction</title>
@@ -1517,7 +1429,6 @@
       <video href="2021.emnlp-main.92.mp4"/>
       <pwccode url="https://github.com/osainz59/Ask2Transformers" additional="false">osainz59/Ask2Transformers</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-main.92.mp4"/>
     </paper>
     <paper id="93">
       <title>Extend, don’t rebuild: Phrasing conditional graph modification as autoregressive sequence labelling</title>
@@ -1551,7 +1462,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tacred">TACRED</pwcdataset>
-      <video href="2021.emnlp-main.94.mp4"/>
     </paper>
     <paper id="95">
       <title>Learning Logic Rules for Document-Level Relation Extraction</title>
@@ -1572,7 +1482,6 @@
       <pwccode url="https://github.com/rudongyu/logire" additional="false">rudongyu/logire</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dwie">DWIE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
-      <video href="2021.emnlp-main.95.mp4"/>
     </paper>
     <paper id="96">
       <title>A Large-Scale Dataset for Empathetic Response Generation</title>
@@ -1590,8 +1499,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/emotionlines">EmotionLines</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
-      <video href="2021.emnlp-main.96.mp4"/>
-      <video href="2021.emnlp-main.96.mp4"/>
     </paper>
     <paper id="97">
       <title>The Perils of Using <fixed-case>M</fixed-case>echanical <fixed-case>T</fixed-case>urk to Evaluate Open-Ended Text Generation</title>
@@ -1605,7 +1512,6 @@
       <doi>10.18653/v1/2021.emnlp-main.97</doi>
       <video href="2021.emnlp-main.97.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
-      <video href="2021.emnlp-main.97.mp4"/>
     </paper>
     <paper id="98">
       <title>Documenting Large Webtext Corpora: A Case Study on the Colossal Clean Crawled Corpus</title>
@@ -1631,7 +1537,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikibio">WikiBio</pwcdataset>
-      <video href="2021.emnlp-main.98.mp4"/>
     </paper>
     <paper id="99">
       <title><fixed-case>A</fixed-case>fro<fixed-case>MT</fixed-case>: Pretraining Strategies and Reproducible Benchmarks for Translation of 8 <fixed-case>A</fixed-case>frican Languages</title>
@@ -1647,7 +1552,6 @@
       <video href="2021.emnlp-main.99.mp4"/>
       <pwccode url="https://github.com/machelreid/afromt" additional="false">machelreid/afromt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
-      <video href="2021.emnlp-main.99.mp4"/>
     </paper>
     <paper id="100">
       <title>Evaluating the Evaluation Metrics for Style Transfer: A Case Study in Multilingual Formality Transfer</title>
@@ -1664,7 +1568,6 @@
       <pwccode url="https://github.com/elbria/xformal-fost-meta" additional="false">elbria/xformal-fost-meta</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
-      <video href="2021.emnlp-main.100.mp4"/>
     </paper>
     <paper id="101">
       <title><fixed-case>MS</fixed-case>-Mentions: Consistently Annotating Entity Mentions in Materials Science Procedural Text</title>
@@ -1683,7 +1586,6 @@
       <revision id="1" href="2021.emnlp-main.101v1" hash="b1672106"/>
       <revision id="2" href="2021.emnlp-main.101v2" hash="d979c2f3" date="2022-02-27">Added missing acknowledgements section.</revision>
       <video href="2021.emnlp-main.101.mp4"/>
-      <video href="2021.emnlp-main.101.mp4"/>
     </paper>
     <paper id="102">
       <title>Understanding Politics via Contextualized Discourse Processing</title>
@@ -1697,7 +1599,6 @@
       <doi>10.18653/v1/2021.emnlp-main.102</doi>
       <video href="2021.emnlp-main.102.mp4"/>
       <pwccode url="https://github.com/pujari-rajkumar/compositional_learner" additional="false">pujari-rajkumar/compositional_learner</pwccode>
-      <video href="2021.emnlp-main.102.mp4"/>
     </paper>
     <paper id="103">
       <title>Conundrums in Event Coreference Resolution: Making Sense of the State of the Art</title>
@@ -1708,7 +1609,6 @@
       <url hash="9ed1e538">2021.emnlp-main.103</url>
       <bibkey>lu-ng-2021-conundrums</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.103</doi>
-      <video href="2021.emnlp-main.103.mp4"/>
       <video href="2021.emnlp-main.103.mp4"/>
     </paper>
     <paper id="104">
@@ -1725,7 +1625,6 @@
       <doi>10.18653/v1/2021.emnlp-main.104</doi>
       <video href="2021.emnlp-main.104.mp4"/>
       <pwccode url="https://github.com/linto-project/linto-dialogue-act-segmentation" additional="false">linto-project/linto-dialogue-act-segmentation</pwccode>
-      <video href="2021.emnlp-main.104.mp4"/>
     </paper>
     <paper id="105">
       <title>Narrative Embedding: <fixed-case>R</fixed-case>e-<fixed-case>C</fixed-case>ontextualization Through Attention</title>
@@ -1737,7 +1636,6 @@
       <url hash="676ed77f">2021.emnlp-main.105</url>
       <bibkey>wilner-etal-2021-narrative</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.105</doi>
-      <video href="2021.emnlp-main.105.mp4"/>
       <video href="2021.emnlp-main.105.mp4"/>
     </paper>
     <paper id="106">
@@ -1754,8 +1652,6 @@
       <pwccode url="https://github.com/helw150/event_entity_coref_ecb_plus" additional="false">helw150/event_entity_coref_ecb_plus</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ecb">ECB+</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/gun-violence-corpus">Gun Violence Corpus</pwcdataset>
-      <video href="2021.emnlp-main.106.mp4"/>
-      <video href="2021.emnlp-main.106.mp4"/>
     </paper>
     <paper id="107">
       <title>Salience-Aware Event Chain Modeling for Narrative Understanding</title>
@@ -1770,7 +1666,6 @@
       <video href="2021.emnlp-main.107.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/torque">Torque</pwcdataset>
-      <video href="2021.emnlp-main.107.mp4"/>
     </paper>
     <paper id="108">
       <title>Asking It All: Generating Contextualized Questions for any Semantic Role</title>
@@ -1791,7 +1686,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qa-srl">QA-SRL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qa-srl-bank-2-0">QA-SRL Bank 2.0</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.108.mp4"/>
     </paper>
     <paper id="109">
       <title>Fast, Effective, and Self-Supervised: Transforming Masked Language Models into Universal Lexical and Sentence Encoders</title>
@@ -1814,7 +1708,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sts-benchmark">STS Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semantic-textual-similarity-2012-2016">Semantic Textual Similarity (2012 - 2016)</pwcdataset>
-      <video href="2021.emnlp-main.109.mp4"/>
     </paper>
     <paper id="110">
       <title><fixed-case>R</fixed-case>ule<fixed-case>BERT</fixed-case>: Teaching Soft Rules to Pre-Trained Language Models</title>
@@ -1830,7 +1723,6 @@
       <video href="2021.emnlp-main.110.mp4"/>
       <pwccode url="https://github.com/mhmdsaiid/rulebert" additional="false">mhmdsaiid/rulebert</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/lama">LAMA</pwcdataset>
-      <video href="2021.emnlp-main.110.mp4"/>
     </paper>
     <paper id="111">
       <title>Stepmothers are mean and academics are pretentious: What do pretrained language models learn about you?</title>
@@ -1842,7 +1734,6 @@
       <url hash="7d796f71">2021.emnlp-main.111</url>
       <bibkey>choenni-etal-2021-stepmothers</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.111</doi>
-      <video href="2021.emnlp-main.111.mp4"/>
       <video href="2021.emnlp-main.111.mp4"/>
     </paper>
     <paper id="112">
@@ -1858,7 +1749,6 @@
       <video href="2021.emnlp-main.112.mp4"/>
       <pwccode url="https://github.com/sapienzanlp/consec" additional="false">sapienzanlp/consec</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.emnlp-main.112.mp4"/>
     </paper>
     <paper id="113">
       <title>Shortcutted Commonsense: Data Spuriousness in Deep Learning of Commonsense Reasoning</title>
@@ -1880,7 +1770,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/piqa">PIQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webtext">WebText</pwcdataset>
-      <video href="2021.emnlp-main.113.mp4"/>
     </paper>
     <paper id="114">
       <title>When differential privacy meets <fixed-case>NLP</fixed-case>: The devil is in the detail</title>
@@ -1892,7 +1781,6 @@
       <doi>10.18653/v1/2021.emnlp-main.114</doi>
       <video href="2021.emnlp-main.114.mp4"/>
       <pwccode url="https://github.com/habernal/emnlp2021-differential-privacy-nlp" additional="true">habernal/emnlp2021-differential-privacy-nlp</pwccode>
-      <video href="2021.emnlp-main.114.mp4"/>
     </paper>
     <paper id="115">
       <title>Achieving Model Robustness through Discrete Adversarial Training</title>
@@ -1908,7 +1796,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/boolq">BoolQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.115.mp4"/>
     </paper>
     <paper id="116">
       <title>Debiasing Methods in Natural Language Understanding Make Bias More Accessible</title>
@@ -1924,7 +1811,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.116.mp4"/>
     </paper>
     <paper id="117">
       <title>Evaluating the Robustness of Neural Language Models to Input Perturbations</title>
@@ -1938,7 +1824,6 @@
       <video href="2021.emnlp-main.117.mp4"/>
       <pwccode url="https://github.com/mmoradi-iut/nlp-perturbation" additional="false">mmoradi-iut/nlp-perturbation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.117.mp4"/>
     </paper>
     <paper id="118">
       <title>How much pretraining data do language models need to learn syntax?</title>
@@ -1952,7 +1837,6 @@
       <doi>10.18653/v1/2021.emnlp-main.118</doi>
       <video href="2021.emnlp-main.118.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.emnlp-main.118.mp4"/>
     </paper>
     <paper id="119">
       <title>Sorting through the noise: Testing robustness of information processing in pre-trained language models</title>
@@ -1963,7 +1847,6 @@
       <url hash="ca031c31">2021.emnlp-main.119</url>
       <bibkey>pandia-ettinger-2021-sorting</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.119</doi>
-      <video href="2021.emnlp-main.119.mp4"/>
       <video href="2021.emnlp-main.119.mp4"/>
     </paper>
     <paper id="120">
@@ -1983,7 +1866,6 @@
       <pwccode url="https://github.com/allenai/contrastive-explanations" additional="false">allenai/contrastive-explanations</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.120.mp4"/>
     </paper>
     <paper id="121">
       <title>On the Transferability of Adversarial Attacks against Neural Text Classifier</title>
@@ -2000,7 +1882,6 @@
       <video href="2021.emnlp-main.121.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.121.mp4"/>
     </paper>
     <paper id="122">
       <title>Conditional probing: measuring usable information beyond a baseline</title>
@@ -2016,7 +1897,6 @@
       <video href="2021.emnlp-main.122.mp4"/>
       <pwccode url="https://github.com/john-hewitt/conditional-probing" additional="false">john-hewitt/conditional-probing</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.122.mp4"/>
     </paper>
     <paper id="123">
       <title><fixed-case>GFST</fixed-case>: <fixed-case>G</fixed-case>ender-Filtered Self-Training for More Accurate Gender in Translation</title>
@@ -2031,7 +1911,6 @@
       <doi>10.18653/v1/2021.emnlp-main.123</doi>
       <video href="2021.emnlp-main.123.mp4"/>
       <pwccode url="https://github.com/amazon-research/gfst-nmt" additional="false">amazon-research/gfst-nmt</pwccode>
-      <video href="2021.emnlp-main.123.mp4"/>
     </paper>
     <paper id="124">
       <title>“Wikily” Supervised Neural Translation Tailored to Cross-Lingual Tasks</title>
@@ -2045,7 +1924,6 @@
       <doi>10.18653/v1/2021.emnlp-main.124</doi>
       <video href="2021.emnlp-main.124.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptual-captions">Conceptual Captions</pwcdataset>
-      <video href="2021.emnlp-main.124.mp4"/>
     </paper>
     <paper id="125">
       <title>m<fixed-case>T</fixed-case>6: Multilingual Pretrained Text-to-Text Transformer with Translation Pairs</title>
@@ -2070,7 +1948,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wikilingua">WikiLingua</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.emnlp-main.125.mp4"/>
     </paper>
     <paper id="126">
       <title>Improving Zero-Shot Cross-Lingual Transfer Learning via Robust Training</title>
@@ -2087,7 +1964,6 @@
       <pwccode url="https://github.com/uclanlp/robust-xlt" additional="false">uclanlp/robust-xlt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/paws-x">PAWS-X</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.126.mp4"/>
     </paper>
     <paper id="127">
       <title>Speechformer: Reducing Information Loss in Direct Speech Translation</title>
@@ -2103,7 +1979,6 @@
       <video href="2021.emnlp-main.127.mp4"/>
       <pwccode url="https://github.com/sarapapi/fbk-fairseq" additional="false">sarapapi/fbk-fairseq</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
-      <video href="2021.emnlp-main.127.mp4"/>
     </paper>
     <paper id="128">
       <title>Is “moby dick” a Whale or a Bird? Named Entities and Terminology in Speech Translation</title>
@@ -2119,7 +1994,6 @@
       <doi>10.18653/v1/2021.emnlp-main.128</doi>
       <video href="2021.emnlp-main.128.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/europarl-st">Europarl-ST</pwcdataset>
-      <video href="2021.emnlp-main.128.mp4"/>
     </paper>
     <paper id="129">
       <title><fixed-case>H</fixed-case>inted<fixed-case>BT</fixed-case>: <fixed-case>A</fixed-case>ugmenting <fixed-case>B</fixed-case>ack-<fixed-case>T</fixed-case>ranslation with Quality and Transliteration Hints</title>
@@ -2132,7 +2006,6 @@
       <url hash="a0266bca">2021.emnlp-main.129</url>
       <bibkey>ramnath-etal-2021-hintedbt</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.129</doi>
-      <video href="2021.emnlp-main.129.mp4"/>
       <video href="2021.emnlp-main.129.mp4"/>
     </paper>
     <paper id="130">
@@ -2147,7 +2020,6 @@
       <doi>10.18653/v1/2021.emnlp-main.130</doi>
       <video href="2021.emnlp-main.130.mp4"/>
       <pwccode url="https://github.com/sfu-natlang/supervised-simultaneous-mt" additional="false">sfu-natlang/supervised-simultaneous-mt</pwccode>
-      <video href="2021.emnlp-main.130.mp4"/>
     </paper>
     <paper id="131">
       <title>Nearest Neighbour Few-Shot Learning for Cross-lingual Classification</title>
@@ -2161,7 +2033,6 @@
       <doi>10.18653/v1/2021.emnlp-main.131</doi>
       <video href="2021.emnlp-main.131.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.131.mp4"/>
     </paper>
     <paper id="132">
       <title>Cross-Attention is All You Need: <fixed-case>A</fixed-case>dapting Pretrained <fixed-case>T</fixed-case>ransformers for Machine Translation</title>
@@ -2175,7 +2046,6 @@
       <doi>10.18653/v1/2021.emnlp-main.132</doi>
       <video href="2021.emnlp-main.132.mp4"/>
       <pwccode url="https://github.com/mgheini/xattn-transfer-for-mt" additional="false">mgheini/xattn-transfer-for-mt</pwccode>
-      <video href="2021.emnlp-main.132.mp4"/>
     </paper>
     <paper id="133">
       <title>Effects of Parameter Norm Growth During Transformer Training: Inductive Bias from Gradient Descent</title>
@@ -2193,7 +2063,6 @@
       <pwccode url="https://github.com/viking-sudo-rm/norm-growth" additional="false">viking-sudo-rm/norm-growth</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.133.mp4"/>
     </paper>
     <paper id="134">
       <title>Foreseeing the Benefits of Incidental Supervision</title>
@@ -2210,7 +2079,6 @@
       <pwccode url="https://github.com/CogComp/PABI" additional="true">CogComp/PABI</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/qa-srl-bank-2-0">QA-SRL Bank 2.0</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.134.mp4"/>
     </paper>
     <paper id="135">
       <title>Competency Problems: On Finding and Removing Artifacts in Language Data</title>
@@ -2233,7 +2101,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.emnlp-main.135.mp4"/>
     </paper>
     <paper id="136">
       <title>Knowledge-Aware Meta-learning for Low-Resource Text Classification</title>
@@ -2248,7 +2115,6 @@
       <doi>10.18653/v1/2021.emnlp-main.136</doi>
       <video href="2021.emnlp-main.136.mp4"/>
       <pwccode url="https://github.com/huaxiuyao/KGML" additional="false">huaxiuyao/KGML</pwccode>
-      <video href="2021.emnlp-main.136.mp4"/>
     </paper>
     <paper id="137">
       <title>Sentence Bottleneck Autoencoders from Transformer Language Models</title>
@@ -2263,7 +2129,6 @@
       <video href="2021.emnlp-main.137.mp4"/>
       <pwccode url="https://github.com/ivanmontero/autobot" additional="false">ivanmontero/autobot</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.emnlp-main.137.mp4"/>
     </paper>
     <paper id="138">
       <title>Efficient Contrastive Learning via Novel Data Augmentation and Curriculum Learning</title>
@@ -2278,7 +2143,6 @@
       <doi>10.18653/v1/2021.emnlp-main.138</doi>
       <video href="2021.emnlp-main.138.mp4"/>
       <pwccode url="https://github.com/vano1205/efficientcl" additional="false">vano1205/efficientcl</pwccode>
-      <video href="2021.emnlp-main.138.mp4"/>
     </paper>
     <paper id="139">
       <title><fixed-case>CR</fixed-case>-Walker: Tree-Structured Graph Reasoning and Dialog Acts for Conversational Recommendation</title>
@@ -2294,7 +2158,6 @@
       <pwccode url="https://github.com/truthless11/CR-Walker" additional="false">truthless11/CR-Walker</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/redial">ReDial</pwcdataset>
-      <video href="2021.emnlp-main.139.mp4"/>
     </paper>
     <paper id="140">
       <title><fixed-case>DIALKI</fixed-case>: Knowledge Identification in Conversational Systems through Dialogue-Document Contextualization</title>
@@ -2313,7 +2176,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/holl-e">Holl-E</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/doc2dial">doc2dial</pwcdataset>
-      <video href="2021.emnlp-main.140.mp4"/>
     </paper>
     <paper id="141">
       <title>Iconary: A Pictionary-Based Game for Testing Multimodal Communication with Drawings and Text</title>
@@ -2341,7 +2203,6 @@
       <video href="2021.emnlp-main.141.mp4"/>
       <pwccode url="https://github.com/allenai/iconary" additional="false">allenai/iconary</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/iconary">Iconary</pwcdataset>
-      <video href="2021.emnlp-main.141.mp4"/>
     </paper>
     <paper id="142">
       <title>Self-training Improves Pre-training for Few-shot Learning in Task-oriented Dialog Systems</title>
@@ -2358,7 +2219,6 @@
       <doi>10.18653/v1/2021.emnlp-main.142</doi>
       <video href="2021.emnlp-main.142.mp4"/>
       <pwccode url="https://github.com/mifei/st-tod" additional="false">mifei/st-tod</pwccode>
-      <video href="2021.emnlp-main.142.mp4"/>
     </paper>
     <paper id="143">
       <title>Contextual Rephrase Detection for Reducing Friction in Dialogue Systems</title>
@@ -2374,7 +2234,6 @@
       <url hash="e658da22">2021.emnlp-main.143</url>
       <bibkey>wang-etal-2021-contextual</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.143</doi>
-      <video href="2021.emnlp-main.143.mp4"/>
       <video href="2021.emnlp-main.143.mp4"/>
     </paper>
     <paper id="144">
@@ -2395,7 +2254,6 @@
       <doi>10.18653/v1/2021.emnlp-main.144</doi>
       <video href="2021.emnlp-main.144.mp4"/>
       <pwccode url="https://github.com/jianguoz/Few-Shot-Intent-Detection" additional="true">jianguoz/Few-Shot-Intent-Detection</pwccode>
-      <video href="2021.emnlp-main.144.mp4"/>
     </paper>
     <paper id="145">
       <title>“It doesn’t look good for a date”: Transforming Critiques into Preferences for Conversational Recommendation Systems</title>
@@ -2425,7 +2283,6 @@
       <doi>10.18653/v1/2021.emnlp-main.146</doi>
       <video href="2021.emnlp-main.146.mp4"/>
       <pwccode url="https://github.com/hd10-iupui/attentionrank" additional="false">hd10-iupui/attentionrank</pwccode>
-      <video href="2021.emnlp-main.146.mp4"/>
     </paper>
     <paper id="147">
       <title>Unsupervised Relation Extraction: A Variational Autoencoder Approach</title>
@@ -2436,7 +2293,6 @@
       <url hash="113693c2">2021.emnlp-main.147</url>
       <bibkey>yuan-eldardiry-2021-unsupervised</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.147</doi>
-      <video href="2021.emnlp-main.147.mp4"/>
       <video href="2021.emnlp-main.147.mp4"/>
     </paper>
     <paper id="148">
@@ -2455,7 +2311,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/kilt">KILT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/t-rex">T-REx</pwcdataset>
-      <video href="2021.emnlp-main.148.mp4"/>
     </paper>
     <paper id="149">
       <title>Everything Is All It Takes: A Multipronged Strategy for Zero-Shot Cross-Lingual Information Extraction</title>
@@ -2479,7 +2334,6 @@
       <doi>10.18653/v1/2021.emnlp-main.149</doi>
       <video href="2021.emnlp-main.149.mp4"/>
       <pwccode url="https://github.com/shijie-wu/crosslingual-nlp" additional="true">shijie-wu/crosslingual-nlp</pwccode>
-      <video href="2021.emnlp-main.149.mp4"/>
     </paper>
     <paper id="150">
       <title>Harms of Gender Exclusivity and Challenges in Non-Binary Representation in Language Technologies</title>
@@ -2494,7 +2348,6 @@
       <url hash="aabd4ddb">2021.emnlp-main.150</url>
       <bibkey>dev-etal-2021-harms</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.150</doi>
-      <video href="2021.emnlp-main.150.mp4"/>
       <video href="2021.emnlp-main.150.mp4"/>
     </paper>
     <paper id="151">
@@ -2513,7 +2366,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/coco-captions">COCO Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
-      <video href="2021.emnlp-main.151.mp4"/>
     </paper>
     <paper id="152">
       <title>Style Pooling: Automatic Text Style Obfuscation for Improved Classification Fairness</title>
@@ -2526,7 +2378,6 @@
       <doi>10.18653/v1/2021.emnlp-main.152</doi>
       <video href="2021.emnlp-main.152.mp4"/>
       <pwccode url="https://github.com/mireshghallah/style-pooling" additional="false">mireshghallah/style-pooling</pwccode>
-      <video href="2021.emnlp-main.152.mp4"/>
     </paper>
     <paper id="153">
       <title>Modeling Disclosive Transparency in <fixed-case>NLP</fixed-case> Application Descriptions</title>
@@ -2542,7 +2393,6 @@
       <doi>10.18653/v1/2021.emnlp-main.153</doi>
       <video href="2021.emnlp-main.153.mp4"/>
       <pwccode url="https://github.com/michaelsaxon/disclosive-transparency" additional="false">michaelsaxon/disclosive-transparency</pwccode>
-      <video href="2021.emnlp-main.153.mp4"/>
     </paper>
     <paper id="154">
       <title>Reconstruction Attack on Instance Encoding for Language Understanding</title>
@@ -2557,7 +2407,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.154.mp4"/>
     </paper>
     <paper id="155">
       <title>Fairness-aware Class Imbalanced Learning</title>
@@ -2571,7 +2420,6 @@
       <url hash="6acc4529">2021.emnlp-main.155</url>
       <bibkey>subramanian-etal-2021-fairness</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.155</doi>
-      <video href="2021.emnlp-main.155.mp4"/>
       <video href="2021.emnlp-main.155.mp4"/>
     </paper>
     <paper id="156">
@@ -2587,7 +2435,6 @@
       <doi>10.18653/v1/2021.emnlp-main.156</doi>
       <video href="2021.emnlp-main.156.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.156.mp4"/>
     </paper>
     <paper id="157">
       <title>Local Word Discovery for Interactive Transcription</title>
@@ -2598,7 +2445,6 @@
       <url hash="3c358880">2021.emnlp-main.157</url>
       <bibkey>lane-bird-2021-local</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.157</doi>
-      <video href="2021.emnlp-main.157.mp4"/>
       <video href="2021.emnlp-main.157.mp4"/>
     </paper>
     <paper id="158">
@@ -2617,7 +2463,6 @@
       <bibkey>maimaiti-etal-2021-segment</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.158</doi>
       <video href="2021.emnlp-main.158.mp4"/>
-      <video href="2021.emnlp-main.158.mp4"/>
     </paper>
     <paper id="159">
       <title>Minimal Supervision for Morphological Inflection</title>
@@ -2630,7 +2475,6 @@
       <doi>10.18653/v1/2021.emnlp-main.159</doi>
       <video href="2021.emnlp-main.159.mp4"/>
       <pwccode url="https://github.com/onlplab/morphodetection" additional="false">onlplab/morphodetection</pwccode>
-      <video href="2021.emnlp-main.159.mp4"/>
     </paper>
     <paper id="160">
       <title>Fast <fixed-case>W</fixed-case>ord<fixed-case>P</fixed-case>iece Tokenization</title>
@@ -2646,7 +2490,6 @@
       <doi>10.18653/v1/2021.emnlp-main.160</doi>
       <video href="2021.emnlp-main.160.mp4"/>
       <pwccode url="https://github.com/tensorflow/text/blob/master/docs/api_docs/python/text/FastWordpieceTokenizer.md" additional="false">tensorflow/text</pwccode>
-      <video href="2021.emnlp-main.160.mp4"/>
     </paper>
     <paper id="161">
       <title>You should evaluate your language model on marginal likelihood over tokenisations</title>
@@ -2659,7 +2502,6 @@
       <doi>10.18653/v1/2021.emnlp-main.161</doi>
       <video href="2021.emnlp-main.161.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mc4">mC4</pwcdataset>
-      <video href="2021.emnlp-main.161.mp4"/>
     </paper>
     <paper id="162">
       <title>Broaden the Vision: Geo-Diverse Visual Commonsense Reasoning</title>
@@ -2677,7 +2519,6 @@
       <pwccode url="https://github.com/wadeyin9712/gd-vcr" additional="false">wadeyin9712/gd-vcr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gd-vcr">GD-VCR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vcr">VCR</pwcdataset>
-      <video href="2021.emnlp-main.162.mp4"/>
     </paper>
     <paper id="163">
       <title>Reference-Centric Models for Grounded Collaborative Dialogue</title>
@@ -2691,7 +2532,6 @@
       <doi>10.18653/v1/2021.emnlp-main.163</doi>
       <video href="2021.emnlp-main.163.mp4"/>
       <pwccode url="https://github.com/dpfried/onecommon" additional="false">dpfried/onecommon</pwccode>
-      <video href="2021.emnlp-main.163.mp4"/>
     </paper>
     <paper id="164">
       <title><fixed-case>C</fixed-case>ross<fixed-case>VQA</fixed-case>: Scalably Generating Benchmarks for Systematically Testing <fixed-case>VQA</fixed-case> Generalization</title>
@@ -2714,7 +2554,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering-v2-0">Visual Question Answering v2.0</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vizwiz">VizWiz</pwcdataset>
-      <video href="2021.emnlp-main.164.mp4"/>
     </paper>
     <paper id="165">
       <title>Visual Goal-Step Inference using wiki<fixed-case>H</fixed-case>ow</title>
@@ -2734,7 +2573,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wikihow-image">wikiHow-image</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/coin">COIN</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/howto100m">HowTo100M</pwcdataset>
-      <video href="2021.emnlp-main.165.mp4"/>
     </paper>
     <paper id="166">
       <title>Systematic Generalization on g<fixed-case>SCAN</fixed-case>: <fixed-case>W</fixed-case>hat is Nearly Solved and What is Next?</title>
@@ -2751,7 +2589,6 @@
       <video href="2021.emnlp-main.166.mp4"/>
       <pwccode url="https://github.com/LauraRuis/groundedSCAN" additional="false">LauraRuis/groundedSCAN</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.emnlp-main.166.mp4"/>
     </paper>
     <paper id="167">
       <title>Effect of Visual Extensions on Natural Language Understanding in Vision-and-Language Models</title>
@@ -2769,7 +2606,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.167.mp4"/>
     </paper>
     <paper id="168">
       <title>Neural Path Hunter: Reducing Hallucination in Dialogue Systems via Path Grounding</title>
@@ -2785,7 +2621,6 @@
       <video href="2021.emnlp-main.168.mp4"/>
       <pwccode url="https://github.com/nouhadziri/neural-path-hunter" additional="false">nouhadziri/neural-path-hunter</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opendialkg">OpenDialKG</pwcdataset>
-      <video href="2021.emnlp-main.168.mp4"/>
     </paper>
     <paper id="169">
       <title>Thinking Clearly, Talking Fast: Concept-Guided Non-Autoregressive Generation for Open-Domain Dialogue Systems</title>
@@ -2800,7 +2635,6 @@
       <doi>10.18653/v1/2021.emnlp-main.169</doi>
       <video href="2021.emnlp-main.169.mp4"/>
       <pwccode url="https://github.com/rowitzou/cg-nar" additional="false">rowitzou/cg-nar</pwccode>
-      <video href="2021.emnlp-main.169.mp4"/>
     </paper>
     <paper id="170">
       <title>Perspective-taking and Pragmatics for Generating Empathetic Responses Focused on Emotion Causes</title>
@@ -2818,7 +2652,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/empatheticdialogues">EmpatheticDialogues</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/reccon">RECCON</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ecpe-xia-and-ding-2019">Xia and Ding, 2019</pwcdataset>
-      <video href="2021.emnlp-main.170.mp4"/>
     </paper>
     <paper id="171">
       <title>Generation and Extraction Combined Dialogue State Tracking with Hierarchical Ontology Integration</title>
@@ -2834,7 +2667,6 @@
       <video href="2021.emnlp-main.171.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/crosswoz">CrossWOZ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.emnlp-main.171.mp4"/>
     </paper>
     <paper id="172">
       <title><fixed-case>C</fixed-case>o<fixed-case>LV</fixed-case>: A Collaborative Latent Variable Model for Knowledge-Grounded Dialogue Generation</title>
@@ -2850,7 +2682,6 @@
       <video href="2021.emnlp-main.172.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/holl-e">Holl-E</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
-      <video href="2021.emnlp-main.172.mp4"/>
     </paper>
     <paper id="173">
       <title><fixed-case>A</fixed-case> <fixed-case>T</fixed-case>hree-<fixed-case>S</fixed-case>tage <fixed-case>L</fixed-case>earning <fixed-case>F</fixed-case>ramework for <fixed-case>L</fixed-case>ow-<fixed-case>R</fixed-case>esource <fixed-case>K</fixed-case>nowledge-<fixed-case>G</fixed-case>rounded <fixed-case>D</fixed-case>ialogue <fixed-case>G</fixed-case>eneration</title>
@@ -2867,7 +2698,6 @@
       <doi>10.18653/v1/2021.emnlp-main.173</doi>
       <video href="2021.emnlp-main.173.mp4"/>
       <pwccode url="https://github.com/neukg/kat-tslf" additional="false">neukg/kat-tslf</pwccode>
-      <video href="2021.emnlp-main.173.mp4"/>
     </paper>
     <paper id="174">
       <title>Intention Reasoning Network for Multi-Domain End-to-end Task-Oriented Dialogue</title>
@@ -2881,7 +2711,6 @@
       <url hash="8252b8c9">2021.emnlp-main.174</url>
       <bibkey>ma-etal-2021-intention</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.174</doi>
-      <video href="2021.emnlp-main.174.mp4"/>
       <video href="2021.emnlp-main.174.mp4"/>
     </paper>
     <paper id="175">
@@ -2900,7 +2729,6 @@
       <video href="2021.emnlp-main.175.mp4"/>
       <pwccode url="https://github.com/pku-sixing/emnlp2021-mske_dialog" additional="false">pku-sixing/emnlp2021-mske_dialog</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.emnlp-main.175.mp4"/>
     </paper>
     <paper id="176">
       <title>Domain-Lifelong Learning for Dialogue State Tracking via Knowledge Preservation Networks</title>
@@ -2921,7 +2749,6 @@
       <video href="2021.emnlp-main.176.mp4"/>
       <pwccode url="https://github.com/liuqingbin/knowledge-preservation-networks" additional="false">liuqingbin/knowledge-preservation-networks</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sgd">SGD</pwcdataset>
-      <video href="2021.emnlp-main.176.mp4"/>
     </paper>
     <paper id="177">
       <title><fixed-case>CSAGN</fixed-case>: Conversational Structure Aware Graph Network for Conversational Semantic Role Labeling</title>
@@ -2935,7 +2762,6 @@
       <doi>10.18653/v1/2021.emnlp-main.177</doi>
       <video href="2021.emnlp-main.177.mp4"/>
       <pwccode url="https://github.com/hahahawu/CSAGN" additional="false">hahahawu/CSAGN</pwccode>
-      <video href="2021.emnlp-main.177.mp4"/>
     </paper>
     <paper id="178">
       <title>Different Strokes for Different Folks: Investigating Appropriate Further Pre-training Approaches for Diverse Dialogue Tasks</title>
@@ -2947,7 +2773,6 @@
       <url hash="b72dc2d4">2021.emnlp-main.178</url>
       <bibkey>qiu-etal-2021-different</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.178</doi>
-      <video href="2021.emnlp-main.178.mp4"/>
       <video href="2021.emnlp-main.178.mp4"/>
     </paper>
     <paper id="179">
@@ -2964,7 +2789,6 @@
       <video href="2021.emnlp-main.179.mp4"/>
       <pwccode url="https://github.com/nealcly/ke-blender" additional="false">nealcly/ke-blender</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
-      <video href="2021.emnlp-main.179.mp4"/>
     </paper>
     <paper id="180">
       <title>An Evaluation Dataset and Strategy for Building Robust Multi-turn Response Selection Model</title>
@@ -2978,7 +2802,6 @@
       <doi>10.18653/v1/2021.emnlp-main.180</doi>
       <video href="2021.emnlp-main.180.mp4"/>
       <pwccode url="https://github.com/kakaoenterprise/koradvmrstestdata" additional="false">kakaoenterprise/koradvmrstestdata</pwccode>
-      <video href="2021.emnlp-main.180.mp4"/>
     </paper>
     <paper id="181">
       <title>Unsupervised Conversation Disentanglement through Co-Training</title>
@@ -2992,7 +2815,6 @@
       <doi>10.18653/v1/2021.emnlp-main.181</doi>
       <video href="2021.emnlp-main.181.mp4"/>
       <pwccode url="https://github.com/layneins/unsupervised_dialo_disentanglement" additional="false">layneins/unsupervised_dialo_disentanglement</pwccode>
-      <video href="2021.emnlp-main.181.mp4"/>
     </paper>
     <paper id="182">
       <title>Don’t be Contradicted with Anything! <fixed-case>CI</fixed-case>-<fixed-case>T</fixed-case>o<fixed-case>D</fixed-case>: Towards Benchmarking Consistency for Task-oriented Dialogue System</title>
@@ -3009,7 +2831,6 @@
       <doi>10.18653/v1/2021.emnlp-main.182</doi>
       <video href="2021.emnlp-main.182.mp4"/>
       <pwccode url="https://github.com/yizhen20133868/ci-tod" additional="false">yizhen20133868/ci-tod</pwccode>
-      <video href="2021.emnlp-main.182.mp4"/>
     </paper>
     <paper id="183">
       <title>Transferable Persona-Grounded Dialogues via Grounded Minimal Edits</title>
@@ -3024,7 +2845,6 @@
       <doi>10.18653/v1/2021.emnlp-main.183</doi>
       <video href="2021.emnlp-main.183.mp4"/>
       <pwccode url="https://github.com/thu-coai/grounded-minimal-edit" additional="false">thu-coai/grounded-minimal-edit</pwccode>
-      <video href="2021.emnlp-main.183.mp4"/>
     </paper>
     <paper id="184">
       <title><fixed-case>EARL</fixed-case>: Informative Knowledge-Grounded Conversation Generation with Entity-Agnostic Representation Learning</title>
@@ -3041,7 +2861,6 @@
       <video href="2021.emnlp-main.184.mp4"/>
       <pwccode url="https://github.com/thu-coai/earl" additional="false">thu-coai/earl</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opendialkg">OpenDialKG</pwcdataset>
-      <video href="2021.emnlp-main.184.mp4"/>
     </paper>
     <paper id="185">
       <title><fixed-case>D</fixed-case>ialogue<fixed-case>CSE</fixed-case>: Dialogue-based Contrastive Learning of Sentence Embeddings</title>
@@ -3060,7 +2879,6 @@
       <pwccode url="https://github.com/wangruicn/dialoguecse" additional="false">wangruicn/dialoguecse</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.185.mp4"/>
     </paper>
     <paper id="186">
       <title>Improving Graph-based Sentence Ordering with Iteratively Predicted Pairwise Orderings</title>
@@ -3080,7 +2898,6 @@
       <doi>10.18653/v1/2021.emnlp-main.186</doi>
       <video href="2021.emnlp-main.186.mp4"/>
       <pwccode url="https://github.com/deeplearnxmu/irseg" additional="false">deeplearnxmu/irseg</pwccode>
-      <video href="2021.emnlp-main.186.mp4"/>
     </paper>
     <paper id="187">
       <title>Not Just Classification: Recognizing Implicit Discourse Relation on Joint Modeling of Classification and Generation</title>
@@ -3095,7 +2912,6 @@
       <bibkey>jiang-etal-2021-just</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.187</doi>
       <video href="2021.emnlp-main.187.mp4"/>
-      <video href="2021.emnlp-main.187.mp4"/>
     </paper>
     <paper id="188">
       <title>A Language Model-based Generative Classifier for Sentence-level Discourse Parsing</title>
@@ -3107,7 +2923,6 @@
       <url hash="23efabaf">2021.emnlp-main.188</url>
       <bibkey>zhang-etal-2021-language</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.188</doi>
-      <video href="2021.emnlp-main.188.mp4"/>
       <video href="2021.emnlp-main.188.mp4"/>
     </paper>
     <paper id="189">
@@ -3126,7 +2941,6 @@
       <pwccode url="https://github.com/chengjunyan1/sp-transformer" additional="false">chengjunyan1/sp-transformer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multimodal-opinionlevel-sentiment-intensity">Multimodal Opinionlevel Sentiment Intensity</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ur-funny">UR-FUNNY</pwcdataset>
-      <video href="2021.emnlp-main.189.mp4"/>
     </paper>
     <paper id="190">
       <title>Hierarchical Multi-label Text Classification with Horizontal and Vertical Category Correlations</title>
@@ -3145,7 +2959,6 @@
       <doi>10.18653/v1/2021.emnlp-main.190</doi>
       <video href="2021.emnlp-main.190.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/web-of-science-dataset">WOS</pwcdataset>
-      <video href="2021.emnlp-main.190.mp4"/>
     </paper>
     <paper id="191">
       <title><fixed-case>R</fixed-case>ank<fixed-case>NAS</fixed-case>: Efficient Neural Architecture Search by Pairwise Ranking</title>
@@ -3180,7 +2993,6 @@
       <video href="2021.emnlp-main.192.mp4"/>
       <pwccode url="https://github.com/valuesimplex/flitext" additional="false">valuesimplex/flitext</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.192.mp4"/>
     </paper>
     <paper id="193">
       <title>Evaluating Debiasing Techniques for Intersectional Biases</title>
@@ -3195,7 +3007,6 @@
       <bibkey>subramanian-etal-2021-evaluating</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.193</doi>
       <video href="2021.emnlp-main.193.mp4"/>
-      <video href="2021.emnlp-main.193.mp4"/>
     </paper>
     <paper id="194">
       <title>Definition Modelling for Appropriate Specificity</title>
@@ -3207,7 +3018,6 @@
       <url hash="2859225b">2021.emnlp-main.194</url>
       <bibkey>huang-etal-2021-definition</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.194</doi>
-      <video href="2021.emnlp-main.194.mp4"/>
       <video href="2021.emnlp-main.194.mp4"/>
     </paper>
     <paper id="195">
@@ -3227,7 +3037,6 @@
       <video href="2021.emnlp-main.195.mp4"/>
       <pwccode url="https://github.com/xiaofei05/tsst" additional="false">xiaofei05/tsst</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
-      <video href="2021.emnlp-main.195.mp4"/>
     </paper>
     <paper id="196">
       <title>Integrating Semantic Scenario and Word Relations for Abstractive Sentence Summarization</title>
@@ -3241,7 +3050,6 @@
       <url hash="525f2c13">2021.emnlp-main.196</url>
       <bibkey>guan-etal-2021-integrating</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.196</doi>
-      <video href="2021.emnlp-main.196.mp4"/>
       <video href="2021.emnlp-main.196.mp4"/>
     </paper>
     <paper id="197">
@@ -3257,7 +3065,6 @@
       <video href="2021.emnlp-main.197.mp4"/>
       <pwccode url="https://github.com/txannie/zp-dnlg" additional="false">txannie/zp-dnlg</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/matinf">MATINF</pwcdataset>
-      <video href="2021.emnlp-main.197.mp4"/>
     </paper>
     <paper id="198">
       <title>Adaptive Bridge between Training and Inference for Dialogue Generation</title>
@@ -3273,7 +3080,6 @@
       <attachment type="Software" hash="42a862a4">2021.emnlp-main.198.Software.zip</attachment>
       <bibkey>xu-etal-2021-adaptive</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.198</doi>
-      <video href="2021.emnlp-main.198.mp4"/>
       <video href="2021.emnlp-main.198.mp4"/>
     </paper>
     <paper id="199">
@@ -3293,7 +3099,6 @@
       <doi>10.18653/v1/2021.emnlp-main.199</doi>
       <video href="2021.emnlp-main.199.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
-      <video href="2021.emnlp-main.199.mp4"/>
     </paper>
     <paper id="200">
       <title>Building the Directed Semantic Graph for Coherent Long Text Generation</title>
@@ -3305,7 +3110,6 @@
       <url hash="b4691e10">2021.emnlp-main.200</url>
       <bibkey>wang-etal-2021-building</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.200</doi>
-      <video href="2021.emnlp-main.200.mp4"/>
       <video href="2021.emnlp-main.200.mp4"/>
     </paper>
     <paper id="201">
@@ -3322,7 +3126,6 @@
       <pwccode url="https://github.com/sion-zcfei/ignd" additional="false">sion-zcfei/ignd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.201.mp4"/>
     </paper>
     <paper id="202">
       <title>Asking Questions Like Educational Experts: <fixed-case>A</fixed-case>utomatically Generating Question-Answer Pairs on Real-World Examination Data</title>
@@ -3337,7 +3140,6 @@
       <video href="2021.emnlp-main.202.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.202.mp4"/>
     </paper>
     <paper id="203">
       <title>Syntactically-Informed Unsupervised Paraphrasing with Non-Parallel Data</title>
@@ -3357,7 +3159,6 @@
       <video href="2021.emnlp-main.203.mp4"/>
       <pwccode url="https://github.com/lanse-sir/sup" additional="false">lanse-sir/sup</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.203.mp4"/>
     </paper>
     <paper id="204">
       <title>Exploring Task Difficulty for Few-Shot Relation Extraction</title>
@@ -3373,7 +3174,6 @@
       <pwccode url="https://github.com/hanjiale/hcrp" additional="false">hanjiale/hcrp</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel-2-0">FewRel 2.0</pwcdataset>
-      <video href="2021.emnlp-main.204.mp4"/>
     </paper>
     <paper id="205">
       <title><fixed-case>M</fixed-case>u<fixed-case>VER</fixed-case>: <fixed-case>I</fixed-case>mproving First-Stage Entity Retrieval with Multi-View Entity Representations</title>
@@ -3392,7 +3192,6 @@
       <video href="2021.emnlp-main.205.mp4"/>
       <pwccode url="https://github.com/alibaba-nlp/muver" additional="false">alibaba-nlp/muver</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/zeshel">ZESHEL</pwcdataset>
-      <video href="2021.emnlp-main.205.mp4"/>
     </paper>
     <paper id="206">
       <title>Treasures Outside Contexts: Improving Event Detection via Global Statistics</title>
@@ -3407,7 +3206,6 @@
       <doi>10.18653/v1/2021.emnlp-main.206</doi>
       <video href="2021.emnlp-main.206.mp4"/>
       <pwccode url="https://github.com/buted/ssjdn" additional="false">buted/ssjdn</pwccode>
-      <video href="2021.emnlp-main.206.mp4"/>
     </paper>
     <paper id="207">
       <title>Uncertain Local-to-Global Networks for Document-Level Event Factuality Identification</title>
@@ -3423,7 +3221,6 @@
       <doi>10.18653/v1/2021.emnlp-main.207</doi>
       <video href="2021.emnlp-main.207.mp4"/>
       <pwccode url="https://github.com/cpf-nlpr/ulgn4docefi" additional="false">cpf-nlpr/ulgn4docefi</pwccode>
-      <video href="2021.emnlp-main.207.mp4"/>
     </paper>
     <paper id="208">
       <title>A Novel Global Feature-Oriented Relational Triple Extraction Model based on Table Filling</title>
@@ -3442,7 +3239,6 @@
       <video href="2021.emnlp-main.208.mp4"/>
       <pwccode url="https://github.com/neukg/GRTE" additional="false">neukg/GRTE</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.emnlp-main.208.mp4"/>
     </paper>
     <paper id="209">
       <title>Structure-Augmented Keyphrase Generation</title>
@@ -3458,7 +3254,6 @@
       <video href="2021.emnlp-main.209.mp4"/>
       <pwccode url="https://github.com/jihyukkim-nlp/straugkg" additional="false">jihyukkim-nlp/straugkg</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/kp20k">KP20k</pwcdataset>
-      <video href="2021.emnlp-main.209.mp4"/>
     </paper>
     <paper id="210">
       <title>An Empirical Study on Multiple Information Sources for Zero-Shot Fine-Grained Entity Typing</title>
@@ -3474,7 +3269,6 @@
       <url hash="25bf15b4">2021.emnlp-main.210</url>
       <bibkey>chen-etal-2021-empirical</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.210</doi>
-      <video href="2021.emnlp-main.210.mp4"/>
       <video href="2021.emnlp-main.210.mp4"/>
     </paper>
     <paper id="211">
@@ -3509,7 +3303,6 @@
       <video href="2021.emnlp-main.212.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.212.mp4"/>
     </paper>
     <paper id="213">
       <title>Heterogeneous Graph Neural Networks for Keyphrase Generation</title>
@@ -3525,7 +3318,6 @@
       <video href="2021.emnlp-main.213.mp4"/>
       <pwccode url="https://github.com/jiacheng-ye/kg_gater" additional="false">jiacheng-ye/kg_gater</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/kp20k">KP20k</pwcdataset>
-      <video href="2021.emnlp-main.213.mp4"/>
     </paper>
     <paper id="214">
       <title>Machine Reading Comprehension as Data Augmentation: A Case Study on Implicit Event Argument Extraction</title>
@@ -3541,7 +3333,6 @@
       <revision id="2" href="2021.emnlp-main.214v2" hash="7a22ed6d" date="2022-01-02">Corrected sponsor number in the Acknowledgments section.</revision>
       <video href="2021.emnlp-main.214.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wikievents">WikiEvents</pwcdataset>
-      <video href="2021.emnlp-main.214.mp4"/>
     </paper>
     <paper id="215">
       <title><fixed-case>I</fixed-case>mportance <fixed-case>E</fixed-case>stimation from <fixed-case>M</fixed-case>ultiple <fixed-case>P</fixed-case>erspectives for <fixed-case>K</fixed-case>eyphrase <fixed-case>E</fixed-case>xtraction</title>
@@ -3555,7 +3346,6 @@
       <doi>10.18653/v1/2021.emnlp-main.215</doi>
       <video href="2021.emnlp-main.215.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/kp20k">KP20k</pwcdataset>
-      <video href="2021.emnlp-main.215.mp4"/>
     </paper>
     <paper id="216">
       <title>Gradient Imitation Reinforcement Learning for Low Resource Relation Extraction</title>
@@ -3574,7 +3364,6 @@
       <video href="2021.emnlp-main.216.mp4"/>
       <pwccode url="https://github.com/thu-bpm/gradlre" additional="false">thu-bpm/gradlre</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2010-task-8">SemEval-2010 Task 8</pwcdataset>
-      <video href="2021.emnlp-main.216.mp4"/>
     </paper>
     <paper id="217">
       <title>Low-resource Taxonomy Enrichment with Pretrained Language Models</title>
@@ -3586,7 +3375,6 @@
       <url hash="a6756f7d">2021.emnlp-main.217</url>
       <bibkey>takeoka-etal-2021-low</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.217</doi>
-      <video href="2021.emnlp-main.217.mp4"/>
       <video href="2021.emnlp-main.217.mp4"/>
     </paper>
     <paper id="218">
@@ -3604,7 +3392,6 @@
       <doi>10.18653/v1/2021.emnlp-main.218</doi>
       <video href="2021.emnlp-main.218.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/funsd">FUNSD</pwcdataset>
-      <video href="2021.emnlp-main.218.mp4"/>
     </paper>
     <paper id="219">
       <title>Synchronous Dual Network with Cross-Type Attention for Joint Entity and Relation Extraction</title>
@@ -3617,7 +3404,6 @@
       <doi>10.18653/v1/2021.emnlp-main.219</doi>
       <video href="2021.emnlp-main.219.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.emnlp-main.219.mp4"/>
     </paper>
     <paper id="220">
       <title>Less is More: Pretrain a Strong <fixed-case>S</fixed-case>iamese Encoder for Dense Text Retrieval Using a Weak Decoder</title>
@@ -3641,7 +3427,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mind">MIND</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.emnlp-main.220.mp4"/>
     </paper>
     <paper id="221">
       <title><fixed-case>T</fixed-case>rans<fixed-case>P</fixed-case>rompt: Towards an Automatic Transferable Prompting Framework for Few-shot Text Classification</title>
@@ -3662,7 +3447,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.221.mp4"/>
     </paper>
     <paper id="222">
       <title>Weakly-supervised Text Classification Based on Keyword Graph</title>
@@ -3680,7 +3464,6 @@
       <pwccode url="https://github.com/zhanglu-cst/classkg" additional="false">zhanglu-cst/classkg</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.222.mp4"/>
     </paper>
     <paper id="223">
       <title>Efficient-<fixed-case>F</fixed-case>ed<fixed-case>R</fixed-case>ec: Efficient Federated Learning Framework for Privacy-Preserving News Recommendation</title>
@@ -3698,7 +3481,6 @@
       <video href="2021.emnlp-main.223.mp4"/>
       <pwccode url="https://github.com/yjw1029/efficient-fedrec" additional="false">yjw1029/efficient-fedrec</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mind">MIND</pwcdataset>
-      <video href="2021.emnlp-main.223.mp4"/>
     </paper>
     <paper id="224">
       <title><fixed-case>R</fixed-case>ocket<fixed-case>QA</fixed-case>v2: A Joint Training Method for Dense Passage Retrieval and Passage Re-ranking</title>
@@ -3719,7 +3501,6 @@
       <pwccode url="https://github.com/paddlepaddle/rocketqa" additional="false">paddlepaddle/rocketqa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.emnlp-main.224.mp4"/>
     </paper>
     <paper id="225">
       <title>Dealing with Typos for <fixed-case>BERT</fixed-case>-based Passage Retrieval and Ranking</title>
@@ -3733,7 +3514,6 @@
       <video href="2021.emnlp-main.225.mp4"/>
       <pwccode url="https://github.com/ielab/typos-aware-bert" additional="true">ielab/typos-aware-bert</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
-      <video href="2021.emnlp-main.225.mp4"/>
     </paper>
     <paper id="226">
       <title>From Alignment to Assignment: Frustratingly Simple Unsupervised Entity Alignment</title>
@@ -3750,7 +3530,6 @@
       <video href="2021.emnlp-main.226.mp4"/>
       <pwccode url="https://github.com/maoxinn/seu" additional="false">maoxinn/seu</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dbp15k">DBP15K</pwcdataset>
-      <video href="2021.emnlp-main.226.mp4"/>
     </paper>
     <paper id="227">
       <title>Simple and Effective Unsupervised Redundancy Elimination to Compress Dense Vectors for Passage Retrieval</title>
@@ -3765,7 +3544,6 @@
       <bibkey>ma-etal-2021-simple</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.227</doi>
       <video href="2021.emnlp-main.227.mp4"/>
-      <video href="2021.emnlp-main.227.mp4"/>
     </paper>
     <paper id="228">
       <title>Relation Extraction with Word Graphs from N-grams</title>
@@ -3779,7 +3557,6 @@
       <doi>10.18653/v1/2021.emnlp-main.228</doi>
       <video href="2021.emnlp-main.228.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2010-task-8">SemEval-2010 Task 8</pwcdataset>
-      <video href="2021.emnlp-main.228.mp4"/>
     </paper>
     <paper id="229">
       <title>A <fixed-case>B</fixed-case>ayesian Framework for Information-Theoretic Probing</title>
@@ -3792,7 +3569,6 @@
       <doi>10.18653/v1/2021.emnlp-main.229</doi>
       <video href="2021.emnlp-main.229.mp4"/>
       <pwccode url="https://github.com/rycolab/bayesian-mi" additional="false">rycolab/bayesian-mi</pwccode>
-      <video href="2021.emnlp-main.229.mp4"/>
     </paper>
     <paper id="230">
       <title>Masked Language Modeling and the Distributional Hypothesis: Order Word Matters Pre-training for Little</title>
@@ -3816,7 +3592,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.emnlp-main.230.mp4"/>
     </paper>
     <paper id="231">
       <title>What’s Hidden in a One-layer Randomly Weighted Transformer?</title>
@@ -3834,7 +3609,6 @@
       <pwccode url="https://github.com/sincerass/one_layer_lottery_ticket" additional="false">sincerass/one_layer_lottery_ticket</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
-      <video href="2021.emnlp-main.231.mp4"/>
     </paper>
     <paper id="232">
       <title>Rethinking Denoised Auto-Encoding in Language Pre-Training</title>
@@ -3854,7 +3628,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/gqa">GQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.emnlp-main.232.mp4"/>
     </paper>
     <paper id="233">
       <title>Lifelong Explainer for Lifelong Learners</title>
@@ -3870,7 +3643,6 @@
       <doi>10.18653/v1/2021.emnlp-main.233</doi>
       <video href="2021.emnlp-main.233.mp4"/>
       <pwccode url="https://github.com/situsnow/lle" additional="false">situsnow/lle</pwccode>
-      <video href="2021.emnlp-main.233.mp4"/>
     </paper>
     <paper id="234">
       <title>Linguistic Dependencies and Statistical Dependence</title>
@@ -3887,7 +3659,6 @@
       <pwccode url="https://github.com/mcqll/cpmi-dependencies" additional="false">mcqll/cpmi-dependencies</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.emnlp-main.234.mp4"/>
     </paper>
     <paper id="235">
       <title>Modeling Human Sentence Processing with Left-Corner Recurrent Neural Network Grammars</title>
@@ -3899,7 +3670,6 @@
       <url hash="11d3baf4">2021.emnlp-main.235</url>
       <bibkey>yoshida-etal-2021-modeling</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.235</doi>
-      <video href="2021.emnlp-main.235.mp4"/>
       <video href="2021.emnlp-main.235.mp4"/>
     </paper>
     <paper id="236">
@@ -3919,7 +3689,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xtreme">XTREME</pwcdataset>
-      <video href="2021.emnlp-main.236.mp4"/>
     </paper>
     <paper id="237">
       <title>Explore Better Relative Position Embeddings from Encoding Perspective for Transformer Models</title>
@@ -3940,7 +3709,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.237.mp4"/>
     </paper>
     <paper id="238">
       <title>Adversarial Mixing Policy for Relaxing Locally Linear Constraints in Mixup</title>
@@ -3957,7 +3725,6 @@
       <video href="2021.emnlp-main.238.mp4"/>
       <pwccode url="https://github.com/pai-smallisallyourneed/mixup-amp" additional="false">pai-smallisallyourneed/mixup-amp</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.238.mp4"/>
     </paper>
     <paper id="239">
       <title>Is this the end of the gold standard? A straightforward reference-less grammatical error correction metric</title>
@@ -3968,7 +3735,6 @@
       <url hash="fc7b3e03">2021.emnlp-main.239</url>
       <bibkey>islam-magnani-2021-end</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.239</doi>
-      <video href="2021.emnlp-main.239.mp4"/>
       <video href="2021.emnlp-main.239.mp4"/>
     </paper>
     <paper id="240">
@@ -3983,7 +3749,6 @@
       <url hash="8ad1c2d5">2021.emnlp-main.240</url>
       <bibkey>araujo-etal-2021-augmenting</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.240</doi>
-      <video href="2021.emnlp-main.240.mp4"/>
       <video href="2021.emnlp-main.240.mp4"/>
     </paper>
     <paper id="241">
@@ -4041,7 +3806,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
-      <video href="2021.emnlp-main.243.mp4"/>
     </paper>
     <paper id="244">
       <title>Scalable Font Reconstruction with Dual Latent Manifolds</title>
@@ -4054,7 +3818,6 @@
       <url hash="436dac35">2021.emnlp-main.244</url>
       <bibkey>srivatsan-etal-2021-scalable</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.244</doi>
-      <video href="2021.emnlp-main.244.mp4"/>
       <video href="2021.emnlp-main.244.mp4"/>
     </paper>
     <paper id="245">
@@ -4072,7 +3835,6 @@
       <doi>10.18653/v1/2021.emnlp-main.245</doi>
       <video href="2021.emnlp-main.245.mp4"/>
       <pwccode url="https://github.com/subhajit1411/slate-text-based-rl" additional="false">subhajit1411/slate-text-based-rl</pwccode>
-      <video href="2021.emnlp-main.245.mp4"/>
     </paper>
     <paper id="246">
       <title>Layer-wise Model Pruning based on Mutual Information</title>
@@ -4091,7 +3853,6 @@
       <video href="2021.emnlp-main.246.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.246.mp4"/>
     </paper>
     <paper id="247">
       <title>Hierarchical Heterogeneous Graph Representation Learning for Short Text Classification</title>
@@ -4106,7 +3867,6 @@
       <doi>10.18653/v1/2021.emnlp-main.247</doi>
       <video href="2021.emnlp-main.247.mp4"/>
       <pwccode url="https://github.com/tata1661/shine-emnlp21" additional="false">tata1661/shine-emnlp21</pwccode>
-      <video href="2021.emnlp-main.247.mp4"/>
     </paper>
     <paper id="248">
       <title><tex-math>k</tex-math><fixed-case>F</fixed-case>olden: <tex-math>k</tex-math>-Fold Ensemble for Out-Of-Distribution Detection</title>
@@ -4142,7 +3902,6 @@
       <pwccode url="https://github.com/gucci-j/light-transformer-emnlp2021" additional="false">gucci-j/light-transformer-emnlp2021</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.249.mp4"/>
     </paper>
     <paper id="250">
       <title><fixed-case>HRKD</fixed-case>: Hierarchical Relational Knowledge Distillation for Cross-domain Language Model Compression</title>
@@ -4158,7 +3917,6 @@
       <video href="2021.emnlp-main.250.mp4"/>
       <pwccode url="https://github.com/cheneydon/hrkd" additional="false">cheneydon/hrkd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-main.250.mp4"/>
     </paper>
     <paper id="251">
       <title>Searching for an Effective Defender: Benchmarking Defense against Adversarial Word Substitution</title>
@@ -4179,7 +3937,6 @@
       <pwccode url="https://github.com/rockylzy/textdefender" additional="false">rockylzy/textdefender</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.251.mp4"/>
     </paper>
     <paper id="252">
       <title>Re-embedding Difficult Samples via Mutual Information Constrained Semantically Oversampling for Imbalanced Text Classification</title>
@@ -4196,7 +3953,6 @@
       <bibkey>tian-etal-2021-embedding</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.252</doi>
       <video href="2021.emnlp-main.252.mp4"/>
-      <video href="2021.emnlp-main.252.mp4"/>
     </paper>
     <paper id="253">
       <title>Beyond Text: Incorporating Metadata and Label Structure for Multi-Label Document Classification using Heterogeneous Graphs</title>
@@ -4211,7 +3967,6 @@
       <bibkey>ye-etal-2021-beyond</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.253</doi>
       <video href="2021.emnlp-main.253.mp4"/>
-      <video href="2021.emnlp-main.253.mp4"/>
     </paper>
     <paper id="254">
       <title>Natural Language Processing Meets Quantum Physics: A Survey and Categorization</title>
@@ -4224,7 +3979,6 @@
       <url hash="77b35949">2021.emnlp-main.254</url>
       <bibkey>wu-etal-2021-natural</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.254</doi>
-      <video href="2021.emnlp-main.254.mp4"/>
       <video href="2021.emnlp-main.254.mp4"/>
     </paper>
     <paper id="255">
@@ -4241,7 +3995,6 @@
       <bibkey>li-etal-2021-metats</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.255</doi>
       <video href="2021.emnlp-main.255.mp4"/>
-      <video href="2021.emnlp-main.255.mp4"/>
     </paper>
     <paper id="256">
       <title>Neural Machine Translation with Heterogeneous Topic Knowledge Embeddings</title>
@@ -4257,7 +4010,6 @@
       <video href="2021.emnlp-main.256.mp4"/>
       <pwccode url="https://github.com/Vicky-Wil/topic-NMT" additional="false">Vicky-Wil/topic-NMT</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
-      <video href="2021.emnlp-main.256.mp4"/>
     </paper>
     <paper id="257">
       <title>Allocating Large Vocabulary Capacity for Cross-Lingual Language Model Pre-Training</title>
@@ -4281,7 +4033,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.emnlp-main.257.mp4"/>
     </paper>
     <paper id="258">
       <title>Recurrent Attention for Neural Machine Translation</title>
@@ -4297,7 +4048,6 @@
       <doi>10.18653/v1/2021.emnlp-main.258</doi>
       <video href="2021.emnlp-main.258.mp4"/>
       <pwccode url="https://github.com/lemon0830/ran" additional="false">lemon0830/ran</pwccode>
-      <video href="2021.emnlp-main.258.mp4"/>
     </paper>
     <paper id="259">
       <title>Learning from Multiple Noisy Augmented Data Sets for Better Cross-Lingual Spoken Language Understanding</title>
@@ -4314,7 +4064,6 @@
       <bibkey>guo-etal-2021-learning</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.259</doi>
       <video href="2021.emnlp-main.259.mp4"/>
-      <video href="2021.emnlp-main.259.mp4"/>
     </paper>
     <paper id="260">
       <title>Enlivening Redundant Heads in Multi-head Self-attention for Machine Translation</title>
@@ -4327,7 +4076,6 @@
       <url hash="69019f53">2021.emnlp-main.260</url>
       <bibkey>zhang-etal-2021-enlivening</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.260</doi>
-      <video href="2021.emnlp-main.260.mp4"/>
       <video href="2021.emnlp-main.260.mp4"/>
     </paper>
     <paper id="261">
@@ -4343,7 +4091,6 @@
       <doi>10.18653/v1/2021.emnlp-main.261</doi>
       <video href="2021.emnlp-main.261.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.emnlp-main.261.mp4"/>
     </paper>
     <paper id="262">
       <title>Encouraging Lexical Translation Consistency for Document-Level Neural Machine Translation</title>
@@ -4356,7 +4103,6 @@
       <url hash="bac39b58">2021.emnlp-main.262</url>
       <bibkey>lyu-etal-2021-encouraging</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.262</doi>
-      <video href="2021.emnlp-main.262.mp4"/>
       <video href="2021.emnlp-main.262.mp4"/>
     </paper>
     <paper id="263">
@@ -4384,7 +4130,6 @@
       <doi>10.18653/v1/2021.emnlp-main.264</doi>
       <video href="2021.emnlp-main.264.mp4"/>
       <pwccode url="https://github.com/adaxry/ss_on_decoding_steps" additional="false">adaxry/ss_on_decoding_steps</pwccode>
-      <video href="2021.emnlp-main.264.mp4"/>
     </paper>
     <paper id="265">
       <title>Learning to Rewrite for Non-Autoregressive Neural Machine Translation</title>
@@ -4398,7 +4143,6 @@
       <doi>10.18653/v1/2021.emnlp-main.265</doi>
       <video href="2021.emnlp-main.265.mp4"/>
       <pwccode url="https://github.com/xwgeng/rewritenat" additional="false">xwgeng/rewritenat</pwccode>
-      <video href="2021.emnlp-main.265.mp4"/>
     </paper>
     <paper id="266">
       <title><fixed-case>SHAPE</fixed-case>: <fixed-case>S</fixed-case>hifted Absolute Position Embedding for Transformers</title>
@@ -4411,7 +4155,6 @@
       <url hash="08df10e5">2021.emnlp-main.266</url>
       <bibkey>kiyono-etal-2021-shape</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.266</doi>
-      <video href="2021.emnlp-main.266.mp4"/>
       <video href="2021.emnlp-main.266.mp4"/>
     </paper>
     <paper id="267">
@@ -4430,7 +4173,6 @@
       <bibkey>zheng-etal-2021-self</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.267</doi>
       <video href="2021.emnlp-main.267.mp4"/>
-      <video href="2021.emnlp-main.267.mp4"/>
     </paper>
     <paper id="268">
       <title>Generalised Unsupervised Domain Adaptation of Neural Machine Translation with Cross-Lingual Data Selection</title>
@@ -4445,7 +4187,6 @@
       <doi>10.18653/v1/2021.emnlp-main.268</doi>
       <video href="2021.emnlp-main.268.mp4"/>
       <pwccode url="https://github.com/trangvu/guda" additional="false">trangvu/guda</pwccode>
-      <video href="2021.emnlp-main.268.mp4"/>
     </paper>
     <paper id="269">
       <title><fixed-case>STANKER</fixed-case>: Stacking Network based on Level-grained Attention-masked <fixed-case>BERT</fixed-case> for Rumor Detection on Social Media</title>
@@ -4461,7 +4202,6 @@
       <doi>10.18653/v1/2021.emnlp-main.269</doi>
       <video href="2021.emnlp-main.269.mp4"/>
       <pwccode url="https://github.com/fip-lab/stanker" additional="false">fip-lab/stanker</pwccode>
-      <video href="2021.emnlp-main.269.mp4"/>
     </paper>
     <paper id="270">
       <title><fixed-case>A</fixed-case>ctive<fixed-case>EA</fixed-case>: Active Learning for Neural Entity Alignment</title>
@@ -4477,7 +4217,6 @@
       <doi>10.18653/v1/2021.emnlp-main.270</doi>
       <video href="2021.emnlp-main.270.mp4"/>
       <pwccode url="https://github.com/uq-neusoft-health-data-science/activeea" additional="false">uq-neusoft-health-data-science/activeea</pwccode>
-      <video href="2021.emnlp-main.270.mp4"/>
     </paper>
     <paper id="271">
       <title>Cost-effective End-to-end Information Extraction for Semi-structured Document Images</title>
@@ -4491,7 +4230,6 @@
       <url hash="6418ff11">2021.emnlp-main.271</url>
       <bibkey>hwang-etal-2021-cost</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.271</doi>
-      <video href="2021.emnlp-main.271.mp4"/>
       <video href="2021.emnlp-main.271.mp4"/>
     </paper>
     <paper id="272">
@@ -4508,7 +4246,6 @@
       <video href="2021.emnlp-main.272.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mawps">MAWPS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/math23k">Math23K</pwcdataset>
-      <video href="2021.emnlp-main.272.mp4"/>
     </paper>
     <paper id="273">
       <title><fixed-case>G</fixed-case>raph<fixed-case>MR</fixed-case>: Graph Neural Network for Mathematical Reasoning</title>
@@ -4522,7 +4259,6 @@
       <url hash="45cbf0ac">2021.emnlp-main.273</url>
       <bibkey>feng-etal-2021-graphmr</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.273</doi>
-      <video href="2021.emnlp-main.273.mp4"/>
       <video href="2021.emnlp-main.273.mp4"/>
     </paper>
     <paper id="274">
@@ -4574,7 +4310,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/klue">KLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/korquad">KorQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.274.mp4"/>
     </paper>
     <paper id="275">
       <title><fixed-case>APIR</fixed-case>ec<fixed-case>X</fixed-case>: Cross-Library <fixed-case>API</fixed-case> Recommendation via Pre-Trained Language Model</title>
@@ -4588,7 +4323,6 @@
       <url hash="7f8992d5">2021.emnlp-main.275</url>
       <bibkey>kang-etal-2021-apirecx</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.275</doi>
-      <video href="2021.emnlp-main.275.mp4"/>
       <video href="2021.emnlp-main.275.mp4"/>
     </paper>
     <paper id="276">
@@ -4607,7 +4341,6 @@
       <doi>10.18653/v1/2021.emnlp-main.276</doi>
       <video href="2021.emnlp-main.276.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/umls">UMLS</pwcdataset>
-      <video href="2021.emnlp-main.276.mp4"/>
     </paper>
     <paper id="277">
       <title><fixed-case>BPM</fixed-case>_<fixed-case>MT</fixed-case>: Enhanced Backchannel Prediction Model using Multi-Task Learning</title>
@@ -4621,7 +4354,6 @@
       <url hash="ebe35ccd">2021.emnlp-main.277</url>
       <bibkey>jang-etal-2021-bpm</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.277</doi>
-      <video href="2021.emnlp-main.277.mp4"/>
       <video href="2021.emnlp-main.277.mp4"/>
     </paper>
     <paper id="278">
@@ -4640,7 +4372,6 @@
       <video href="2021.emnlp-main.278.mp4"/>
       <pwccode url="https://github.com/zequnl/graphex" additional="false">zequnl/graphex</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/graphine">Graphine</pwcdataset>
-      <video href="2021.emnlp-main.278.mp4"/>
     </paper>
     <paper id="279">
       <title>Leveraging Order-Free Tag Relations for Context-Aware Recommendation</title>
@@ -4653,7 +4384,6 @@
       <url hash="28ae4fd0">2021.emnlp-main.279</url>
       <bibkey>kang-etal-2021-leveraging</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.279</doi>
-      <video href="2021.emnlp-main.279.mp4"/>
       <video href="2021.emnlp-main.279.mp4"/>
     </paper>
     <paper id="280">
@@ -4673,7 +4403,6 @@
       <bibkey>xiao-etal-2021-end</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.280</doi>
       <video href="2021.emnlp-main.280.mp4"/>
-      <video href="2021.emnlp-main.280.mp4"/>
     </paper>
     <paper id="281">
       <title>Self-Supervised Curriculum Learning for Spelling Error Correction</title>
@@ -4685,7 +4414,6 @@
       <url hash="81d36531">2021.emnlp-main.281</url>
       <bibkey>gan-etal-2021-self</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.281</doi>
-      <video href="2021.emnlp-main.281.mp4"/>
       <video href="2021.emnlp-main.281.mp4"/>
     </paper>
     <paper id="282">
@@ -4700,7 +4428,6 @@
       <url hash="b364cb3a">2021.emnlp-main.282</url>
       <bibkey>hong-etal-2021-fix</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.282</doi>
-      <video href="2021.emnlp-main.282.mp4"/>
       <video href="2021.emnlp-main.282.mp4"/>
     </paper>
     <paper id="283">
@@ -4720,7 +4447,6 @@
       <bibkey>kimura-etal-2021-neuro</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.283</doi>
       <video href="2021.emnlp-main.283.mp4"/>
-      <video href="2021.emnlp-main.283.mp4"/>
     </paper>
     <paper id="284">
       <title>Biomedical Concept Normalization by Leveraging Hypernyms</title>
@@ -4737,7 +4463,6 @@
       <doi>10.18653/v1/2021.emnlp-main.284</doi>
       <video href="2021.emnlp-main.284.mp4"/>
       <pwccode url="https://github.com/yan-cheng/bcnh" additional="false">yan-cheng/bcnh</pwccode>
-      <video href="2021.emnlp-main.284.mp4"/>
     </paper>
     <paper id="285">
       <title>Leveraging Capsule Routing to Associate Knowledge with Medical Literature Hierarchically</title>
@@ -4755,7 +4480,6 @@
       <doi>10.18653/v1/2021.emnlp-main.285</doi>
       <video href="2021.emnlp-main.285.mp4"/>
       <pwccode url="https://github.com/gdls/hicapsrkl" additional="false">gdls/hicapsrkl</pwccode>
-      <video href="2021.emnlp-main.285.mp4"/>
     </paper>
     <paper id="286">
       <title>Label-Enhanced Hierarchical Contextualized Representation for Sequential Metaphor Identification</title>
@@ -4770,7 +4494,6 @@
       <url hash="303b1959">2021.emnlp-main.286</url>
       <bibkey>li-etal-2021-label</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.286</doi>
-      <video href="2021.emnlp-main.286.mp4"/>
       <video href="2021.emnlp-main.286.mp4"/>
     </paper>
     <paper id="287">
@@ -4804,7 +4527,6 @@
       <video href="2021.emnlp-main.288.mp4"/>
       <pwccode url="https://github.com/ginobilinie/xray_report_generation" additional="false">ginobilinie/xray_report_generation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/chexpert">CheXpert</pwcdataset>
-      <video href="2021.emnlp-main.288.mp4"/>
     </paper>
     <paper id="289">
       <title>Enhancing Document Ranking with Task-adaptive Training and Segmented Token Recovery Mechanism</title>
@@ -4821,7 +4543,6 @@
       <doi>10.18653/v1/2021.emnlp-main.289</doi>
       <video href="2021.emnlp-main.289.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
-      <video href="2021.emnlp-main.289.mp4"/>
     </paper>
     <paper id="290">
       <title>Abstract, Rationale, Stance: A Joint Model for Scientific Claim Verification</title>
@@ -4837,7 +4558,6 @@
       <video href="2021.emnlp-main.290.mp4"/>
       <pwccode url="https://github.com/zhiweizhang97/arsjointmodel" additional="false">zhiweizhang97/arsjointmodel</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
-      <video href="2021.emnlp-main.290.mp4"/>
     </paper>
     <paper id="291">
       <title>A Fine-Grained Domain Adaption Model for Joint Word Segmentation and <fixed-case>POS</fixed-case> Tagging</title>
@@ -4854,7 +4574,6 @@
       <doi>10.18653/v1/2021.emnlp-main.291</doi>
       <video href="2021.emnlp-main.291.mp4"/>
       <pwccode url="https://github.com/jzx555/fgda" additional="false">jzx555/fgda</pwccode>
-      <video href="2021.emnlp-main.291.mp4"/>
     </paper>
     <paper id="292">
       <title>Answering Open-Domain Questions of Varying Reasoning Steps from Text</title>
@@ -4872,7 +4591,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/kilt">KILT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.292.mp4"/>
     </paper>
     <paper id="293">
       <title>Adaptive Information Seeking for Open-Domain Question Answering</title>
@@ -4891,7 +4609,6 @@
       <pwccode url="https://github.com/zycdev/aiso" additional="false">zycdev/aiso</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.293.mp4"/>
     </paper>
     <paper id="294">
       <title>Mapping probability word problems to executable representations</title>
@@ -4909,7 +4626,6 @@
       <doi>10.18653/v1/2021.emnlp-main.294</doi>
       <video href="2021.emnlp-main.294.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mathqa">MathQA</pwcdataset>
-      <video href="2021.emnlp-main.294.mp4"/>
     </paper>
     <paper id="295">
       <title>Enhancing Multiple-choice Machine Reading Comprehension by Punishing Illogical Interpretations</title>
@@ -4931,7 +4647,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multirc">MultiRC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.emnlp-main.295.mp4"/>
     </paper>
     <paper id="296">
       <title>Large-Scale Relation Learning for Question Answering over Knowledge Bases with Pre-trained Language Models</title>
@@ -4951,7 +4666,6 @@
       <video href="2021.emnlp-main.296.mp4"/>
       <pwccode url="https://github.com/yym6472/kbqarelationlearning" additional="false">yym6472/kbqarelationlearning</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
-      <video href="2021.emnlp-main.296.mp4"/>
     </paper>
     <paper id="297">
       <title>Phrase Retrieval Learns Passage Retrieval, Too</title>
@@ -4969,7 +4683,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.297.mp4"/>
     </paper>
     <paper id="298">
       <title>Neural Natural Logic Inference for Interpretable Question Answering</title>
@@ -4985,7 +4698,6 @@
       <doi>10.18653/v1/2021.emnlp-main.298</doi>
       <video href="2021.emnlp-main.298.mp4"/>
       <pwccode url="https://github.com/shijihao/neunli" additional="false">shijihao/neunli</pwccode>
-      <video href="2021.emnlp-main.298.mp4"/>
     </paper>
     <paper id="299">
       <title>Smoothing Dialogue States for Open Conversational Machine Reading</title>
@@ -5002,7 +4714,6 @@
       <video href="2021.emnlp-main.299.mp4"/>
       <pwccode url="https://github.com/ozyyshr/oscar" additional="false">ozyyshr/oscar</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sharc">ShARC</pwcdataset>
-      <video href="2021.emnlp-main.299.mp4"/>
     </paper>
     <paper id="300">
       <title><fixed-case>F</fixed-case>in<fixed-case>QA</fixed-case>: A Dataset of Numerical Reasoning over Financial Data</title>
@@ -5027,7 +4738,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/finqa">FinQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mathqa">MathQA</pwcdataset>
-      <video href="2021.emnlp-main.300.mp4"/>
     </paper>
     <paper id="301">
       <title><fixed-case>F</fixed-case>i<fixed-case>D</fixed-case>-Ex: Improving Sequence-to-Sequence Models for Extractive Rationale Generation</title>
@@ -5042,7 +4752,6 @@
       <url hash="93756ecd">2021.emnlp-main.301</url>
       <bibkey>lakhotia-etal-2021-fid</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.301</doi>
-      <video href="2021.emnlp-main.301.mp4"/>
       <video href="2021.emnlp-main.301.mp4"/>
     </paper>
     <paper id="302">
@@ -5061,7 +4770,6 @@
       <pwccode url="https://github.com/INK-USC/RockNER" additional="false">INK-USC/RockNER</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ontorock">OntoRock</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ontonotes-5-0">OntoNotes 5.0</pwcdataset>
-      <video href="2021.emnlp-main.302.mp4"/>
     </paper>
     <paper id="303">
       <title>Diagnosing the First-Order Logical Reasoning Ability Through <fixed-case>L</fixed-case>ogic<fixed-case>NLI</fixed-case></title>
@@ -5079,7 +4787,6 @@
       <video href="2021.emnlp-main.303.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/logiqa">LogiQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/reclor">ReClor</pwcdataset>
-      <video href="2021.emnlp-main.303.mp4"/>
     </paper>
     <paper id="304">
       <title>Constructing a Psychometric Testbed for Fair Natural Language Processing</title>
@@ -5097,7 +4804,6 @@
       <video href="2021.emnlp-main.304.mp4"/>
       <pwccode url="https://github.com/nd-hal/fair-psych-nlp" additional="false">nd-hal/fair-psych-nlp</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/psychometric-nlp">Psychometric NLP</pwcdataset>
-      <video href="2021.emnlp-main.304.mp4"/>
     </paper>
     <paper id="305">
       <title><fixed-case>COUGH</fixed-case>: A Challenge Dataset and Models for <fixed-case>COVID</fixed-case>-19 <fixed-case>FAQ</fixed-case> Retrieval</title>
@@ -5114,7 +4820,6 @@
       <video href="2021.emnlp-main.305.mp4"/>
       <pwccode url="https://github.com/sunlab-osu/covid-faq" additional="false">sunlab-osu/covid-faq</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cough">COUGH</pwcdataset>
-      <video href="2021.emnlp-main.305.mp4"/>
     </paper>
     <paper id="306">
       <title><fixed-case>C</fixed-case>hinese <fixed-case>WPLC</fixed-case>: A <fixed-case>C</fixed-case>hinese Dataset for Evaluating Pretrained Language Models on Word Prediction Given Long-Range Context</title>
@@ -5132,7 +4837,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/lambada">LAMBADA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
-      <video href="2021.emnlp-main.306.mp4"/>
     </paper>
     <paper id="307">
       <title><fixed-case>W</fixed-case>ino<fixed-case>L</fixed-case>ogic: <fixed-case>A</fixed-case> Zero-Shot Logic-based Diagnostic Dataset for <fixed-case>W</fixed-case>inograd <fixed-case>S</fixed-case>chema <fixed-case>C</fixed-case>hallenge</title>
@@ -5153,7 +4857,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
-      <video href="2021.emnlp-main.307.mp4"/>
     </paper>
     <paper id="308">
       <title>Pseudo Zero Pronoun Resolution Improves Zero Anaphora Resolution</title>
@@ -5169,7 +4872,6 @@
       <doi>10.18653/v1/2021.emnlp-main.308</doi>
       <video href="2021.emnlp-main.308.mp4"/>
       <pwccode url="https://github.com/ryuto10/pzero-improves-zar" additional="false">ryuto10/pzero-improves-zar</pwccode>
-      <video href="2021.emnlp-main.308.mp4"/>
     </paper>
     <paper id="309">
       <title>Aligning Cross-lingual Sentence Representations with Dual Momentum Contrast</title>
@@ -5183,7 +4885,6 @@
       <doi>10.18653/v1/2021.emnlp-main.309</doi>
       <video href="2021.emnlp-main.309.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.emnlp-main.309.mp4"/>
     </paper>
     <paper id="310">
       <title>Total Recall: a Customized Continual Learning Method for Neural Semantic Parsers</title>
@@ -5197,7 +4898,6 @@
       <doi>10.18653/v1/2021.emnlp-main.310</doi>
       <video href="2021.emnlp-main.310.mp4"/>
       <pwccode url="https://github.com/zhuang-li/cl_nsp" additional="false">zhuang-li/cl_nsp</pwccode>
-      <video href="2021.emnlp-main.310.mp4"/>
     </paper>
     <paper id="311">
       <title>Exophoric Pronoun Resolution in Dialogues with Topic Regularization</title>
@@ -5215,7 +4915,6 @@
       <video href="2021.emnlp-main.311.mp4"/>
       <pwccode url="https://github.com/hkust-knowcomp/exo-pcr" additional="false">hkust-knowcomp/exo-pcr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/vispro">VisPro</pwcdataset>
-      <video href="2021.emnlp-main.311.mp4"/>
     </paper>
     <paper id="312">
       <title>Context-Aware Interaction Network for Question Matching</title>
@@ -5228,7 +4927,6 @@
       <url hash="88d61c2f">2021.emnlp-main.312</url>
       <bibkey>hu-etal-2021-context</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.312</doi>
-      <video href="2021.emnlp-main.312.mp4"/>
       <video href="2021.emnlp-main.312.mp4"/>
     </paper>
     <paper id="313">
@@ -5246,7 +4944,6 @@
       <doi>10.18653/v1/2021.emnlp-main.313</doi>
       <video href="2021.emnlp-main.313.mp4"/>
       <pwccode url="https://github.com/liu-zichen/TEMP" additional="false">liu-zichen/TEMP</pwccode>
-      <video href="2021.emnlp-main.313.mp4"/>
     </paper>
     <paper id="314">
       <title>A Graph-Based Neural Model for End-to-End Frame Semantic Parsing</title>
@@ -5261,7 +4958,6 @@
       <video href="2021.emnlp-main.314.mp4"/>
       <pwccode url="https://github.com/ch4osmy7h/framenetparser" additional="false">ch4osmy7h/framenetparser</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
-      <video href="2021.emnlp-main.314.mp4"/>
     </paper>
     <paper id="315">
       <title>Virtual Data Augmentation: A Robust and General Framework for Fine-tuning Pre-trained Models</title>
@@ -5281,7 +4977,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.emnlp-main.315.mp4"/>
     </paper>
     <paper id="316">
       <title><fixed-case>CATE</fixed-case>: A Contrastive Pre-trained Model for Metaphor Detection with Semi-supervised Learning</title>
@@ -5294,7 +4989,6 @@
       <url hash="78659a3c">2021.emnlp-main.316</url>
       <bibkey>lin-etal-2021-cate</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.316</doi>
-      <video href="2021.emnlp-main.316.mp4"/>
       <video href="2021.emnlp-main.316.mp4"/>
     </paper>
     <paper id="317">
@@ -5312,7 +5006,6 @@
       <doi>10.18653/v1/2021.emnlp-main.317</doi>
       <video href="2021.emnlp-main.317.mp4"/>
       <pwccode url="https://github.com/zyxnlp/aclt" additional="false">zyxnlp/aclt</pwccode>
-      <video href="2021.emnlp-main.317.mp4"/>
     </paper>
     <paper id="318">
       <title>Seeking Common but Distinguishing Difference, A Joint Aspect-based Sentiment Analysis Model</title>
@@ -5331,7 +5024,6 @@
       <video href="2021.emnlp-main.318.mp4"/>
       <pwccode url="https://github.com/betahj/pairabsa" additional="false">betahj/pairabsa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aste-data-v2">ASTE-Data-V2</pwcdataset>
-      <video href="2021.emnlp-main.318.mp4"/>
     </paper>
     <paper id="319">
       <title>Argument Pair Extraction with Mutual Guidance and Inter-sentence Relation Graph</title>
@@ -5348,7 +5040,6 @@
       <doi>10.18653/v1/2021.emnlp-main.319</doi>
       <video href="2021.emnlp-main.319.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/rr">RR</pwcdataset>
-      <video href="2021.emnlp-main.319.mp4"/>
     </paper>
     <paper id="320">
       <title>Emotion Inference in Multi-Turn Conversations with Addressee-Aware Module and Ensemble Strategy</title>
@@ -5368,7 +5059,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/emorynlp">EmoryNLP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
-      <video href="2021.emnlp-main.320.mp4"/>
     </paper>
     <paper id="321">
       <title>Improving Federated Learning for Aspect-based Sentiment Analysis via Topic Memories</title>
@@ -5381,7 +5071,6 @@
       <url hash="7975515f">2021.emnlp-main.321</url>
       <bibkey>qin-etal-2021-improving-federated</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.321</doi>
-      <video href="2021.emnlp-main.321.mp4"/>
       <video href="2021.emnlp-main.321.mp4"/>
     </paper>
     <paper id="322">
@@ -5396,7 +5085,6 @@
       <doi>10.18653/v1/2021.emnlp-main.322</doi>
       <video href="2021.emnlp-main.322.mp4"/>
       <pwccode url="https://github.com/nustm/coqe" additional="false">nustm/coqe</pwccode>
-      <video href="2021.emnlp-main.322.mp4"/>
     </paper>
     <paper id="323">
       <title><fixed-case>CTAL</fixed-case>: Pre-training Cross-modal Transformer for Audio-and-Language Representations</title>
@@ -5415,7 +5103,6 @@
       <pwccode url="https://github.com/ydkwim/ctal" additional="false">ydkwim/ctal</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/iemocap">IEMOCAP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
-      <video href="2021.emnlp-main.323.mp4"/>
     </paper>
     <paper id="324">
       <title>Relation-aware Video Reading Comprehension for Temporal Language Grounding</title>
@@ -5434,7 +5121,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/activitynet-captions">ActivityNet Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/charades">Charades</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/charades-sta">Charades-STA</pwcdataset>
-      <video href="2021.emnlp-main.324.mp4"/>
     </paper>
     <paper id="325">
       <title>Mutual-Learning Improves End-to-End Speech Translation</title>
@@ -5449,7 +5135,6 @@
       <doi>10.18653/v1/2021.emnlp-main.325</doi>
       <video href="2021.emnlp-main.325.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/must-c">MuST-C</pwcdataset>
-      <video href="2021.emnlp-main.325.mp4"/>
     </paper>
     <paper id="326">
       <title>Vision Guided Generative Pre-trained Language Models for Multimodal Abstractive Summarization</title>
@@ -5466,7 +5151,6 @@
       <video href="2021.emnlp-main.326.mp4"/>
       <pwccode url="https://github.com/hltchkust/vg-gplms" additional="false">hltchkust/vg-gplms</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/how2">How2</pwcdataset>
-      <video href="2021.emnlp-main.326.mp4"/>
     </paper>
     <paper id="327">
       <title>Natural Language Video Localization with Learnable Moment Proposals</title>
@@ -5484,7 +5168,6 @@
       <pwccode url="https://github.com/xiaoneil/lpnet" additional="false">xiaoneil/lpnet</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/activitynet-captions">ActivityNet Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/charades-sta">Charades-STA</pwcdataset>
-      <video href="2021.emnlp-main.327.mp4"/>
     </paper>
     <paper id="328">
       <title>Language-Aligned Waypoint (<fixed-case>LAW</fixed-case>) Supervision for Vision-and-Language Navigation in Continuous Environments</title>
@@ -5499,7 +5182,6 @@
       <bibkey>raychaudhuri-etal-2021-language</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.328</doi>
       <video href="2021.emnlp-main.328.mp4"/>
-      <video href="2021.emnlp-main.328.mp4"/>
     </paper>
     <paper id="329">
       <title>How to leverage the multimodal <fixed-case>EHR</fixed-case> data for better medical prediction?</title>
@@ -5510,7 +5192,6 @@
       <url hash="e3eea29c">2021.emnlp-main.329</url>
       <bibkey>yang-wu-2021-leverage</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.329</doi>
-      <video href="2021.emnlp-main.329.mp4"/>
       <video href="2021.emnlp-main.329.mp4"/>
     </paper>
     <paper id="330">
@@ -5526,7 +5207,6 @@
       <doi>10.18653/v1/2021.emnlp-main.330</doi>
       <video href="2021.emnlp-main.330.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
-      <video href="2021.emnlp-main.330.mp4"/>
     </paper>
     <paper id="331">
       <title>Frame Semantic-Enhanced Sentence Modeling for Sentence-level Extractive Text Summarization</title>
@@ -5540,7 +5220,6 @@
       <url hash="a1101768">2021.emnlp-main.331</url>
       <bibkey>guan-etal-2021-frame</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.331</doi>
-      <video href="2021.emnlp-main.331.mp4"/>
       <video href="2021.emnlp-main.331.mp4"/>
     </paper>
     <paper id="332">
@@ -5559,7 +5238,6 @@
       <doi>10.18653/v1/2021.emnlp-main.332</doi>
       <video href="2021.emnlp-main.332.mp4"/>
       <pwccode url="https://github.com/DeepSoftwareAnalytics/CAST" additional="false">DeepSoftwareAnalytics/CAST</pwccode>
-      <video href="2021.emnlp-main.332.mp4"/>
     </paper>
     <paper id="333">
       <title><fixed-case>S</fixed-case>g<fixed-case>S</fixed-case>um:Transforming Multi-document Summarization into Sub-graph Selection</title>
@@ -5577,7 +5255,6 @@
       <video href="2021.emnlp-main.333.mp4"/>
       <pwccode url="https://github.com/PaddlePaddle/Research/tree/master/NLP/EMNLP2021-SgSum" additional="false">PaddlePaddle/Research</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multi-news">Multi-News</pwcdataset>
-      <video href="2021.emnlp-main.333.mp4"/>
     </paper>
     <paper id="334">
       <title>Event Graph based Sentence Fusion</title>
@@ -5592,7 +5269,6 @@
       <doi>10.18653/v1/2021.emnlp-main.334</doi>
       <video href="2021.emnlp-main.334.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/multi-news">Multi-News</pwcdataset>
-      <video href="2021.emnlp-main.334.mp4"/>
     </paper>
     <paper id="335">
       <title>Transformer-based Lexically Constrained Headline Generation</title>
@@ -5611,7 +5287,6 @@
       <video href="2021.emnlp-main.335.mp4"/>
       <pwccode url="https://github.com/asahi-research/script-for-transformer-based-seq2bf" additional="false">asahi-research/script-for-transformer-based-seq2bf</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/jnc">JNC</pwcdataset>
-      <video href="2021.emnlp-main.335.mp4"/>
     </paper>
     <paper id="336">
       <title>Learn to Copy from the Copying History: Correlational Copy Network for Abstractive Summarization</title>
@@ -5631,7 +5306,6 @@
       <pwccode url="https://github.com/hrlinlp/coconet" additional="false">hrlinlp/coconet</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.emnlp-main.336.mp4"/>
     </paper>
     <paper id="337">
       <title>Gradient-Based Adversarial Factual Consistency Evaluation for Abstractive Summarization</title>
@@ -5646,7 +5320,6 @@
       <doi>10.18653/v1/2021.emnlp-main.337</doi>
       <video href="2021.emnlp-main.337.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
-      <video href="2021.emnlp-main.337.mp4"/>
     </paper>
     <paper id="338">
       <title>Word Reordering for Zero-shot Cross-lingual Structured Prediction</title>
@@ -5699,7 +5372,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/newsqa">NewsQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.340.mp4"/>
     </paper>
     <paper id="341">
       <title><fixed-case>T</fixed-case>ransfer<fixed-case>N</fixed-case>et: An Effective and Transparent Framework for Multi-hop Question Answering over Relation Graph</title>
@@ -5718,7 +5390,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/metaqa">MetaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/simplequestions">SimpleQuestions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikimovies">WikiMovies</pwcdataset>
-      <video href="2021.emnlp-main.341.mp4"/>
     </paper>
     <paper id="342">
       <title>Topic Transferable Table Question Answering</title>
@@ -5739,7 +5410,6 @@
       <pwccode url="https://github.com/ibm/t3qa" additional="false">ibm/t3qa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitablequestions">WikiTableQuestions</pwcdataset>
-      <video href="2021.emnlp-main.342.mp4"/>
     </paper>
     <paper id="343">
       <title><fixed-case>W</fixed-case>eb<fixed-case>SRC</fixed-case>: A Dataset for Web-Based Structural Reading Comprehension</title>
@@ -5758,7 +5428,6 @@
       <doi>10.18653/v1/2021.emnlp-main.343</doi>
       <video href="2021.emnlp-main.343.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.343.mp4"/>
     </paper>
     <paper id="344">
       <title>Cryptonite: A Cryptic Crossword Benchmark for Extreme Ambiguity in Language</title>
@@ -5773,7 +5442,6 @@
       <doi>10.18653/v1/2021.emnlp-main.344</doi>
       <video href="2021.emnlp-main.344.mp4"/>
       <pwccode url="https://github.com/aviaefrat/cryptonite" additional="false">aviaefrat/cryptonite</pwccode>
-      <video href="2021.emnlp-main.344.mp4"/>
     </paper>
     <paper id="345">
       <title>End-to-End Entity Resolution and Question Answering Using Differentiable Knowledge Graphs</title>
@@ -5788,7 +5456,6 @@
       <doi>10.18653/v1/2021.emnlp-main.345</doi>
       <video href="2021.emnlp-main.345.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/simplequestions">SimpleQuestions</pwcdataset>
-      <video href="2021.emnlp-main.345.mp4"/>
     </paper>
     <paper id="346">
       <title>Improving Query Graph Generation for Complex Question Answering over Knowledge Base</title>
@@ -5803,7 +5470,6 @@
       <doi>10.18653/v1/2021.emnlp-main.346</doi>
       <video href="2021.emnlp-main.346.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/simplequestions">SimpleQuestions</pwcdataset>
-      <video href="2021.emnlp-main.346.mp4"/>
     </paper>
     <paper id="347">
       <title><fixed-case>D</fixed-case>isco<fixed-case>DVT</fixed-case>: <fixed-case>G</fixed-case>enerating Long Text with Discourse-Aware Discrete Variational Transformer</title>
@@ -5818,7 +5484,6 @@
       <pwccode url="https://github.com/cdjhz/discodvt" additional="false">cdjhz/discodvt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bookcorpus">BookCorpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/writingprompts">WritingPrompts</pwcdataset>
-      <video href="2021.emnlp-main.347.mp4"/>
     </paper>
     <paper id="348">
       <title>Mathematical Word Problem Generation from Commonsense Knowledge Graph and Equations</title>
@@ -5837,7 +5502,6 @@
       <pwccode url="https://github.com/tal-ai/make_emnlp2021" additional="false">tal-ai/make_emnlp2021</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mawps">MAWPS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mathqa">MathQA</pwcdataset>
-      <video href="2021.emnlp-main.348.mp4"/>
     </paper>
     <paper id="349">
       <title>Generic resources are what you need: Style transfer tasks without task-specific parallel training data</title>
@@ -5852,7 +5516,6 @@
       <video href="2021.emnlp-main.349.mp4"/>
       <pwccode url="https://github.com/laihuiyuan/generic-resources-for-tst" additional="false">laihuiyuan/generic-resources-for-tst</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
-      <video href="2021.emnlp-main.349.mp4"/>
     </paper>
     <paper id="350">
       <title>Revisiting Pivot-Based Paraphrase Generation: Language Is Not the Only Optional Pivot</title>
@@ -5864,7 +5527,6 @@
       <url hash="4f481e59">2021.emnlp-main.350</url>
       <bibkey>cai-etal-2021-revisiting</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.350</doi>
-      <video href="2021.emnlp-main.350.mp4"/>
       <video href="2021.emnlp-main.350.mp4"/>
     </paper>
     <paper id="351">
@@ -5881,7 +5543,6 @@
       <pwccode url="https://github.com/ukplab/structadapt" additional="false">ukplab/structadapt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/amr3-0">AMR3.0</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ldc2020t02">LDC2020T02</pwcdataset>
-      <video href="2021.emnlp-main.351.mp4"/>
     </paper>
     <paper id="352">
       <title>Data-to-text Generation by Splicing Together Nearest Neighbors</title>
@@ -5896,7 +5557,6 @@
       <video href="2021.emnlp-main.352.mp4"/>
       <pwccode url="https://github.com/swiseman/neighbor-splicing" additional="false">swiseman/neighbor-splicing</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikibio">WikiBio</pwcdataset>
-      <video href="2021.emnlp-main.352.mp4"/>
     </paper>
     <paper id="353">
       <title>Contextualize Knowledge Bases with Transformer for End-to-end Task-Oriented Dialogue Systems</title>
@@ -5938,7 +5598,6 @@
       <video href="2021.emnlp-main.355.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/redial">ReDial</pwcdataset>
-      <video href="2021.emnlp-main.355.mp4"/>
     </paper>
     <paper id="356">
       <title><fixed-case>D</fixed-case>u<fixed-case>R</fixed-case>ec<fixed-case>D</fixed-case>ial 2.0: A Bilingual Parallel Corpus for Conversational Recommendation</title>
@@ -5956,7 +5615,6 @@
       <pwccode url="https://github.com/liuzeming01/durecdial" additional="false">liuzeming01/durecdial</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/durecdial">DuRecDial</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/redial">ReDial</pwcdataset>
-      <video href="2021.emnlp-main.356.mp4"/>
     </paper>
     <paper id="357">
       <title>End-to-End Learning of Flowchart Grounded Task-Oriented Dialogs</title>
@@ -5972,7 +5630,6 @@
       <video href="2021.emnlp-main.357.mp4"/>
       <pwccode url="https://github.com/dair-iitd/flonet" additional="false">dair-iitd/flonet</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/flodial">FloDial</pwcdataset>
-      <video href="2021.emnlp-main.357.mp4"/>
     </paper>
     <paper id="358">
       <title>Dimensional Emotion Detection from Categorical Emotion</title>
@@ -5991,7 +5648,6 @@
       <pwccode url="https://github.com/sungjoonpark/emotiondetection" additional="false">sungjoonpark/emotiondetection</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/emobank">EmoBank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/isear">ISEAR</pwcdataset>
-      <video href="2021.emnlp-main.358.mp4"/>
     </paper>
     <paper id="359">
       <title>Not All Negatives are Equal: <fixed-case>L</fixed-case>abel-Aware Contrastive Loss for Fine-grained Text Classification</title>
@@ -6007,7 +5663,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/goemotions">GoEmotions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/isear">ISEAR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.359.mp4"/>
     </paper>
     <paper id="360">
       <title>Joint Multi-modal Aspect-Sentiment Analysis with Auxiliary Cross-modal Relation Detection</title>
@@ -6025,7 +5680,6 @@
       <doi>10.18653/v1/2021.emnlp-main.360</doi>
       <video href="2021.emnlp-main.360.mp4"/>
       <pwccode url="https://github.com/manlp-suda/jml" additional="false">manlp-suda/jml</pwccode>
-      <video href="2021.emnlp-main.360.mp4"/>
     </paper>
     <paper id="361">
       <title>Solving Aspect Category Sentiment Analysis as a Text Generation Task</title>
@@ -6042,7 +5696,6 @@
       <video href="2021.emnlp-main.361.mp4"/>
       <pwccode url="https://github.com/lgw863/acsa-generation" additional="false">lgw863/acsa-generation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mams">MAMS</pwcdataset>
-      <video href="2021.emnlp-main.361.mp4"/>
     </paper>
     <paper id="362">
       <title>Semantics-Preserved Data Augmentation for Aspect-Based Sentiment Analysis</title>
@@ -6060,7 +5713,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mams">MAMS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/stocknet-1">StockNet</pwcdataset>
-      <video href="2021.emnlp-main.362.mp4"/>
     </paper>
     <paper id="363">
       <title>The Effect of Round-Trip Translation on Fairness in Sentiment Analysis</title>
@@ -6073,7 +5725,6 @@
       <bibkey>christiansen-etal-2021-effect</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.363</doi>
       <video href="2021.emnlp-main.363.mp4"/>
-      <video href="2021.emnlp-main.363.mp4"/>
     </paper>
     <paper id="364">
       <title><fixed-case>CH</fixed-case>o<fixed-case>R</fixed-case>a<fixed-case>L</fixed-case>: Collecting Humor Reaction Labels from Millions of Social Media Users</title>
@@ -6085,7 +5736,6 @@
       <url hash="05b67585">2021.emnlp-main.364</url>
       <bibkey>yang-etal-2021-choral</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.364</doi>
-      <video href="2021.emnlp-main.364.mp4"/>
       <video href="2021.emnlp-main.364.mp4"/>
     </paper>
     <paper id="365">
@@ -6104,7 +5754,6 @@
       <doi>10.18653/v1/2021.emnlp-main.365</doi>
       <video href="2021.emnlp-main.365.mp4"/>
       <pwccode url="https://github.com/xiaolinAndy/CSDS" additional="false">xiaolinAndy/CSDS</pwccode>
-      <video href="2021.emnlp-main.365.mp4"/>
     </paper>
     <paper id="366">
       <title><fixed-case>C</fixed-case>od<fixed-case>RED</fixed-case>: A Cross-Document Relation Extraction Dataset for Acquiring Knowledge in the Wild</title>
@@ -6126,7 +5775,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/knowledgenet">KnowledgeNet</pwcdataset>
-      <video href="2021.emnlp-main.366.mp4"/>
     </paper>
     <paper id="367">
       <title>Building and Evaluating Open-Domain Dialogue Corpora with Clarifying Questions</title>
@@ -6144,7 +5792,6 @@
       <pwccode url="https://github.com/aliannejadi/ClariQ" additional="false">aliannejadi/ClariQ</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/clariq">ClariQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qulac">Qulac</pwcdataset>
-      <video href="2021.emnlp-main.367.mp4"/>
     </paper>
     <paper id="368">
       <title>We Need to Talk About train-dev-test Splits</title>
@@ -6157,7 +5804,6 @@
       <doi>10.18653/v1/2021.emnlp-main.368</doi>
       <video href="2021.emnlp-main.368.mp4"/>
       <pwccode url="https://bitbucket.org/robvanderg/tuneset" additional="false">robvanderg/tuneset</pwccode>
-      <video href="2021.emnlp-main.368.mp4"/>
     </paper>
     <paper id="369">
       <title><fixed-case>P</fixed-case>ho<fixed-case>MT</fixed-case>: A High-Quality and Large-Scale Benchmark Dataset for <fixed-case>V</fixed-case>ietnamese-<fixed-case>E</fixed-case>nglish Machine Translation</title>
@@ -6176,7 +5822,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/phomt">PhoMT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikimatrix">WikiMatrix</pwcdataset>
-      <video href="2021.emnlp-main.369.mp4"/>
     </paper>
     <paper id="370">
       <title>Lying Through One’s Teeth: A Study on Verbal Leakage Cues</title>
@@ -6204,7 +5849,6 @@
       <pwccode url="https://github.com/yangyi-chen/maya" additional="false">yangyi-chen/maya</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.371.mp4"/>
     </paper>
     <paper id="372">
       <title>All Bark and No Bite: Rogue Dimensions in Transformer Language Models Obscure Representational Quality</title>
@@ -6217,7 +5861,6 @@
       <doi>10.18653/v1/2021.emnlp-main.372</doi>
       <video href="2021.emnlp-main.372.mp4"/>
       <pwccode url="https://github.com/wtimkey/rogue-dimensions" additional="false">wtimkey/rogue-dimensions</pwccode>
-      <video href="2021.emnlp-main.372.mp4"/>
     </paper>
     <paper id="373">
       <title><fixed-case>I</fixed-case>ncorporating <fixed-case>R</fixed-case>esidual and <fixed-case>N</fixed-case>ormalization <fixed-case>L</fixed-case>ayers into <fixed-case>A</fixed-case>nalysis of <fixed-case>M</fixed-case>asked <fixed-case>L</fixed-case>anguage <fixed-case>M</fixed-case>odels</title>
@@ -6235,7 +5878,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.373.mp4"/>
     </paper>
     <paper id="374">
       <title>Mind the Style of Text! Adversarial and Backdoor Attacks Based on Text Style Transfer</title>
@@ -6254,7 +5896,6 @@
       <pwccode url="https://github.com/thunlp/styleattack" additional="false">thunlp/styleattack</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hate-speech">Hate Speech</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.374.mp4"/>
     </paper>
     <paper id="375">
       <title>Sociolectal Analysis of Pretrained Language Models</title>
@@ -6268,7 +5909,6 @@
       <bibkey>zhang-etal-2021-sociolectal</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.375</doi>
       <video href="2021.emnlp-main.375.mp4"/>
-      <video href="2021.emnlp-main.375.mp4"/>
     </paper>
     <paper id="376">
       <title>Examining Cross-lingual Contextual Embeddings with Orthogonal Structural Probes</title>
@@ -6279,7 +5919,6 @@
       <url hash="029bce0d">2021.emnlp-main.376</url>
       <bibkey>limisiewicz-marecek-2021-examining</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.376</doi>
-      <video href="2021.emnlp-main.376.mp4"/>
       <video href="2021.emnlp-main.376.mp4"/>
     </paper>
     <paper id="377">
@@ -6292,7 +5931,6 @@
       <url hash="5e9da7db">2021.emnlp-main.377</url>
       <bibkey>li-etal-2021-transformers</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.377</doi>
-      <video href="2021.emnlp-main.377.mp4"/>
       <video href="2021.emnlp-main.377.mp4"/>
     </paper>
     <paper id="378">
@@ -6310,7 +5948,6 @@
       <doi>10.18653/v1/2021.emnlp-main.378</doi>
       <video href="2021.emnlp-main.378.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/open-entity-1">Open Entity</pwcdataset>
-      <video href="2021.emnlp-main.378.mp4"/>
     </paper>
     <paper id="379">
       <title>Enhanced Language Representation with Label Knowledge for Span Extraction</title>
@@ -6325,7 +5962,6 @@
       <doi>10.18653/v1/2021.emnlp-main.379</doi>
       <video href="2021.emnlp-main.379.mp4"/>
       <pwccode url="https://github.com/akeepers/lear" additional="false">akeepers/lear</pwccode>
-      <video href="2021.emnlp-main.379.mp4"/>
     </paper>
     <paper id="380">
       <title><fixed-case>PRIDE</fixed-case>: <fixed-case>P</fixed-case>redicting <fixed-case>R</fixed-case>elationships in <fixed-case>C</fixed-case>onversations</title>
@@ -6340,7 +5976,6 @@
       <doi>10.18653/v1/2021.emnlp-main.380</doi>
       <video href="2021.emnlp-main.380.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ddrel">DDRel</pwcdataset>
-      <video href="2021.emnlp-main.380.mp4"/>
     </paper>
     <paper id="381">
       <title>Extracting Fine-Grained Knowledge Graphs of Scientific Claims: Dataset and Transformer-Based Results</title>
@@ -6356,7 +5991,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cord-19">CORD-19</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scirex">SciREX</pwcdataset>
-      <video href="2021.emnlp-main.381.mp4"/>
     </paper>
     <paper id="382">
       <title>Sequential Cross-Document Coreference Resolution</title>
@@ -6370,7 +6004,6 @@
       <doi>10.18653/v1/2021.emnlp-main.382</doi>
       <video href="2021.emnlp-main.382.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ecb">ECB+</pwcdataset>
-      <video href="2021.emnlp-main.382.mp4"/>
     </paper>
     <paper id="383">
       <title>Mixture-of-Partitions: Infusing Large Biomedical Knowledge Graphs into <fixed-case>BERT</fixed-case></title>
@@ -6387,7 +6020,6 @@
       <video href="2021.emnlp-main.383.mp4"/>
       <pwccode url="https://github.com/cambridgeltl/mop" additional="false">cambridgeltl/mop</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/pubmedqa">PubMedQA</pwcdataset>
-      <video href="2021.emnlp-main.383.mp4"/>
     </paper>
     <paper id="384">
       <title>Filling the Gaps in <fixed-case>A</fixed-case>ncient <fixed-case>A</fixed-case>kkadian Texts: A Masked Language Modelling Approach</title>
@@ -6404,7 +6036,6 @@
       <doi>10.18653/v1/2021.emnlp-main.384</doi>
       <video href="2021.emnlp-main.384.mp4"/>
       <pwccode url="https://github.com/slab-nlp/akk" additional="false">slab-nlp/akk</pwccode>
-      <video href="2021.emnlp-main.384.mp4"/>
     </paper>
     <paper id="385">
       <title><fixed-case>AV</fixed-case>oca<fixed-case>D</fixed-case>o: Strategy for Adapting Vocabulary to Downstream Domain</title>
@@ -6419,7 +6050,6 @@
       <doi>10.18653/v1/2021.emnlp-main.385</doi>
       <video href="2021.emnlp-main.385.mp4"/>
       <pwccode url="https://github.com/Jimin9401/avocado" additional="false">Jimin9401/avocado</pwccode>
-      <video href="2021.emnlp-main.385.mp4"/>
     </paper>
     <paper id="386">
       <title>Can We Improve Model Robustness through Secondary Attribute Counterfactuals?</title>
@@ -6434,7 +6064,6 @@
       <url hash="84016528">2021.emnlp-main.386</url>
       <bibkey>balashankar-etal-2021-improve</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.386</doi>
-      <video href="2021.emnlp-main.386.mp4"/>
       <video href="2021.emnlp-main.386.mp4"/>
     </paper>
     <paper id="387">
@@ -6455,7 +6084,6 @@
       <video href="2021.emnlp-main.387.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/codesearchnet">CodeSearchNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/codexglue">CodeXGLUE</pwcdataset>
-      <video href="2021.emnlp-main.387.mp4"/>
     </paper>
     <paper id="388">
       <title>Can Language Models be Biomedical Knowledge Bases?</title>
@@ -6474,7 +6102,6 @@
       <pwccode url="https://github.com/dmis-lab/biolama" additional="false">dmis-lab/biolama</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/biolama">BioLAMA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/lama">LAMA</pwcdataset>
-      <video href="2021.emnlp-main.388.mp4"/>
     </paper>
     <paper id="389">
       <title><fixed-case>L</fixed-case>ayout<fixed-case>R</fixed-case>eader: Pre-training of Text and Layout for Reading Order Detection</title>
@@ -6491,7 +6118,6 @@
       <video href="2021.emnlp-main.389.mp4"/>
       <pwccode url="https://github.com/microsoft/unilm" additional="false">microsoft/unilm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/readingbank">ReadingBank</pwcdataset>
-      <video href="2021.emnlp-main.389.mp4"/>
     </paper>
     <paper id="390">
       <title>Region under <fixed-case>D</fixed-case>iscussion for visual dialog</title>
@@ -6511,7 +6137,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/guesswhat">GuessWhat?!</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visdial">VisDial</pwcdataset>
-      <video href="2021.emnlp-main.390.mp4"/>
     </paper>
     <paper id="391">
       <title>Learning grounded word meaning representations on similarity graphs</title>
@@ -6525,7 +6150,6 @@
       <doi>10.18653/v1/2021.emnlp-main.391</doi>
       <video href="2021.emnlp-main.391.mp4"/>
       <pwccode url="https://github.com/mdimiccoli/hm-sge" additional="false">mdimiccoli/hm-sge</pwccode>
-      <video href="2021.emnlp-main.391.mp4"/>
     </paper>
     <paper id="392">
       <title><fixed-case>W</fixed-case>hy<fixed-case>A</fixed-case>ct: Identifying Action Reasons in Lifestyle Vlogs</title>
@@ -6546,7 +6170,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vcr">VCR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vlogs">Vlogs</pwcdataset>
-      <video href="2021.emnlp-main.392.mp4"/>
     </paper>
     <paper id="393">
       <title>Genre as Weak Supervision for Cross-lingual Dependency Parsing</title>
@@ -6561,7 +6184,6 @@
       <video href="2021.emnlp-main.393.mp4"/>
       <pwccode url="https://github.com/personads/ud-selection" additional="false">personads/ud-selection</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.emnlp-main.393.mp4"/>
     </paper>
     <paper id="394">
       <title>On the Relation between Syntactic Divergence and Zero-Shot Performance</title>
@@ -6578,7 +6200,6 @@
       <pwccode url="https://github.com/ofirarviv/improving-ud" additional="false">ofirarviv/improving-ud</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/translated-tacred">Translated TACRED</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.emnlp-main.394.mp4"/>
     </paper>
     <paper id="395">
       <title>Improved Latent Tree Induction with Distant Supervision via Span Constraints</title>
@@ -6600,7 +6221,6 @@
       <pwccode url="https://github.com/iesl/distantly-supervised-diora" additional="false">iesl/distantly-supervised-diora</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/medmentions">MedMentions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.emnlp-main.395.mp4"/>
     </paper>
     <paper id="396">
       <title>Aligning Multidimensional Worldviews and Discovering Ideological Differences</title>
@@ -6612,7 +6232,6 @@
       <url hash="d7217dc0">2021.emnlp-main.396</url>
       <bibkey>milbauer-etal-2021-aligning</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.396</doi>
-      <video href="2021.emnlp-main.396.mp4"/>
       <video href="2021.emnlp-main.396.mp4"/>
     </paper>
     <paper id="397">
@@ -6629,7 +6248,6 @@
       <video href="2021.emnlp-main.397.mp4"/>
       <pwccode url="https://github.com/abaheti95/toxichat" additional="false">abaheti95/toxichat</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sbic">SBIC</pwcdataset>
-      <video href="2021.emnlp-main.397.mp4"/>
     </paper>
     <paper id="398">
       <title>Multi-Modal Open-Domain Dialogue</title>
@@ -6648,7 +6266,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/convai2">ConvAI2</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/empatheticdialogues">EmpatheticDialogues</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
-      <video href="2021.emnlp-main.398.mp4"/>
     </paper>
     <paper id="399">
       <title>A Label-Aware <fixed-case>BERT</fixed-case> Attention Network for Zero-Shot Multi-Intent Detection in Spoken Language Understanding</title>
@@ -6666,7 +6283,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mixatis">MixATIS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mixsnips-1">MixSNIPs</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sgd">SGD</pwcdataset>
-      <video href="2021.emnlp-main.399.mp4"/>
     </paper>
     <paper id="400">
       <title>Zero-Shot Dialogue Disentanglement by Self-Supervised Entangled Response Selection</title>
@@ -6679,7 +6295,6 @@
       <doi>10.18653/v1/2021.emnlp-main.400</doi>
       <video href="2021.emnlp-main.400.mp4"/>
       <pwccode url="https://github.com/chijames/zero_shot_dialogue_disentanglement" additional="false">chijames/zero_shot_dialogue_disentanglement</pwccode>
-      <video href="2021.emnlp-main.400.mp4"/>
     </paper>
     <paper id="401">
       <title><fixed-case>SIMMC</fixed-case> 2.0: A Task-oriented Dialog Dataset for Immersive Multimodal Conversations</title>
@@ -6697,7 +6312,6 @@
       <pwccode url="https://github.com/facebookresearch/simmc2" additional="false">facebookresearch/simmc2</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/simmc">SIMMC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.emnlp-main.401.mp4"/>
     </paper>
     <paper id="402">
       <title><fixed-case>RAST</fixed-case>: Domain-Robust Dialogue Rewriting as Sequence Tagging</title>
@@ -6712,7 +6326,6 @@
       <url hash="8ff8e055">2021.emnlp-main.402</url>
       <bibkey>hao-etal-2021-rast</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.402</doi>
-      <video href="2021.emnlp-main.402.mp4"/>
       <video href="2021.emnlp-main.402.mp4"/>
     </paper>
     <paper id="403">
@@ -6729,7 +6342,6 @@
       <video href="2021.emnlp-main.403.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/blended-skill-talk">Blended Skill Talk</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/convai2">ConvAI2</pwcdataset>
-      <video href="2021.emnlp-main.403.mp4"/>
     </paper>
     <paper id="404">
       <title>Dialogue State Tracking with a Language Model using Schema-Driven Prompting</title>
@@ -6743,7 +6355,6 @@
       <doi>10.18653/v1/2021.emnlp-main.404</doi>
       <video href="2021.emnlp-main.404.mp4"/>
       <pwccode url="https://github.com/chiahsuan156/dst-as-prompting" additional="false">chiahsuan156/dst-as-prompting</pwccode>
-      <video href="2021.emnlp-main.404.mp4"/>
     </paper>
     <paper id="405">
       <title>Signed Coreference Resolution</title>
@@ -6757,7 +6368,6 @@
       <doi>10.18653/v1/2021.emnlp-main.405</doi>
       <video href="2021.emnlp-main.405.mp4"/>
       <pwccode url="https://github.com/kayoyin/scr" additional="false">kayoyin/scr</pwccode>
-      <video href="2021.emnlp-main.405.mp4"/>
     </paper>
     <paper id="406">
       <title>Consistent Accelerated Inference via Confident Adaptive Transformers</title>
@@ -6774,7 +6384,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vitaminc">VitaminC</pwcdataset>
-      <video href="2021.emnlp-main.406.mp4"/>
     </paper>
     <paper id="407">
       <title>Improving and Simplifying Pattern Exploiting Training</title>
@@ -6798,7 +6407,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
-      <video href="2021.emnlp-main.407.mp4"/>
     </paper>
     <paper id="408">
       <title>Unsupervised Data Augmentation with Naive Augmentation and without Unlabeled Data</title>
@@ -6815,7 +6423,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/evidence-inference">Evidence Inference</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.408.mp4"/>
     </paper>
     <paper id="409">
       <title>Pre-train or Annotate? Domain Adaptation with a Constrained Budget</title>
@@ -6829,7 +6436,6 @@
       <doi>10.18653/v1/2021.emnlp-main.409</doi>
       <video href="2021.emnlp-main.409.mp4"/>
       <pwccode url="https://github.com/bflashcp3f/procbert" additional="false">bflashcp3f/procbert</pwccode>
-      <video href="2021.emnlp-main.409.mp4"/>
     </paper>
     <paper id="410">
       <title>Lawyers are Dishonest? Quantifying Representational Harms in Commonsense Knowledge Resources</title>
@@ -6847,7 +6453,6 @@
       <video href="2021.emnlp-main.410.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/genericskb">GenericsKB</pwcdataset>
-      <video href="2021.emnlp-main.410.mp4"/>
     </paper>
     <paper id="411">
       <title><fixed-case>OSC</fixed-case>a<fixed-case>R</fixed-case>: Orthogonal Subspace Correction and Rectification of Biases in Word Embeddings</title>
@@ -6864,7 +6469,6 @@
       <pwccode url="https://github.com/Shaul1321/nullspace_projection" additional="false">Shaul1321/nullspace_projection</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.411.mp4"/>
     </paper>
     <paper id="412">
       <title>Sentence-Permuted Paragraph Generation</title>
@@ -6882,7 +6486,6 @@
       <pwccode url="https://github.com/wyu97/permgen" additional="false">wyu97/permgen</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/agenda">AGENDA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/rocstories">ROCStories</pwcdataset>
-      <video href="2021.emnlp-main.412.mp4"/>
     </paper>
     <paper id="413">
       <title>Extract, Denoise and Enforce: Evaluating and Improving Concept Preservation for Text-to-Text Generation</title>
@@ -6899,7 +6502,6 @@
       <video href="2021.emnlp-main.413.mp4"/>
       <pwccode url="https://github.com/morningmoni/ede" additional="true">morningmoni/ede</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.413.mp4"/>
     </paper>
     <paper id="414">
       <title>Paraphrase Generation: A Survey of the State of the Art</title>
@@ -6912,7 +6514,6 @@
       <doi>10.18653/v1/2021.emnlp-main.414</doi>
       <video href="2021.emnlp-main.414.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
-      <video href="2021.emnlp-main.414.mp4"/>
     </paper>
     <paper id="415">
       <title>Exposure Bias versus Self-Recovery: Are Distortions Really Incremental for Autoregressive Text Generation?</title>
@@ -6925,7 +6526,6 @@
       <url hash="512311c2">2021.emnlp-main.415</url>
       <bibkey>he-etal-2021-exposure</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.415</doi>
-      <video href="2021.emnlp-main.415.mp4"/>
       <video href="2021.emnlp-main.415.mp4"/>
     </paper>
     <paper id="416">
@@ -6944,7 +6544,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsqa">NewsQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.416.mp4"/>
     </paper>
     <paper id="417">
       <title>Unsupervised Paraphrasing with Pretrained Language Models</title>
@@ -6959,7 +6558,6 @@
       <url hash="41742221">2021.emnlp-main.417</url>
       <bibkey>niu-etal-2021-unsupervised</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.417</doi>
-      <video href="2021.emnlp-main.417.mp4"/>
       <video href="2021.emnlp-main.417.mp4"/>
     </paper>
     <paper id="418">
@@ -6989,7 +6587,6 @@
       <doi>10.18653/v1/2021.emnlp-main.419</doi>
       <video href="2021.emnlp-main.419.mp4"/>
       <pwccode url="https://github.com/dataminr-ai/joganic" additional="false">dataminr-ai/joganic</pwccode>
-      <video href="2021.emnlp-main.419.mp4"/>
     </paper>
     <paper id="420">
       <title><fixed-case>AESOP</fixed-case>: Paraphrase Generation with Adaptive Syntactic Control</title>
@@ -7004,7 +6601,6 @@
       <video href="2021.emnlp-main.420.mp4"/>
       <pwccode url="https://github.com/pluslabnlp/aesop" additional="false">pluslabnlp/aesop</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.emnlp-main.420.mp4"/>
     </paper>
     <paper id="421">
       <title>Refocusing on Relevance: Personalization in <fixed-case>NLG</fixed-case></title>
@@ -7018,7 +6614,6 @@
       <doi>10.18653/v1/2021.emnlp-main.421</doi>
       <video href="2021.emnlp-main.421.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mimic-iii">MIMIC-III</pwcdataset>
-      <video href="2021.emnlp-main.421.mp4"/>
     </paper>
     <paper id="422">
       <title>The Future is not One-dimensional: Complex Event Schema Induction by Graph Modeling for Event Prediction</title>
@@ -7037,7 +6632,6 @@
       <doi>10.18653/v1/2021.emnlp-main.422</doi>
       <video href="2021.emnlp-main.422.mp4"/>
       <pwccode url="https://github.com/limanling/temporal-graph-schema" additional="false">limanling/temporal-graph-schema</pwccode>
-      <video href="2021.emnlp-main.422.mp4"/>
     </paper>
     <paper id="423">
       <title>Learning Constraints and Descriptive Segmentation for Subevent Detection</title>
@@ -7065,7 +6659,6 @@
       <bibkey>wang-etal-2021-chemner</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.424</doi>
       <video href="2021.emnlp-main.424.mp4"/>
-      <video href="2021.emnlp-main.424.mp4"/>
     </paper>
     <paper id="425">
       <title>Moving on from <fixed-case>O</fixed-case>nto<fixed-case>N</fixed-case>otes: Coreference Resolution Model Transfer</title>
@@ -7079,7 +6672,6 @@
       <video href="2021.emnlp-main.425.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/gap-coreference-dataset">GAP Coreference Dataset</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/preco">PreCo</pwcdataset>
-      <video href="2021.emnlp-main.425.mp4"/>
     </paper>
     <paper id="426">
       <title>Document-level Entity-based Extraction as Template Generation</title>
@@ -7095,7 +6687,6 @@
       <pwccode url="https://github.com/PlusLabNLP/TempGen" additional="false">PlusLabNLP/TempGen</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/muc-4">MUC-4</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scirex">SciREX</pwcdataset>
-      <video href="2021.emnlp-main.426.mp4"/>
     </paper>
     <paper id="427">
       <title>Learning Prototype Representations Across Few-Shot Tasks for Event Detection</title>
@@ -7109,7 +6700,6 @@
       <doi>10.18653/v1/2021.emnlp-main.427</doi>
       <video href="2021.emnlp-main.427.mp4"/>
       <pwccode url="https://github.com/laiviet/fsl-proact" additional="false">laiviet/fsl-proact</pwccode>
-      <video href="2021.emnlp-main.427.mp4"/>
     </paper>
     <paper id="428">
       <title>Lifelong Event Detection with Knowledge Transfer</title>
@@ -7124,7 +6714,6 @@
       <video href="2021.emnlp-main.428.mp4"/>
       <pwccode url="https://github.com/perfec-yu/lifelong-ed" additional="false">perfec-yu/lifelong-ed</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/maven">MAVEN</pwcdataset>
-      <video href="2021.emnlp-main.428.mp4"/>
     </paper>
     <paper id="429">
       <title>Modular Self-Supervision for Document-Level Relation Extraction</title>
@@ -7141,7 +6730,6 @@
       <doi>10.18653/v1/2021.emnlp-main.429</doi>
       <video href="2021.emnlp-main.429.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/docred">DocRED</pwcdataset>
-      <video href="2021.emnlp-main.429.mp4"/>
     </paper>
     <paper id="430">
       <title>Unsupervised Paraphrasing Consistency Training for Low Resource Named Entity Recognition</title>
@@ -7170,7 +6758,6 @@
       <video href="2021.emnlp-main.431.mp4"/>
       <pwccode url="https://github.com/lemaoliu/fet-data" additional="false">lemaoliu/fet-data</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/figer">FIGER</pwcdataset>
-      <video href="2021.emnlp-main.431.mp4"/>
     </paper>
     <paper id="432">
       <title>Adversarial Attack against Cross-lingual Knowledge Graph Alignment</title>
@@ -7189,7 +6776,6 @@
       <bibkey>zhang-etal-2021-adversarial-attack</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.432</doi>
       <video href="2021.emnlp-main.432.mp4"/>
-      <video href="2021.emnlp-main.432.mp4"/>
     </paper>
     <paper id="433">
       <title>Towards Realistic Few-Shot Relation Extraction</title>
@@ -7205,7 +6791,6 @@
       <pwccode url="https://github.com/bloomberg/emnlp21_fewrel" additional="false">bloomberg/emnlp21_fewrel</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel-2-0">FewRel 2.0</pwcdataset>
-      <video href="2021.emnlp-main.433.mp4"/>
     </paper>
     <paper id="434">
       <title>Data Augmentation for Cross-Domain Named Entity Recognition</title>
@@ -7220,7 +6805,6 @@
       <doi>10.18653/v1/2021.emnlp-main.434</doi>
       <video href="2021.emnlp-main.434.mp4"/>
       <pwccode url="https://github.com/ritual-uh/style_ner" additional="false">ritual-uh/style_ner</pwccode>
-      <video href="2021.emnlp-main.434.mp4"/>
     </paper>
     <paper id="435">
       <title>Incorporating medical knowledge in <fixed-case>BERT</fixed-case> for clinical relation extraction</title>
@@ -7234,7 +6818,6 @@
       <video href="2021.emnlp-main.435.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/blue">BLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/umls">UMLS</pwcdataset>
-      <video href="2021.emnlp-main.435.mp4"/>
     </paper>
     <paper id="436">
       <title><fixed-case>ECONET</fixed-case>: Effective Continual Pretraining of Language Models for Event Temporal Reasoning</title>
@@ -7250,7 +6833,6 @@
       <pwccode url="https://github.com/pluslabnlp/econet" additional="true">pluslabnlp/econet</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mc-taco">MC-TACO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/torque">Torque</pwcdataset>
-      <video href="2021.emnlp-main.436.mp4"/>
     </paper>
     <paper id="437">
       <title>Learning from Noisy Labels for Entity-Centric Information Extraction</title>
@@ -7266,7 +6848,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll">CoNLL++</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tacred">TACRED</pwcdataset>
-      <video href="2021.emnlp-main.437.mp4"/>
     </paper>
     <paper id="438">
       <title>Extracting Material Property Measurement Data from Scientific Articles</title>
@@ -7281,7 +6862,6 @@
       <doi>10.18653/v1/2021.emnlp-main.438</doi>
       <video href="2021.emnlp-main.438.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
-      <video href="2021.emnlp-main.438.mp4"/>
     </paper>
     <paper id="439">
       <title>Modeling Document-Level Context for Event Detection via Important Context Selection</title>
@@ -7296,7 +6876,6 @@
       <bibkey>pouran-ben-veyseh-etal-2021-modeling</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.439</doi>
       <video href="2021.emnlp-main.439.mp4"/>
-      <video href="2021.emnlp-main.439.mp4"/>
     </paper>
     <paper id="440">
       <title>Crosslingual Transfer Learning for Relation and Event Extraction via Word Category and Class Alignments</title>
@@ -7309,7 +6888,6 @@
       <url hash="47ae30a8">2021.emnlp-main.440</url>
       <bibkey>nguyen-etal-2021-crosslingual</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.440</doi>
-      <video href="2021.emnlp-main.440.mp4"/>
       <video href="2021.emnlp-main.440.mp4"/>
     </paper>
     <paper id="441">
@@ -7326,7 +6904,6 @@
       <video href="2021.emnlp-main.441.mp4"/>
       <pwccode url="https://github.com/mickeystroller/etypeclus" additional="false">mickeystroller/etypeclus</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.emnlp-main.441.mp4"/>
     </paper>
     <paper id="442">
       <title><fixed-case>PDALN</fixed-case>: Progressive Domain Adaptation over a Pre-trained Model for Low-Resource Cross-Domain Named Entity Recognition</title>
@@ -7342,7 +6919,6 @@
       <doi>10.18653/v1/2021.emnlp-main.442</doi>
       <video href="2021.emnlp-main.442.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2016-ner">WNUT 2016 NER</pwcdataset>
-      <video href="2021.emnlp-main.442.mp4"/>
     </paper>
     <paper id="443">
       <title>Multi-Vector Attention Models for Deep Re-ranking</title>
@@ -7355,7 +6931,6 @@
       <doi>10.18653/v1/2021.emnlp-main.443</doi>
       <video href="2021.emnlp-main.443.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
-      <video href="2021.emnlp-main.443.mp4"/>
     </paper>
     <paper id="444">
       <title>Toward Deconfounding the Effect of Entity Demographics for Question Answering Accuracy</title>
@@ -7371,7 +6946,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.444.mp4"/>
     </paper>
     <paper id="445">
       <title>Exploring Strategies for Generalizable Commonsense Reasoning with Pre-trained Models</title>
@@ -7390,7 +6964,6 @@
       <pwccode url="https://github.com/mayer123/cs_model_adaptation" additional="false">mayer123/cs_model_adaptation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/commongen">CommonGen</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.445.mp4"/>
     </paper>
     <paper id="446">
       <title>Transformer Feed-Forward Layers Are Key-Value Memories</title>
@@ -7407,7 +6980,6 @@
       <pwccode url="https://github.com/mega002/ff-layers" additional="false">mega002/ff-layers</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.446.mp4"/>
     </paper>
     <paper id="447">
       <title>Connecting Attributions and <fixed-case>QA</fixed-case> Model Behavior on Realistic Counterfactuals</title>
@@ -7423,7 +6995,6 @@
       <pwccode url="https://github.com/xiye17/EvalQAExpl" additional="false">xiye17/EvalQAExpl</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.447.mp4"/>
     </paper>
     <paper id="448">
       <title>How Do Neural Sequence Models Generalize? Local and Global Cues for Out-of-Distribution Prediction</title>
@@ -7434,7 +7005,6 @@
       <url hash="39e82f9f">2021.emnlp-main.448</url>
       <bibkey>bau-andreas-2021-neural</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.448</doi>
-      <video href="2021.emnlp-main.448.mp4"/>
       <video href="2021.emnlp-main.448.mp4"/>
     </paper>
     <paper id="449">
@@ -7453,7 +7023,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.449.mp4"/>
     </paper>
     <paper id="450">
       <title>Human Rationales as Attribution Priors for Explainable Stance Detection</title>
@@ -7466,7 +7035,6 @@
       <doi>10.18653/v1/2021.emnlp-main.450</doi>
       <video href="2021.emnlp-main.450.mp4"/>
       <pwccode url="https://github.com/sahilj97/explainable-stance-detection" additional="false">sahilj97/explainable-stance-detection</pwccode>
-      <video href="2021.emnlp-main.450.mp4"/>
     </paper>
     <paper id="451">
       <title>The Stem Cell Hypothesis: Dilemma behind Multi-Task Learning with Transformer Encoders</title>
@@ -7479,7 +7047,6 @@
       <doi>10.18653/v1/2021.emnlp-main.451</doi>
       <video href="2021.emnlp-main.451.mp4"/>
       <pwccode url="https://github.com/emorynlp/stem-cell-hypothesis" additional="false">emorynlp/stem-cell-hypothesis</pwccode>
-      <video href="2021.emnlp-main.451.mp4"/>
     </paper>
     <paper id="452">
       <title>Text Counterfactuals via Latent Optimization and <fixed-case>S</fixed-case>hapley-Guided Search</title>
@@ -7494,7 +7061,6 @@
       <video href="2021.emnlp-main.452.mp4"/>
       <pwccode url="https://github.com/QuintinPope/CLOSS" additional="false">QuintinPope/CLOSS</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.452.mp4"/>
     </paper>
     <paper id="453">
       <title>“Average” Approximates “First Principal Component”? An Empirical Analysis on Representations from Neural Language Models</title>
@@ -7508,7 +7074,6 @@
       <doi>10.18653/v1/2021.emnlp-main.453</doi>
       <video href="2021.emnlp-main.453.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/kp20k">KP20k</pwcdataset>
-      <video href="2021.emnlp-main.453.mp4"/>
     </paper>
     <paper id="454">
       <title>Controlled Evaluation of Grammatical Knowledge in <fixed-case>M</fixed-case>andarin <fixed-case>C</fixed-case>hinese Language Models</title>
@@ -7523,7 +7088,6 @@
       <doi>10.18653/v1/2021.emnlp-main.454</doi>
       <video href="2021.emnlp-main.454.mp4"/>
       <pwccode url="https://github.com/yiwenwang03/syntactic-generalization-mandarin" additional="false">yiwenwang03/syntactic-generalization-mandarin</pwccode>
-      <video href="2021.emnlp-main.454.mp4"/>
     </paper>
     <paper id="455">
       <title><fixed-case>G</fixed-case>rad<fixed-case>TS</fixed-case>: A Gradient-Based Automatic Auxiliary Task Selection Method Based on Transformer Networks</title>
@@ -7541,7 +7105,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/meld">MELD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.emnlp-main.455.mp4"/>
     </paper>
     <paper id="456">
       <title><fixed-case>N</fixed-case>egat<fixed-case>ER</fixed-case>: <fixed-case>U</fixed-case>nsupervised <fixed-case>D</fixed-case>iscovery of <fixed-case>N</fixed-case>egatives in <fixed-case>C</fixed-case>ommonsense <fixed-case>K</fixed-case>nowledge <fixed-case>B</fixed-case>ases</title>
@@ -7555,7 +7118,6 @@
       <doi>10.18653/v1/2021.emnlp-main.456</doi>
       <video href="2021.emnlp-main.456.mp4"/>
       <pwccode url="https://github.com/tsafavi/negater" additional="false">tsafavi/negater</pwccode>
-      <video href="2021.emnlp-main.456.mp4"/>
     </paper>
     <paper id="457">
       <title>Instance-adaptive training with noise-robust losses against noisy labels</title>
@@ -7571,7 +7133,6 @@
       <video href="2021.emnlp-main.457.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.457.mp4"/>
     </paper>
     <paper id="458">
       <title>Distributionally Robust Multilingual Machine Translation</title>
@@ -7587,7 +7148,6 @@
       <doi>10.18653/v1/2021.emnlp-main.458</doi>
       <video href="2021.emnlp-main.458.mp4"/>
       <pwccode url="https://github.com/violet-zct/fairseq-dro-mnmt" additional="false">violet-zct/fairseq-dro-mnmt</pwccode>
-      <video href="2021.emnlp-main.458.mp4"/>
     </paper>
     <paper id="459">
       <title>Model Selection for Cross-lingual Transfer</title>
@@ -7600,7 +7160,6 @@
       <doi>10.18653/v1/2021.emnlp-main.459</doi>
       <video href="2021.emnlp-main.459.mp4"/>
       <pwccode url="https://github.com/edchengg/model_selection" additional="false">edchengg/model_selection</pwccode>
-      <video href="2021.emnlp-main.459.mp4"/>
     </paper>
     <paper id="460">
       <title>Continual Few-Shot Learning for Text Classification</title>
@@ -7618,7 +7177,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.460.mp4"/>
     </paper>
     <paper id="461">
       <title>Efficient Nearest Neighbor Language Models</title>
@@ -7634,7 +7192,6 @@
       <pwccode url="https://github.com/jxhe/efficient-knnlm" additional="true">jxhe/efficient-knnlm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.461.mp4"/>
     </paper>
     <paper id="462">
       <title><fixed-case>ST</fixed-case>ra<fixed-case>TA</fixed-case>: Self-Training with Task Augmentation for Better Few-shot Learning</title>
@@ -7656,7 +7213,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.462.mp4"/>
     </paper>
     <paper id="463">
       <title><fixed-case>TADPOLE</fixed-case>: <fixed-case>T</fixed-case>ask <fixed-case>AD</fixed-case>apted <fixed-case>P</fixed-case>re-Training via <fixed-case>A</fixed-case>n<fixed-case>O</fixed-case>ma<fixed-case>L</fixed-case>y <fixed-case>D</fixed-case><fixed-case>E</fixed-case>tection</title>
@@ -7672,7 +7228,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
-      <video href="2021.emnlp-main.463.mp4"/>
     </paper>
     <paper id="464">
       <title>Gradient-based Adversarial Attacks against Text Transformers</title>
@@ -7690,7 +7245,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-main.464.mp4"/>
     </paper>
     <paper id="465">
       <title>Do Transformer Modifications Transfer Across Implementations and Applications?</title>
@@ -7720,7 +7274,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/c4">C4</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestions">WebQuestions</pwcdataset>
-      <video href="2021.emnlp-main.465.mp4"/>
     </paper>
     <paper id="466">
       <title>Paired Examples as Indirect Supervision in Latent Decision Models</title>
@@ -7755,7 +7308,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mpqa-opinion-corpus">MPQA Opinion Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.emnlp-main.467.mp4"/>
     </paper>
     <paper id="468">
       <title>Muppet: Massive Multi-task Representations with Pre-Finetuning</title>
@@ -7789,7 +7341,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/swag">SWAG</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.emnlp-main.468.mp4"/>
     </paper>
     <paper id="469">
       <title>Diverse Distributions of Self-Supervised Tasks for Meta-Learning in <fixed-case>NLP</fixed-case></title>
@@ -7808,7 +7359,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel-2-0">FewRel 2.0</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.emnlp-main.469.mp4"/>
     </paper>
     <paper id="470">
       <title>A Simple and Effective Method To Eliminate the Self Language Bias in Multilingual Representations</title>
@@ -7825,7 +7375,6 @@
       <pwccode url="https://github.com/ziyi-yang/lir" additional="false">ziyi-yang/lir</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad-r">LAReQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wiki-40b">Wiki-40B</pwcdataset>
-      <video href="2021.emnlp-main.470.mp4"/>
     </paper>
     <paper id="471">
       <title>A Massively Multilingual Analysis of Cross-linguality in Shared Embedding Space</title>
@@ -7840,7 +7389,6 @@
       <doi>10.18653/v1/2021.emnlp-main.471</doi>
       <video href="2021.emnlp-main.471.mp4"/>
       <pwccode url="https://github.com/alexjonesnlp/xlanalysis5k" additional="false">alexjonesnlp/xlanalysis5k</pwccode>
-      <video href="2021.emnlp-main.471.mp4"/>
     </paper>
     <paper id="472">
       <title>Frustratingly Simple but Surprisingly Strong: Using Language-Independent Features for Zero-shot Cross-lingual Semantic Parsing</title>
@@ -7856,7 +7404,6 @@
       <doi>10.18653/v1/2021.emnlp-main.472</doi>
       <video href="2021.emnlp-main.472.mp4"/>
       <pwccode url="https://github.com/gt-salt/multilingual-drs-semantic-parsing" additional="false">gt-salt/multilingual-drs-semantic-parsing</pwccode>
-      <video href="2021.emnlp-main.472.mp4"/>
     </paper>
     <paper id="473">
       <title>Improving Simultaneous Translation by Incorporating Pseudo-References with Fewer Reorderings</title>
@@ -7870,7 +7417,6 @@
       <url hash="55262223">2021.emnlp-main.473</url>
       <bibkey>chen-etal-2021-improving-simultaneous</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.473</doi>
-      <video href="2021.emnlp-main.473.mp4"/>
       <video href="2021.emnlp-main.473.mp4"/>
     </paper>
     <paper id="474">
@@ -7888,7 +7434,6 @@
       <doi>10.18653/v1/2021.emnlp-main.474</doi>
       <video href="2021.emnlp-main.474.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mlqe-pe">MLQE-PE</pwcdataset>
-      <video href="2021.emnlp-main.474.mp4"/>
     </paper>
     <paper id="475">
       <title>A Large-Scale Study of Machine Translation in <fixed-case>T</fixed-case>urkic Languages</title>
@@ -7915,7 +7460,6 @@
       <doi>10.18653/v1/2021.emnlp-main.475</doi>
       <video href="2021.emnlp-main.475.mp4"/>
       <pwccode url="https://github.com/turkic-interlingua/til-mt" additional="false">turkic-interlingua/til-mt</pwccode>
-      <video href="2021.emnlp-main.475.mp4"/>
     </paper>
     <paper id="476">
       <title>Analyzing the Surprising Variability in Word Embedding Stability Across Languages</title>
@@ -7929,7 +7473,6 @@
       <doi>10.18653/v1/2021.emnlp-main.476</doi>
       <video href="2021.emnlp-main.476.mp4"/>
       <pwccode url="https://github.com/laura-burdick/multilingual-stability" additional="false">laura-burdick/multilingual-stability</pwccode>
-      <video href="2021.emnlp-main.476.mp4"/>
     </paper>
     <paper id="477">
       <title>Rule-based Morphological Inflection Improves Neural Terminology Translation</title>
@@ -7942,7 +7485,6 @@
       <doi>10.18653/v1/2021.emnlp-main.477</doi>
       <video href="2021.emnlp-main.477.mp4"/>
       <pwccode url="https://github.com/izecson/terminology-translation" additional="false">izecson/terminology-translation</pwccode>
-      <video href="2021.emnlp-main.477.mp4"/>
     </paper>
     <paper id="478">
       <title>Data and Parameter Scaling Laws for Neural Machine Translation</title>
@@ -7956,7 +7498,6 @@
       <doi>10.18653/v1/2021.emnlp-main.478</doi>
       <video href="2021.emnlp-main.478.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
-      <video href="2021.emnlp-main.478.mp4"/>
     </paper>
     <paper id="479">
       <title>Good-Enough Example Extrapolation</title>
@@ -7970,7 +7511,6 @@
       <video href="2021.emnlp-main.479.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fewrel">FewRel</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
-      <video href="2021.emnlp-main.479.mp4"/>
     </paper>
     <paper id="480">
       <title>Learning to Selectively Learn for Weakly-supervised Paraphrase Generation</title>
@@ -7988,7 +7528,6 @@
       <doi>10.18653/v1/2021.emnlp-main.480</doi>
       <video href="2021.emnlp-main.480.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
-      <video href="2021.emnlp-main.480.mp4"/>
     </paper>
     <paper id="481">
       <title>Effective Convolutional Attention Network for Multi-label Clinical Document Classification</title>
@@ -8004,7 +7543,6 @@
       <doi>10.18653/v1/2021.emnlp-main.481</doi>
       <video href="2021.emnlp-main.481.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/mimic-iii">MIMIC-III</pwcdataset>
-      <video href="2021.emnlp-main.481.mp4"/>
     </paper>
     <paper id="482">
       <title>Contrastive Code Representation Learning</title>
@@ -8022,7 +7560,6 @@
       <video href="2021.emnlp-main.482.mp4"/>
       <pwccode url="https://github.com/parasj/contracode" additional="false">parasj/contracode</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/codesearchnet">CodeSearchNet</pwcdataset>
-      <video href="2021.emnlp-main.482.mp4"/>
     </paper>
     <paper id="483">
       <title><fixed-case>IGA</fixed-case>: An Intent-Guided Authoring Assistant</title>
@@ -8042,7 +7579,6 @@
       <video href="2021.emnlp-main.483.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/pomo">PoMo</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikilarge">WikiLarge</pwcdataset>
-      <video href="2021.emnlp-main.483.mp4"/>
     </paper>
     <paper id="484">
       <title>Math Word Problem Generation with Mathematical Consistency and Problem Context Constraints</title>
@@ -8058,7 +7594,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mawps">MAWPS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/math23k">Math23K</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mathqa">MathQA</pwcdataset>
-      <video href="2021.emnlp-main.484.mp4"/>
     </paper>
     <paper id="485">
       <title>Navigating the Kaleidoscope of <fixed-case>COVID</fixed-case>-19 Misinformation Using Deep Learning</title>
@@ -8069,7 +7604,6 @@
       <url hash="3cfc2d12">2021.emnlp-main.485</url>
       <bibkey>chen-hasan-2021-navigating</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.485</doi>
-      <video href="2021.emnlp-main.485.mp4"/>
       <video href="2021.emnlp-main.485.mp4"/>
     </paper>
     <paper id="486">
@@ -8084,7 +7618,6 @@
       <doi>10.18653/v1/2021.emnlp-main.486</doi>
       <video href="2021.emnlp-main.486.mp4"/>
       <pwccode url="https://github.com/junwang4/detecting-health-advice" additional="false">junwang4/detecting-health-advice</pwccode>
-      <video href="2021.emnlp-main.486.mp4"/>
     </paper>
     <paper id="487">
       <title>A Semantic Feature-Wise Transformation Relation Network for Automatic Short Answer Grading</title>
@@ -8096,7 +7629,6 @@
       <url hash="66e9b312">2021.emnlp-main.487</url>
       <bibkey>li-etal-2021-semantic</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.487</doi>
-      <video href="2021.emnlp-main.487.mp4"/>
       <video href="2021.emnlp-main.487.mp4"/>
     </paper>
     <paper id="488">
@@ -8111,7 +7643,6 @@
       <video href="2021.emnlp-main.488.mp4"/>
       <pwccode url="https://github.com/gurdaspuriya/evaluating-scholarly-impact" additional="false">gurdaspuriya/evaluating-scholarly-impact</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/s2orc">S2ORC</pwcdataset>
-      <video href="2021.emnlp-main.488.mp4"/>
     </paper>
     <paper id="489">
       <title>A Scalable Framework for Learning From Implicit User Feedback to Improve Natural Language Understanding in Large-Scale Conversational <fixed-case>AI</fixed-case> Systems</title>
@@ -8128,7 +7659,6 @@
       <url hash="66d00b1e">2021.emnlp-main.489</url>
       <bibkey>park-etal-2021-scalable</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.489</doi>
-      <video href="2021.emnlp-main.489.mp4"/>
       <video href="2021.emnlp-main.489.mp4"/>
     </paper>
     <paper id="490">
@@ -8147,7 +7677,6 @@
       <pwccode url="https://github.com/stonybrooknlp/suqa" additional="false">stonybrooknlp/suqa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
-      <video href="2021.emnlp-main.490.mp4"/>
     </paper>
     <paper id="491">
       <title><fixed-case>F</fixed-case>ewshot<fixed-case>QA</fixed-case>: A simple framework for few-shot learning of question answering tasks using pre-trained text-to-text models</title>
@@ -8162,7 +7691,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mrqa-2019">MRQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
-      <video href="2021.emnlp-main.491.mp4"/>
     </paper>
     <paper id="492">
       <title>Multi-stage Training with Improved Negative Contrast for Neural Passage Retrieval</title>
@@ -8179,7 +7707,6 @@
       <video href="2021.emnlp-main.492.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ms-marco">MS MARCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.emnlp-main.492.mp4"/>
     </paper>
     <paper id="493">
       <title>Perhaps <fixed-case>PTLM</fixed-case>s Should Go to School – A Task to Assess Open Book and Closed Book <fixed-case>QA</fixed-case></title>
@@ -8198,7 +7725,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/arc">ARC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/boolq">BoolQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.493.mp4"/>
     </paper>
     <paper id="494">
       <title><fixed-case>R</fixed-case>eason<fixed-case>BERT</fixed-case>: <fixed-case>P</fixed-case>re-trained to Reason with Distant Supervision</title>
@@ -8223,7 +7749,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.494.mp4"/>
     </paper>
     <paper id="495">
       <title>Single-dataset Experts for Multi-dataset Question Answering</title>
@@ -8245,7 +7770,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.495.mp4"/>
     </paper>
     <paper id="496">
       <title>Simple Entity-Centric Questions Challenge Dense Retrievers</title>
@@ -8263,7 +7787,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/entityquestions">EntityQuestions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paq">PAQ</pwcdataset>
-      <video href="2021.emnlp-main.496.mp4"/>
     </paper>
     <paper id="497">
       <title>Mitigating False-Negative Contexts in Multi-document Question Answering with Retrieval Marginalization</title>
@@ -8280,7 +7803,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iirc">IIRC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.emnlp-main.497.mp4"/>
     </paper>
     <paper id="498">
       <title><fixed-case>M</fixed-case>ulti<fixed-case>D</fixed-case>oc2<fixed-case>D</fixed-case>ial: Modeling Dialogues Grounded in Multiple Documents</title>
@@ -8302,7 +7824,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/quac">QuAC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sharc">ShARC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/doc2dial">doc2dial</pwcdataset>
-      <video href="2021.emnlp-main.498.mp4"/>
     </paper>
     <paper id="499">
       <title><fixed-case>G</fixed-case>up<fixed-case>S</fixed-case>hup: Summarizing Open-Domain Code-Switched Conversations</title>
@@ -8324,7 +7845,6 @@
       <video href="2021.emnlp-main.499.mp4"/>
       <pwccode url="https://github.com/midas-research/gupshup" additional="false">midas-research/gupshup</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.emnlp-main.499.mp4"/>
     </paper>
     <paper id="500">
       <title><fixed-case>B</fixed-case>i<fixed-case>SECT</fixed-case>: Learning to Split and Rephrase Sentences with Bitexts</title>
@@ -8341,7 +7861,6 @@
       <video href="2021.emnlp-main.500.mp4"/>
       <pwccode url="https://github.com/mounicam/bisect" additional="false">mounicam/bisect</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bisect">BiSECT</pwcdataset>
-      <video href="2021.emnlp-main.500.mp4"/>
     </paper>
     <paper id="501">
       <title>Data Collection vs. Knowledge Graph Completion: What is Needed to Improve Coverage?</title>
@@ -8352,7 +7871,6 @@
       <url hash="70928075">2021.emnlp-main.501</url>
       <bibkey>church-bian-2021-data</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.501</doi>
-      <video href="2021.emnlp-main.501.mp4"/>
       <video href="2021.emnlp-main.501.mp4"/>
     </paper>
     <paper id="502">
@@ -8371,7 +7889,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/paws-x">PAWS-X</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.emnlp-main.502.mp4"/>
     </paper>
     <paper id="503">
       <title>On the Benefit of Syntactic Supervision for Cross-lingual Transfer in Semantic Role Labeling</title>
@@ -8386,7 +7903,6 @@
       <video href="2021.emnlp-main.503.mp4"/>
       <pwccode url="https://github.com/zzsfornlp/zmsp" additional="false">zzsfornlp/zmsp</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.emnlp-main.503.mp4"/>
     </paper>
     <paper id="504">
       <title>Implicit Premise Generation with Discourse-aware Commonsense Knowledge Models</title>
@@ -8401,7 +7917,6 @@
       <video href="2021.emnlp-main.504.mp4"/>
       <pwccode url="https://github.com/tuhinjubcse/enthymemesemnlp2021" additional="false">tuhinjubcse/enthymemesemnlp2021</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/art-dataset">ART Dataset</pwcdataset>
-      <video href="2021.emnlp-main.504.mp4"/>
     </paper>
     <paper id="505">
       <title>Inducing Transformer’s Compositional Generalization Ability via Auxiliary Sequence Prediction Tasks</title>
@@ -8416,7 +7931,6 @@
       <pwccode url="https://github.com/jiangyctarheel/compositional-auxseq" additional="false">jiangyctarheel/compositional-auxseq</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cfq">CFQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scan">SCAN</pwcdataset>
-      <video href="2021.emnlp-main.505.mp4"/>
     </paper>
     <paper id="506">
       <title>Flexible Generation of Natural Language Deductions</title>
@@ -8436,7 +7950,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/proofwriter">ProofWriter</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qasc">QASC</pwcdataset>
-      <video href="2021.emnlp-main.506.mp4"/>
     </paper>
     <paper id="507">
       <title>Structure-aware Fine-tuning of Sequence-to-sequence Transformers for Transition-based <fixed-case>AMR</fixed-case> Parsing</title>
@@ -8453,7 +7966,6 @@
       <doi>10.18653/v1/2021.emnlp-main.507</doi>
       <video href="2021.emnlp-main.507.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ldc2017t10">LDC2017T10</pwcdataset>
-      <video href="2021.emnlp-main.507.mp4"/>
     </paper>
     <paper id="508">
       <title>Think about it! Improving defeasible reasoning by first modeling the question scenario.</title>
@@ -8473,7 +7985,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/atomic">ATOMIC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wiqa">WIQA</pwcdataset>
-      <video href="2021.emnlp-main.508.mp4"/>
     </paper>
     <paper id="509">
       <title>Open Aspect Target Sentiment Classification with Natural Language Prompts</title>
@@ -8492,7 +8003,6 @@
       <pwccode url="https://github.com/ronaldseoh/atsc_prompts" additional="false">ronaldseoh/atsc_prompts</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2014-task-4-sub-task-2">SemEval 2014 Task 4 Sub Task 2</pwcdataset>
-      <video href="2021.emnlp-main.509.mp4"/>
     </paper>
     <paper id="510">
       <title>Does <fixed-case>BERT</fixed-case> Learn as Humans Perceive? Understanding Linguistic Styles through Lexica</title>
@@ -8507,7 +8017,6 @@
       <video href="2021.emnlp-main.510.mp4"/>
       <pwccode url="https://github.com/sweetpeach/hummingbird" additional="false">sweetpeach/hummingbird</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/hummingbird">Hummingbird</pwcdataset>
-      <video href="2021.emnlp-main.510.mp4"/>
     </paper>
     <paper id="511">
       <title>Improving Stance Detection with Multi-Dataset Learning and Knowledge Distillation</title>
@@ -8521,7 +8030,6 @@
       <doi>10.18653/v1/2021.emnlp-main.511</doi>
       <video href="2021.emnlp-main.511.mp4"/>
       <pwccode url="https://github.com/chuchun8/mdl-stance-distillation" additional="false">chuchun8/mdl-stance-distillation</pwccode>
-      <video href="2021.emnlp-main.511.mp4"/>
     </paper>
     <paper id="512">
       <title>Discovering the Unknown Knowns: Turning Implicit Knowledge in the Dataset into Explicit Training Examples for Visual Question Answering</title>
@@ -8540,7 +8048,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering-v2-0">Visual Question Answering v2.0</pwcdataset>
-      <video href="2021.emnlp-main.512.mp4"/>
     </paper>
     <paper id="513">
       <title>Improving Pre-trained Vision-and-Language Embeddings for Phrase Grounding</title>
@@ -8554,7 +8061,6 @@
       <video href="2021.emnlp-main.513.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.emnlp-main.513.mp4"/>
     </paper>
     <paper id="514">
       <title>Sequential Randomized Smoothing for Adversarially Robust Speech Recognition</title>
@@ -8568,7 +8074,6 @@
       <video href="2021.emnlp-main.514.mp4"/>
       <pwccode url="https://github.com/raphaelolivier/smoothingasr" additional="false">raphaelolivier/smoothingasr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
-      <video href="2021.emnlp-main.514.mp4"/>
     </paper>
     <paper id="515">
       <title>Hitting your <fixed-case>MARQ</fixed-case>: Multimodal <fixed-case>AR</fixed-case>gument Quality Assessment in Long Debate Video</title>
@@ -8587,7 +8092,6 @@
       <video href="2021.emnlp-main.515.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/dbates">DBATES</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ibm-rank-30k">IBM-Rank-30k</pwcdataset>
-      <video href="2021.emnlp-main.515.mp4"/>
     </paper>
     <paper id="516">
       <title>Mind the Context: The Impact of Contextualization in Neural Module Networks for Grounding Visual Referring Expressions</title>
@@ -8604,7 +8108,6 @@
       <video href="2021.emnlp-main.516.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/clevr">CLEVR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/clevr-ref">CLEVR-Ref+</pwcdataset>
-      <video href="2021.emnlp-main.516.mp4"/>
     </paper>
     <paper id="517">
       <title>Weakly-Supervised Visual-Retriever-Reader for Knowledge-based Question Answering</title>
@@ -8622,7 +8125,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ok-vqa">OK-VQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.emnlp-main.517.mp4"/>
     </paper>
     <paper id="518">
       <title><fixed-case>NDH</fixed-case>-Full: Learning and Evaluating Navigational Agents on Full-Length Dialogue</title>
@@ -8636,7 +8138,6 @@
       <doi>10.18653/v1/2021.emnlp-main.518</doi>
       <video href="2021.emnlp-main.518.mp4"/>
       <pwccode url="https://github.com/hyounghk/ndh-full" additional="false">hyounghk/ndh-full</pwccode>
-      <video href="2021.emnlp-main.518.mp4"/>
     </paper>
     <paper id="519">
       <title>Timeline Summarization based on Event Graph Compression via Time-Aware Optimal Transport</title>
@@ -8654,7 +8155,6 @@
       <doi>10.18653/v1/2021.emnlp-main.519</doi>
       <video href="2021.emnlp-main.519.mp4"/>
       <pwccode url="https://github.com/limanling/event-graph-summarization" additional="false">limanling/event-graph-summarization</pwccode>
-      <video href="2021.emnlp-main.519.mp4"/>
     </paper>
     <paper id="520">
       <title><fixed-case>S</fixed-case>tream<fixed-case>H</fixed-case>over: Livestream Transcript Summarization and Annotation</title>
@@ -8675,7 +8175,6 @@
       <doi>10.18653/v1/2021.emnlp-main.520</doi>
       <video href="2021.emnlp-main.520.mp4"/>
       <pwccode url="https://github.com/ucfnlp/streamhover" additional="false">ucfnlp/streamhover</pwccode>
-      <video href="2021.emnlp-main.520.mp4"/>
     </paper>
     <paper id="521">
       <title>Cross-Register Projection for Headline Part of Speech Tagging</title>
@@ -8690,7 +8189,6 @@
       <video href="2021.emnlp-main.521.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/english-web-treebank">English Web Treebank</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sentence-compression">Sentence Compression</pwcdataset>
-      <video href="2021.emnlp-main.521.mp4"/>
     </paper>
     <paper id="522">
       <title>Editing Factual Knowledge in Language Models</title>
@@ -8718,7 +8216,6 @@
       <pwccode url="https://github.com/bzhangGo/zero" additional="true">bzhangGo/zero</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2016">WMT 2016</pwcdataset>
-      <video href="2021.emnlp-main.523.mp4"/>
     </paper>
     <paper id="524">
       <title>Knowledge Base Completion Meets Transfer Learning</title>
@@ -8732,7 +8229,6 @@
       <video href="2021.emnlp-main.524.mp4"/>
       <pwccode url="https://github.com/vid-koci/kbctransferlearning" additional="false">vid-koci/kbctransferlearning</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/olpbench">OLPBENCH</pwcdataset>
-      <video href="2021.emnlp-main.524.mp4"/>
     </paper>
     <paper id="525">
       <title><fixed-case>SPECTRA</fixed-case>: Sparse Structured Text Rationalization</title>
@@ -8748,7 +8244,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.525.mp4"/>
     </paper>
     <paper id="526">
       <title>Towards Zero-Shot Knowledge Distillation for Natural Language Processing</title>
@@ -8767,7 +8262,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.526.mp4"/>
     </paper>
     <paper id="527">
       <title>Adversarial Regularization as Stackelberg Game: An Unrolled Optimization Approach</title>
@@ -8791,7 +8285,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mrpc">MRPC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.527.mp4"/>
     </paper>
     <paper id="528">
       <title>Aspect-Controllable Opinion Summarization</title>
@@ -8805,7 +8298,6 @@
       <doi>10.18653/v1/2021.emnlp-main.528</doi>
       <video href="2021.emnlp-main.528.mp4"/>
       <pwccode url="https://github.com/rktamplayo/acesum" additional="false">rktamplayo/acesum</pwccode>
-      <video href="2021.emnlp-main.528.mp4"/>
     </paper>
     <paper id="529">
       <title><fixed-case>Q</fixed-case>uest<fixed-case>E</fixed-case>val: Summarization Asks for Fact-based Evaluation</title>
@@ -8823,7 +8315,6 @@
       <doi>10.18653/v1/2021.emnlp-main.529</doi>
       <video href="2021.emnlp-main.529.mp4"/>
       <pwccode url="https://github.com/recitalAI/QuestEval" additional="true">recitalAI/QuestEval</pwccode>
-      <video href="2021.emnlp-main.529.mp4"/>
     </paper>
     <paper id="530">
       <title>Simple Conversational Data Augmentation for Semi-supervised Abstractive Dialogue Summarization</title>
@@ -8837,7 +8328,6 @@
       <video href="2021.emnlp-main.530.mp4"/>
       <pwccode url="https://github.com/gt-salt/coda" additional="false">gt-salt/coda</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.emnlp-main.530.mp4"/>
     </paper>
     <paper id="531">
       <title>Finding a Balanced Degree of Automation for Summary Evaluation</title>
@@ -8850,7 +8340,6 @@
       <doi>10.18653/v1/2021.emnlp-main.531</doi>
       <video href="2021.emnlp-main.531.mp4"/>
       <pwccode url="https://github.com/zhangshiyue/lite2-3pyramid" additional="false">zhangshiyue/lite2-3pyramid</pwccode>
-      <video href="2021.emnlp-main.531.mp4"/>
     </paper>
     <paper id="532">
       <title><fixed-case>CLIFF</fixed-case>: Contrastive Learning for Improving Faithfulness and Factuality in Abstractive Summarization</title>
@@ -8863,7 +8352,6 @@
       <doi>10.18653/v1/2021.emnlp-main.532</doi>
       <video href="2021.emnlp-main.532.mp4"/>
       <pwccode url="https://github.com/makcedward/nlpaug" additional="false">makcedward/nlpaug</pwccode>
-      <video href="2021.emnlp-main.532.mp4"/>
     </paper>
     <paper id="533">
       <title>Multilingual Unsupervised Neural Machine Translation with Denoising Adapters</title>
@@ -8878,7 +8366,6 @@
       <doi>10.18653/v1/2021.emnlp-main.533</doi>
       <video href="2021.emnlp-main.533.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/flores">FLoRes</pwcdataset>
-      <video href="2021.emnlp-main.533.mp4"/>
     </paper>
     <paper id="534">
       <title><fixed-case>BERT</fixed-case>, m<fixed-case>BERT</fixed-case>, or <fixed-case>B</fixed-case>i<fixed-case>BERT</fixed-case>? A Study on Contextualized Embeddings for Neural Machine Translation</title>
@@ -8894,7 +8381,6 @@
       <pwccode url="https://github.com/fe1ixxu/BiBERT" additional="true">fe1ixxu/BiBERT</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/oscar">OSCAR</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
-      <video href="2021.emnlp-main.534.mp4"/>
     </paper>
     <paper id="535">
       <title>Controlling Machine Translation for Multiple Attributes with Additive Interventions</title>
@@ -8909,7 +8395,6 @@
       <doi>10.18653/v1/2021.emnlp-main.535</doi>
       <video href="2021.emnlp-main.535.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/jesc">JESC</pwcdataset>
-      <video href="2021.emnlp-main.535.mp4"/>
     </paper>
     <paper id="536">
       <title>A Generative Framework for Simultaneous Machine Translation</title>
@@ -8921,7 +8406,6 @@
       <url hash="764afb8e">2021.emnlp-main.536</url>
       <bibkey>miao-etal-2021-generative</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.536</doi>
-      <video href="2021.emnlp-main.536.mp4"/>
       <video href="2021.emnlp-main.536.mp4"/>
     </paper>
     <paper id="537">
@@ -8938,7 +8422,6 @@
       <doi>10.18653/v1/2021.emnlp-main.537</doi>
       <video href="2021.emnlp-main.537.mp4"/>
       <pwccode url="https://github.com/mingzi151/interpretationdata" additional="false">mingzi151/interpretationdata</pwccode>
-      <video href="2021.emnlp-main.537.mp4"/>
     </paper>
     <paper id="538">
       <title>Boosting Cross-Lingual Transfer via Self-Learning with Uncertainty Estimation</title>
@@ -8956,7 +8439,6 @@
       <video href="2021.emnlp-main.538.mp4"/>
       <pwccode url="https://github.com/lxucs/multilingual-sl" additional="false">lxucs/multilingual-sl</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.538.mp4"/>
     </paper>
     <paper id="539">
       <title><fixed-case>L</fixed-case>evenshtein Training for Word-level Quality Estimation</title>
@@ -8971,7 +8453,6 @@
       <doi>10.18653/v1/2021.emnlp-main.539</doi>
       <video href="2021.emnlp-main.539.mp4"/>
       <pwccode url="https://github.com/shuoyangd/stenella" additional="false">shuoyangd/stenella</pwccode>
-      <video href="2021.emnlp-main.539.mp4"/>
     </paper>
     <paper id="540">
       <title>Interactive Machine Comprehension with Dynamic Knowledge Graphs</title>
@@ -8984,7 +8465,6 @@
       <video href="2021.emnlp-main.540.mp4"/>
       <pwccode url="https://github.com/xingdi-eric-yuan/imrc_graph_public" additional="false">xingdi-eric-yuan/imrc_graph_public</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.540.mp4"/>
     </paper>
     <paper id="541">
       <title>Residual Adapters for Parameter-Efficient <fixed-case>ASR</fixed-case> Adaptation to Atypical and Accented Speech</title>
@@ -8998,7 +8478,6 @@
       <url hash="8fcee1f2">2021.emnlp-main.541</url>
       <bibkey>tomanek-etal-2021-residual</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.541</doi>
-      <video href="2021.emnlp-main.541.mp4"/>
       <video href="2021.emnlp-main.541.mp4"/>
     </paper>
     <paper id="542">
@@ -9014,7 +8493,6 @@
       <doi>10.18653/v1/2021.emnlp-main.542</doi>
       <video href="2021.emnlp-main.542.mp4"/>
       <pwccode url="https://github.com/FuxiaoLiu/VisualNews-Repository" additional="false">FuxiaoLiu/VisualNews-Repository</pwccode>
-      <video href="2021.emnlp-main.542.mp4"/>
     </paper>
     <paper id="543">
       <title>Integrating Visuospatial, Linguistic, and Commonsense Structure into Story Visualization</title>
@@ -9029,7 +8507,6 @@
       <pwccode url="https://github.com/adymaharana/vlcstorygan" additional="false">adymaharana/vlcstorygan</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
-      <video href="2021.emnlp-main.543.mp4"/>
     </paper>
     <paper id="544">
       <title><fixed-case>V</fixed-case>ideo<fixed-case>CLIP</fixed-case>: Contrastive Pre-training for Zero-shot Video-Text Understanding</title>
@@ -9054,7 +8531,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/howto100m">HowTo100M</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/msr-vtt">MSR-VTT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/youcook2">YouCook2</pwcdataset>
-      <video href="2021.emnlp-main.544.mp4"/>
     </paper>
     <paper id="545">
       <title><fixed-case>N</fixed-case>ews<fixed-case>CLIP</fixed-case>pings: <fixed-case>A</fixed-case>utomatic <fixed-case>G</fixed-case>eneration of <fixed-case>O</fixed-case>ut-of-<fixed-case>C</fixed-case>ontext <fixed-case>M</fixed-case>ultimodal <fixed-case>M</fixed-case>edia</title>
@@ -9070,7 +8546,6 @@
       <pwccode url="https://github.com/g-luo/news_clippings" additional="false">g-luo/news_clippings</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/newsclippings">NewsCLIPpings</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptual-captions">Conceptual Captions</pwcdataset>
-      <video href="2021.emnlp-main.545.mp4"/>
     </paper>
     <paper id="546">
       <title>Powering Comparative Classification with Sentiment Analysis via Domain Adaptive Knowledge Transfer</title>
@@ -9085,7 +8560,6 @@
       <doi>10.18653/v1/2021.emnlp-main.546</doi>
       <video href="2021.emnlp-main.546.mp4"/>
       <pwccode url="https://github.com/zyli93/saecon" additional="false">zyli93/saecon</pwccode>
-      <video href="2021.emnlp-main.546.mp4"/>
     </paper>
     <paper id="547">
       <title>Tribrid: Stance Classification with Neural Inconsistency Detection</title>
@@ -9100,7 +8574,6 @@
       <video href="2021.emnlp-main.547.mp4"/>
       <pwccode url="https://github.com/karmaresearch/tribrid" additional="false">karmaresearch/tribrid</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/perspectrum">Perspectrum</pwcdataset>
-      <video href="2021.emnlp-main.547.mp4"/>
     </paper>
     <paper id="548">
       <title><fixed-case>SYSML</fixed-case>: <fixed-case>S</fixed-case>t<fixed-case>Y</fixed-case>lometry with <fixed-case>S</fixed-case>tructure and <fixed-case>M</fixed-case>ultitask <fixed-case>L</fixed-case>earning: <fixed-case>I</fixed-case>mplications for <fixed-case>D</fixed-case>arknet Forum Migrant Analysis</title>
@@ -9114,7 +8587,6 @@
       <doi>10.18653/v1/2021.emnlp-main.548</doi>
       <video href="2021.emnlp-main.548.mp4"/>
       <pwccode url="https://github.com/pranavmaneriker/sysml" additional="false">pranavmaneriker/sysml</pwccode>
-      <video href="2021.emnlp-main.548.mp4"/>
     </paper>
     <paper id="549">
       <title>Few-Shot Emotion Recognition in Conversation with Sequential Prototypical Networks</title>
@@ -9131,7 +8603,6 @@
       <video href="2021.emnlp-main.549.mp4"/>
       <pwccode url="https://github.com/gguibon/protoseq" additional="false">gguibon/protoseq</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
-      <video href="2021.emnlp-main.549.mp4"/>
     </paper>
     <paper id="550">
       <title><fixed-case>CLASSIC</fixed-case>: Continual and Contrastive Learning of Aspect Sentiment Classification Tasks</title>
@@ -9146,7 +8617,6 @@
       <doi>10.18653/v1/2021.emnlp-main.550</doi>
       <video href="2021.emnlp-main.550.mp4"/>
       <pwccode url="https://github.com/zixuanke/pycontinual" additional="false">zixuanke/pycontinual</pwccode>
-      <video href="2021.emnlp-main.550.mp4"/>
     </paper>
     <paper id="551">
       <title>Implicit Sentiment Analysis with Event-centered Text Representation</title>
@@ -9161,7 +8631,6 @@
       <doi>10.18653/v1/2021.emnlp-main.551</doi>
       <video href="2021.emnlp-main.551.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/framenet">FrameNet</pwcdataset>
-      <video href="2021.emnlp-main.551.mp4"/>
     </paper>
     <paper id="552">
       <title><fixed-case>S</fixed-case>im<fixed-case>CSE</fixed-case>: Simple Contrastive Learning of Sentence Embeddings</title>
@@ -9184,7 +8653,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sts-benchmark">STS Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semantic-textual-similarity-2012-2016">Semantic Textual Similarity (2012 - 2016)</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.emnlp-main.552.mp4"/>
     </paper>
     <paper id="553">
       <title>When is Wall a Pared and when a Muro?: Extracting Rules Governing Lexical Selection</title>
@@ -9199,7 +8667,6 @@
       <doi>10.18653/v1/2021.emnlp-main.553</doi>
       <video href="2021.emnlp-main.553.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
-      <video href="2021.emnlp-main.553.mp4"/>
     </paper>
     <paper id="554">
       <title>Aligning Actions Across Recipe Graphs</title>
@@ -9217,7 +8684,6 @@
       <video href="2021.emnlp-main.554.mp4"/>
       <pwccode url="https://github.com/coli-saar/ara" additional="false">coli-saar/ara</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/microsoft-research-multimodal-aligned-recipe">Microsoft Research Multimodal Aligned Recipe Corpus</pwcdataset>
-      <video href="2021.emnlp-main.554.mp4"/>
     </paper>
     <paper id="555">
       <title>Generating Datasets with Pretrained Language Models</title>
@@ -9234,7 +8700,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sick">SICK</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sts-benchmark">STS Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/semantic-textual-similarity-2012-2016">Semantic Textual Similarity (2012 - 2016)</pwcdataset>
-      <video href="2021.emnlp-main.555.mp4"/>
     </paper>
     <paper id="556">
       <title>Continuous Entailment Patterns for Lexical Inference in Context</title>
@@ -9248,7 +8713,6 @@
       <video href="2021.emnlp-main.556.mp4"/>
       <pwccode url="https://github.com/mnschmit/conan" additional="false">mnschmit/conan</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sherliic">SherLIiC</pwcdataset>
-      <video href="2021.emnlp-main.556.mp4"/>
     </paper>
     <paper id="557">
       <title>Numeracy enhances the Literacy of Language Models</title>
@@ -9265,7 +8729,6 @@
       <doi>10.18653/v1/2021.emnlp-main.557</doi>
       <video href="2021.emnlp-main.557.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiconvert">WikiConvert</pwcdataset>
-      <video href="2021.emnlp-main.557.mp4"/>
     </paper>
     <paper id="558">
       <title>Students Who Study Together Learn Better: On the Importance of Collective Knowledge Distillation for Domain Transfer in Fact Verification</title>
@@ -9279,7 +8742,6 @@
       <doi>10.18653/v1/2021.emnlp-main.558</doi>
       <video href="2021.emnlp-main.558.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/figer">FIGER</pwcdataset>
-      <video href="2021.emnlp-main.558.mp4"/>
     </paper>
     <paper id="559">
       <title><fixed-case>M</fixed-case>ulti<fixed-case>EURLEX</fixed-case> - A multi-lingual and multi-label legal document classification dataset for zero-shot cross-lingual transfer</title>
@@ -9297,7 +8759,6 @@
       <pwccode url="https://github.com/nlpaueb/multi-eurlex" additional="false">nlpaueb/multi-eurlex</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/eurlex57k">EURLEX57K</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.emnlp-main.559.mp4"/>
     </paper>
     <paper id="560">
       <title>Joint Passage Ranking for Diverse Multi-Answer Retrieval</title>
@@ -9313,7 +8774,6 @@
       <doi>10.18653/v1/2021.emnlp-main.560</doi>
       <video href="2021.emnlp-main.560.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.emnlp-main.560.mp4"/>
     </paper>
     <paper id="561">
       <title>Generative Context Pair Selection for Multi-hop Question Answering</title>
@@ -9332,7 +8792,6 @@
       <video href="2021.emnlp-main.561.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikihop">WikiHop</pwcdataset>
-      <video href="2021.emnlp-main.561.mp4"/>
     </paper>
     <paper id="562">
       <title>Synthetic Data Augmentation for Zero-Shot Cross-Lingual Question Answering</title>
@@ -9352,7 +8811,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mlqa">MLQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.emnlp-main.562.mp4"/>
     </paper>
     <paper id="563">
       <title>Have You Seen That Number? Investigating Extrapolation in Question Answering Models</title>
@@ -9368,7 +8826,6 @@
       <doi>10.18653/v1/2021.emnlp-main.563</doi>
       <video href="2021.emnlp-main.563.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
-      <video href="2021.emnlp-main.563.mp4"/>
     </paper>
     <paper id="564">
       <title>Surface Form Competition: Why the Highest Probability Answer Isn’t Always Right</title>
@@ -9389,7 +8846,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/commonsenseqa">CommonsenseQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/hellaswag">HellaSwag</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.564.mp4"/>
     </paper>
     <paper id="565">
       <title>Entity-Based Knowledge Conflicts in Question Answering</title>
@@ -9408,7 +8864,6 @@
       <pwccode url="https://github.com/apple/ml-knowledge-conflicts" additional="false">apple/ml-knowledge-conflicts</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsqa">NewsQA</pwcdataset>
-      <video href="2021.emnlp-main.565.mp4"/>
     </paper>
     <paper id="566">
       <title>Back-Training excels Self-Training at Unsupervised Domain Adaptation of Question Generation and Passage Retrieval</title>
@@ -9428,7 +8883,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/pubmedqa">PubMedQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/vqg">VQG</pwcdataset>
-      <video href="2021.emnlp-main.566.mp4"/>
     </paper>
     <paper id="567">
       <title><fixed-case>DWUG</fixed-case>: A large Resource of Diachronic Word Usage Graphs in Four Languages</title>
@@ -9469,7 +8923,6 @@
       <doi>10.18653/v1/2021.emnlp-main.569</doi>
       <video href="2021.emnlp-main.569.mp4"/>
       <pwccode url="https://github.com/nlpsoc/stel" additional="false">nlpsoc/stel</pwccode>
-      <video href="2021.emnlp-main.569.mp4"/>
     </paper>
     <paper id="570">
       <title>Evaluating the Morphosyntactic Well-formedness of Generated Texts</title>
@@ -9487,7 +8940,6 @@
       <doi>10.18653/v1/2021.emnlp-main.570</doi>
       <video href="2021.emnlp-main.570.mp4"/>
       <pwccode url="https://github.com/adithya7/lambre" additional="false">adithya7/lambre</pwccode>
-      <video href="2021.emnlp-main.570.mp4"/>
     </paper>
     <paper id="571">
       <title><fixed-case>AM</fixed-case>2i<fixed-case>C</fixed-case>o: Evaluating Word Meaning in Context across Low-Resource Languages with Adversarial Examples</title>
@@ -9507,7 +8959,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xl-wic">XL-WiC</pwcdataset>
-      <video href="2021.emnlp-main.571.mp4"/>
     </paper>
     <paper id="572">
       <title><fixed-case>C</fixed-case>ross<fixed-case>F</fixed-case>it: A Few-shot Learning Challenge for Cross-task Generalization in <fixed-case>NLP</fixed-case></title>
@@ -9527,7 +8978,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quoref">Quoref</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/race">RACE</pwcdataset>
-      <video href="2021.emnlp-main.572.mp4"/>
     </paper>
     <paper id="573">
       <title>On the Influence of Masking Policies in Intermediate Pre-training</title>
@@ -9551,7 +9001,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ropes">ROPES</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestions">WebQuestions</pwcdataset>
-      <video href="2021.emnlp-main.573.mp4"/>
     </paper>
     <paper id="574">
       <title><fixed-case>V</fixed-case>al<fixed-case>N</fixed-case>orm Quantifies Semantics to Reveal Consistent Valence Biases Across Languages and Over Centuries</title>
@@ -9565,7 +9014,6 @@
       <video href="2021.emnlp-main.574.mp4"/>
       <pwccode url="https://github.com/autumntoney/ValNorm" additional="true">autumntoney/ValNorm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.emnlp-main.574.mp4"/>
     </paper>
     <paper id="575">
       <title>Perturbation <fixed-case>C</fixed-case>heck<fixed-case>L</fixed-case>ists for Evaluating <fixed-case>NLG</fixed-case> Evaluation Metrics</title>
@@ -9581,7 +9029,6 @@
       <doi>10.18653/v1/2021.emnlp-main.575</doi>
       <video href="2021.emnlp-main.575.mp4"/>
       <pwccode url="https://github.com/iitmnlp/evaleval" additional="false">iitmnlp/evaleval</pwccode>
-      <video href="2021.emnlp-main.575.mp4"/>
     </paper>
     <paper id="576">
       <title>Robust Open-Vocabulary Translation from Visual Text Representations</title>
@@ -9596,7 +9043,6 @@
       <video href="2021.emnlp-main.576.mp4"/>
       <pwccode url="https://github.com/esalesky/visrep" additional="false">esalesky/visrep</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mtnt">MTNT</pwcdataset>
-      <video href="2021.emnlp-main.576.mp4"/>
     </paper>
     <paper id="577">
       <title>Don’t Go Far Off: An Empirical Study on Neural Poetry Translation</title>
@@ -9608,7 +9054,6 @@
       <url hash="89f96c72">2021.emnlp-main.577</url>
       <bibkey>chakrabarty-etal-2021-dont</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.577</doi>
-      <video href="2021.emnlp-main.577.mp4"/>
       <video href="2021.emnlp-main.577.mp4"/>
     </paper>
     <paper id="578">
@@ -9627,7 +9072,6 @@
       <video href="2021.emnlp-main.578.mp4"/>
       <pwccode url="https://github.com/yilinyang7/fairseq_multi_fix" additional="false">yilinyang7/fairseq_multi_fix</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/opus-100">OPUS-100</pwcdataset>
-      <video href="2021.emnlp-main.578.mp4"/>
     </paper>
     <paper id="579">
       <title>Learning Kernel-Smoothed Machine Translation with Retrieved Examples</title>
@@ -9645,7 +9089,6 @@
       <video href="2021.emnlp-main.579.mp4"/>
       <pwccode url="https://github.com/jiangqn/kster" additional="false">jiangqn/kster</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
-      <video href="2021.emnlp-main.579.mp4"/>
     </paper>
     <paper id="580">
       <title>Uncertainty-Aware Balancing for Multilingual and Multi-Domain Neural Machine Translation Training</title>
@@ -9662,7 +9105,6 @@
       <doi>10.18653/v1/2021.emnlp-main.580</doi>
       <video href="2021.emnlp-main.580.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
-      <video href="2021.emnlp-main.580.mp4"/>
     </paper>
     <paper id="581">
       <title>Universal Simultaneous Machine Translation with Mixture-of-Experts Wait-k Policy</title>
@@ -9675,7 +9117,6 @@
       <doi>10.18653/v1/2021.emnlp-main.581</doi>
       <video href="2021.emnlp-main.581.mp4"/>
       <pwccode url="https://github.com/ictnlp/moe-waitk" additional="false">ictnlp/moe-waitk</pwccode>
-      <video href="2021.emnlp-main.581.mp4"/>
     </paper>
     <paper id="582">
       <title>How much coffee was consumed during <fixed-case>EMNLP</fixed-case> 2019? Fermi Problems: A New Reasoning Challenge for <fixed-case>AI</fixed-case></title>
@@ -9689,7 +9130,6 @@
       <url hash="37be56eb">2021.emnlp-main.582</url>
       <bibkey>kalyan-etal-2021-much</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.582</doi>
-      <video href="2021.emnlp-main.582.mp4"/>
       <video href="2021.emnlp-main.582.mp4"/>
     </paper>
     <paper id="583">
@@ -9707,7 +9147,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/paralex">Paralex</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikiqa">WikiQA</pwcdataset>
-      <video href="2021.emnlp-main.583.mp4"/>
     </paper>
     <paper id="584">
       <title>Learning with Instance Bundles for Reading Comprehension</title>
@@ -9724,7 +9163,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/hotpotqa">HotpotQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/quoref">Quoref</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ropes">ROPES</pwcdataset>
-      <video href="2021.emnlp-main.584.mp4"/>
     </paper>
     <paper id="585">
       <title>Explaining Answers with Entailment Trees</title>
@@ -9746,7 +9184,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/proofwriter">ProofWriter</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/worldtree">Worldtree</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/eqasc">eQASC</pwcdataset>
-      <video href="2021.emnlp-main.585.mp4"/>
     </paper>
     <paper id="586">
       <title><fixed-case>S</fixed-case>ituated<fixed-case>QA</fixed-case>: Incorporating Extra-Linguistic Contexts into <fixed-case>QA</fixed-case></title>
@@ -9761,7 +9198,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/situatedqa">SituatedQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.emnlp-main.586.mp4"/>
     </paper>
     <paper id="587">
       <title><fixed-case>C</fixed-case>onv<fixed-case>A</fixed-case>buse: Data, Analysis, and Benchmarks for Nuanced Abuse Detection in Conversational <fixed-case>AI</fixed-case></title>
@@ -9775,7 +9211,6 @@
       <doi>10.18653/v1/2021.emnlp-main.587</doi>
       <video href="2021.emnlp-main.587.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/olid">OLID</pwcdataset>
-      <video href="2021.emnlp-main.587.mp4"/>
     </paper>
     <paper id="588">
       <title>Conversational Multi-Hop Reasoning with Neural Commonsense Knowledge and Symbolic Logic Rules</title>
@@ -9791,7 +9226,6 @@
       <doi>10.18653/v1/2021.emnlp-main.588</doi>
       <video href="2021.emnlp-main.588.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.emnlp-main.588.mp4"/>
     </paper>
     <paper id="589">
       <title>Towards Automatic Evaluation of Dialog Systems: A Model-Free Off-Policy Evaluation Approach</title>
@@ -9808,7 +9242,6 @@
       <video href="2021.emnlp-main.589.mp4"/>
       <pwccode url="https://github.com/google-research/google-research" additional="false">google-research/google-research</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/convai2">ConvAI2</pwcdataset>
-      <video href="2021.emnlp-main.589.mp4"/>
     </paper>
     <paper id="590">
       <title>Continual Learning in Task-Oriented Dialogue Systems</title>
@@ -9830,7 +9263,6 @@
       <video href="2021.emnlp-main.590.mp4"/>
       <pwccode url="https://github.com/andreamad8/ToDCL" additional="false">andreamad8/ToDCL</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sgd">SGD</pwcdataset>
-      <video href="2021.emnlp-main.590.mp4"/>
     </paper>
     <paper id="591">
       <title>Multilingual and Cross-Lingual Intent Detection from Spoken Data</title>
@@ -9850,8 +9282,6 @@
       <doi>10.18653/v1/2021.emnlp-main.591</doi>
       <video href="2021.emnlp-main.591.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
-      <video href="2021.emnlp-main.591.mp4"/>
-      <video href="2021.emnlp-main.591.mp4"/>
     </paper>
     <paper id="592">
       <title>Investigating Robustness of Dialog Models to Popular Figurative Language Constructs</title>
@@ -9867,7 +9297,6 @@
       <video href="2021.emnlp-main.592.mp4"/>
       <pwccode url="https://github.com/vgtomahawk/dialog-fig-speech-robust" additional="false">vgtomahawk/dialog-fig-speech-robust</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/dailydialog">DailyDialog</pwcdataset>
-      <video href="2021.emnlp-main.592.mp4"/>
     </paper>
     <paper id="593">
       <title>Effective Sequence-to-Sequence Dialogue State Tracking</title>
@@ -9886,7 +9315,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/dialogue-state-tracking-challenge">Dialogue State Tracking Challenge</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-oz">Wizard-of-Oz</pwcdataset>
-      <video href="2021.emnlp-main.593.mp4"/>
     </paper>
     <paper id="594">
       <title><fixed-case>MS</fixed-case>ˆ2: Multi-Document Summarization of Medical Studies</title>
@@ -9923,7 +9351,6 @@
       <revision id="2" href="2021.emnlp-main.595v2" hash="c820e9c2" date="2022-03-28">Fixed results in Table 7 for reproducability purposes.</revision>
       <video href="2021.emnlp-main.595.mp4"/>
       <pwccode url="https://github.com/jmhessel/clipscore" additional="true">jmhessel/clipscore</pwccode>
-      <video href="2021.emnlp-main.595.mp4"/>
     </paper>
     <paper id="596">
       <title>On the Challenges of Evaluating Compositional Explanations in Multi-Hop Inference: Relevance, Completeness, and Expert Ratings</title>
@@ -9939,7 +9366,6 @@
       <video href="2021.emnlp-main.596.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/qasc">QASC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/worldtree">Worldtree</pwcdataset>
-      <video href="2021.emnlp-main.596.mp4"/>
     </paper>
     <paper id="597">
       <title><fixed-case>ESTER</fixed-case>: A Machine Reading Comprehension Dataset for Reasoning about Event Semantic Relations</title>
@@ -9957,7 +9383,6 @@
       <doi>10.18653/v1/2021.emnlp-main.597</doi>
       <video href="2021.emnlp-main.597.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/torque">Torque</pwcdataset>
-      <video href="2021.emnlp-main.597.mp4"/>
     </paper>
     <paper id="598">
       <title><fixed-case>RICA</fixed-case>: Evaluating Robust Inference Capabilities Based on Commonsense Axioms</title>
@@ -9973,7 +9398,6 @@
       <url hash="17445795">2021.emnlp-main.598</url>
       <bibkey>zhou-etal-2021-rica</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.598</doi>
-      <video href="2021.emnlp-main.598.mp4"/>
       <video href="2021.emnlp-main.598.mp4"/>
     </paper>
     <paper id="599">
@@ -9992,7 +9416,6 @@
       <video href="2021.emnlp-main.599.mp4"/>
       <pwccode url="https://github.com/tanyuqian/ctc-gen-eval" additional="false">tanyuqian/ctc-gen-eval</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cnn-daily-mail-1">CNN/Daily Mail</pwcdataset>
-      <video href="2021.emnlp-main.599.mp4"/>
     </paper>
     <paper id="600">
       <title><fixed-case>MATE</fixed-case>: Multi-view Attention for Table Transformer Efficiency</title>
@@ -10010,7 +9433,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/hybridqa">HybridQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sqa">SQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tabfact">TabFact</pwcdataset>
-      <video href="2021.emnlp-main.600.mp4"/>
     </paper>
     <paper id="601">
       <title>Learning with Different Amounts of Annotation: From Zero to Many Labels</title>
@@ -10027,7 +9449,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/chaosnli">ChaosNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.601.mp4"/>
     </paper>
     <paper id="602">
       <title>When Attention Meets Fast Recurrence: Training Language Models with Reduced Compute</title>
@@ -10042,7 +9463,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/billion-word-benchmark">Billion Word Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.602.mp4"/>
     </paper>
     <paper id="603">
       <title>Universal-<fixed-case>KD</fixed-case>: Attention-based Output-Grounded Intermediate Layer Knowledge Distillation</title>
@@ -10063,7 +9483,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.603.mp4"/>
     </paper>
     <paper id="604">
       <title>Highly Parallel Autoregressive Entity Linking with Discriminative Correction</title>
@@ -10078,7 +9497,6 @@
       <video href="2021.emnlp-main.604.mp4"/>
       <pwccode url="https://github.com/nicola-decao/efficient-autoregressive-EL" additional="false">nicola-decao/efficient-autoregressive-EL</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aida-conll-yago">AIDA CoNLL-YAGO</pwcdataset>
-      <video href="2021.emnlp-main.604.mp4"/>
     </paper>
     <paper id="605">
       <title>Word-Level Coreference Resolution</title>
@@ -10092,7 +9510,6 @@
       <pwccode url="https://github.com/vdobrovolskii/wl-coref" additional="false">vdobrovolskii/wl-coref</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2012-1">CoNLL-2012</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/ontonotes-5-0">OntoNotes 5.0</pwcdataset>
-      <video href="2021.emnlp-main.605.mp4"/>
     </paper>
     <paper id="606">
       <title>A Secure and Efficient Federated Learning Framework for <fixed-case>NLP</fixed-case></title>
@@ -10112,8 +9529,6 @@
       <bibkey>wang-etal-2021-secure</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.606</doi>
       <video href="2021.emnlp-main.606.mp4"/>
-      <video href="2021.emnlp-main.606.mp4"/>
-      <video href="2021.emnlp-main.606.mp4"/>
     </paper>
     <paper id="607">
       <title>Controllable Semantic Parsing via Retrieval Augmentation</title>
@@ -10128,7 +9543,6 @@
       <video href="2021.emnlp-main.607.mp4"/>
       <pwccode url="https://github.com/google-research/language/tree/master/language/casper" additional="false">google-research/language</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mtop">MTOP</pwcdataset>
-      <video href="2021.emnlp-main.607.mp4"/>
     </paper>
     <paper id="608">
       <title>Constrained Language Models Yield Few-Shot Semantic Parsers</title>
@@ -10150,7 +9564,6 @@
       <video href="2021.emnlp-main.608.mp4"/>
       <pwccode url="https://github.com/microsoft/semantic_parsing_with_constrained_lm" additional="false">microsoft/semantic_parsing_with_constrained_lm</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/break">BREAK</pwcdataset>
-      <video href="2021.emnlp-main.608.mp4"/>
     </paper>
     <paper id="609">
       <title><fixed-case>E</fixed-case>xpla<fixed-case>G</fixed-case>raphs: An Explanation Graph Generation Task for Structured Commonsense Reasoning</title>
@@ -10165,7 +9578,6 @@
       <doi>10.18653/v1/2021.emnlp-main.609</doi>
       <video href="2021.emnlp-main.609.mp4"/>
       <pwccode url="https://github.com/swarnaHub/ExplaGraphs" additional="false">swarnaHub/ExplaGraphs</pwccode>
-      <video href="2021.emnlp-main.609.mp4"/>
     </paper>
     <paper id="610">
       <title>Connect-the-Dots: Bridging Semantics between Words and Definitions via Aligning Word Sense Inventories</title>
@@ -10184,7 +9596,6 @@
       <pwccode url="https://github.com/tencent-ailab/EMNLP21_SemEq" additional="true">tencent-ailab/EMNLP21_SemEq</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wic">WiC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.emnlp-main.610.mp4"/>
     </paper>
     <paper id="611">
       <title><fixed-case>LM</fixed-case>-Critic: Language Models for Unsupervised Grammatical Error Correction</title>
@@ -10203,7 +9614,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/gmeg-yahoo">GMEG-yahoo</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/locness-corpus">WI-LOCNESS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/yahoo-answers">Yahoo! Answers</pwcdataset>
-      <video href="2021.emnlp-main.611.mp4"/>
     </paper>
     <paper id="612">
       <title>Language-agnostic Representation from Multilingual Sentence Encoders for Cross-lingual Similarity Estimation</title>
@@ -10218,7 +9628,6 @@
       <doi>10.18653/v1/2021.emnlp-main.612</doi>
       <video href="2021.emnlp-main.612.mp4"/>
       <pwccode url="https://github.com/nattaptiy/qe_disentangled" additional="false">nattaptiy/qe_disentangled</pwccode>
-      <video href="2021.emnlp-main.612.mp4"/>
     </paper>
     <paper id="613">
       <title>Classifying Dyads for Militarized Conflict Analysis</title>
@@ -10234,7 +9643,6 @@
       <doi>10.18653/v1/2021.emnlp-main.613</doi>
       <video href="2021.emnlp-main.613.mp4"/>
       <pwccode url="https://github.com/conflict-ai/conflictwiki" additional="false">conflict-ai/conflictwiki</pwccode>
-      <video href="2021.emnlp-main.613.mp4"/>
     </paper>
     <paper id="614">
       <title>Point-of-Interest Type Prediction using Text and Images</title>
@@ -10248,7 +9656,6 @@
       <video href="2021.emnlp-main.614.mp4"/>
       <pwccode url="https://github.com/danaesavi/poi-type-prediction" additional="false">danaesavi/poi-type-prediction</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
-      <video href="2021.emnlp-main.614.mp4"/>
     </paper>
     <paper id="615">
       <title>Come hither or go away? Recognising pre-electoral coalition signals in the news</title>
@@ -10263,7 +9670,6 @@
       <url hash="8a06a6f1">2021.emnlp-main.615</url>
       <bibkey>rehbein-etal-2021-come</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.615</doi>
-      <video href="2021.emnlp-main.615.mp4"/>
       <video href="2021.emnlp-main.615.mp4"/>
     </paper>
     <paper id="616">
@@ -10281,7 +9687,6 @@
       <doi>10.18653/v1/2021.emnlp-main.616</doi>
       <video href="2021.emnlp-main.616.mp4"/>
       <pwccode url="https://github.com/polyusmart/personalized-hashtag-preferences" additional="false">polyusmart/personalized-hashtag-preferences</pwccode>
-      <video href="2021.emnlp-main.616.mp4"/>
     </paper>
     <paper id="617">
       <title>Learning Neural Templates for Recommender Dialogue System</title>
@@ -10301,7 +9706,6 @@
       <doi>10.18653/v1/2021.emnlp-main.617</doi>
       <video href="2021.emnlp-main.617.mp4"/>
       <pwccode url="https://github.com/jokieleung/ntrd" additional="false">jokieleung/ntrd</pwccode>
-      <video href="2021.emnlp-main.617.mp4"/>
     </paper>
     <paper id="618">
       <title>Proxy Indicators for the Quality of Open-domain Dialogues</title>
@@ -10325,7 +9729,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/usr-personachat">USR-PersonaChat</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/usr-topicalchat">USR-TopicalChat</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
-      <video href="2021.emnlp-main.618.mp4"/>
     </paper>
     <paper id="619">
       <title><tex-math>Q^{2}</tex-math>: <fixed-case>E</fixed-case>valuating Factual Consistency in Knowledge-Grounded Dialogues via Question Generation and Question Answering</title>
@@ -10344,7 +9747,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wizard-of-wikipedia">Wizard of Wikipedia</pwcdataset>
-      <video href="2021.emnlp-main.619.mp4"/>
     </paper>
     <paper id="620">
       <title>Knowledge-Aware Graph-Enhanced <fixed-case>GPT</fixed-case>-2 for Dialogue State Tracking</title>
@@ -10359,7 +9761,6 @@
       <video href="2021.emnlp-main.620.mp4"/>
       <pwccode url="https://github.com/linweizhedragon/knowledge-aware-graph-enhanced-gpt-2-for-dialogue-state-tracking" additional="false">linweizhedragon/knowledge-aware-graph-enhanced-gpt-2-for-dialogue-state-tracking</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.emnlp-main.620.mp4"/>
     </paper>
     <paper id="621">
       <title>A Collaborative Multi-agent Reinforcement Learning Framework for Dialog Action Decomposition</title>
@@ -10372,7 +9773,6 @@
       <doi>10.18653/v1/2021.emnlp-main.621</doi>
       <video href="2021.emnlp-main.621.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/multiwoz">MultiWOZ</pwcdataset>
-      <video href="2021.emnlp-main.621.mp4"/>
     </paper>
     <paper id="622">
       <title>Zero-Shot Dialogue State Tracking via Cross-Task Transfer</title>
@@ -10403,7 +9803,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.622.mp4"/>
     </paper>
     <paper id="623">
       <title>Uncertainty Measures in Neural Belief Tracking and the Effects on Dialogue Policy Performance</title>
@@ -10421,7 +9820,6 @@
       <bibkey>van-niekerk-etal-2021-uncertainty</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.623</doi>
       <video href="2021.emnlp-main.623.mp4"/>
-      <video href="2021.emnlp-main.623.mp4"/>
     </paper>
     <paper id="624">
       <title>Dynamic Forecasting of Conversation Derailment</title>
@@ -10432,7 +9830,6 @@
       <url hash="4c08ad5a">2021.emnlp-main.624</url>
       <bibkey>kementchedjhieva-sogaard-2021-dynamic</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.624</doi>
-      <video href="2021.emnlp-main.624.mp4"/>
       <video href="2021.emnlp-main.624.mp4"/>
     </paper>
     <paper id="625">
@@ -10449,7 +9846,6 @@
       <doi>10.18653/v1/2021.emnlp-main.625</doi>
       <video href="2021.emnlp-main.625.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
-      <video href="2021.emnlp-main.625.mp4"/>
     </paper>
     <paper id="626">
       <title><fixed-case>AdapterDrop</fixed-case>: <fixed-case>O</fixed-case>n the Efficiency of Adapters in Transformers</title>
@@ -10467,7 +9863,6 @@
       <doi>10.18653/v1/2021.emnlp-main.626</doi>
       <video href="2021.emnlp-main.626.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.emnlp-main.626.mp4"/>
     </paper>
     <paper id="627">
       <title>Understanding and Overcoming the Challenges of Efficient Transformer Quantization</title>
@@ -10483,7 +9878,6 @@
       <pwccode url="https://github.com/qualcomm-ai-research/transformer-quantization" additional="false">qualcomm-ai-research/transformer-quantization</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.emnlp-main.627.mp4"/>
     </paper>
     <paper id="628">
       <title><fixed-case>CAPE</fixed-case>: Context-Aware Private Embeddings for Private Language Learning</title>
@@ -10499,7 +9893,6 @@
       <revision id="1" href="2021.emnlp-main.628v1" hash="78618ae7"/>
       <revision id="2" href="2021.emnlp-main.628v2" hash="b207e072" date="2022-06-22">Updated some experiment results.</revision>
       <pwccode url="" additional="true"/>
-      <video href="2021.emnlp-main.628.mp4"/>
     </paper>
     <paper id="629">
       <title>Text Detoxification using Large Pre-trained Neural Models</title>
@@ -10517,7 +9910,6 @@
       <doi>10.18653/v1/2021.emnlp-main.629</doi>
       <video href="2021.emnlp-main.629.mp4"/>
       <pwccode url="https://github.com/skoltech-nlp/detox" additional="false">skoltech-nlp/detox</pwccode>
-      <video href="2021.emnlp-main.629.mp4"/>
     </paper>
     <paper id="630">
       <title>Document-Level Text Simplification: Dataset, Criteria and Baseline</title>
@@ -10533,7 +9925,6 @@
       <pwccode url="https://github.com/rlsnlp/document-level-text-simplification" additional="false">rlsnlp/document-level-text-simplification</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/newsela">Newsela</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikilarge">WikiLarge</pwcdataset>
-      <video href="2021.emnlp-main.630.mp4"/>
     </paper>
     <paper id="631">
       <title>A Bag of Tricks for Dialogue Summarization</title>
@@ -10548,7 +9939,6 @@
       <video href="2021.emnlp-main.631.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/commongen">CommonGen</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
-      <video href="2021.emnlp-main.631.mp4"/>
     </paper>
     <paper id="632">
       <title>Paraphrasing Compound Nominalizations</title>
@@ -10580,7 +9970,6 @@
       <pwccode url="https://github.com/ThomasScialom/QuestEval" additional="true">ThomasScialom/QuestEval</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikibio">WikiBio</pwcdataset>
-      <video href="2021.emnlp-main.633.mp4"/>
     </paper>
     <paper id="634">
       <title>Low-Rank Subspaces for Unsupervised Entity Linking</title>
@@ -10611,7 +10000,6 @@
       <pwccode url="https://github.com/4ai/tdeer" additional="false">4ai/tdeer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/nyt11-hrl">NYT11-HRL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webnlg">WebNLG</pwcdataset>
-      <video href="2021.emnlp-main.635.mp4"/>
     </paper>
     <paper id="636">
       <title>Extracting Event Temporal Relations via Hyperbolic Geometry</title>
@@ -10626,7 +10014,6 @@
       <video href="2021.emnlp-main.636.mp4"/>
       <pwccode url="https://github.com/xingwei-warwick/hyper-event-temprel" additional="false">xingwei-warwick/hyper-event-temprel</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/tcr">TCR</pwcdataset>
-      <video href="2021.emnlp-main.636.mp4"/>
     </paper>
     <paper id="637">
       <title>Honey or Poison? Solving the Trigger Curse in Few-shot Event Detection via Causal Intervention</title>
@@ -10642,7 +10029,6 @@
       <video href="2021.emnlp-main.637.mp4"/>
       <pwccode url="https://github.com/chen700564/causalfsed" additional="false">chen700564/causalfsed</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/maven">MAVEN</pwcdataset>
-      <video href="2021.emnlp-main.637.mp4"/>
     </paper>
     <paper id="638">
       <title>Back to the Basics: A Quantitative Analysis of Statistical and Graph-Based Term Weighting Schemes for Keyword Extraction</title>
@@ -10657,7 +10043,6 @@
       <video href="2021.emnlp-main.638.mp4"/>
       <pwccode url="https://github.com/asahi417/kex" additional="false">asahi417/kex</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/semeval-2018-task-9-hypernym-discovery">SemEval-2018 Task 9: Hypernym Discovery</pwcdataset>
-      <video href="2021.emnlp-main.638.mp4"/>
     </paper>
     <paper id="639">
       <title>Time-dependent Entity Embedding is not All You Need: A Re-evaluation of Temporal Knowledge Graph Completion Models under a Unified Framework</title>
@@ -10672,7 +10057,6 @@
       <doi>10.18653/v1/2021.emnlp-main.639</doi>
       <video href="2021.emnlp-main.639.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/icews">ICEWS</pwcdataset>
-      <video href="2021.emnlp-main.639.mp4"/>
     </paper>
     <paper id="640">
       <title>Matching-oriented Embedding Quantization For Ad-hoc Retrieval</title>
@@ -10688,7 +10072,6 @@
       <doi>10.18653/v1/2021.emnlp-main.640</doi>
       <video href="2021.emnlp-main.640.mp4"/>
       <pwccode url="https://github.com/microsoft/mopq" additional="false">microsoft/mopq</pwccode>
-      <video href="2021.emnlp-main.640.mp4"/>
     </paper>
     <paper id="641">
       <title>Efficient Mind-Map Generation via Sequence-to-Graph and Reinforced Graph Refinement</title>
@@ -10702,7 +10085,6 @@
       <url hash="48d46828">2021.emnlp-main.641</url>
       <bibkey>hu-etal-2021-efficient</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.641</doi>
-      <video href="2021.emnlp-main.641.mp4"/>
       <video href="2021.emnlp-main.641.mp4"/>
     </paper>
     <paper id="642">
@@ -10721,7 +10103,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.642.mp4"/>
     </paper>
     <paper id="643">
       <title>Balancing Methods for Multi-label Text Classification with Long-Tailed Class Distribution</title>
@@ -10738,7 +10119,6 @@
       <video href="2021.emnlp-main.643.mp4"/>
       <pwccode url="https://github.com/Roche/BalancedLossNLP" additional="true">Roche/BalancedLossNLP</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/reuters-21578">Reuters-21578</pwcdataset>
-      <video href="2021.emnlp-main.643.mp4"/>
     </paper>
     <paper id="644">
       <title><fixed-case>B</fixed-case>ayesian Topic Regression for Causal Inference</title>
@@ -10755,7 +10135,6 @@
       <doi>10.18653/v1/2021.emnlp-main.644</doi>
       <video href="2021.emnlp-main.644.mp4"/>
       <pwccode url="https://github.com/maximilianahrens/data" additional="false">maximilianahrens/data</pwccode>
-      <video href="2021.emnlp-main.644.mp4"/>
     </paper>
     <paper id="645">
       <title>Enjoy the Salience: Towards Better Transformer-based Faithful Explanations with Word Salience</title>
@@ -10769,7 +10148,6 @@
       <video href="2021.emnlp-main.645.mp4"/>
       <pwccode url="https://github.com/gchrysostomou/saloss" additional="false">gchrysostomou/saloss</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.645.mp4"/>
     </paper>
     <paper id="646">
       <title><fixed-case>W</fixed-case>hat’s in Your Head? <fixed-case>E</fixed-case>mergent Behaviour in Multi-Task Transformer Models</title>
@@ -10784,7 +10162,6 @@
       <doi>10.18653/v1/2021.emnlp-main.646</doi>
       <video href="2021.emnlp-main.646.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
-      <video href="2021.emnlp-main.646.mp4"/>
     </paper>
     <paper id="647">
       <title>Don’t Search for a Search Method — Simple Heuristics Suffice for Adversarial Text Attacks</title>
@@ -10797,7 +10174,6 @@
       <url hash="103f9e6a">2021.emnlp-main.647</url>
       <bibkey>berger-etal-2021-dont</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.647</doi>
-      <video href="2021.emnlp-main.647.mp4"/>
       <video href="2021.emnlp-main.647.mp4"/>
     </paper>
     <paper id="648">
@@ -10813,7 +10189,6 @@
       <doi>10.18653/v1/2021.emnlp-main.648</doi>
       <video href="2021.emnlp-main.648.mp4"/>
       <pwccode url="https://github.com/perubhardwaj/attributionattack" additional="false">perubhardwaj/attributionattack</pwccode>
-      <video href="2021.emnlp-main.648.mp4"/>
     </paper>
     <paper id="649">
       <title>Locke’s Holiday: Belief Bias in Machine Reading</title>
@@ -10825,7 +10200,6 @@
       <doi>10.18653/v1/2021.emnlp-main.649</doi>
       <video href="2021.emnlp-main.649.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
-      <video href="2021.emnlp-main.649.mp4"/>
     </paper>
     <paper id="650">
       <title>Sequence Length is a Domain: Length-based Overfitting in Transformer Models</title>
@@ -10836,7 +10210,6 @@
       <url hash="55a0b05d">2021.emnlp-main.650</url>
       <bibkey>varis-bojar-2021-sequence</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.650</doi>
-      <video href="2021.emnlp-main.650.mp4"/>
       <video href="2021.emnlp-main.650.mp4"/>
     </paper>
     <paper id="651">
@@ -10854,7 +10227,6 @@
       <video href="2021.emnlp-main.651.mp4"/>
       <pwccode url="https://github.com/maximilianmozes/human_adversaries" additional="false">maximilianmozes/human_adversaries</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.651.mp4"/>
     </paper>
     <paper id="652">
       <title>Is Information Density Uniform in Task-Oriented Dialogues?</title>
@@ -10870,7 +10242,6 @@
       <video href="2021.emnlp-main.652.mp4"/>
       <pwccode url="https://github.com/dmg-illc/uid-dialogue" additional="false">dmg-illc/uid-dialogue</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/photobook">PhotoBook</pwcdataset>
-      <video href="2021.emnlp-main.652.mp4"/>
     </paper>
     <paper id="653">
       <title>On Homophony and Rényi Entropy</title>
@@ -10885,7 +10256,6 @@
       <doi>10.18653/v1/2021.emnlp-main.653</doi>
       <video href="2021.emnlp-main.653.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/celex">CELEX</pwcdataset>
-      <video href="2021.emnlp-main.653.mp4"/>
     </paper>
     <paper id="654">
       <title>Synthetic Textual Features for the Large-Scale Detection of Basic-level Categories in <fixed-case>E</fixed-case>nglish and <fixed-case>M</fixed-case>andarin</title>
@@ -10896,7 +10266,6 @@
       <url hash="1a55c0cd">2021.emnlp-main.654</url>
       <bibkey>chen-teufel-2021-synthetic</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.654</doi>
-      <video href="2021.emnlp-main.654.mp4"/>
       <video href="2021.emnlp-main.654.mp4"/>
     </paper>
     <paper id="655">
@@ -10915,7 +10284,6 @@
       <video href="2021.emnlp-main.655.mp4"/>
       <pwccode url="https://github.com/jhl-hust/titer" additional="false">jhl-hust/titer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/icews">ICEWS</pwcdataset>
-      <video href="2021.emnlp-main.655.mp4"/>
     </paper>
     <paper id="656">
       <title>Code-switched inspired losses for spoken dialog representations</title>
@@ -10943,7 +10311,6 @@
       <video href="2021.emnlp-main.657.mp4"/>
       <pwccode url="https://github.com/guojiapub/bique" additional="false">guojiapub/bique</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
-      <video href="2021.emnlp-main.657.mp4"/>
     </paper>
     <paper id="658">
       <title>Learning Neural Ordinary Equations for Forecasting Future Links on Temporal Knowledge Graphs</title>
@@ -10959,7 +10326,6 @@
       <doi>10.18653/v1/2021.emnlp-main.658</doi>
       <video href="2021.emnlp-main.658.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/icews">ICEWS</pwcdataset>
-      <video href="2021.emnlp-main.658.mp4"/>
     </paper>
     <paper id="659">
       <title><fixed-case>RAP</fixed-case>: <fixed-case>R</fixed-case>obustness-<fixed-case>A</fixed-case>ware <fixed-case>P</fixed-case>erturbations for Defending against Backdoor Attacks on <fixed-case>NLP</fixed-case> Models</title>
@@ -10976,7 +10342,6 @@
       <video href="2021.emnlp-main.659.mp4"/>
       <pwccode url="https://github.com/lancopku/rap" additional="false">lancopku/rap</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
-      <video href="2021.emnlp-main.659.mp4"/>
     </paper>
     <paper id="660">
       <title><fixed-case>FAME</fixed-case>: <fixed-case>F</fixed-case>eature-Based Adversarial Meta-Embeddings for Robust Input Representations</title>
@@ -10991,7 +10356,6 @@
       <doi>10.18653/v1/2021.emnlp-main.660</doi>
       <video href="2021.emnlp-main.660.mp4"/>
       <pwccode url="https://github.com/boschresearch/adversarial_meta_embeddings" additional="false">boschresearch/adversarial_meta_embeddings</pwccode>
-      <video href="2021.emnlp-main.660.mp4"/>
     </paper>
     <paper id="661">
       <title>A Strong Baseline for Query Efficient Attacks in a Black Box Setting</title>
@@ -11007,7 +10371,6 @@
       <pwccode url="https://github.com/rishabhmaheshwary/query-attack" additional="false">rishabhmaheshwary/query-attack</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-main.661.mp4"/>
     </paper>
     <paper id="662">
       <title>Machine Translation Decoding beyond Beam Search</title>
@@ -11025,7 +10388,6 @@
       <bibkey>leblond-etal-2021-machine</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.662</doi>
       <video href="2021.emnlp-main.662.mp4"/>
-      <video href="2021.emnlp-main.662.mp4"/>
     </paper>
     <paper id="663">
       <title>Document Graph for Neural Machine Translation</title>
@@ -11039,7 +10401,6 @@
       <url hash="77613875">2021.emnlp-main.663</url>
       <bibkey>xu-etal-2021-document-graph</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.663</doi>
-      <video href="2021.emnlp-main.663.mp4"/>
       <video href="2021.emnlp-main.663.mp4"/>
     </paper>
     <paper id="664">
@@ -11056,7 +10417,6 @@
       <video href="2021.emnlp-main.664.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/opus-100">OPUS-100</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2018">WMT 2018</pwcdataset>
-      <video href="2021.emnlp-main.664.mp4"/>
     </paper>
     <paper id="665">
       <title>Graph Algorithms for Multiparallel Word Alignment</title>
@@ -11073,7 +10433,6 @@
       <doi>10.18653/v1/2021.emnlp-main.665</doi>
       <video href="2021.emnlp-main.665.mp4"/>
       <pwccode url="https://github.com/cisnlp/graph-align" additional="false">cisnlp/graph-align</pwccode>
-      <video href="2021.emnlp-main.665.mp4"/>
     </paper>
     <paper id="666">
       <title>Improving the Quality Trade-Off for Neural Machine Translation Multi-Domain Adaptation</title>
@@ -11089,7 +10448,6 @@
       <bibkey>hasler-etal-2021-improving</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.666</doi>
       <video href="2021.emnlp-main.666.mp4"/>
-      <video href="2021.emnlp-main.666.mp4"/>
     </paper>
     <paper id="667">
       <title>Language Modeling, Lexical Translation, Reordering: The Training Process of <fixed-case>NMT</fixed-case> through the Lens of Classical <fixed-case>SMT</fixed-case></title>
@@ -11101,7 +10459,6 @@
       <url hash="c13d7926">2021.emnlp-main.667</url>
       <bibkey>voita-etal-2021-language</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.667</doi>
-      <video href="2021.emnlp-main.667.mp4"/>
       <video href="2021.emnlp-main.667.mp4"/>
     </paper>
     <paper id="668">
@@ -11115,7 +10472,6 @@
       <doi>10.18653/v1/2021.emnlp-main.668</doi>
       <video href="2021.emnlp-main.668.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.668.mp4"/>
     </paper>
     <paper id="669">
       <title>Rethinking Data Augmentation for Low-Resource Neural Machine Translation: A Multi-Task Learning Approach</title>
@@ -11130,7 +10486,6 @@
       <doi>10.18653/v1/2021.emnlp-main.669</doi>
       <video href="2021.emnlp-main.669.mp4"/>
       <pwccode url="https://github.com/transducens/mtl-da-emnlp" additional="false">transducens/mtl-da-emnlp</pwccode>
-      <video href="2021.emnlp-main.669.mp4"/>
     </paper>
     <paper id="670">
       <title>Wino-<fixed-case>X</fixed-case>: Multilingual <fixed-case>W</fixed-case>inograd Schemas for Commonsense Reasoning and Coreference Resolution</title>
@@ -11145,7 +10500,6 @@
       <video href="2021.emnlp-main.670.mp4"/>
       <pwccode url="https://github.com/demelin/wino-x" additional="false">demelin/wino-x</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
-      <video href="2021.emnlp-main.670.mp4"/>
     </paper>
     <paper id="671">
       <title>One Source, Two Targets: <fixed-case>C</fixed-case>hallenges and Rewards of Dual Decoding</title>
@@ -11158,7 +10512,6 @@
       <doi>10.18653/v1/2021.emnlp-main.671</doi>
       <video href="2021.emnlp-main.671.mp4"/>
       <pwccode url="https://github.com/jitao-xu/dual-decoding" additional="false">jitao-xu/dual-decoding</pwccode>
-      <video href="2021.emnlp-main.671.mp4"/>
     </paper>
     <paper id="672">
       <title>Discrete and Soft Prompting for Multilingual Models</title>
@@ -11172,7 +10525,6 @@
       <video href="2021.emnlp-main.672.mp4"/>
       <pwccode url="https://github.com/mprompting/xlmrprompt" additional="false">mprompting/xlmrprompt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-main.672.mp4"/>
     </paper>
     <paper id="673">
       <title>Vision Matters When It Should: Sanity Checking Multimodal Machine Translation Models</title>
@@ -11188,7 +10540,6 @@
       <pwccode url="https://github.com/jiaodali/vision-matters-when-it-should" additional="false">jiaodali/vision-matters-when-it-should</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptual-captions">Conceptual Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multisense">MultiSense</pwcdataset>
-      <video href="2021.emnlp-main.673.mp4"/>
     </paper>
     <paper id="674">
       <title>Efficient Inference for Multilingual Neural Machine Translation</title>
@@ -11204,7 +10555,6 @@
       <doi>10.18653/v1/2021.emnlp-main.674</doi>
       <video href="2021.emnlp-main.674.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/paracrawl">ParaCrawl</pwcdataset>
-      <video href="2021.emnlp-main.674.mp4"/>
     </paper>
     <paper id="675">
       <title>Role of <fixed-case>L</fixed-case>anguage <fixed-case>R</fixed-case>elatedness in <fixed-case>M</fixed-case>ultilingual <fixed-case>F</fixed-case>ine-tuning of <fixed-case>L</fixed-case>anguage <fixed-case>M</fixed-case>odels: <fixed-case>A</fixed-case> <fixed-case>C</fixed-case>ase <fixed-case>S</fixed-case>tudy in <fixed-case>I</fixed-case>ndo-<fixed-case>A</fixed-case>ryan <fixed-case>L</fixed-case>anguages</title>
@@ -11222,7 +10572,6 @@
       <video href="2021.emnlp-main.675.mp4"/>
       <pwccode url="https://github.com/ibm/indo-aryan-language-family-model" additional="false">ibm/indo-aryan-language-family-model</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/indicglue">IndicGLUE</pwcdataset>
-      <video href="2021.emnlp-main.675.mp4"/>
     </paper>
     <paper id="676">
       <title>Comparing Feature-Engineering and Feature-Learning Approaches for Multilingual Translationese Classification</title>
@@ -11237,7 +10586,6 @@
       <bibkey>pylypenko-etal-2021-comparing</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.676</doi>
       <video href="2021.emnlp-main.676.mp4"/>
-      <video href="2021.emnlp-main.676.mp4"/>
     </paper>
     <paper id="677">
       <title>Multi-Sentence Resampling: A Simple Approach to Alleviate Dataset Length Bias and Beam-Search Degradation</title>
@@ -11251,7 +10599,6 @@
       <video href="2021.emnlp-main.677.mp4"/>
       <pwccode url="https://github.com/yandex-research/msr" additional="false">yandex-research/msr</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
-      <video href="2021.emnlp-main.677.mp4"/>
     </paper>
     <paper id="678">
       <title>Cross-Policy Compliance Detection via Question Answering</title>
@@ -11266,7 +10613,6 @@
       <video href="2021.emnlp-main.678.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/boolq">BoolQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sharc">ShARC</pwcdataset>
-      <video href="2021.emnlp-main.678.mp4"/>
     </paper>
     <paper id="679">
       <title>Meta-<fixed-case>LMTC</fixed-case>: Meta-Learning for Large-Scale Multi-Label Text Classification</title>
@@ -11283,7 +10629,6 @@
       <doi>10.18653/v1/2021.emnlp-main.679</doi>
       <video href="2021.emnlp-main.679.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/eurlex57k">EURLEX57K</pwcdataset>
-      <video href="2021.emnlp-main.679.mp4"/>
     </paper>
     <paper id="680">
       <title>Unsupervised Multi-View Post-<fixed-case>OCR</fixed-case> Error Correction With Language Models</title>
@@ -11298,7 +10643,6 @@
       <bibkey>gupta-etal-2021-unsupervised-multi</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.680</doi>
       <video href="2021.emnlp-main.680.mp4"/>
-      <video href="2021.emnlp-main.680.mp4"/>
     </paper>
     <paper id="681">
       <title>Parallel Refinements for Lexically Constrained Text Generation with <fixed-case>BART</fixed-case></title>
@@ -11310,7 +10654,6 @@
       <doi>10.18653/v1/2021.emnlp-main.681</doi>
       <video href="2021.emnlp-main.681.mp4"/>
       <pwccode url="https://github.com/nlpcode/cbart" additional="false">nlpcode/cbart</pwccode>
-      <video href="2021.emnlp-main.681.mp4"/>
     </paper>
     <paper id="682">
       <title><fixed-case>BERT</fixed-case>-Beta: A Proactive Probabilistic Approach to Text Moderation</title>
@@ -11323,7 +10666,6 @@
       <url hash="2a0644f6">2021.emnlp-main.682</url>
       <bibkey>tan-etal-2021-bert</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.682</doi>
-      <video href="2021.emnlp-main.682.mp4"/>
       <video href="2021.emnlp-main.682.mp4"/>
     </paper>
     <paper id="683">
@@ -11339,7 +10681,6 @@
       <doi>10.18653/v1/2021.emnlp-main.683</doi>
       <video href="2021.emnlp-main.683.mp4"/>
       <pwccode url="https://github.com/declare-lab/sentence-ordering" additional="false">declare-lab/sentence-ordering</pwccode>
-      <video href="2021.emnlp-main.683.mp4"/>
     </paper>
     <paper id="684">
       <title>Preventing Author Profiling through Zero-Shot Multilingual Back-Translation</title>
@@ -11357,7 +10698,6 @@
       <video href="2021.emnlp-main.684.mp4"/>
       <pwccode url="https://github.com/uds-lsv/author-profiling-prevention-bt" additional="false">uds-lsv/author-profiling-prevention-bt</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cola">CoLA</pwcdataset>
-      <video href="2021.emnlp-main.684.mp4"/>
     </paper>
     <paper id="685">
       <title><fixed-case>C</fixed-case>ode<fixed-case>T</fixed-case>5: Identifier-aware Unified Pre-trained Encoder-Decoder Models for Code Understanding and Generation</title>
@@ -11375,7 +10715,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/concode">CONCODE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/codesearchnet">CodeSearchNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/codexglue">CodeXGLUE</pwcdataset>
-      <video href="2021.emnlp-main.685.mp4"/>
     </paper>
     <paper id="686">
       <title>Detect and Classify – Joint Span Detection and Classification for Health Outcomes</title>
@@ -11391,7 +10730,6 @@
       <doi>10.18653/v1/2021.emnlp-main.686</doi>
       <video href="2021.emnlp-main.686.mp4"/>
       <pwccode url="https://github.com/MichealAbaho/Label-Context-Aware-Attention-Model" additional="false">MichealAbaho/Label-Context-Aware-Attention-Model</pwccode>
-      <video href="2021.emnlp-main.686.mp4"/>
     </paper>
     <paper id="687">
       <title><fixed-case>M</fixed-case>ulti-Class Grammatical Error Detection for Correction: <fixed-case>A</fixed-case> Tale of Two Systems</title>
@@ -11406,7 +10744,6 @@
       <doi>10.18653/v1/2021.emnlp-main.687</doi>
       <video href="2021.emnlp-main.687.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fce">FCE</pwcdataset>
-      <video href="2021.emnlp-main.687.mp4"/>
     </paper>
     <paper id="688">
       <title>Towards Zero-shot Commonsense Reasoning with Self-supervised Refinement of Language Models</title>
@@ -11423,7 +10760,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
-      <video href="2021.emnlp-main.688.mp4"/>
     </paper>
     <paper id="689">
       <title>To Share or not to Share: <fixed-case>P</fixed-case>redicting Sets of Sources for Model Transfer Learning</title>
@@ -11438,7 +10774,6 @@
       <doi>10.18653/v1/2021.emnlp-main.689</doi>
       <video href="2021.emnlp-main.689.mp4"/>
       <pwccode url="https://github.com/boschresearch/predicting_sets_of_sources" additional="false">boschresearch/predicting_sets_of_sources</pwccode>
-      <video href="2021.emnlp-main.689.mp4"/>
     </paper>
     <paper id="690">
       <title>Self-Supervised Detection of Contextual Synonyms in a Multi-Class Setting: Phenotype Annotation Use Case</title>
@@ -11457,7 +10792,6 @@
       <bibkey>zhang-etal-2021-self</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.690</doi>
       <video href="2021.emnlp-main.690.mp4"/>
-      <video href="2021.emnlp-main.690.mp4"/>
     </paper>
     <paper id="691">
       <title><fixed-case>C</fixed-case>lause<fixed-case>R</fixed-case>ec: A Clause Recommendation Framework for <fixed-case>AI</fixed-case>-aided Contract Authoring</title>
@@ -11471,7 +10805,6 @@
       <url hash="04b4c4d0">2021.emnlp-main.691</url>
       <bibkey>aggarwal-etal-2021-clauserec</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.691</doi>
-      <video href="2021.emnlp-main.691.mp4"/>
       <video href="2021.emnlp-main.691.mp4"/>
     </paper>
     <paper id="692">
@@ -11487,7 +10820,6 @@
       <doi>10.18653/v1/2021.emnlp-main.692</doi>
       <video href="2021.emnlp-main.692.mp4"/>
       <pwccode url="https://github.com/rootroo-ltd/finnishdialectidentification" additional="false">rootroo-ltd/finnishdialectidentification</pwccode>
-      <video href="2021.emnlp-main.692.mp4"/>
     </paper>
     <paper id="693">
       <title><fixed-case>E</fixed-case>nglish Machine Reading Comprehension Datasets: A Survey</title>
@@ -11547,7 +10879,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wikireading">WikiReading</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/worldtree">Worldtree</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/emrqa">emrQA</pwcdataset>
-      <video href="2021.emnlp-main.693.mp4"/>
     </paper>
     <paper id="694">
       <title>Expanding End-to-End Question Answering on Differentiable Knowledge Graphs with Intersection</title>
@@ -11562,7 +10893,6 @@
       <video href="2021.emnlp-main.694.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/complexwebquestions">ComplexWebQuestions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestionssp">WebQuestionsSP</pwcdataset>
-      <video href="2021.emnlp-main.694.mp4"/>
     </paper>
     <paper id="695">
       <title>Structured Context and High-Coverage Grammar for Conversational Question Answering over Knowledge Graphs</title>
@@ -11577,7 +10907,6 @@
       <video href="2021.emnlp-main.695.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/csqa">CSQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/convquestions">ConvQuestions</pwcdataset>
-      <video href="2021.emnlp-main.695.mp4"/>
     </paper>
     <paper id="696">
       <title>Improving Question Answering Model Robustness with Synthetic Adversarial Data Generation</title>
@@ -11597,7 +10926,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/mrqa-2019">MRQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
-      <video href="2021.emnlp-main.696.mp4"/>
     </paper>
     <paper id="697">
       <title><fixed-case>B</fixed-case>elief<fixed-case>B</fixed-case>ank: Adding Memory to a Pre-Trained Language Model for a Systematic Notion of Belief</title>
@@ -11612,7 +10940,6 @@
       <doi>10.18653/v1/2021.emnlp-main.697</doi>
       <video href="2021.emnlp-main.697.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
-      <video href="2021.emnlp-main.697.mp4"/>
     </paper>
     <paper id="698">
       <title><fixed-case>MLEC-QA</fixed-case>: <fixed-case>A</fixed-case> <fixed-case>C</fixed-case>hinese <fixed-case>M</fixed-case>ulti-<fixed-case>C</fixed-case>hoice <fixed-case>B</fixed-case>iomedical <fixed-case>Q</fixed-case>uestion <fixed-case>A</fixed-case>nswering <fixed-case>D</fixed-case>ataset</title>
@@ -11627,7 +10954,6 @@
       <video href="2021.emnlp-main.698.mp4"/>
       <pwccode url="https://github.com/judenpech/mlec-qa" additional="false">judenpech/mlec-qa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/headqa">HeadQA</pwcdataset>
-      <video href="2021.emnlp-main.698.mp4"/>
     </paper>
     <paper id="699">
       <title><fixed-case>I</fixed-case>ndo<fixed-case>NLG</fixed-case>: Benchmark and Resources for Evaluating <fixed-case>I</fixed-case>ndonesian Natural Language Generation</title>
@@ -11654,7 +10980,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/gem">GEM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/liputan6">Liputan6</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/tydi-qa">TyDi QA</pwcdataset>
-      <video href="2021.emnlp-main.699.mp4"/>
     </paper>
     <paper id="700">
       <title>Is Multi-Hop Reasoning Really Explainable? Towards Benchmarking Reasoning Interpretability</title>
@@ -11672,7 +10997,6 @@
       <doi>10.18653/v1/2021.emnlp-main.700</doi>
       <video href="2021.emnlp-main.700.mp4"/>
       <pwccode url="https://github.com/THU-KEG/BIMR" additional="false">THU-KEG/BIMR</pwccode>
-      <video href="2021.emnlp-main.700.mp4"/>
     </paper>
     <paper id="701">
       <title>Global Explainability of <fixed-case>BERT</fixed-case>-Based Evaluation Metrics by Disentangling along Linguistic Factors</title>
@@ -11687,7 +11011,6 @@
       <video href="2021.emnlp-main.701.mp4"/>
       <pwccode url="https://github.com/steffeneger/global-explainability-metrics" additional="false">steffeneger/global-explainability-metrics</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/paws">PAWS</pwcdataset>
-      <video href="2021.emnlp-main.701.mp4"/>
     </paper>
     <paper id="702">
       <title>Exploring Underexplored Limitations of Cross-Domain Text-to-<fixed-case>SQL</fixed-case> Generalization</title>
@@ -11701,7 +11024,6 @@
       <doi>10.18653/v1/2021.emnlp-main.702</doi>
       <video href="2021.emnlp-main.702.mp4"/>
       <pwccode url="https://github.com/ygan/spider-dk" additional="false">ygan/spider-dk</pwccode>
-      <video href="2021.emnlp-main.702.mp4"/>
     </paper>
     <paper id="703">
       <title>What happens if you treat ordinal ratings as interval data? Human evaluations in <fixed-case>NLP</fixed-case> are even more under-powered than you think</title>
@@ -11712,7 +11034,6 @@
       <url hash="0ae161fc">2021.emnlp-main.703</url>
       <bibkey>howcroft-rieser-2021-happens</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.703</doi>
-      <video href="2021.emnlp-main.703.mp4"/>
       <video href="2021.emnlp-main.703.mp4"/>
     </paper>
     <paper id="704">
@@ -11728,7 +11049,6 @@
       <video href="2021.emnlp-main.704.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/opensubtitles">OpenSubtitles</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
-      <video href="2021.emnlp-main.704.mp4"/>
     </paper>
     <paper id="705">
       <title>Benchmarking Commonsense Knowledge Base Population with an Effective Evaluation Dataset</title>
@@ -11748,7 +11068,6 @@
       <pwccode url="https://github.com/hkust-knowcomp/cskb-population" additional="true">hkust-knowcomp/cskb-population</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glucose">GLUCOSE</pwcdataset>
-      <video href="2021.emnlp-main.705.mp4"/>
     </paper>
     <paper id="706">
       <title>Enhancing the Context Representation in Similarity-based Word Sense Disambiguation</title>
@@ -11763,7 +11082,6 @@
       <doi>10.18653/v1/2021.emnlp-main.706</doi>
       <video href="2021.emnlp-main.706.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.emnlp-main.706.mp4"/>
     </paper>
     <paper id="707">
       <title>Data Augmentation with Hierarchical <fixed-case>SQL</fixed-case>-to-Question Generation for Cross-domain Text-to-<fixed-case>SQL</fixed-case> Parsing</title>
@@ -11784,7 +11102,6 @@
       <pwccode url="https://github.com/PaddlePaddle/Research" additional="false">PaddlePaddle/Research</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/spider-1">SPIDER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikisql">WikiSQL</pwcdataset>
-      <video href="2021.emnlp-main.707.mp4"/>
     </paper>
     <paper id="708">
       <title><fixed-case>SPARQL</fixed-case>ing Database Queries from Intermediate Question Decompositions</title>
@@ -11800,7 +11117,6 @@
       <pwccode url="https://github.com/yandex-research/sparqling-queries" additional="false">yandex-research/sparqling-queries</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/break">BREAK</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/spider-1">SPIDER</pwcdataset>
-      <video href="2021.emnlp-main.708.mp4"/>
     </paper>
     <paper id="709">
       <title>Time-aware Graph Neural Network for Entity Alignment between Temporal Knowledge Graphs</title>
@@ -11815,7 +11131,6 @@
       <video href="2021.emnlp-main.709.mp4"/>
       <pwccode url="https://github.com/soledad921/tea-gnn" additional="false">soledad921/tea-gnn</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/yago">YAGO</pwcdataset>
-      <video href="2021.emnlp-main.709.mp4"/>
     </paper>
     <paper id="710">
       <title>Cross-Domain Label-Adaptive Stance Detection</title>
@@ -11830,7 +11145,6 @@
       <doi>10.18653/v1/2021.emnlp-main.710</doi>
       <video href="2021.emnlp-main.710.mp4"/>
       <pwccode url="https://github.com/checkstep/mole-stance" additional="false">checkstep/mole-stance</pwccode>
-      <video href="2021.emnlp-main.710.mp4"/>
     </paper>
     <paper id="711">
       <title>Text <fixed-case>A</fixed-case>uto<fixed-case>A</fixed-case>ugment: Learning Compositional Augmentation Policy for Text Classification</title>
@@ -11848,7 +11162,6 @@
       <pwccode url="https://github.com/lancopku/text-autoaugment" additional="false">lancopku/text-autoaugment</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.711.mp4"/>
     </paper>
     <paper id="712">
       <title>Distilling Relation Embeddings from Pretrained Language Models</title>
@@ -11864,7 +11177,6 @@
       <pwccode url="https://github.com/asahi417/relbert" additional="false">asahi417/relbert</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/evalution">EVALution</pwcdataset>
-      <video href="2021.emnlp-main.712.mp4"/>
     </paper>
     <paper id="713">
       <title>Avoiding Inference Heuristics in Few-shot Prompt-based Finetuning</title>
@@ -11883,7 +11195,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paws">PAWS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.713.mp4"/>
     </paper>
     <paper id="714">
       <title>A Differentiable Relaxation of Graph Segmentation and Alignment for <fixed-case>AMR</fixed-case> Parsing</title>
@@ -11897,7 +11208,6 @@
       <doi>10.18653/v1/2021.emnlp-main.714</doi>
       <video href="2021.emnlp-main.714.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ldc2017t10">LDC2017T10</pwcdataset>
-      <video href="2021.emnlp-main.714.mp4"/>
     </paper>
     <paper id="715">
       <title>Integrating Personalized <fixed-case>P</fixed-case>age<fixed-case>R</fixed-case>ank into Neural Word Sense Disambiguation</title>
@@ -11912,7 +11222,6 @@
       <video href="2021.emnlp-main.715.mp4"/>
       <pwccode url="https://github.com/sapienzanlp/neural-pagerank-wsd" additional="false">sapienzanlp/neural-pagerank-wsd</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.emnlp-main.715.mp4"/>
     </paper>
     <paper id="716">
       <title>Cross-lingual Sentence Embedding using Multi-Task Learning</title>
@@ -11931,7 +11240,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.716.mp4"/>
     </paper>
     <paper id="717">
       <title><fixed-case>NB</fixed-case>-<fixed-case>MLM</fixed-case>: Efficient Domain Adaptation of Masked Language Models for Sentiment Analysis</title>
@@ -11945,7 +11253,6 @@
       <doi>10.18653/v1/2021.emnlp-main.717</doi>
       <video href="2021.emnlp-main.717.mp4"/>
       <pwccode url="https://github.com/nvanva/nb-mlm" additional="false">nvanva/nb-mlm</pwccode>
-      <video href="2021.emnlp-main.717.mp4"/>
     </paper>
     <paper id="718">
       <title>Revisiting Self-training for Few-shot Learning of Language Model</title>
@@ -11969,7 +11276,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.718.mp4"/>
     </paper>
     <paper id="719">
       <title>Bridging Perception, Memory, and Inference through Semantic Relations</title>
@@ -11981,7 +11287,6 @@
       <url hash="e57ef23e">2021.emnlp-main.719</url>
       <bibkey>bjorklund-etal-2021-bridging</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.719</doi>
-      <video href="2021.emnlp-main.719.mp4"/>
       <video href="2021.emnlp-main.719.mp4"/>
     </paper>
     <paper id="720">
@@ -11999,7 +11304,6 @@
       <video href="2021.emnlp-main.720.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/cmu-mosei">CMU-MOSEI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multimodal-opinionlevel-sentiment-intensity">Multimodal Opinionlevel Sentiment Intensity</pwcdataset>
-      <video href="2021.emnlp-main.720.mp4"/>
     </paper>
     <paper id="721">
       <title><fixed-case>YASO</fixed-case>: <fixed-case>A</fixed-case> Targeted Sentiment Analysis Evaluation Dataset for Open-Domain Reviews</title>
@@ -12018,7 +11322,6 @@
       <pwccode url="https://github.com/IBM/yaso-tsa" additional="true">IBM/yaso-tsa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/yaso">YASO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.721.mp4"/>
     </paper>
     <paper id="722">
       <title>An Empirical Study on Leveraging Position Embeddings for Target-oriented Opinion Words Extraction</title>
@@ -12032,7 +11335,6 @@
       <doi>10.18653/v1/2021.emnlp-main.722</doi>
       <video href="2021.emnlp-main.722.mp4"/>
       <pwccode url="https://github.com/samensah/encoders_towe_emnlp2021" additional="false">samensah/encoders_towe_emnlp2021</pwccode>
-      <video href="2021.emnlp-main.722.mp4"/>
     </paper>
     <paper id="723">
       <title>Improving Multimodal Fusion with Hierarchical Mutual Information Maximization for Multimodal Sentiment Analysis</title>
@@ -12046,7 +11348,6 @@
       <doi>10.18653/v1/2021.emnlp-main.723</doi>
       <video href="2021.emnlp-main.723.mp4"/>
       <pwccode url="https://github.com/declare-lab/multimodal-deep-learning" additional="true">declare-lab/multimodal-deep-learning</pwccode>
-      <video href="2021.emnlp-main.723.mp4"/>
     </paper>
     <paper id="724">
       <title><fixed-case>BERT</fixed-case>4<fixed-case>GCN</fixed-case>: Using <fixed-case>BERT</fixed-case> Intermediate Layers to Augment <fixed-case>GCN</fixed-case> for Aspect-based Sentiment Classification</title>
@@ -12060,7 +11361,6 @@
       <bibkey>xiao-etal-2021-bert4gcn</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.724</doi>
       <video href="2021.emnlp-main.724.mp4"/>
-      <video href="2021.emnlp-main.724.mp4"/>
     </paper>
     <paper id="725">
       <title>Does Social Pressure Drive Persuasion in Online Fora?</title>
@@ -12071,7 +11371,6 @@
       <url hash="320a3ed5">2021.emnlp-main.725</url>
       <bibkey>jain-srivastava-2021-social</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.725</doi>
-      <video href="2021.emnlp-main.725.mp4"/>
       <video href="2021.emnlp-main.725.mp4"/>
     </paper>
     <paper id="726">
@@ -12089,7 +11388,6 @@
       <doi>10.18653/v1/2021.emnlp-main.726</doi>
       <video href="2021.emnlp-main.726.mp4"/>
       <pwccode url="https://github.com/isakzhang/absa-quad" additional="false">isakzhang/absa-quad</pwccode>
-      <video href="2021.emnlp-main.726.mp4"/>
     </paper>
     <paper id="727">
       <title>Cross-lingual Aspect-based Sentiment Analysis with Aspect Term Code-Switching</title>
@@ -12105,7 +11403,6 @@
       <doi>10.18653/v1/2021.emnlp-main.727</doi>
       <video href="2021.emnlp-main.727.mp4"/>
       <pwccode url="https://github.com/isakzhang/xabsa" additional="false">isakzhang/xabsa</pwccode>
-      <video href="2021.emnlp-main.727.mp4"/>
     </paper>
     <paper id="728">
       <title>Towards Label-Agnostic Emotion Embeddings</title>
@@ -12117,7 +11414,6 @@
       <url hash="c429039c">2021.emnlp-main.728</url>
       <bibkey>buechel-etal-2021-towards</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.728</doi>
-      <video href="2021.emnlp-main.728.mp4"/>
       <video href="2021.emnlp-main.728.mp4"/>
     </paper>
     <paper id="729">
@@ -12133,7 +11429,6 @@
       <doi>10.18653/v1/2021.emnlp-main.729</doi>
       <video href="2021.emnlp-main.729.mp4"/>
       <pwccode url="https://github.com/sunlight-ym/cbd_style_transfer" additional="false">sunlight-ym/cbd_style_transfer</pwccode>
-      <video href="2021.emnlp-main.729.mp4"/>
     </paper>
     <paper id="730">
       <title>Exploring Non-Autoregressive Text Style Transfer</title>
@@ -12147,7 +11442,6 @@
       <video href="2021.emnlp-main.730.mp4"/>
       <pwccode url="https://github.com/sunlight-ym/nar_style_transfer" additional="false">sunlight-ym/nar_style_transfer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/gyafc">GYAFC</pwcdataset>
-      <video href="2021.emnlp-main.730.mp4"/>
     </paper>
     <paper id="731">
       <title><fixed-case>PASTE</fixed-case>: A Tagging-Free Decoding Framework Using Pointer Networks for Aspect Sentiment Triplet Extraction</title>
@@ -12164,7 +11458,6 @@
       <video href="2021.emnlp-main.731.mp4"/>
       <pwccode url="https://github.com/rajdeep345/paste" additional="false">rajdeep345/paste</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/aste-data-v2">ASTE-Data-V2</pwcdataset>
-      <video href="2021.emnlp-main.731.mp4"/>
     </paper>
     <paper id="732">
       <title>Adaptive Proposal Generation Network for Temporal Sentence Localization in Videos</title>
@@ -12180,7 +11473,6 @@
       <video href="2021.emnlp-main.732.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/activitynet-captions">ActivityNet Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/charades-sta">Charades-STA</pwcdataset>
-      <video href="2021.emnlp-main.732.mp4"/>
     </paper>
     <paper id="733">
       <title>Progressively Guide to Attend: An Iterative Alignment Framework for Temporal Sentence Grounding</title>
@@ -12196,7 +11488,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/activitynet-captions">ActivityNet Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/charades">Charades</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/charades-sta">Charades-STA</pwcdataset>
-      <video href="2021.emnlp-main.733.mp4"/>
     </paper>
     <paper id="734">
       <title>Language Models are Few-Shot Butlers</title>
@@ -12209,7 +11500,6 @@
       <doi>10.18653/v1/2021.emnlp-main.734</doi>
       <video href="2021.emnlp-main.734.mp4"/>
       <pwccode url="https://github.com/vmicheli/lm-butlers" additional="false">vmicheli/lm-butlers</pwccode>
-      <video href="2021.emnlp-main.734.mp4"/>
     </paper>
     <paper id="735">
       <title><fixed-case>R</fixed-case>ˆ3<fixed-case>N</fixed-case>et:Relation-embedded Representation Reconstruction Network for Change Captioning</title>
@@ -12226,7 +11516,6 @@
       <video href="2021.emnlp-main.735.mp4"/>
       <pwccode url="https://github.com/tuyunbin/r3net" additional="false">tuyunbin/r3net</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/spot-the-diff">Spot-the-diff</pwcdataset>
-      <video href="2021.emnlp-main.735.mp4"/>
     </paper>
     <paper id="736">
       <title>Looking for Confirmations: An Effective and Human-Like Visual Dialogue Strategy</title>
@@ -12240,7 +11529,6 @@
       <video href="2021.emnlp-main.736.mp4"/>
       <pwccode url="https://github.com/albertotestoni/confirm_it" additional="false">albertotestoni/confirm_it</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/guesswhat">GuessWhat?!</pwcdataset>
-      <video href="2021.emnlp-main.736.mp4"/>
     </paper>
     <paper id="737">
       <title>A Unified Speaker Adaptation Approach for <fixed-case>ASR</fixed-case></title>
@@ -12258,7 +11546,6 @@
       <video href="2021.emnlp-main.737.mp4"/>
       <pwccode url="https://github.com/zyzpower/gradprune_speaker" additional="false">zyzpower/gradprune_speaker</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/librispeech">LibriSpeech</pwcdataset>
-      <video href="2021.emnlp-main.737.mp4"/>
     </paper>
     <paper id="738">
       <title>Caption Enriched Samples for Improving Hateful Memes Detection</title>
@@ -12273,7 +11560,6 @@
       <doi>10.18653/v1/2021.emnlp-main.738</doi>
       <video href="2021.emnlp-main.738.mp4"/>
       <pwccode url="https://github.com/efrat-safanov/caption-enriched-samples-research" additional="false">efrat-safanov/caption-enriched-samples-research</pwccode>
-      <video href="2021.emnlp-main.738.mp4"/>
     </paper>
     <paper id="739">
       <title>Sparsity and Sentence Structure in Encoder-Decoder Attention of Summarization Systems</title>
@@ -12284,7 +11570,6 @@
       <url hash="5a462584">2021.emnlp-main.739</url>
       <bibkey>manakul-gales-2021-sparsity</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.739</doi>
-      <video href="2021.emnlp-main.739.mp4"/>
       <video href="2021.emnlp-main.739.mp4"/>
     </paper>
     <paper id="740">
@@ -12302,7 +11587,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/orangesum">OrangeSum</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flue-french-language-understanding-evaluation">FLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
-      <video href="2021.emnlp-main.740.mp4"/>
     </paper>
     <paper id="741">
       <title><fixed-case>ARMAN</fixed-case>: <fixed-case>P</fixed-case>re-training with <fixed-case>S</fixed-case>emantically <fixed-case>S</fixed-case>electing and <fixed-case>R</fixed-case>eordering of <fixed-case>S</fixed-case>entences for <fixed-case>P</fixed-case>ersian <fixed-case>A</fixed-case>bstractive <fixed-case>S</fixed-case>ummarization</title>
@@ -12320,7 +11604,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/cc100">CC100</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/perkey">PerKey</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/pn-summary">pn-summary</pwcdataset>
-      <video href="2021.emnlp-main.741.mp4"/>
     </paper>
     <paper id="742">
       <title>Models and Datasets for Cross-Lingual Summarisation</title>
@@ -12334,7 +11617,6 @@
       <video href="2021.emnlp-main.742.mp4"/>
       <pwccode url="https://github.com/lauhaide/clads" additional="false">lauhaide/clads</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikilingua">WikiLingua</pwcdataset>
-      <video href="2021.emnlp-main.742.mp4"/>
     </paper>
     <paper id="743">
       <title>Learning Opinion Summarizers by Selecting Informative Reviews</title>
@@ -12348,7 +11630,6 @@
       <doi>10.18653/v1/2021.emnlp-main.743</doi>
       <video href="2021.emnlp-main.743.mp4"/>
       <pwccode url="https://github.com/abrazinskas/selsum" additional="false">abrazinskas/selsum</pwccode>
-      <video href="2021.emnlp-main.743.mp4"/>
     </paper>
     <paper id="744">
       <title>Enriching and Controlling Global Semantics for Text Summarization</title>
@@ -12363,7 +11644,6 @@
       <doi>10.18653/v1/2021.emnlp-main.744</doi>
       <video href="2021.emnlp-main.744.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/reddit-tifu">Reddit TIFU</pwcdataset>
-      <video href="2021.emnlp-main.744.mp4"/>
     </paper>
     <paper id="745">
       <title>Revisiting Tri-training of Dependency Parsers</title>
@@ -12376,7 +11656,6 @@
       <doi>10.18653/v1/2021.emnlp-main.745</doi>
       <video href="2021.emnlp-main.745.mp4"/>
       <pwccode url="https://github.com/jowagner/mtb-tri-training" additional="true">jowagner/mtb-tri-training</pwccode>
-      <video href="2021.emnlp-main.745.mp4"/>
     </paper>
     <paper id="746">
       <title>Bridge to Target Domain by Prototypical Contrastive Learning and Label Confusion: Re-explore Zero-Shot Learning for Slot Filling</title>
@@ -12393,7 +11672,6 @@
       <doi>10.18653/v1/2021.emnlp-main.746</doi>
       <video href="2021.emnlp-main.746.mp4"/>
       <pwccode url="https://github.com/w-lw/pclc" additional="false">w-lw/pclc</pwccode>
-      <video href="2021.emnlp-main.746.mp4"/>
     </paper>
     <paper id="747">
       <title>Neuralizing Regular Expressions for Slot Filling</title>
@@ -12407,7 +11685,6 @@
       <doi>10.18653/v1/2021.emnlp-main.747</doi>
       <video href="2021.emnlp-main.747.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/atis">ATIS</pwcdataset>
-      <video href="2021.emnlp-main.747.mp4"/>
     </paper>
     <paper id="748">
       <title>Causal Direction of Data Collection Matters: Implications of Causal and Anticausal Learning for <fixed-case>NLP</fixed-case></title>
@@ -12425,7 +11702,6 @@
       <doi>10.18653/v1/2021.emnlp-main.748</doi>
       <video href="2021.emnlp-main.748.mp4"/>
       <pwccode url="https://github.com/zhijing-jin/icm4nlp" additional="false">zhijing-jin/icm4nlp</pwccode>
-      <video href="2021.emnlp-main.748.mp4"/>
     </paper>
     <paper id="749">
       <title>Raise a Child in Large Language Model: Towards Effective and Generalizable Fine-tuning</title>
@@ -12447,7 +11723,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sick">SICK</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
-      <video href="2021.emnlp-main.749.mp4"/>
     </paper>
     <paper id="750">
       <title>Knowledge Graph Representation Learning using Ordinary Differential Equations</title>
@@ -12464,7 +11739,6 @@
       <doi>10.18653/v1/2021.emnlp-main.750</doi>
       <video href="2021.emnlp-main.750.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
-      <video href="2021.emnlp-main.750.mp4"/>
     </paper>
     <paper id="751">
       <title><fixed-case>K</fixed-case>now<fixed-case>MAN</fixed-case>: Weakly Supervised Multinomial Adversarial Networks</title>
@@ -12480,7 +11754,6 @@
       <doi>10.18653/v1/2021.emnlp-main.751</doi>
       <video href="2021.emnlp-main.751.mp4"/>
       <pwccode url="https://github.com/luisamaerz/knowman" additional="false">luisamaerz/knowman</pwccode>
-      <video href="2021.emnlp-main.751.mp4"/>
     </paper>
     <paper id="752">
       <title><fixed-case>ONION</fixed-case>: A Simple and Effective Defense Against Textual Backdoor Attacks</title>
@@ -12499,7 +11772,6 @@
       <pwccode url="https://github.com/thunlp/ONION" additional="true">thunlp/ONION</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ag-news">AG News</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.752.mp4"/>
     </paper>
     <paper id="753">
       <title>Value-aware Approximate Attention</title>
@@ -12512,7 +11784,6 @@
       <doi>10.18653/v1/2021.emnlp-main.753</doi>
       <video href="2021.emnlp-main.753.mp4"/>
       <pwccode url="https://github.com/ag1988/value_aware_attn" additional="false">ag1988/value_aware_attn</pwccode>
-      <video href="2021.emnlp-main.753.mp4"/>
     </paper>
     <paper id="754">
       <title>Contrastive Domain Adaptation for Question Answering using Limited Text Corpora</title>
@@ -12531,7 +11802,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/searchqa">SearchQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/triviaqa">TriviaQA</pwcdataset>
-      <video href="2021.emnlp-main.754.mp4"/>
     </paper>
     <paper id="755">
       <title>Case-based Reasoning for Natural Language Queries over Knowledge Bases</title>
@@ -12555,7 +11825,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/simplequestions">SimpleQuestions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestions">WebQuestions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/webquestionssp">WebQuestionsSP</pwcdataset>
-      <video href="2021.emnlp-main.755.mp4"/>
     </paper>
     <paper id="756">
       <title>Distantly-Supervised Dense Retrieval Enables Open-Domain Question Answering without Evidence Annotation</title>
@@ -12570,7 +11839,6 @@
       <doi>10.18653/v1/2021.emnlp-main.756</doi>
       <video href="2021.emnlp-main.756.mp4"/>
       <pwccode url="https://github.com/henryzhao5852/distdr" additional="false">henryzhao5852/distdr</pwccode>
-      <video href="2021.emnlp-main.756.mp4"/>
     </paper>
     <paper id="757">
       <title>What’s in a Name? Answer Equivalence For Open-Domain Question Answering</title>
@@ -12599,7 +11867,6 @@
       <doi>10.18653/v1/2021.emnlp-main.758</doi>
       <video href="2021.emnlp-main.758.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/natural-questions">Natural Questions</pwcdataset>
-      <video href="2021.emnlp-main.758.mp4"/>
     </paper>
     <paper id="759">
       <title>Numerical reasoning in machine reading comprehension tasks: are we there yet?</title>
@@ -12613,7 +11880,6 @@
       <doi>10.18653/v1/2021.emnlp-main.759</doi>
       <video href="2021.emnlp-main.759.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
-      <video href="2021.emnlp-main.759.mp4"/>
     </paper>
     <paper id="760">
       <title>Set Generation Networks for End-to-End Knowledge Base Population</title>
@@ -12629,8 +11895,6 @@
       <bibkey>sui-etal-2021-set</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.760</doi>
       <video href="2021.emnlp-main.760.mp4"/>
-      <video href="2021.emnlp-main.760.mp4"/>
-      <video href="2021.emnlp-main.760.mp4"/>
     </paper>
     <paper id="761">
       <title>Knowing False Negatives: An Adversarial Training Method for Distantly Supervised Relation Extraction</title>
@@ -12644,7 +11908,6 @@
       <doi>10.18653/v1/2021.emnlp-main.761</doi>
       <video href="2021.emnlp-main.761.mp4"/>
       <pwccode url="https://github.com/nju-websoft/fan" additional="false">nju-websoft/fan</pwccode>
-      <video href="2021.emnlp-main.761.mp4"/>
     </paper>
     <paper id="762">
       <title>Progressive Adversarial Learning for Bootstrapping: A Case Study on Entity Set Expansion</title>
@@ -12658,7 +11921,6 @@
       <doi>10.18653/v1/2021.emnlp-main.762</doi>
       <video href="2021.emnlp-main.762.mp4"/>
       <pwccode url="https://github.com/lingyongyan/bootstrapgan" additional="false">lingyongyan/bootstrapgan</pwccode>
-      <video href="2021.emnlp-main.762.mp4"/>
     </paper>
     <paper id="763">
       <title>Uncovering Main Causalities for Long-tailed Information Extraction</title>
@@ -12675,7 +11937,6 @@
       <video href="2021.emnlp-main.763.mp4"/>
       <pwccode url="https://github.com/heyyyyyyg/cfie" additional="false">heyyyyyyg/cfie</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/maven">MAVEN</pwcdataset>
-      <video href="2021.emnlp-main.763.mp4"/>
     </paper>
     <paper id="764">
       <title>Maximal Clique Based Non-Autoregressive Open Information Extraction</title>
@@ -12691,8 +11952,6 @@
       <bibkey>yu-etal-2021-maximal</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.764</doi>
       <video href="2021.emnlp-main.764.mp4"/>
-      <video href="2021.emnlp-main.764.mp4"/>
-      <video href="2021.emnlp-main.764.mp4"/>
     </paper>
     <paper id="765">
       <title>A Relation-Oriented Clustering Method for Open Relation Extraction</title>
@@ -12707,7 +11966,6 @@
       <doi>10.18653/v1/2021.emnlp-main.765</doi>
       <video href="2021.emnlp-main.765.mp4"/>
       <pwccode url="https://github.com/ac-zyx/rocore" additional="false">ac-zyx/rocore</pwccode>
-      <video href="2021.emnlp-main.765.mp4"/>
     </paper>
     <paper id="766">
       <title>Exploring Methods for Generating Feedback Comments for Writing Learning</title>
@@ -12721,7 +11979,6 @@
       <doi>10.18653/v1/2021.emnlp-main.766</doi>
       <video href="2021.emnlp-main.766.mp4"/>
       <pwccode url="https://github.com/k-hanawa/fcg_emnlp2021" additional="false">k-hanawa/fcg_emnlp2021</pwccode>
-      <video href="2021.emnlp-main.766.mp4"/>
     </paper>
     <paper id="767">
       <title>A Role-Selected Sharing Network for Joint Machine-Human Chatting Handoff and Service Satisfaction Analysis</title>
@@ -12740,7 +11997,6 @@
       <doi>10.18653/v1/2021.emnlp-main.767</doi>
       <video href="2021.emnlp-main.767.mp4"/>
       <pwccode url="https://github.com/weijialau/rssn" additional="false">weijialau/rssn</pwccode>
-      <video href="2021.emnlp-main.767.mp4"/>
     </paper>
     <paper id="768">
       <title>Meta Distant Transfer Learning for Pre-trained Language Models</title>
@@ -12759,7 +12015,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.768.mp4"/>
     </paper>
     <paper id="769">
       <title><fixed-case>U</fixed-case>ni<fixed-case>KER</fixed-case>: A Unified Framework for Combining Embedding and Definite Horn Rule Reasoning for Knowledge Graph Inference</title>
@@ -12772,7 +12027,6 @@
       <url hash="945bf38d">2021.emnlp-main.769</url>
       <bibkey>cheng-etal-2021-uniker</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.769</doi>
-      <video href="2021.emnlp-main.769.mp4"/>
       <video href="2021.emnlp-main.769.mp4"/>
     </paper>
     <paper id="770">
@@ -12788,7 +12042,6 @@
       <attachment type="Software" hash="cc7b3ac0">2021.emnlp-main.770.Software.zip</attachment>
       <bibkey>feng-etal-2021-wasserstein</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.770</doi>
-      <video href="2021.emnlp-main.770.mp4"/>
       <video href="2021.emnlp-main.770.mp4"/>
     </paper>
     <paper id="771">
@@ -12806,7 +12059,6 @@
       <bibkey>bai-etal-2021-jointly</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.771</doi>
       <video href="2021.emnlp-main.771.mp4"/>
-      <video href="2021.emnlp-main.771.mp4"/>
     </paper>
     <paper id="772">
       <title>Inflate and Shrink:Enriching and Reducing Interactions for Fast Text-Image Retrieval</title>
@@ -12821,7 +12073,6 @@
       <doi>10.18653/v1/2021.emnlp-main.772</doi>
       <video href="2021.emnlp-main.772.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
-      <video href="2021.emnlp-main.772.mp4"/>
     </paper>
     <paper id="773">
       <title>On Pursuit of Designing Multi-modal Transformer for Video Grounding</title>
@@ -12840,7 +12091,6 @@
       <video href="2021.emnlp-main.773.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/activitynet-captions">ActivityNet Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/charades-sta">Charades-STA</pwcdataset>
-      <video href="2021.emnlp-main.773.mp4"/>
     </paper>
     <paper id="774">
       <title><fixed-case>COVR</fixed-case>: A Test-Bed for Visually Grounded Compositional Generalization with Real Images</title>
@@ -12857,7 +12107,6 @@
       <pwccode url="https://github.com/benbogin/covr-dataset" additional="false">benbogin/covr-dataset</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-genome">Visual Genome</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.emnlp-main.774.mp4"/>
     </paper>
     <paper id="775">
       <title>Vision-and-Language or Vision-for-Language? On Cross-Modal Influence in Multimodal Transformers</title>
@@ -12873,7 +12122,6 @@
       <pwccode url="https://github.com/e-bug/volta" additional="true">e-bug/volta</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/conceptual-captions">Conceptual Captions</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/flickr30k">Flickr30k</pwcdataset>
-      <video href="2021.emnlp-main.775.mp4"/>
     </paper>
     <paper id="776">
       <title><fixed-case>H</fixed-case>yp<fixed-case>M</fixed-case>ix: Hyperbolic Interpolative Data Augmentation</title>
@@ -12892,7 +12140,6 @@
       <pwccode url="https://github.com/caisa-lab/hypmix-emnlp" additional="false">caisa-lab/hypmix-emnlp</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cifar-10">CIFAR-10</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/cifar-100">CIFAR-100</pwcdataset>
-      <video href="2021.emnlp-main.776.mp4"/>
     </paper>
     <paper id="777">
       <title>Integrating Deep Event-Level and Script-Level Information for Script Event Prediction</title>
@@ -12909,7 +12156,6 @@
       <doi>10.18653/v1/2021.emnlp-main.777</doi>
       <video href="2021.emnlp-main.777.mp4"/>
       <pwccode url="https://github.com/waltbai/MCPredictor" additional="false">waltbai/MCPredictor</pwccode>
-      <video href="2021.emnlp-main.777.mp4"/>
     </paper>
     <paper id="778">
       <title><fixed-case>QA</fixed-case>-Align: Representing Cross-Text Content Overlap by Aligning Question-Answer Propositions</title>
@@ -12927,7 +12173,6 @@
       <pwccode url="https://github.com/danielabweiss/qa-align" additional="false">danielabweiss/qa-align</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ecb">ECB+</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qa-srl">QA-SRL</pwcdataset>
-      <video href="2021.emnlp-main.778.mp4"/>
     </paper>
     <paper id="779">
       <title><fixed-case>PICARD</fixed-case>: Parsing Incrementally for Constrained Auto-Regressive Decoding from Language Models</title>
@@ -12943,7 +12188,6 @@
       <pwccode url="https://github.com/ElementAI/picard" additional="false">ElementAI/picard</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cosql">CoSQL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/spider-1">SPIDER</pwcdataset>
-      <video href="2021.emnlp-main.779.mp4"/>
     </paper>
     <paper id="780">
       <title>Exploiting <fixed-case>T</fixed-case>witter as Source of Large Corpora of Weakly Similar Pairs for Semantic Sentence Embeddings</title>
@@ -12958,7 +12202,6 @@
       <pwccode url="https://github.com/marco-digio/twitter4sse" additional="false">marco-digio/twitter4sse</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/pit">PIT</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/twitter-news-url-corpus">TURL</pwcdataset>
-      <video href="2021.emnlp-main.780.mp4"/>
     </paper>
     <paper id="781">
       <title>Guilt by Association: Emotion Intensities in Lexical Representations</title>
@@ -12969,7 +12212,6 @@
       <url hash="640e8a71">2021.emnlp-main.781</url>
       <bibkey>raji-de-melo-2021-guilt</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.781</doi>
-      <video href="2021.emnlp-main.781.mp4"/>
       <video href="2021.emnlp-main.781.mp4"/>
     </paper>
     <paper id="782">
@@ -12994,7 +12236,6 @@
       <doi>10.18653/v1/2021.emnlp-main.783</doi>
       <video href="2021.emnlp-main.783.mp4"/>
       <pwccode url="https://github.com/shamikroy/moral-role-prediction" additional="false">shamikroy/moral-role-prediction</pwccode>
-      <video href="2021.emnlp-main.783.mp4"/>
     </paper>
     <paper id="784">
       <title>Measuring Sentence-Level and Aspect-Level (Un)certainty in Science Communications</title>
@@ -13005,7 +12246,6 @@
       <url hash="eeea8468">2021.emnlp-main.784</url>
       <bibkey>pei-jurgens-2021-measuring</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.784</doi>
-      <video href="2021.emnlp-main.784.mp4"/>
       <video href="2021.emnlp-main.784.mp4"/>
     </paper>
     <paper id="785">
@@ -13021,7 +12261,6 @@
       <video href="2021.emnlp-main.785.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.785.mp4"/>
     </paper>
     <paper id="786">
       <title>Rumor Detection on <fixed-case>T</fixed-case>witter with Claim-Guided Hierarchical Graph Attention Networks</title>
@@ -13036,7 +12275,6 @@
       <url hash="b6f272a5">2021.emnlp-main.786</url>
       <bibkey>lin-etal-2021-rumor</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.786</doi>
-      <video href="2021.emnlp-main.786.mp4"/>
       <video href="2021.emnlp-main.786.mp4"/>
     </paper>
     <paper id="787">
@@ -13053,7 +12291,6 @@
       <doi>10.18653/v1/2021.emnlp-main.787</doi>
       <video href="2021.emnlp-main.787.mp4"/>
       <pwccode url="https://github.com/hikoseon12/learning-bill-similarity" additional="false">hikoseon12/learning-bill-similarity</pwccode>
-      <video href="2021.emnlp-main.787.mp4"/>
     </paper>
     <paper id="788">
       <title><fixed-case>SWEAT</fixed-case>: Scoring Polarization of Topics across Different Corpora</title>
@@ -13068,7 +12305,6 @@
       <doi>10.18653/v1/2021.emnlp-main.788</doi>
       <video href="2021.emnlp-main.788.mp4"/>
       <pwccode url="https://github.com/vinid/sweat" additional="false">vinid/sweat</pwccode>
-      <video href="2021.emnlp-main.788.mp4"/>
     </paper>
     <paper id="789">
       <title>“So You Think You’re Funny?”: Rating the Humour Quotient in Standup Comedy</title>
@@ -13084,7 +12320,6 @@
       <doi>10.18653/v1/2021.emnlp-main.789</doi>
       <video href="2021.emnlp-main.789.mp4"/>
       <pwccode url="https://github.com/theextrasemicolon/ai-openmic" additional="false">theextrasemicolon/ai-openmic</pwccode>
-      <video href="2021.emnlp-main.789.mp4"/>
     </paper>
     <paper id="790">
       <title>“Was it “stated” or was it “claimed”?: How linguistic bias affects generative language models</title>
@@ -13115,7 +12350,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.emnlp-main.791.mp4"/>
     </paper>
     <paper id="792">
       <title>A Simple Geometric Method for Cross-Lingual Linguistic Transformations with Pre-trained Autoencoders</title>
@@ -13131,7 +12365,6 @@
       <doi>10.18653/v1/2021.emnlp-main.792</doi>
       <video href="2021.emnlp-main.792.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/senteval">SentEval</pwcdataset>
-      <video href="2021.emnlp-main.792.mp4"/>
     </paper>
     <paper id="793">
       <title>An Information-Theoretic Characterization of Morphological Fusion</title>
@@ -13145,7 +12378,6 @@
       <doi>10.18653/v1/2021.emnlp-main.793</doi>
       <video href="2021.emnlp-main.793.mp4"/>
       <pwccode url="https://github.com/neilrathi/morphological-fusion" additional="false">neilrathi/morphological-fusion</pwccode>
-      <video href="2021.emnlp-main.793.mp4"/>
     </paper>
     <paper id="794">
       <title>The Effect of Efficient Messaging and Input Variability on Neural-Agent Iterated Language Learning</title>
@@ -13157,7 +12389,6 @@
       <url hash="e97aea41">2021.emnlp-main.794</url>
       <bibkey>lian-etal-2021-effect</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.794</doi>
-      <video href="2021.emnlp-main.794.mp4"/>
       <video href="2021.emnlp-main.794.mp4"/>
     </paper>
     <paper id="795">
@@ -13174,7 +12405,6 @@
       <doi>10.18653/v1/2021.emnlp-main.795</doi>
       <video href="2021.emnlp-main.795.mp4"/>
       <pwccode url="https://github.com/webis-de/emnlp-21" additional="false">webis-de/emnlp-21</pwccode>
-      <video href="2021.emnlp-main.795.mp4"/>
     </paper>
     <paper id="796">
       <title><fixed-case>C</fixed-case>hinese Opinion Role Labeling with Corpus Translation: A Pivot Study</title>
@@ -13192,7 +12422,6 @@
       <video href="2021.emnlp-main.796.mp4"/>
       <pwccode url="https://github.com/zenrran/chineseorl-with-corpus-translation" additional="false">zenrran/chineseorl-with-corpus-translation</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mpqa-opinion-corpus">MPQA Opinion Corpus</pwcdataset>
-      <video href="2021.emnlp-main.796.mp4"/>
     </paper>
     <paper id="797">
       <title><fixed-case>M</fixed-case>assive<fixed-case>S</fixed-case>umm: a very large-scale, very multilingual, news summarisation dataset</title>
@@ -13211,7 +12440,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/mlsum">MLSUM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/newsroom">NEWSROOM</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/new-york-times-annotated-corpus">New York Times Annotated Corpus</pwcdataset>
-      <video href="2021.emnlp-main.797.mp4"/>
     </paper>
     <paper id="798">
       <title><fixed-case>AUTOSUMM</fixed-case>: Automatic Model Creation for Text Summarization</title>
@@ -13228,7 +12456,6 @@
       <bibkey>nangi-etal-2021-autosumm</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.798</doi>
       <video href="2021.emnlp-main.798.mp4"/>
-      <video href="2021.emnlp-main.798.mp4"/>
     </paper>
     <paper id="799">
       <title>Investigating the Helpfulness of Word-Level Quality Estimation for Post-Editing Machine Translation Output</title>
@@ -13244,7 +12471,6 @@
       <doi>10.18653/v1/2021.emnlp-main.799</doi>
       <video href="2021.emnlp-main.799.mp4"/>
       <pwccode url="https://github.com/nicoherbig/mmpe" additional="false">nicoherbig/mmpe</pwccode>
-      <video href="2021.emnlp-main.799.mp4"/>
     </paper>
     <paper id="800">
       <title><fixed-case>UNK</fixed-case>s Everywhere: <fixed-case>A</fixed-case>dapting Multilingual Language Models to New Scripts</title>
@@ -13260,7 +12486,6 @@
       <video href="2021.emnlp-main.800.mp4"/>
       <pwccode url="https://github.com/adapter-hub/unks_everywhere" additional="true">adapter-hub/unks_everywhere</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.emnlp-main.800.mp4"/>
     </paper>
     <paper id="801">
       <title>Neural Machine Translation Quality and Post-Editing Performance</title>
@@ -13274,7 +12499,6 @@
       <attachment type="Software" hash="4cb2c9fd">2021.emnlp-main.801.Software.zip</attachment>
       <bibkey>zouhar-etal-2021-neural</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.801</doi>
-      <video href="2021.emnlp-main.801.mp4"/>
       <video href="2021.emnlp-main.801.mp4"/>
     </paper>
     <paper id="802">
@@ -13309,7 +12533,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/xcopa">XCOPA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xquad">XQuAD</pwcdataset>
-      <video href="2021.emnlp-main.802.mp4"/>
     </paper>
     <paper id="803">
       <title>Contrastive Conditioning for Assessing Disambiguation in <fixed-case>MT</fixed-case>: <fixed-case>A</fixed-case> Case Study of Distilled Bias</title>
@@ -13322,7 +12545,6 @@
       <doi>10.18653/v1/2021.emnlp-main.803</doi>
       <video href="2021.emnlp-main.803.mp4"/>
       <pwccode url="https://github.com/zurichnlp/contrastive-conditioning" additional="false">zurichnlp/contrastive-conditioning</pwccode>
-      <video href="2021.emnlp-main.803.mp4"/>
     </paper>
     <paper id="804">
       <title><fixed-case>M</fixed-case>easuring Association Between Labels and Free-Text Rationales</title>
@@ -13342,7 +12564,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/commonsenseqa">CommonsenseQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/e-snli">e-SNLI</pwcdataset>
-      <video href="2021.emnlp-main.804.mp4"/>
     </paper>
     <paper id="805">
       <title>Discretized Integrated Gradients for Explaining Language Models</title>
@@ -13357,7 +12578,6 @@
       <pwccode url="https://github.com/ink-usc/dig" additional="true">ink-usc/dig</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.805.mp4"/>
     </paper>
     <paper id="806">
       <title>Putting Words in <fixed-case>BERT</fixed-case>’s Mouth: Navigating Contextualized Vector Spaces with Pseudowords</title>
@@ -13388,7 +12608,6 @@
       <video href="2021.emnlp-main.807.mp4"/>
       <pwccode url="https://github.com/keyonvafa/sequential-rationales" additional="true">keyonvafa/sequential-rationales</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/lambada">LAMBADA</pwcdataset>
-      <video href="2021.emnlp-main.807.mp4"/>
     </paper>
     <paper id="808">
       <title><fixed-case>F</fixed-case>ast<fixed-case>IF</fixed-case>: Scalable Influence Functions for Efficient Model Interpretation and Debugging</title>
@@ -13407,7 +12626,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/anli">ANLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wilds">Wilds</pwcdataset>
-      <video href="2021.emnlp-main.808.mp4"/>
     </paper>
     <paper id="809">
       <title>Studying word order through iterative shuffling</title>
@@ -13424,7 +12642,6 @@
       <pwccode url="https://github.com/malkin1729/ibis" additional="false">malkin1729/ibis</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/qnli">QNLI</pwcdataset>
-      <video href="2021.emnlp-main.809.mp4"/>
     </paper>
     <paper id="810">
       <title>Distantly-Supervised Named Entity Recognition with Noise-Robust Learning and Language Model Augmented Self-Training</title>
@@ -13442,7 +12659,6 @@
       <doi>10.18653/v1/2021.emnlp-main.810</doi>
       <video href="2021.emnlp-main.810.mp4"/>
       <pwccode url="https://github.com/yumeng5/roster" additional="false">yumeng5/roster</pwccode>
-      <video href="2021.emnlp-main.810.mp4"/>
     </paper>
     <paper id="811">
       <title>Open Knowledge Graphs Canonicalization using Variational Autoencoders</title>
@@ -13458,7 +12674,6 @@
       <doi>10.18653/v1/2021.emnlp-main.811</doi>
       <video href="2021.emnlp-main.811.mp4"/>
       <pwccode url="https://github.com/IBM/Open-KG-canonicalization" additional="false">IBM/Open-KG-canonicalization</pwccode>
-      <video href="2021.emnlp-main.811.mp4"/>
     </paper>
     <paper id="812">
       <title><fixed-case>H</fixed-case>itt<fixed-case>ER</fixed-case>: Hierarchical Transformers for Knowledge Graph Embeddings</title>
@@ -13475,7 +12690,6 @@
       <doi>10.18653/v1/2021.emnlp-main.812</doi>
       <video href="2021.emnlp-main.812.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/fb15k-237">FB15k-237</pwcdataset>
-      <video href="2021.emnlp-main.812.mp4"/>
     </paper>
     <paper id="813">
       <title>Few-Shot Named Entity Recognition: An Empirical Baseline Study</title>
@@ -13497,7 +12711,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snips">SNIPS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wnut-2017-emerging-and-rare-entity">WNUT 2017</pwcdataset>
-      <video href="2021.emnlp-main.813.mp4"/>
     </paper>
     <paper id="814">
       <title><fixed-case>XLE</fixed-case>nt: Mining a Large Cross-lingual Entity Dataset with Lexical-Semantic-Phonetic Word Alignment</title>
@@ -13513,7 +12726,6 @@
       <doi>10.18653/v1/2021.emnlp-main.814</doi>
       <video href="2021.emnlp-main.814.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/xlent">XLEnt</pwcdataset>
-      <video href="2021.emnlp-main.814.mp4"/>
     </paper>
     <paper id="815">
       <title>Utilizing Relative Event Time to Enhance Event-Event Temporal Relation Extraction</title>
@@ -13526,7 +12738,6 @@
       <doi>10.18653/v1/2021.emnlp-main.815</doi>
       <video href="2021.emnlp-main.815.mp4"/>
       <pwccode url="https://github.com/wenhycs/emnlp2021-utilizing-relative-event-time-to-enhance-event-event-temporal-relation-extraction" additional="false">wenhycs/emnlp2021-utilizing-relative-event-time-to-enhance-event-event-temporal-relation-extraction</pwccode>
-      <video href="2021.emnlp-main.815.mp4"/>
     </paper>
     <paper id="816">
       <title>Separating Retention from Extraction in the Evaluation of End-to-end <fixed-case>R</fixed-case>elation <fixed-case>E</fixed-case>xtraction</title>
@@ -13541,7 +12752,6 @@
       <doi>10.18653/v1/2021.emnlp-main.816</doi>
       <video href="2021.emnlp-main.816.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/scierc">SciERC</pwcdataset>
-      <video href="2021.emnlp-main.816.mp4"/>
     </paper>
     <paper id="817">
       <title>Automatic Text Evaluation through the Lens of <fixed-case>W</fixed-case>asserstein Barycenters</title>
@@ -13558,7 +12768,6 @@
       <pwccode url="" additional="true"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2016">WMT 2016</pwcdataset>
-      <video href="2021.emnlp-main.817.mp4"/>
     </paper>
     <paper id="818">
       <title>Visually Grounded Reasoning across Languages and Cultures</title>
@@ -13578,7 +12787,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/marvl">MaRVL</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/iglue">IGLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/nlvr">NLVR</pwcdataset>
-      <video href="2021.emnlp-main.818.mp4"/>
     </paper>
     <paper id="819">
       <title>Back to Square One: Artifact Detection, Training and Commonsense Disentanglement in the <fixed-case>W</fixed-case>inograd Schema</title>
@@ -13594,7 +12802,6 @@
       <video href="2021.emnlp-main.819.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/wsc">WSC</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winogrande">WinoGrande</pwcdataset>
-      <video href="2021.emnlp-main.819.mp4"/>
     </paper>
     <paper id="820">
       <title>Robustness Evaluation of Entity Disambiguation Using Prior Probes: the Case of Entity Overshadowing</title>
@@ -13607,7 +12814,6 @@
       <url hash="e98cd7fe">2021.emnlp-main.820</url>
       <bibkey>provatorova-etal-2021-robustness</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.820</doi>
-      <video href="2021.emnlp-main.820.mp4"/>
       <video href="2021.emnlp-main.820.mp4"/>
     </paper>
     <paper id="821">
@@ -13630,7 +12836,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ocnli">OCNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-main.821.mp4"/>
     </paper>
     <paper id="822">
       <title>Agreeing to Disagree: Annotating Offensive Language Datasets with Annotators’ Disagreement</title>
@@ -13658,7 +12863,6 @@
       <doi>10.18653/v1/2021.emnlp-main.823</doi>
       <video href="2021.emnlp-main.823.mp4"/>
       <pwccode url="https://github.com/stanojevic/fast-mst-algorithm" additional="false">stanojevic/fast-mst-algorithm</pwccode>
-      <video href="2021.emnlp-main.823.mp4"/>
     </paper>
     <paper id="824">
       <title>Efficient Sampling of Dependency Structure</title>
@@ -13674,7 +12878,6 @@
       <revision id="1" href="2021.emnlp-main.824v1" hash="2c5b6dd2"/>
       <revision id="2" href="2021.emnlp-main.824v2" hash="76763412" date="2022-07-08">Corrected Theorem 2.</revision>
       <pwccode url="https://github.com/rycolab/treesample" additional="false">rycolab/treesample</pwccode>
-      <video href="2021.emnlp-main.824.mp4"/>
     </paper>
     <paper id="825">
       <title>Reducing Discontinuous to Continuous Parsing with Pointer Network Reordering</title>
@@ -13688,7 +12891,6 @@
       <video href="2021.emnlp-main.825.mp4"/>
       <pwccode url="https://github.com/danifg/Pointer-Network-Reordering" additional="false">danifg/Pointer-Network-Reordering</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/penn-treebank">Penn Treebank</pwcdataset>
-      <video href="2021.emnlp-main.825.mp4"/>
     </paper>
     <paper id="826">
       <title>A New Representation for Span-based <fixed-case>CCG</fixed-case> Parsing</title>
@@ -13701,7 +12903,6 @@
       <doi>10.18653/v1/2021.emnlp-main.826</doi>
       <video href="2021.emnlp-main.826.mp4"/>
       <pwccode url="https://github.com/yosihide/span-based-ccg-derivation" additional="false">yosihide/span-based-ccg-derivation</pwccode>
-      <video href="2021.emnlp-main.826.mp4"/>
     </paper>
     <paper id="827">
       <title><fixed-case>W</fixed-case>hat to Pre-Train on? <fixed-case>E</fixed-case>fficient Intermediate Task Selection</title>
@@ -13722,7 +12923,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/drop">DROP</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.emnlp-main.827.mp4"/>
     </paper>
     <paper id="828">
       <title><fixed-case>P</fixed-case>ermute<fixed-case>F</fixed-case>ormer: Efficient Relative Position Encoding for Long Sequences</title>
@@ -13736,7 +12936,6 @@
       <pwccode url="https://github.com/cpcp1998/permuteformer" additional="false">cpcp1998/permuteformer</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.828.mp4"/>
     </paper>
     <paper id="829">
       <title>Block Pruning For Faster Transformers</title>
@@ -13756,7 +12955,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/quora-question-pairs">Quora Question Pairs</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.829.mp4"/>
     </paper>
     <paper id="830">
       <title>Finetuning Pretrained Transformers into <fixed-case>RNN</fixed-case>s</title>
@@ -13778,7 +12976,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2014">WMT 2014</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.emnlp-main.830.mp4"/>
     </paper>
     <paper id="831">
       <title>How to Train <fixed-case>BERT</fixed-case> with an Academic Budget</title>
@@ -13802,7 +12999,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sts-benchmark">STS Benchmark</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/superglue">SuperGLUE</pwcdataset>
-      <video href="2021.emnlp-main.831.mp4"/>
     </paper>
     <paper id="832">
       <title>Beyond Preserved Accuracy: Evaluating Loyalty and Robustness of <fixed-case>BERT</fixed-case> Compression</title>
@@ -13821,7 +13017,6 @@
       <pwccode url="https://github.com/jetrunner/beyond-preserved-accuracy" additional="false">jetrunner/beyond-preserved-accuracy</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-main.832.mp4"/>
     </paper>
     <paper id="833">
       <title><fixed-case>I</fixed-case>ndo<fixed-case>BERT</fixed-case>weet: A Pretrained Language Model for <fixed-case>I</fixed-case>ndonesian <fixed-case>T</fixed-case>witter with Effective Domain-Specific Vocabulary Initialization</title>
@@ -13835,7 +13030,6 @@
       <doi>10.18653/v1/2021.emnlp-main.833</doi>
       <video href="2021.emnlp-main.833.mp4"/>
       <pwccode url="https://github.com/indolem/indobertweet" additional="false">indolem/indobertweet</pwccode>
-      <video href="2021.emnlp-main.833.mp4"/>
     </paper>
     <paper id="834">
       <title>Pushing on Text Readability Assessment: A Transformer Meets Handcrafted Linguistic Features</title>
@@ -13852,7 +13046,6 @@
       <video href="2021.emnlp-main.834.mp4"/>
       <pwccode url="https://github.com/brucewlee/lingfeat" additional="false">brucewlee/lingfeat</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/onestopenglish">OneStopEnglish</pwcdataset>
-      <video href="2021.emnlp-main.834.mp4"/>
     </paper>
     <paper id="835">
       <title>Types of Out-of-Distribution Texts and How to Detect Them</title>
@@ -13873,7 +13066,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/rte">RTE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/snli">SNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/sst">SST</pwcdataset>
-      <video href="2021.emnlp-main.835.mp4"/>
     </paper>
     <paper id="836">
       <title>Self-training with Few-shot Rationalization</title>
@@ -13889,7 +13081,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/boolq">BoolQ</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/fever">FEVER</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/e-snli">e-SNLI</pwcdataset>
-      <video href="2021.emnlp-main.836.mp4"/>
     </paper>
     <paper id="837">
       <title><fixed-case>MTA</fixed-case>dam: Automatic Balancing of Multiple Training Loss Terms</title>
@@ -13904,7 +13095,6 @@
       <pwccode url="https://github.com/ItzikMalkiel/MTAdam" additional="false">ItzikMalkiel/MTAdam</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/bsd">BSD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/set14">Set14</pwcdataset>
-      <video href="2021.emnlp-main.837.mp4"/>
     </paper>
     <paper id="838">
       <title>Softmax Tree: An Accurate, Fast Classifier When the Number of Classes Is Large</title>
@@ -13916,7 +13106,6 @@
       <url hash="479737b0">2021.emnlp-main.838</url>
       <bibkey>zharmagambetov-etal-2021-softmax</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.838</doi>
-      <video href="2021.emnlp-main.838.mp4"/>
       <video href="2021.emnlp-main.838.mp4"/>
     </paper>
     <paper id="839">
@@ -13949,7 +13138,6 @@
       <bibkey>mckenna-etal-2021-multivalent</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.840</doi>
       <video href="2021.emnlp-main.840.mp4"/>
-      <video href="2021.emnlp-main.840.mp4"/>
     </paper>
     <paper id="841">
       <title>Is Everything in Order? A Simple Way to Order Sentences</title>
@@ -13964,7 +13152,6 @@
       <doi>10.18653/v1/2021.emnlp-main.841</doi>
       <video href="2021.emnlp-main.841.mp4"/>
       <pwccode url="https://github.com/fabrahman/rebart" additional="false">fabrahman/rebart</pwccode>
-      <video href="2021.emnlp-main.841.mp4"/>
     </paper>
     <paper id="842">
       <title><fixed-case>V</fixed-case>ee<fixed-case>A</fixed-case>lign: Multifaceted Context Representation Using Dual Attention for Ontology Alignment</title>
@@ -13979,7 +13166,6 @@
       <doi>10.18653/v1/2021.emnlp-main.842</doi>
       <video href="2021.emnlp-main.842.mp4"/>
       <pwccode url="https://github.com/remorax/veealign" additional="false">remorax/veealign</pwccode>
-      <video href="2021.emnlp-main.842.mp4"/>
     </paper>
     <paper id="843">
       <title>Finding needles in a haystack: Sampling Structurally-diverse Training Sets from Synthetic Data for Compositional Generalization</title>
@@ -13993,7 +13179,6 @@
       <doi>10.18653/v1/2021.emnlp-main.843</doi>
       <video href="2021.emnlp-main.843.mp4"/>
       <pwccode url="https://github.com/inbaroren/scfg-sampling-for-comp-gen" additional="false">inbaroren/scfg-sampling-for-comp-gen</pwccode>
-      <video href="2021.emnlp-main.843.mp4"/>
     </paper>
     <paper id="844">
       <title><fixed-case>G</fixed-case>ene<fixed-case>S</fixed-case>is: <fixed-case>A</fixed-case> <fixed-case>G</fixed-case>enerative <fixed-case>A</fixed-case>pproach to <fixed-case>S</fixed-case>ubstitutes in <fixed-case>C</fixed-case>ontext</title>
@@ -14007,7 +13192,6 @@
       <doi>10.18653/v1/2021.emnlp-main.844</doi>
       <video href="2021.emnlp-main.844.mp4"/>
       <pwccode url="https://github.com/sapienzanlp/genesis" additional="false">sapienzanlp/genesis</pwccode>
-      <video href="2021.emnlp-main.844.mp4"/>
     </paper>
     <paper id="845">
       <title>Semi-Supervised Exaggeration Detection of Health Science Press Releases</title>
@@ -14020,7 +13204,6 @@
       <doi>10.18653/v1/2021.emnlp-main.845</doi>
       <video href="2021.emnlp-main.845.mp4"/>
       <pwccode url="https://github.com/copenlu/scientific-exaggeration-detection" additional="false">copenlu/scientific-exaggeration-detection</pwccode>
-      <video href="2021.emnlp-main.845.mp4"/>
     </paper>
     <paper id="846">
       <title>Phrase-<fixed-case>BERT</fixed-case>: Improved Phrase Embeddings from <fixed-case>BERT</fixed-case> with an Application to Corpus Exploration</title>
@@ -14037,7 +13220,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/big-bird">BiRD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/paws">PAWS</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/the-pile">The Pile</pwcdataset>
-      <video href="2021.emnlp-main.846.mp4"/>
     </paper>
     <paper id="847">
       <title>Detecting Contact-Induced Semantic Shifts: <fixed-case>W</fixed-case>hat Can Embedding-Based Methods Do in Practice?</title>
@@ -14049,7 +13231,6 @@
       <url hash="336fccdb">2021.emnlp-main.847</url>
       <bibkey>miletic-etal-2021-detecting</bibkey>
       <doi>10.18653/v1/2021.emnlp-main.847</doi>
-      <video href="2021.emnlp-main.847.mp4"/>
       <video href="2021.emnlp-main.847.mp4"/>
     </paper>
   </volume>
@@ -14081,7 +13262,6 @@
       <bibkey>li-etal-2021-miss</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.1</doi>
       <video href="2021.emnlp-demo.1.mp4"/>
-      <video href="2021.emnlp-demo.1.mp4"/>
     </paper>
     <paper id="2">
       <title>Automatic Construction of Enterprise Knowledge Base</title>
@@ -14107,7 +13287,6 @@
       <bibkey>perry-2021-lighttag</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.3</doi>
       <video href="2021.emnlp-demo.3.mp4"/>
-      <video href="2021.emnlp-demo.3.mp4"/>
     </paper>
     <paper id="4">
       <title><fixed-case>T</fixed-case>rans<fixed-case>I</fixed-case>ns: Document Translation with Markup Reinsertion</title>
@@ -14120,7 +13299,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.4</doi>
       <video href="2021.emnlp-demo.4.mp4"/>
       <pwccode url="https://github.com/dfki-mlt/transins" additional="false">dfki-mlt/transins</pwccode>
-      <video href="2021.emnlp-demo.4.mp4"/>
     </paper>
     <paper id="5">
       <title><fixed-case>ET</fixed-case>: A Workstation for Querying, Editing and Evaluating Annotated Corpora</title>
@@ -14133,7 +13311,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.5</doi>
       <video href="2021.emnlp-demo.5.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.emnlp-demo.5.mp4"/>
     </paper>
     <paper id="6">
       <title>N-<fixed-case>LTP</fixed-case>: An Open-source Neural Language Technology Platform for <fixed-case>C</fixed-case>hinese</title>
@@ -14148,7 +13325,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.6</doi>
       <video href="2021.emnlp-demo.6.mp4"/>
       <pwccode url="https://github.com/HIT-SCIR/ltp" additional="false">HIT-SCIR/ltp</pwccode>
-      <video href="2021.emnlp-demo.6.mp4"/>
     </paper>
     <paper id="7">
       <title><fixed-case>COMBO</fixed-case>: State-of-the-Art Morphosyntactic Analysis</title>
@@ -14159,7 +13335,6 @@
       <url hash="689b8b62">2021.emnlp-demo.7</url>
       <bibkey>klimaszewski-wroblewska-2021-combo-state</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.7</doi>
-      <video href="2021.emnlp-demo.7.mp4"/>
       <video href="2021.emnlp-demo.7.mp4"/>
     </paper>
     <paper id="8">
@@ -14175,7 +13350,6 @@
       <url hash="5a8bb868">2021.emnlp-demo.8</url>
       <bibkey>min-etal-2021-excavatorcovid</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.8</doi>
-      <video href="2021.emnlp-demo.8.mp4"/>
       <video href="2021.emnlp-demo.8.mp4"/>
     </paper>
     <paper id="9">
@@ -14194,7 +13368,6 @@
       <bibkey>park-etal-2021-koas</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.9</doi>
       <video href="2021.emnlp-demo.9.mp4"/>
-      <video href="2021.emnlp-demo.9.mp4"/>
     </paper>
     <paper id="10">
       <title><fixed-case>R</fixed-case>ep<fixed-case>G</fixed-case>raph: Visualising and Analysing Meaning Representation Graphs</title>
@@ -14207,7 +13380,6 @@
       <url hash="12007af4">2021.emnlp-demo.10</url>
       <bibkey>cohen-etal-2021-repgraph</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.10</doi>
-      <video href="2021.emnlp-demo.10.mp4"/>
       <video href="2021.emnlp-demo.10.mp4"/>
     </paper>
     <paper id="11">
@@ -14227,7 +13399,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/xnli">XNLI</pwcdataset>
-      <video href="2021.emnlp-demo.11.mp4"/>
     </paper>
     <paper id="12">
       <title><fixed-case>LM</fixed-case>diff: A Visual Diff Tool to Compare Language Models</title>
@@ -14244,7 +13415,6 @@
       <pwccode url="https://github.com/hendrikstrobelt/lmdiff" additional="false">hendrikstrobelt/lmdiff</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/commonsenseqa">CommonsenseQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/winobias">WinoBias</pwcdataset>
-      <video href="2021.emnlp-demo.12.mp4"/>
     </paper>
     <paper id="13">
       <title>Semantic Context Path Labeling for Semantic Exploration of User Reviews</title>
@@ -14257,7 +13427,6 @@
       <url hash="6329344c">2021.emnlp-demo.13</url>
       <bibkey>ait-mokhtar-etal-2021-semantic</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.13</doi>
-      <video href="2021.emnlp-demo.13.mp4"/>
       <video href="2021.emnlp-demo.13.mp4"/>
     </paper>
     <paper id="14">
@@ -14277,7 +13446,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/ok-vqa">OK-VQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/textvqa">TextVQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/visual-question-answering">Visual Question Answering</pwcdataset>
-      <video href="2021.emnlp-demo.14.mp4"/>
     </paper>
     <paper id="15">
       <title>Athena 2.0: Contextualized Dialogue Management for an <fixed-case>A</fixed-case>lexa <fixed-case>P</fixed-case>rize <fixed-case>S</fixed-case>ocial<fixed-case>B</fixed-case>ot</title>
@@ -14302,7 +13470,6 @@
       <bibkey>walker-etal-2021-athena</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.15</doi>
       <video href="2021.emnlp-demo.15.mp4"/>
-      <video href="2021.emnlp-demo.15.mp4"/>
     </paper>
     <paper id="16">
       <title><fixed-case>SPRING</fixed-case> <fixed-case>G</fixed-case>oes <fixed-case>O</fixed-case>nline: <fixed-case>E</fixed-case>nd-to-<fixed-case>E</fixed-case>nd <fixed-case>AMR</fixed-case> <fixed-case>P</fixed-case>arsing and <fixed-case>G</fixed-case>eneration</title>
@@ -14318,7 +13485,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.16</doi>
       <video href="2021.emnlp-demo.16.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/bio">Bio</pwcdataset>
-      <video href="2021.emnlp-demo.16.mp4"/>
     </paper>
     <paper id="17">
       <title>fairseq Sˆ2: A Scalable and Integrable Speech Synthesis Toolkit</title>
@@ -14352,7 +13518,6 @@
       <bibkey>yousef-etal-2021-press</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.18</doi>
       <video href="2021.emnlp-demo.18.mp4"/>
-      <video href="2021.emnlp-demo.18.mp4"/>
     </paper>
     <paper id="19">
       <title><fixed-case>UMR</fixed-case>-Writer: A Web Application for Annotating Uniform Meaning Representations</title>
@@ -14366,7 +13531,6 @@
       <bibkey>zhao-etal-2021-umr</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.19</doi>
       <video href="2021.emnlp-demo.19.mp4"/>
-      <video href="2021.emnlp-demo.19.mp4"/>
     </paper>
     <paper id="20">
       <title><fixed-case>T</fixed-case>ranslate<fixed-case>L</fixed-case>ocally: Blazing-fast translation running on the local <fixed-case>CPU</fixed-case></title>
@@ -14378,7 +13542,6 @@
       <url hash="cd51f6e4">2021.emnlp-demo.20</url>
       <bibkey>bogoychev-etal-2021-translatelocally</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.20</doi>
-      <video href="2021.emnlp-demo.20.mp4"/>
       <video href="2021.emnlp-demo.20.mp4"/>
     </paper>
     <paper id="21">
@@ -14425,7 +13588,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/glue">GLUE</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/squad">SQuAD</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/universal-dependencies">Universal Dependencies</pwcdataset>
-      <video href="2021.emnlp-demo.21.mp4"/>
     </paper>
     <paper id="22">
       <title>Summary Explorer: Visualizing the State of the Art in Text Summarization</title>
@@ -14441,7 +13603,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.22</doi>
       <video href="2021.emnlp-demo.22.mp4"/>
       <pwccode url="https://github.com/webis-de/summary-explorer" additional="false">webis-de/summary-explorer</pwccode>
-      <video href="2021.emnlp-demo.22.mp4"/>
     </paper>
     <paper id="23">
       <title><fixed-case>M</fixed-case>eet<fixed-case>D</fixed-case>ot: Videoconferencing with Live Translation Captions</title>
@@ -14458,7 +13619,6 @@
       <url hash="b6a7f620">2021.emnlp-demo.23</url>
       <bibkey>arkhangorodsky-etal-2021-meetdot</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.23</doi>
-      <video href="2021.emnlp-demo.23.mp4"/>
       <video href="2021.emnlp-demo.23.mp4"/>
     </paper>
     <paper id="24">
@@ -14478,7 +13638,6 @@
       <video href="2021.emnlp-demo.24.mp4"/>
       <pwccode url="https://github.com/iesl/box-embeddings" additional="false">iesl/box-embeddings</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/multinli">MultiNLI</pwcdataset>
-      <video href="2021.emnlp-demo.24.mp4"/>
     </paper>
     <paper id="25">
       <title><fixed-case>L</fixed-case>exi<fixed-case>C</fixed-case>lean: An annotation tool for rapid multi-task lexical normalisation</title>
@@ -14494,7 +13653,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.25</doi>
       <video href="2021.emnlp-demo.25.mp4"/>
       <pwccode url="https://github.com/nlp-tlp/lexiclean" additional="false">nlp-tlp/lexiclean</pwccode>
-      <video href="2021.emnlp-demo.25.mp4"/>
     </paper>
     <paper id="26">
       <title>T3-Vis: visual analytic for Training and fine-Tuning Transformers in <fixed-case>NLP</fixed-case></title>
@@ -14510,7 +13668,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.26</doi>
       <video href="2021.emnlp-demo.26.mp4"/>
       <pwccode url="https://github.com/raymondzmc/t3-vis" additional="false">raymondzmc/t3-vis</pwccode>
-      <video href="2021.emnlp-demo.26.mp4"/>
     </paper>
     <paper id="27">
       <title><fixed-case>D</fixed-case>omi<fixed-case>K</fixed-case>now<fixed-case>S</fixed-case>: A Library for Integration of Symbolic Domain Knowledge in Deep Learning</title>
@@ -14526,7 +13683,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.27</doi>
       <video href="2021.emnlp-demo.27.mp4"/>
       <pwccode url="https://github.com/hlr/domiknows" additional="false">hlr/domiknows</pwccode>
-      <video href="2021.emnlp-demo.27.mp4"/>
     </paper>
     <paper id="28">
       <title><fixed-case>O</fixed-case>pen<fixed-case>F</fixed-case>raming: Open-sourced Tool for Computational Framing Analysis of Multilingual Data</title>
@@ -14549,7 +13705,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.28</doi>
       <video href="2021.emnlp-demo.28.mp4"/>
       <pwccode url="https://github.com/vibss2397/openframing" additional="false">vibss2397/openframing</pwccode>
-      <video href="2021.emnlp-demo.28.mp4"/>
     </paper>
     <paper id="29">
       <title><fixed-case>I</fixed-case>r<fixed-case>E</fixed-case>ne-viz: Visualizing Energy Consumption of Transformer Models</title>
@@ -14564,7 +13719,6 @@
       <url hash="09f47612">2021.emnlp-demo.29</url>
       <bibkey>lal-etal-2021-irene</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.29</doi>
-      <video href="2021.emnlp-demo.29.mp4"/>
       <video href="2021.emnlp-demo.29.mp4"/>
     </paper>
     <paper id="30">
@@ -14582,7 +13736,6 @@
       <pwccode url="https://github.com/sharonlevy/open_domain_covidqa" additional="false">sharonlevy/open_domain_covidqa</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/cord-19">CORD-19</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/covidqa">CovidQA</pwcdataset>
-      <video href="2021.emnlp-demo.30.mp4"/>
     </paper>
     <paper id="31">
       <title>Project <fixed-case>D</fixed-case>ebater <fixed-case>API</fixed-case>s: <fixed-case>D</fixed-case>ecomposing the <fixed-case>AI</fixed-case> Grand Challenge</title>
@@ -14598,7 +13751,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.31</doi>
       <video href="2021.emnlp-demo.31.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/ibm-rank-30k">IBM-Rank-30k</pwcdataset>
-      <video href="2021.emnlp-demo.31.mp4"/>
     </paper>
     <paper id="32">
       <title><fixed-case>C</fixed-case>ro<fixed-case>A</fixed-case>no : A Crowd Annotation Platform for Improving Label Consistency of <fixed-case>C</fixed-case>hinese <fixed-case>NER</fixed-case> Dataset</title>
@@ -14616,7 +13768,6 @@
       <url hash="5ef1cf2b">2021.emnlp-demo.32</url>
       <bibkey>zhang-etal-2021-croano</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.32</doi>
-      <video href="2021.emnlp-demo.32.mp4"/>
       <video href="2021.emnlp-demo.32.mp4"/>
     </paper>
     <paper id="33">
@@ -14640,7 +13791,6 @@
       <pwccode url="https://github.com/biu-nlp/ifacetsum" additional="false">biu-nlp/ifacetsum</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/ecb">ECB+</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wec-eng">WEC-Eng</pwcdataset>
-      <video href="2021.emnlp-demo.33.mp4"/>
     </paper>
     <paper id="34">
       <title><fixed-case>AMuSE-WSD</fixed-case>: <fixed-case>A</fixed-case>n All-in-one Multilingual System for Easy <fixed-case>W</fixed-case>ord <fixed-case>S</fixed-case>ense <fixed-case>D</fixed-case>isambiguation</title>
@@ -14656,7 +13806,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.34</doi>
       <video href="2021.emnlp-demo.34.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/word-sense-disambiguation-a-unified">Word Sense Disambiguation: a Unified Evaluation Framework and Empirical Comparison</pwcdataset>
-      <video href="2021.emnlp-demo.34.mp4"/>
     </paper>
     <paper id="35">
       <title><fixed-case>S</fixed-case>eq<fixed-case>A</fixed-case>ttack: <fixed-case>O</fixed-case>n Adversarial Attacks for Named Entity Recognition</title>
@@ -14669,7 +13818,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.35</doi>
       <video href="2021.emnlp-demo.35.mp4"/>
       <pwcdataset url="https://paperswithcode.com/dataset/conll-2003">CoNLL-2003</pwcdataset>
-      <video href="2021.emnlp-demo.35.mp4"/>
     </paper>
     <paper id="36">
       <title><fixed-case>InVeRo-XL</fixed-case>: <fixed-case>M</fixed-case>aking Cross-Lingual <fixed-case>S</fixed-case>emantic <fixed-case>R</fixed-case>ole <fixed-case>L</fixed-case>abeling Accessible with Intelligible Verbs and Roles</title>
@@ -14683,7 +13831,6 @@
       <url hash="c251eec5">2021.emnlp-demo.36</url>
       <bibkey>conia-etal-2021-invero</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.36</doi>
-      <video href="2021.emnlp-demo.36.mp4"/>
       <video href="2021.emnlp-demo.36.mp4"/>
     </paper>
     <paper id="37">
@@ -14709,7 +13856,6 @@
       <pwcdataset url="https://paperswithcode.com/dataset/pubmedqa">PubMedQA</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/samsum-corpus">SAMSum Corpus</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/scisummnet">ScisummNet</pwcdataset>
-      <video href="2021.emnlp-demo.37.mp4"/>
     </paper>
     <paper id="38">
       <title>Chandler: An Explainable Sarcastic Response Generator</title>
@@ -14721,7 +13867,6 @@
       <url hash="75e675dc">2021.emnlp-demo.38</url>
       <bibkey>oprea-etal-2021-chandler</bibkey>
       <doi>10.18653/v1/2021.emnlp-demo.38</doi>
-      <video href="2021.emnlp-demo.38.mp4"/>
       <video href="2021.emnlp-demo.38.mp4"/>
     </paper>
     <paper id="39">
@@ -14737,7 +13882,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.39</doi>
       <video href="2021.emnlp-demo.39.mp4"/>
       <pwccode url="https://github.com/utahnlp/tabpert" additional="false">utahnlp/tabpert</pwccode>
-      <video href="2021.emnlp-demo.39.mp4"/>
     </paper>
     <paper id="40">
       <title><fixed-case>DRIFT</fixed-case>: A Toolkit for Diachronic Analysis of Scientific Literature</title>
@@ -14753,7 +13897,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.40</doi>
       <video href="2021.emnlp-demo.40.mp4"/>
       <pwccode url="https://github.com/rajaswa/DRIFT" additional="false">rajaswa/DRIFT</pwccode>
-      <video href="2021.emnlp-demo.40.mp4"/>
     </paper>
     <paper id="41">
       <title><fixed-case>FAST</fixed-case>: <fixed-case>F</fixed-case>ast <fixed-case>A</fixed-case>nnotation tool for <fixed-case>S</fixed-case>mar<fixed-case>T</fixed-case> devices</title>
@@ -14769,7 +13912,6 @@
       <doi>10.18653/v1/2021.emnlp-demo.41</doi>
       <video href="2021.emnlp-demo.41.mp4"/>
       <pwccode url="https://github.com/cyberagent/fast-annotation-tool" additional="false">cyberagent/fast-annotation-tool</pwccode>
-      <video href="2021.emnlp-demo.41.mp4"/>
     </paper>
     <paper id="42">
       <title>deep<fixed-case>Q</fixed-case>uest-py: <fixed-case>L</fixed-case>arge and Distilled Models for Quality Estimation</title>
@@ -14787,7 +13929,6 @@
       <video href="2021.emnlp-demo.42.mp4"/>
       <pwccode url="https://github.com/sheffieldnlp/deepQuest-py" additional="false">sheffieldnlp/deepQuest-py</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/mlqe">MLQE</pwcdataset>
-      <video href="2021.emnlp-demo.42.mp4"/>
     </paper>
   </volume>
   <volume id="tutorials" ingest-date="2021-11-04">

--- a/data/xml/2021.mwe.xml
+++ b/data/xml/2021.mwe.xml
@@ -109,7 +109,6 @@
       <doi>10.18653/v1/2021.mwe-1.8</doi>
       <bibkey>fleischhauer-2021-light</bibkey>
       <video href="2021.mwe-1.8.mp4"/>
-      <video href="2021.mwe-1.8.mp4"/>
     </paper>
   </volume>
 </collection>

--- a/data/xml/2021.spnlp.xml
+++ b/data/xml/2021.spnlp.xml
@@ -41,8 +41,6 @@
       <doi>10.18653/v1/2021.spnlp-1.2</doi>
       <bibkey>rubin-berant-2021-smbop-semi</bibkey>
       <video href="2021.spnlp-1.2.mp4"/>
-      <video href="2021.spnlp-1.2.mp4"/>
-      <video href="2021.spnlp-1.2.mp4"/>
     </paper>
     <paper id="3">
       <title>Learning compositional structures for semantic graph parsing</title>
@@ -55,8 +53,6 @@
       <doi>10.18653/v1/2021.spnlp-1.3</doi>
       <bibkey>groschwitz-etal-2021-learning</bibkey>
       <pwccode url="https://github.com/coli-saar/am-parser" additional="false">coli-saar/am-parser</pwccode>
-      <video href="2021.spnlp-1.3.mp4"/>
-      <video href="2021.spnlp-1.3.mp4"/>
       <video href="2021.spnlp-1.3.mp4"/>
     </paper>
     <paper id="4">
@@ -84,8 +80,6 @@
       <pwccode url="https://github.com/uralik/mode_recovery" additional="false">uralik/mode_recovery</pwccode>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-103">WikiText-103</pwcdataset>
       <pwcdataset url="https://paperswithcode.com/dataset/wikitext-2">WikiText-2</pwcdataset>
-      <video href="2021.spnlp-1.5.mp4"/>
-      <video href="2021.spnlp-1.5.mp4"/>
       <video href="2021.spnlp-1.5.mp4"/>
     </paper>
     <paper id="6">
@@ -128,8 +122,6 @@
       <doi>10.18653/v1/2021.spnlp-1.8</doi>
       <bibkey>zhang-etal-2021-comparing</bibkey>
       <pwccode url="https://github.com/zzsfornlp/zmsp" additional="false">zzsfornlp/zmsp</pwccode>
-      <video href="2021.spnlp-1.8.mp4"/>
-      <video href="2021.spnlp-1.8.mp4"/>
       <video href="2021.spnlp-1.8.mp4"/>
     </paper>
   </volume>


### PR DESCRIPTION
Some papers have duplicate videos listed (e.g. [here](https://aclanthology.org/2021.acl-long.134/)). This PR removes those.

Code for doing this is [here](https://gist.github.com/GuyAglionby/93c1d6af00e45a802ef3c49f40decfaa). There is some hacky stuff there for ensuring that whitespace stays consistent, but I made sure that only lines with a video tag were changed.

```
➜  acl-anthology git:(guyaglionby-remove-dupe-videos) git diff a615ffe~ a615ffe -U0 | grep '^[+-]' | grep -Ev '^(--- a/|\+\+\+ b/)' | grep -v video | wc -l
       0
```