### PR TITLE
Add event media

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,6 @@ build/.hugo: build/.static build/.pages build/.bibtex build/.mods build/.endnote
 	         -d website/$(ANTHOLOGYDIR) \
 		 -e $(HUGO_ENV) \
 	         --cleanDestinationDir \
-                 --printMemoryUsage \
 	         --minify
 	@cd build/website/$(ANTHOLOGYDIR) \
 	    && ln -s $(ANTHOLOGYFILES) anthology-files \

--- a/bin/anthology/data.py
+++ b/bin/anthology/data.py
@@ -44,6 +44,9 @@ PDF_THUMBNAIL_LOCATION_TEMPLATE = ANTHOLOGY_PREFIX + "/thumb/{}.jpg"
 
 VIDEO_LOCATION_TEMPLATE = ANTHOLOGY_PREFIX + "/{}"
 
+# Where files related to events can be found, e.g., /events/acl-2022/2022.acl.handbook.pdf
+EVENT_LOCATION_TEMPLATE = ANTHOLOGY_PREFIX + "/events/{}/{}"
+
 # Regular expression matching full Anthology IDs
 ANTHOLOGY_ID_REGEX = r"[A-Z]\d{2}-\d{4}"
 
@@ -53,7 +56,7 @@ ANTHOLOGY_FILE_DIR = os.environ.get(
     "ANTHOLOGY_FILES", os.path.join(os.environ["HOME"], "anthology-files")
 )
 
-# Names of XML elements that may appear multiple times
+# Names of XML elements that may appear multiple times, and should be accumulated as a list
 LIST_ELEMENTS = (
     "attachment",
     "author",
@@ -65,7 +68,14 @@ LIST_ELEMENTS = (
     "pwcdataset",
     "video",
     "venue",
-    "colocated",
+)
+
+# Names of XML elements that should not be parsed, so that they can be interpreted later in
+# a context-specific way
+DONT_PARSE_ELEMENTS = (
+    "abstract", 
+    "title", 
+    "booktitle",
 )
 
 # New-style IDs that should be handled as journals

--- a/bin/anthology/events.py
+++ b/bin/anthology/events.py
@@ -15,6 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict
+
+from anthology.utils import parse_element
+from anthology.formatter import MarkupFormatter
+from anthology.data import EVENT_LOCATION_TEMPLATE
+
 
 class EventIndex:
     """
@@ -31,51 +37,86 @@ class EventIndex:
     def __init__(self, venue_index):
         self.events = {}
         self.venue_index = venue_index
+        self.formatter = MarkupFormatter()
+
+    def _create_event(self, event_id):
+        """
+        Creates an event if it doesn't already exists. Initializes the event title
+        to a default value that can later be overridden.
+        """
+        if not event_id in self.events:
+            venue, year = event_id.split("-")
+            venue_name = self.venue_index.get_venue(venue)["name"]
+            self.events[event_id] = {
+                "venue": venue,
+                "year": year,
+                "title": f"{venue_name} ({year})",
+                "links": [],
+                "volumes": [],
+            }
 
     def register_event(self, event_xml):
         """
-        Parses event XML and registers all colocated volumes.
+        Creates a new event from the <event> block in the XML.
         """
-        event = event_xml.attrib["id"]
-        for child_xml in event_xml:
-            if child_xml.tag == "title":
-                self.set_title(child_xml.text, event)
-            elif child_xml.tag == "colocated":
-                self.register_volume(child_xml.text, event)
+        event_id = event_xml.attrib["id"]
+        self._create_event(event_id)
 
-    def set_title(self, title, event):
-        """
-        Sets the the title of an event. This overrides the default title, which just concatenates
-        the venue name with the year. This allows the event name to be overridden in the <event>
-        block in the XML.
-        """
-        if event not in self.events:
-            self.events[event] = {
-                "title": None,
-                "volumes": [],
-            }
-        self.events[event]["title"] = title
+        # parse the top level of the block
+        event_data = parse_element(
+            event_xml, list_elements=["url", "volume-id"], 
+            dont_parse_elements=["meta", "links", "colocated"],
+            # recurse_elements=["meta", "colocated", "links"]
+        )
 
-    def register_volume(self, volume: str, event: str):
+        # copy over on top of default values
+        for key, value in event_data.items():
+            if key == "xml_meta":
+                # parse the children of "meta", raising them to the top level
+                # We also apply the formatter to the title, even though it shouldn't
+                # contain sub-formatting like that found in tables
+                for childkey, childvalue in parse_element(value).items():
+                    if childkey == "xml_title":
+                        # This item preserves the XML, so we need to interpret it
+                        self.events[event_id]["title"] = self.formatter(childvalue, "text")
+                    else:
+                        self.events[event_id][childkey] = childvalue
+
+            elif key == "xml_links":
+                # Copy links as a list of dicts under "links". This is then iterated over
+                # in the hugo template (hugo/layouts/events/single.html
+                for name, url in parse_element(value, list_elements=["url"]).items():
+                    # Rewrite the handbook URL if it's a relative path (which it should be)
+                    if name == "handbook" and not url.startswith("http") and not url.startswith("/"):
+                        url = data.EVENT_LOCATION_TEMPLATE.format(event_id, url)
+
+                    self.events[event_id]["links"].append({ name: url })
+
+            elif key == "xml_colocated":
+                # Turn the colocated volumes into a list of volume IDs
+                for volume_id in parse_element(value, list_elements=["volume-id"]).get("volume-id", []):
+                    self.register_volume(volume_id, event_id)
+
+            else:
+                # all other keys
+                self.events[event_id][key] = value
+
+        # print(event_id, self.events[event_id])
+
+    def register_volume(self, volume: str, event_id: str):
         """
-        Adds a volume to an event.
+        Adds a volume to an event. These are the volumes that will appear on the
+        event page. It should include volumes naturally associated with the event
+        (by virtue of belonging to the event's venue) as well as colocated volumes.
 
         :param volume: The full volume ID (e.g., P19-1, 2022.acl-long)
         :param event: The event (e.g., acl-2019, acl-2022)
         """
-        if event not in self.events:
-            venue, year = event.split("-")
-            venue_name = self.venue_index.get_venue(venue)["name"]
-            self.events[event] = {
-                "venue": venue,
-                "year": year,
-                "title": f"{venue_name} ({year})",
-                "volumes": [],
-            }
+        self._create_event(event_id)
 
-        if volume not in self.events[event]["volumes"]:
-            self.events[event]["volumes"].append(volume)
+        if volume not in self.events[event_id]["volumes"]:
+            self.events[event_id]["volumes"].append(volume)
 
     def items(self):
-        """Iterate over the items."""
+        """Iterate over the events."""
         return self.events.items()

--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -26,7 +26,7 @@ from .formatter import bibtex_encode
 from .people import PersonName
 from .venues import VenueIndex
 
-from typing import List
+from typing import List, Dict
 
 try:
     from yaml import CLoader as Loader
@@ -424,7 +424,7 @@ class AnthologyIndex:
         return self.comments.get(id_, None)
 
     @lru_cache(maxsize=2**16)
-    def resolve_name(self, name, id_=None):
+    def resolve_name(self, name, id_=None) -> Dict:
         """Find person named 'name' and return a dict with fields
         'first', 'last', 'id'"""
         if id_ is None:

--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -23,9 +23,7 @@ from .utils import (
     parse_element,
     infer_url,
     infer_attachment_url,
-    remove_extra_whitespace,
     is_journal,
-    is_volume_id,
 )
 from . import data
 

--- a/bin/create_hugo_yaml.py
+++ b/bin/create_hugo_yaml.py
@@ -257,6 +257,7 @@ if __name__ == "__main__":
 
     log.info("Reading the Anthology data...")
     anthology = Anthology(importdir=args["--importdir"])
+
     log.info("Exporting to YAML...")
     export_anthology(
         anthology, args["--exportdir"], clean=args["--clean"], dryrun=args["--dry-run"]

--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -12254,34 +12254,45 @@ in the Case of Unambiguous Gender</title>
     </paper>
   </volume>
   <event id="acl-2022">
-    <colocated>2022.findings-acl</colocated>
-    <colocated>2022.bigscience-1</colocated>
-    <colocated>2022.bionlp-1</colocated>
-    <colocated>2022.cmcl-1</colocated>
-    <colocated>2022.computel-1</colocated>
-    <colocated>2022.constraint-1</colocated>
-    <colocated>2022.csrr-1</colocated>
-    <colocated>2022.deelio-1</colocated>
-    <colocated>2022.dialdoc-1</colocated>
-    <colocated>2022.dravidianlangtech-1</colocated>
-    <colocated>2022.ecnlp-1</colocated>
-    <colocated>2022.fever-1</colocated>
-    <colocated>2022.fl4nlp-1</colocated>
-    <colocated>2022.humeval-1</colocated>
-    <colocated>2022.in2writing-1</colocated>
-    <colocated>2022.insights-1</colocated>
-    <colocated>2022.iwslt-1</colocated>
-    <colocated>2022.lchange-1</colocated>
-    <colocated>2022.lnls-1</colocated>
-    <colocated>2022.ltedi-1</colocated>
-    <colocated>2022.mml-1</colocated>
-    <colocated>2022.nlp4convai-1</colocated>
-    <colocated>2022.nlppower-1</colocated>
-    <colocated>2022.repl4nlp-1</colocated>
-    <colocated>2022.slpat-1</colocated>
-    <colocated>2022.spanlp-1</colocated>
-    <colocated>2022.spnlp-1</colocated>
-    <colocated>2022.wassa-1</colocated>
-    <colocated>2022.wit-1</colocated>
+    <meta>
+      <title>60th Annual Meeting of the Association for Computational Linguistics</title>
+      <location>Dublin, Ireland</location>
+      <dates>22–27 May, 2022</dates>
+    </meta>
+    <links>
+      <url type="website">https://2022.aclweb.org</url>
+      <url type="handbook">2022.acl.handbook.pdf</url>
+    </links>
+    <colocated>
+      <volume-id>2022.findings-acl</volume-id>
+      <volume-id>2022.bigscience-1</volume-id>
+      <volume-id>2022.bionlp-1</volume-id>
+      <volume-id>2022.cmcl-1</volume-id>
+      <volume-id>2022.computel-1</volume-id>
+      <volume-id>2022.constraint-1</volume-id>
+      <volume-id>2022.csrr-1</volume-id>
+      <volume-id>2022.deelio-1</volume-id>
+      <volume-id>2022.dialdoc-1</volume-id>
+      <volume-id>2022.dravidianlangtech-1</volume-id>
+      <volume-id>2022.ecnlp-1</volume-id>
+      <volume-id>2022.fever-1</volume-id>
+      <volume-id>2022.fl4nlp-1</volume-id>
+      <volume-id>2022.humeval-1</volume-id>
+      <volume-id>2022.in2writing-1</volume-id>
+      <volume-id>2022.insights-1</volume-id>
+      <volume-id>2022.iwslt-1</volume-id>
+      <volume-id>2022.lchange-1</volume-id>
+      <volume-id>2022.lnls-1</volume-id>
+      <volume-id>2022.ltedi-1</volume-id>
+      <volume-id>2022.mml-1</volume-id>
+      <volume-id>2022.nlp4convai-1</volume-id>
+      <volume-id>2022.nlppower-1</volume-id>
+      <volume-id>2022.repl4nlp-1</volume-id>
+      <volume-id>2022.slpat-1</volume-id>
+      <volume-id>2022.spanlp-1</volume-id>
+      <volume-id>2022.spnlp-1</volume-id>
+      <volume-id>2022.wassa-1</volume-id>
+      <volume-id>2022.wit-1</volume-id>
+    </colocated>
   </event>
 </collection>

--- a/data/xml/2022.naacl.xml
+++ b/data/xml/2022.naacl.xml
@@ -8609,30 +8609,32 @@
     </paper>
   </volume>
   <event id="naacl-2022">
-    <colocated>2022.findings-naacl</colocated>
-    <colocated>2022.autosimtrans-1</colocated>
-    <colocated>2022.bea-1</colocated>
-    <colocated>2022.clinicalnlp-1</colocated>
-    <colocated>2022.clpsych-1</colocated>
-    <colocated>2022.dadc-1</colocated>
-    <colocated>2022.deeplo-1</colocated>
-    <colocated>2022.distcurate-1</colocated>
-    <colocated>2022.dlg4nlp-1</colocated>
-    <colocated>2022.emoji-1</colocated>
-    <colocated>2022.gebnlp-1</colocated>
-    <colocated>2022.hcinlp-1</colocated>
-    <colocated>2022.mia-1</colocated>
-    <colocated>2022.privatenlp-1</colocated>
-    <colocated>2022.starsem-1</colocated>
-    <colocated>2022.semeval-1</colocated>
-    <colocated>2022.sigmorphon-1</colocated>
-    <colocated>2022.sigtyp-1</colocated>
-    <colocated>2022.socialnlp-1</colocated>
-    <colocated>2022.suki-1</colocated>
-    <colocated>2022.trustnlp-1</colocated>
-    <colocated>2022.unimplicit-1</colocated>
-    <colocated>2022.wnu-1</colocated>
-    <colocated>2022.woah-1</colocated>
-    <colocated>2022.wordplay-1</colocated>
+    <colocated>
+      <volume-id>2022.findings-naacl</volume-id>
+      <volume-id>2022.autosimtrans-1</volume-id>
+      <volume-id>2022.bea-1</volume-id>
+      <volume-id>2022.clinicalnlp-1</volume-id>
+      <volume-id>2022.clpsych-1</volume-id>
+      <volume-id>2022.dadc-1</volume-id>
+      <volume-id>2022.deeplo-1</volume-id>
+      <volume-id>2022.distcurate-1</volume-id>
+      <volume-id>2022.dlg4nlp-1</volume-id>
+      <volume-id>2022.emoji-1</volume-id>
+      <volume-id>2022.gebnlp-1</volume-id>
+      <volume-id>2022.hcinlp-1</volume-id>
+      <volume-id>2022.mia-1</volume-id>
+      <volume-id>2022.privatenlp-1</volume-id>
+      <volume-id>2022.starsem-1</volume-id>
+      <volume-id>2022.semeval-1</volume-id>
+      <volume-id>2022.sigmorphon-1</volume-id>
+      <volume-id>2022.sigtyp-1</volume-id>
+      <volume-id>2022.socialnlp-1</volume-id>
+      <volume-id>2022.suki-1</volume-id>
+      <volume-id>2022.trustnlp-1</volume-id>
+      <volume-id>2022.unimplicit-1</volume-id>
+      <volume-id>2022.wnu-1</volume-id>
+      <volume-id>2022.woah-1</volume-id>
+      <volume-id>2022.wordplay-1</volume-id>
+    </colocated>
   </event>
 </collection>

--- a/data/xml/N13.xml
+++ b/data/xml/N13.xml
@@ -1695,4 +1695,9 @@
       <video href="N13-4006.2.mp4"/>
     </paper>
   </volume>
+  <event id="naacl-2013">
+    <links>
+      <url type="handbook">2013.naacl.handbook.pdf</url>
+    </links>
+  </event>
 </collection>

--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -2,7 +2,9 @@
 
 b = element b { MarkupText }
 i = element i { MarkupText }
-url = element url { xsd:anyURI }
+url = element url {
+  attribute type { xsd:NCName }? & xsd:anyURI
+}
 fixed-case = element fixed-case { MarkupText }
 tex-math = element tex-math { text }
 MarkupText = (text | b | i | url | fixed-case | tex-math )+
@@ -117,8 +119,17 @@ Volume = element volume {
   Paper*
 }
 Event = element event {
-  attribute id { xsd:string },
-  (element colocated { text }*)
+  attribute id { xsd:string }
+  & element meta {
+    (element title { MarkupText }?
+     & element location { text }?
+     & element dates { text }?
+    )
+  }?
+  & element links { url* }?
+  & element colocated { 
+    element volume-id { text }*
+    }?
 }
 Collection = element collection {
   attribute id { xsd:string },

--- a/hugo/layouts/events/single.html
+++ b/hugo/layouts/events/single.html
@@ -1,15 +1,33 @@
 {{ define "main" }}
+{{ $event := index .Site.Data.events .Params.event_slug }}
 <section id="main">
   <h2 id="title">
     {{ .Title }}
   </h2>
+  {{ with $event.location }}
+  <span>{{ . }}</span><br/>
+  {{ end }}
+  {{ with $event.dates }}
+  <span class="font-weight-light text-muted">{{ . }}</span><br/>
+  {{ end }}
   <hr />
 
   {{/* Get the event and iterate through all the volumes associated with it */}}
-  {{ $event := index .Site.Data.events .Params.event_slug }}
   {{ $volumes := index $event "volumes" }}
   <div class="card bg-light mb-2 mb-lg-4">
     <div class="card-body">
+      {{ if $event.links }}
+      <h4 class="card-title">Links</h4>
+      <ul class="list-pl-responsive">
+        {{ range $event.links }}
+          {{ range $label, $link := . }}
+        <li>
+          <a class="align-middle" href="{{ $link }}">{{ $label }}</a>
+        </li>
+          {{ end }}
+        {{ end }}
+      </ul>
+      {{ end }}
       <h4 class="card-title">Volumes</h4>
       <ul class="list-pl-responsive">
         {{ range $volumes }}


### PR DESCRIPTION
This PR enriches the `<event>` block, supporting adding event-related data such as the handbook (#298).

It builds on existing parsing routines in an attempt to be general.