### PR TITLE
More truecase language families + minor truecase words.

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -831,6 +831,7 @@ Australian Sign Language
 Austria
 Austrian
 Austrian Sign Language
+Austronesian
 Austurland
 Autobank
 Autodesk
@@ -934,6 +935,7 @@ Babil
 Babine
 Babuza
 Babək
+Babylonian
 Babītes novads
 Bacama
 Bacanese Malay
@@ -1050,6 +1052,7 @@ Balti
 Baltic Romani
 Baltinavas novads
 Balto
+Balto Slavic
 Baluchi
 Balvu novads
 Balzan
@@ -1403,6 +1406,7 @@ Biao Mon
 Biatah Bidayuh
 Bibbulman
 Bible
+Bibles
 Bicknell
 Bicol
 Bidhawal
@@ -3319,6 +3323,7 @@ Finn
 Finnish
 Finnish Sign Language
 Finnmark
+Finno Ugric
 Finongan
 Fiorentino
 Fipa
@@ -3584,6 +3589,7 @@ Gera
 German
 German Democratic
 German Sign Language
+Germanic
 Germany
 Gers
 Geruma

--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -136,6 +136,7 @@ African Sign Language
 Afrihili
 Afrikaans
 Afro
+Afroasiatic
 Afyonkarahisar
 Agadez
 Agalega Islands
@@ -375,6 +376,7 @@ Alsungas novads
 Alta
 Alta Verapaz
 Altai
+Altaic
 Altay
 Altayskiy kray
 Alto Paraguay
@@ -2055,6 +2057,7 @@ Catania
 Catanzaro
 Catawba
 Cauca
+Caucasian
 Causeway Coast and Glens
 Cavan
 Cavineña
@@ -2070,6 +2073,7 @@ Cebu
 Cebuano
 Celje
 Celtiberian
+Celtic
 Cemuhî
 Cen
 Centar
@@ -4165,6 +4169,7 @@ Hmong
 Hmong Daw
 Hmong Dô
 Hmong Don
+Hmong Mien
 Hmong Njua
 Hmong Shua
 Hmwaveke
@@ -4632,6 +4637,7 @@ Japan
 Japanese
 Japanese Sign Language
 Japio
+Japonic
 Japrería
 Jaqaru
 Jara
@@ -5314,6 +5320,7 @@ Khmu
 Kho'ini
 Khoekhoe
 Khoibu Naga
+Khoisan
 Kholok
 Khomas
 Khon Kaen
@@ -8172,6 +8179,7 @@ Norrbottens län
 Norte
 Norte de Santander
 North and Latin America
+North Caucasian
 Northamptonshire
 Northern Thai
 Northumberland
@@ -8555,6 +8563,8 @@ Otank
 Otdar Mean Chey
 Oti
 Otjozondjupa
+Oto Manguean
+Otomanguean
 Otomi
 Otoro
 Ottawa
@@ -11772,6 +11782,7 @@ Ura
 Uradhi
 Urak Lawoi'
 Urali
+Uralic
 Urapmin
 Urarina
 Urartian
@@ -12469,6 +12480,7 @@ Yana
 Yanahuanca Pasco Quechua
 Yanda
 Yanda Dom Dogon
+Yandex
 Yandjibara
 Yandruwandha
 Yanesha'


### PR DESCRIPTION
This change includes some (but not all) major language families + adding some more unrelated truecase words (e.g., Yandex).

Please note: Ideally this should be accompanied by the corresponding truecase fixes in the data, but some of these may be quite substantial (e.g., see the papers involving Uralic languages), so this can be done separately.