### PR TITLE
Correction to sileo-etal-2019-aprentissage: Fixed typo and case in translation.

### DIFF
--- a/data/xml/2019.jeptalnrecital.xml
+++ b/data/xml/2019.jeptalnrecital.xml
@@ -802,7 +802,7 @@
       <bibkey>maudet-etal-2019-qwant</bibkey>
     </paper>
     <paper id="8">
-      <title>Aprentissage non-supervisé pour l’appariement et l’étiquetage de cas cliniques en français - <fixed-case>DEFT</fixed-case>2019 (Unsupervised learning for matching and labelling of french clincal cases - <fixed-case>DEFT</fixed-case>2019 )</title>
+      <title>Aprentissage non-supervisé pour l’appariement et l’étiquetage de cas cliniques en français - <fixed-case>DEFT</fixed-case>2019 (Unsupervised learning for matching and labelling of <fixed-case>F</fixed-case>rench clinical cases - <fixed-case>DEFT</fixed-case>2019 )</title>
       <author><first>Damien</first><last>Sileo</last></author>
       <author><first>Tim</first><last>Van de Cruys</last></author>
       <author><first>Philippe</first><last>Muller</last></author>


### PR DESCRIPTION
In `sileo-etal-2019-aprentissage` corrected typo and introduced casing.
