### PR TITLE
Fixed-case treatment for "Uralic", "Germanic" and "Yandex".

### DIFF
--- a/data/xml/2016.amta.xml
+++ b/data/xml/2016.amta.xml
@@ -187,7 +187,7 @@
       <bibkey>amta-2016-conferences-association</bibkey>
     </frontmatter>
     <paper id="1">
-      <title><fixed-case>MT</fixed-case> crowdsource at Yandex</title>
+      <title><fixed-case>MT</fixed-case> crowdsource at <fixed-case>Y</fixed-case>andex</title>
       <author><first>Irina</first><last>Galinskaya</last></author>
       <author><first>Farhat</first><last>Aminov</last></author>
       <pages>1-2</pages>
@@ -271,7 +271,7 @@
       <bibkey>ruopp-2016-reasonable</bibkey>
     </paper>
     <paper id="12">
-      <title><fixed-case>MT</fixed-case> for Uralic Languages: Yandex Approach</title>
+      <title><fixed-case>MT</fixed-case> for <fixed-case>U</fixed-case>ralic Languages: <fixed-case>Y</fixed-case>andex Approach</title>
       <author><first>Irina</first><last>Galinskaya</last></author>
       <author><first>Alexey</first><last>Baytin</last></author>
       <pages>143-144</pages>

--- a/data/xml/2020.iwclul.xml
+++ b/data/xml/2020.iwclul.xml
@@ -2,7 +2,7 @@
 <collection id="2020.iwclul">
   <volume id="1" ingest-date="2020-03-30">
     <meta>
-      <booktitle>Proceedings of the Sixth International Workshop on Computational Linguistics of Uralic Languages</booktitle>
+      <booktitle>Proceedings of the Sixth International Workshop on Computational Linguistics of <fixed-case>U</fixed-case>ralic Languages</booktitle>
       <editor><first>Tommi A</first><last>Pirinen</last></editor>
       <editor><first>Francis M.</first><last>Tyers</last></editor>
       <editor><first>Michael</first><last>Rießler</last></editor>
@@ -29,7 +29,7 @@
       <pwccode url="https://github.com/langdoc/langdoc-pseudonymization" additional="false">langdoc/langdoc-pseudonymization</pwccode>
     </paper>
     <paper id="2">
-      <title>Effort-value payoff in lemmatisation for Uralic languages</title>
+      <title>Effort-value payoff in lemmatisation for <fixed-case>Uralic</fixed-case> languages</title>
       <author><first>Nick</first><last>Howell</last></author>
       <author><first>Maria</first><last>Bibaeva</last></author>
       <author><first>Francis</first><last>M. Tyers</last></author>
@@ -49,7 +49,7 @@
       <doi>10.18653/v1/2020.iwclul-1.3</doi>
     </paper>
     <paper id="4">
-      <title>On Editing Dictionaries for Uralic Languages in an Online Environment</title>
+      <title>On Editing Dictionaries for <fixed-case>U</fixed-case>ralic Languages in an Online Environment</title>
       <author><first>Khalid</first><last>Alnajjar</last></author>
       <author><first>Mika</first><last>Hämäläinen</last></author>
       <author><first>Jack</first><last>Rueter</last></author>
@@ -59,7 +59,7 @@
       <doi>10.18653/v1/2020.iwclul-1.4</doi>
     </paper>
     <paper id="5">
-      <title>Towards a Speech Recognizer for <fixed-case>K</fixed-case>omi, an Endangered and Low-Resource Uralic Language</title>
+      <title>Towards a Speech Recognizer for <fixed-case>K</fixed-case>omi, an Endangered and Low-Resource <fixed-case>Uralic</fixed-case> Language</title>
       <author><first>Nils</first><last>Hjortnaes</last></author>
       <author><first>Niko</first><last>Partanen</last></author>
       <author><first>Michael</first><last>Rießler</last></author>

--- a/data/xml/2020.vardial.xml
+++ b/data/xml/2020.vardial.xml
@@ -191,7 +191,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/conceptnet">ConceptNet</pwcdataset>
     </paper>
     <paper id="16">
-      <title>Uralic Language Identification (<fixed-case>ULI</fixed-case>) 2020 shared task dataset and the Wanca 2017 corpora</title>
+      <title><fixed-case>U</fixed-case>ralic Language Identification (<fixed-case>ULI</fixed-case>) 2020 shared task dataset and the Wanca 2017 corpora</title>
       <author><first>Tommi</first><last>Jauhiainen</last></author>
       <author><first>Heidi</first><last>Jauhiainen</last></author>
       <author><first>Niko</first><last>Partanen</last></author>

--- a/data/xml/2021.iwclul.xml
+++ b/data/xml/2021.iwclul.xml
@@ -2,7 +2,7 @@
 <collection id="2021.iwclul">
   <volume id="1" ingest-date="2021-10-23">
     <meta>
-      <booktitle>Proceedings of the Seventh International Workshop on Computational Linguistics of Uralic Languages</booktitle>
+      <booktitle>Proceedings of the Seventh International Workshop on Computational Linguistics of <fixed-case>U</fixed-case>ralic Languages</booktitle>
       <editor><first>Flammie A</first><last>Pirinen</last></editor>
       <editor><first>Timofey</first><last>Arhangelskiy</last></editor>
       <editor><first>Trond</first><last>Trosterud</last></editor>
@@ -19,7 +19,7 @@
       <bibkey>iwclul-2021-international</bibkey>
     </frontmatter>
     <paper id="1">
-      <title>Keyword spotting for audiovisual archival search in Uralic languages</title>
+      <title>Keyword spotting for audiovisual archival search in <fixed-case>U</fixed-case>ralic languages</title>
       <author><first>Nils</first><last>Hjortnaes</last></author>
       <author><first>Niko</first><last>Partanen</last></author>
       <author><first>Francis M.</first><last>Tyers</last></author>
@@ -28,7 +28,7 @@
       <bibkey>hjortnaes-etal-2021-keyword</bibkey>
     </paper>
     <paper id="2">
-      <title>Evaluating Transferability of <fixed-case>BERT</fixed-case> Models on Uralic Languages</title>
+      <title>Evaluating Transferability of <fixed-case>BERT</fixed-case> Models on <fixed-case>U</fixed-case>ralic Languages</title>
       <author><first>Judit</first><last>Ács</last></author>
       <author><first>Dániel</first><last>Lévai</last></author>
       <author><first>Andras</first><last>Kornai</last></author>

--- a/data/xml/2021.nodalida.xml
+++ b/data/xml/2021.nodalida.xml
@@ -407,7 +407,7 @@
       <pwccode url="https://github.com/poethan/MWE4MT" additional="false">poethan/MWE4MT</pwccode>
     </paper>
     <paper id="36">
-      <title>Grapheme-Based Cross-Language Forced Alignment: Results with Uralic Languages</title>
+      <title>Grapheme-Based Cross-Language Forced Alignment: Results with <fixed-case>U</fixed-case>ralic Languages</title>
       <author><first>Juho</first><last>Leinonen</last></author>
       <author><first>Sami</first><last>Virpioja</last></author>
       <author><first>Mikko</first><last>Kurimo</last></author>

--- a/data/xml/2021.vardial.xml
+++ b/data/xml/2021.vardial.xml
@@ -174,7 +174,7 @@
       <bibkey>jauhiainen-etal-2021-comparing</bibkey>
     </paper>
     <paper id="15">
-      <title>N-gram and Neural Models for Uralic Language Identification: <fixed-case>NRC</fixed-case> at <fixed-case>V</fixed-case>ar<fixed-case>D</fixed-case>ial 2021</title>
+      <title>N-gram and Neural Models for <fixed-case>U</fixed-case>ralic Language Identification: <fixed-case>NRC</fixed-case> at <fixed-case>V</fixed-case>ar<fixed-case>D</fixed-case>ial 2021</title>
       <author><first>Gabriel</first><last>Bernier-Colborne</last></author>
       <author><first>Serge</first><last>Leger</last></author>
       <author><first>Cyril</first><last>Goutte</last></author>

--- a/data/xml/2021.wmt.xml
+++ b/data/xml/2021.wmt.xml
@@ -610,7 +610,7 @@
       <pwccode url="https://github.com/temu-bsc/wmt2021-indoeuropean" additional="false">temu-bsc/wmt2021-indoeuropean</pwccode>
     </paper>
     <paper id="44">
-      <title><fixed-case>E</fixed-case>din<fixed-case>S</fixed-case>aar@<fixed-case>WMT</fixed-case>21: North-Germanic Low-Resource Multilingual <fixed-case>NMT</fixed-case></title>
+      <title><fixed-case>E</fixed-case>din<fixed-case>S</fixed-case>aar@<fixed-case>WMT</fixed-case>21: <fixed-case>N</fixed-case>orth-<fixed-case>G</fixed-case>ermanic Low-Resource Multilingual <fixed-case>NMT</fixed-case></title>
       <author><first>Svetlana</first><last>Tchistiakova</last></author>
       <author><first>Jesujoba</first><last>Alabi</last></author>
       <author><first>Koel</first><last>Dutta Chowdhury</last></author>

--- a/data/xml/L06.xml
+++ b/data/xml/L06.xml
@@ -2239,7 +2239,7 @@
     </paper>
     <paper id="247">
       <author><first>Attila</first><last>Novák</last></author>
-      <title>Morphological Tools for Six Small Uralic Languages</title>
+      <title>Morphological Tools for Six Small <fixed-case>U</fixed-case>ralic Languages</title>
       <url>http://www.lrec-conf.org/proceedings/lrec2006/pdf/416_pdf.pdf</url>
       <abstract>This article presents a set of morphological tools for six small endangered minority languages belonging to the Uralic language family, Udmurt, Komi, Eastern Mari, Northern Mansi, Tundra Nenets and Nganasan. Following an introduction to the languages, the two sets of tools used in the project (MorphoLogic's Humor tools and the Xerox Finite State Tool) are described and compared. The article is concluded by a comparison of the six computational morphologies.</abstract>
       <bibkey>novak-2006-morphological</bibkey>

--- a/data/xml/L18.xml
+++ b/data/xml/L18.xml
@@ -1265,7 +1265,7 @@
       <bibkey>halpern-2018-large</bibkey>
     </paper>
     <paper id="138">
-      <title>Combining Concepts and Their Translations from Structured Dictionaries of Uralic Minority Languages</title>
+      <title>Combining Concepts and Their Translations from Structured Dictionaries of <fixed-case>U</fixed-case>ralic Minority Languages</title>
       <author><first>Mika</first><last>Hämäläinen</last></author>
       <author><first>Liisa Lotta</first><last>Tarvainen</last></author>
       <author><first>Jack</first><last>Rueter</last></author>

--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -7267,7 +7267,7 @@
       <bibkey>ws-2011-language-technologies</bibkey>
     </frontmatter>
     <paper id="1">
-      <title>Endangered Uralic Languages and Language Technologies</title>
+      <title>Endangered <fixed-case>U</fixed-case>ralic Languages and Language Technologies</title>
       <author><first>Gábor</first><last>Prószéky</last></author>
       <pages>1–2</pages>
       <url hash="55f70d84">W11-4101</url>

--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -9821,7 +9821,7 @@
       <bibkey>huang-etal-2014-corpus</bibkey>
     </paper>
     <paper id="2">
-      <title>Diachronic proximity vs. data sparsity in cross-lingual parser projection. A case study on Germanic</title>
+      <title>Diachronic proximity vs. data sparsity in cross-lingual parser projection. A case study on <fixed-case>G</fixed-case>ermanic</title>
       <author><first>Maria</first><last>Sukhareva</last></author>
       <author><first>Christian</first><last>Chiarcos</last></author>
       <pages>11–20</pages>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -1128,7 +1128,7 @@
       <bibkey>rueter-2017-demo</bibkey>
     </paper>
     <paper id="3">
-      <title>Languages under the influence: Building a database of Uralic languages</title>
+      <title>Languages under the influence: Building a database of <fixed-case>U</fixed-case>ralic languages</title>
       <author><first>Eszter</first><last>Simon</last></author>
       <author><first>Nikolett</first><last>Mus</last></author>
       <pages>10–24</pages>

--- a/data/xml/W18.xml
+++ b/data/xml/W18.xml
@@ -180,7 +180,7 @@
       <bibkey>koskenniemi-2018-guessing</bibkey>
     </paper>
     <paper id="7">
-      <title>Tracking Typological Traits of Uralic Languages in Distributed Language Representations</title>
+      <title>Tracking Typological Traits of <fixed-case>U</fixed-case>ralic Languages in Distributed Language Representations</title>
       <author><first>Johannes</first><last>Bjerva</last></author>
       <author><first>Isabelle</first><last>Augenstein</last></author>
       <pages>76–86</pages>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -313,7 +313,7 @@
       <bibkey>ws-2019-international</bibkey>
     </frontmatter>
     <paper id="1">
-      <title>Data-Driven Morphological Analysis for Uralic Languages</title>
+      <title>Data-Driven Morphological Analysis for <fixed-case>U</fixed-case>ralic Languages</title>
       <author><first>Miikka</first><last>Silfverberg</last></author>
       <author><first>Francis</first><last>Tyers</last></author>
       <pages>1–14</pages>
@@ -396,7 +396,7 @@
       <pwcdataset url="https://paperswithcode.com/dataset/wmt-2018">WMT 2018</pwcdataset>
     </paper>
     <paper id="10">
-      <title>Uralic multimedia corpora: <fixed-case>ISO</fixed-case>/<fixed-case>TEI</fixed-case> corpus data in the project <fixed-case>INEL</fixed-case></title>
+      <title><fixed-case>U</fixed-case>ralic multimedia corpora: <fixed-case>ISO</fixed-case>/<fixed-case>TEI</fixed-case> corpus data in the project <fixed-case>INEL</fixed-case></title>
       <author><first>Timofey</first><last>Arkhangelskiy</last></author>
       <author><first>Anne</first><last>Ferger</last></author>
       <author><first>Hanna</first><last>Hedeland</last></author>
@@ -406,7 +406,7 @@
       <bibkey>arkhangelskiy-etal-2019-uralic</bibkey>
     </paper>
     <paper id="11">
-      <title>Corpora of social media in minority Uralic languages</title>
+      <title>Corpora of social media in minority <fixed-case>U</fixed-case>ralic languages</title>
       <author><first>Timofey</first><last>Arkhangelskiy</last></author>
       <pages>125–140</pages>
       <url hash="c392ede3">W19-0311</url>
@@ -17485,7 +17485,7 @@ In this tutorial on MT and post-editing we would like to continue sharing the la
       <bibkey>thomas-2019-universal</bibkey>
     </paper>
     <paper id="9">
-      <title>Survey of Uralic <fixed-case>U</fixed-case>niversal <fixed-case>D</fixed-case>ependencies development</title>
+      <title>Survey of <fixed-case>U</fixed-case>ralic <fixed-case>U</fixed-case>niversal <fixed-case>D</fixed-case>ependencies development</title>
       <author><first>Niko</first><last>Partanen</last></author>
       <author><first>Jack</first><last>Rueter</last></author>
       <pages>78–86</pages>


### PR DESCRIPTION
These words have already been added to `bin/fixedcase/truelist`.