### PR TITLE
Links for CSTFRS

### DIFF
--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -1049,7 +1049,7 @@
       <address>Gothenburg, Sweden</address>
       <month>June</month>
       <year>2019</year>
-      <venue>iwcs</venue>
+      <venue>cstfrs</venue>
     </meta>
     <frontmatter>
       <url hash="f901d643">W19-1000</url>

--- a/data/yaml/sigs/sigsem.yaml
+++ b/data/yaml/sigs/sigsem.yaml
@@ -17,6 +17,7 @@ Meetings:
     - 2021.naloma-1 # Proceedings of the 1st and 2nd Workshops on Natural Logic Meets Machine Learning (NALOMA)
     - 2021.semspace-1 # Proceedings of the 2021 Workshop on Semantic Spaces at the Intersection of NLP, Physics, and Cognitive Science (SemSpace)
     - 2021.icnlsp-1 # Proceedings of The Fourth International Conference on Natural Language and Speech Processing (ICNLSP 2021)
+    - 2021.cstfrs-1
   - 2020:
     - 2020.semeval-1
     - 2020.starsem-1


### PR DESCRIPTION
Linked from SIGSEM page, also corrected venue for 2019.