### PR TITLE
Some case corrections in English translations from French.

### DIFF
--- a/data/xml/2016.jeptalnrecital.xml
+++ b/data/xml/2016.jeptalnrecital.xml
@@ -490,7 +490,7 @@
       <bibkey>delecraz-etal-2016-fusion</bibkey>
     </paper>
     <paper id="42">
-      <title>L’impact des variations temporelles intrinsèques et extrinsèques de la voyelle sur la relation consonne-voyelle : Étude translinguistique sur l’arabe jordanien et le français (The impact of extrinsic and intrisic vowel temporal variations on the consonant-vowel relationship : A trans-linguistic investigation on Jordanian arabic and <fixed-case>F</fixed-case>rench)</title>
+      <title>L’impact des variations temporelles intrinsèques et extrinsèques de la voyelle sur la relation consonne-voyelle : Étude translinguistique sur l’arabe jordanien et le français (The impact of extrinsic and intrisic vowel temporal variations on the consonant-vowel relationship : A trans-linguistic investigation on <fixed-case>J</fixed-case>ordanian <fixed-case>A</fixed-case>rabic and <fixed-case>F</fixed-case>rench)</title>
       <language>fra</language>
       <author><first>Mohammad</first><last>Abuoudeh</last></author>
       <author><first>Olivier</first><last>Crouzet</last></author>
@@ -1602,7 +1602,7 @@
       <bibkey>pineau-etal-2016-segmentation</bibkey>
     </paper>
     <paper id="29">
-      <title>Système hybride pour la reconnaissance des entités nommées arabes à base des <fixed-case>CRF</fixed-case> (Hybrid arabic <fixed-case>NER</fixed-case> system using <fixed-case>CRF</fixed-case> Model)</title>
+      <title>Système hybride pour la reconnaissance des entités nommées arabes à base des <fixed-case>CRF</fixed-case> (Hybrid <fixed-case>A</fixed-case>rabic <fixed-case>NER</fixed-case> system using <fixed-case>CRF</fixed-case> Model)</title>
       <language>fra</language>
       <author><first>Emna</first><last>Hkiri</last></author>
       <author><first>Souheyl</first><last>Mallat</last></author>

--- a/data/xml/2017.jeptalnrecital.xml
+++ b/data/xml/2017.jeptalnrecital.xml
@@ -57,7 +57,7 @@
       <bibkey>bestgen-2017-utilisation</bibkey>
     </paper>
     <paper id="5">
-      <title>Traitement des Mots Hors Vocabulaire pour la Traduction Automatique de Document <fixed-case>OCR</fixed-case>isés en Arabe (This article presents a new system that automatically translates images of arabic documents)</title>
+      <title>Traitement des Mots Hors Vocabulaire pour la Traduction Automatique de Document <fixed-case>OCR</fixed-case>isés en Arabe (This article presents a new system that automatically translates images of <fixed-case>A</fixed-case>rabic documents)</title>
       <language>fra</language>
       <author><first>Kamel</first><last>Bouzidi</last></author>
       <author><first>Zied</first><last>Elloumi</last></author>
@@ -578,7 +578,7 @@
       <bibkey>wolfarth-2017-aligner</bibkey>
     </paper>
     <paper id="6">
-      <title>Générer une grammaire d’arbres adjoints pour l’arabe à partir d’une méta-grammaire (Generate a tree adjoining grammar for arabic from a meta-grammar)</title>
+      <title>Générer une grammaire d’arbres adjoints pour l’arabe à partir d’une méta-grammaire (Generate a tree adjoining grammar for <fixed-case>A</fixed-case>rabic from a meta-grammar)</title>
       <language>fra</language>
       <author><first>Cherifa</first><last>Ben Khelil</last></author>
       <pages>70–80</pages>


### PR DESCRIPTION
Includes following casing corrections:

1.  `abuoudeh-crouzet-2016-limpact`
2. `ben-khelil-2017-generer`
3. `bouzidi-etal-2017-traitement`
4. `hkiri-etal-2016-systeme`