### PR TITLE
fix metadata of 2022.sigdial-1.14 and 2022.lrec-1.617

### DIFF
--- a/data/xml/2022.lrec.xml
+++ b/data/xml/2022.lrec.xml
@@ -7616,12 +7616,12 @@
     </paper>
     <paper id="617">
       <title><fixed-case>HADREB</fixed-case>: Human Appraisals and (<fixed-case>E</fixed-case>nglish) Descriptions of Robot Emotional Behaviors</title>
-      <author><first>Josue</first><last>Torres-Fonsesca</last></author>
+      <author><first>Josue</first><last>Torres-Fonseca</last></author>
       <author><first>Casey</first><last>Kennington</last></author>
       <pages>5739–5748</pages>
       <abstract>Humans sometimes anthropomorphize everyday objects, but especially robots that have human-like qualities and that are often able to interact with and respond to humans in ways that other objects cannot. Humans especially attribute emotion to robot behaviors, partly because humans often use and interpret emotions when interacting with other humans, and they apply that capability when interacting with robots. Moreover, emotions are a fundamental part of the human language system and emotions are used as scaffolding for language learning, making them an integral part of language learning and meaning. However, there are very few datasets that explore how humans perceive the emotional states of robots and how emotional behaviors relate to human language. To address this gap we have collected HADREB, a dataset of human appraisals and English descriptions of robot emotional behaviors collected from over 30 participants. These descriptions and human emotion appraisals are collected using the Mistyrobotics Misty II and the Digital Dream Labs Cozmo (formerly Anki) robots. The dataset contains English descriptions and emotion appraisals of more than 500 descriptions and graded valence labels of 8 emotion pairs for each behavior and each robot. In this paper we describe the process of collecting and cleaning the data, give a general analysis of the data, and evaluate the usefulness of the dataset in two experiments, one using a language model to map descriptions to emotions, the other maps robot behaviors to emotions.</abstract>
       <url hash="19fce756">2022.lrec-1.617</url>
-      <bibkey>torres-fonsesca-kennington-2022-hadreb</bibkey>
+      <bibkey>torres-fonseca-kennington-2022-hadreb</bibkey>
     </paper>
     <paper id="618">
       <title>Dialogue Collection for Recording the Process of Building Common Ground in a Collaborative Task</title>

--- a/data/xml/2022.sigdial.xml
+++ b/data/xml/2022.sigdial.xml
@@ -181,13 +181,13 @@
     </paper>
     <paper id="14">
       <title>Symbol and Communicative Grounding through Object Permanence with a Mobile Robot</title>
-      <author><first>Josue</first><last>Torres-Foncesca</last></author>
+      <author><first>Josue</first><last>Torres-Fonseca</last></author>
       <author><first>Catherine</first><last>Henry</last></author>
       <author><first>Casey</first><last>Kennington</last></author>
       <pages>124–134</pages>
       <abstract>Object permanence is the ability to form and recall mental representations of objects even when they are not in view. Despite being a crucial developmental step for children, object permanence has had only some exploration as it relates to symbol and communicative grounding in spoken dialogue systems. In this paper, we leverage SLAM as a module for tracking object permanence and use a robot platform to move around a scene where it discovers objects and learns how they are denoted. We evaluated by comparing our system’s effectiveness at learning words from human dialogue partners both with and without object permanence. We found that with object permanence, human dialogue partners spoke with the robot and the robot correctly identified objects it had learned about significantly more than without object permanence, which suggests that object permanence helped facilitate communicative and symbol grounding.</abstract>
       <url hash="59987826">2022.sigdial-1.14</url>
-      <bibkey>torres-foncesca-etal-2022-symbol</bibkey>
+      <bibkey>torres-fonseca-etal-2022-symbol</bibkey>
       <video href="https://youtu.be/xxulenUa754"/>
       <pwcdataset url="https://paperswithcode.com/dataset/coco">COCO</pwcdataset>
     </paper>


### PR DESCRIPTION
Fixes #2400 

Last name of first author was corrected from "Torres-Foncesca" to "Torres-Fonseca" in the metadata for both the author under the title and bibkey.

Fixes #2402 

Last name of first author was corrected from "Torres-Fonsesca" to "Torres-Fonseca" in the metadata for both the author under the title and bibkey.

NOTE:

I did not link both papers to a new page ("https://aclanthology.org/people/j/josue-torres-fonseca/") with the correct name spelling as requested in the issues. I'm not sure how to do so or if is done automatically from the metadata. 