### PR TITLE
Correction to sahala-etal-2020-babyfst: Fixed casing.

### DIFF
--- a/data/xml/2020.lrec.xml
+++ b/data/xml/2020.lrec.xml
@@ -5997,7 +5997,7 @@
       <bibkey>hathout-etal-2020-glawinette</bibkey>
     </paper>
     <paper id="479">
-      <title><fixed-case>B</fixed-case>aby<fixed-case>FST</fixed-case> - Towards a Finite-State Based Computational Model of <fixed-case>A</fixed-case>ncient <fixed-case>B</fixed-case>abylonian</title>
+      <title><fixed-case>B</fixed-case>aby<fixed-case>FST</fixed-case> - Towards a Finite-State Based Computational Model of Ancient <fixed-case>B</fixed-case>abylonian</title>
       <author><first>Aleksi</first><last>Sahala</last></author>
       <author><first>Miikka</first><last>Silfverberg</last></author>
       <author><first>Antti</first><last>Arppe</last></author>

--- a/data/xml/2020.lrec.xml
+++ b/data/xml/2020.lrec.xml
@@ -5997,7 +5997,7 @@
       <bibkey>hathout-etal-2020-glawinette</bibkey>
     </paper>
     <paper id="479">
-      <title><fixed-case>B</fixed-case>aby<fixed-case>FST</fixed-case> - Towards a Finite-State Based Computational Model of Ancient Babylonian</title>
+      <title><fixed-case>B</fixed-case>aby<fixed-case>FST</fixed-case> - Towards a Finite-State Based Computational Model of <fixed-case>A</fixed-case>ncient <fixed-case>B</fixed-case>abylonian</title>
       <author><first>Aleksi</first><last>Sahala</last></author>
       <author><first>Miikka</first><last>Silfverberg</last></author>
       <author><first>Antti</first><last>Arppe</last></author>


### PR DESCRIPTION
"Ancient Babylonian" should be explicitly capitalized.