### PR TITLE
Adding a timeout parameter to the HTTP request

### DIFF
--- a/bin/ingest_pwc.py
+++ b/bin/ingest_pwc.py
@@ -70,8 +70,8 @@ if __name__ == "__main__":
         with open(args.infile, "r") as f:
             pwc_meta = json.load(f)
     else:
-        # Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
-        res = requests.get("https://paperswithcode.com/integrations/acl", timeout=0.4)
+        # Adds a 30s 'timeout' threshold for HTTP request
+        res = requests.get("https://paperswithcode.com/integrations/acl", timeout=30)
         if res.ok:
             pwc_meta = res.json()
         else:

--- a/bin/ingest_pwc.py
+++ b/bin/ingest_pwc.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
             pwc_meta = json.load(f)
     else:
         # Adds a 30s 'timeout' threshold for HTTP request
-        res = requests.get("https://paperswithcode.com/integrations/acl", timeout=30)
+        res = requests.get("https://paperswithcode.com/integrations/acl/", timeout=30)
         if res.ok:
             pwc_meta = res.json()
         else:

--- a/bin/ingest_pwc.py
+++ b/bin/ingest_pwc.py
@@ -70,7 +70,8 @@ if __name__ == "__main__":
         with open(args.infile, "r") as f:
             pwc_meta = json.load(f)
     else:
-        res = requests.get("https://paperswithcode.com/integrations/acl")
+        # Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+        res = requests.get("https://paperswithcode.com/integrations/acl", timeout=0.4)
         if res.ok:
             pwc_meta = res.json()
         else:


### PR DESCRIPTION
In the file: ingest_pwc.py, a request is made without a timeout parameter. The requests.get method in Python does not use any default timeout value and should be explicitly set. Otherwise, if the recipient server is unavailable to service the request, the application making the request may stall indefinitely.  

What should be the timeout value? A good practice is to set it under 500ms. This PR proposes the value to be 400ms. However, this may vary depending on the use case. More information is available in: https://docs.python-requests.org/en/latest/user/advanced/#timeouts