### PR TITLE
Correction to kataja-koskenniemi-1988-finite: Casing.

### DIFF
--- a/data/xml/C88.xml
+++ b/data/xml/C88.xml
@@ -442,7 +442,7 @@
       <bibkey>kasper-1988-experimental</bibkey>
     </paper>
     <paper id="64">
-      <title>Finite-state Description of <fixed-case>S</fixed-case>emitic Morphology: A Case Study of Ancient Accadian</title>
+      <title>Finite-state Description of <fixed-case>S</fixed-case>emitic Morphology: A Case Study of Ancient <fixed-case>A</fixed-case>ccadian</title>
       <author><first>Laura</first><last>Kataja</last></author>
       <author><first>Kimmo</first><last>Koskenniemi</last></author>
       <url hash="5638625f">C88-1064</url>


### PR DESCRIPTION
"Accadian" should be upper-case.
