### PR TITLE
Fix casing in the title of muhammad-etal-2022-naijasenti

### DIFF
--- a/data/xml/2022.lrec.xml
+++ b/data/xml/2022.lrec.xml
@@ -770,7 +770,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/imdb-movie-reviews">IMDb Movie Reviews</pwcdataset>
     </paper>
     <paper id="63">
-      <title><fixed-case>N</fixed-case>aija<fixed-case>S</fixed-case>enti: A Nigerian <fixed-case>T</fixed-case>witter Sentiment Corpus for Multilingual Sentiment Analysis</title>
+      <title><fixed-case>N</fixed-case>aija<fixed-case>S</fixed-case>enti: A <fixed-case>N</fixed-case>igerian <fixed-case>T</fixed-case>witter Sentiment Corpus for Multilingual Sentiment Analysis</title>
       <author><first>Shamsuddeen Hassan</first><last>Muhammad</last></author>
       <author><first>David Ifeoluwa</first><last>Adelani</last></author>
       <author><first>Sebastian</first><last>Ruder</last></author>


### PR DESCRIPTION
Fix casing: "nigerian" -> "Nigerian"
