### PR TITLE
Re-add authors for 2022.nejlt-1.6 delisted in OJS

### DIFF
--- a/data/xml/2022.nejlt.xml
+++ b/data/xml/2022.nejlt.xml
@@ -63,7 +63,13 @@
     <paper id="6">
       <title><fixed-case>S</fixed-case>panish <fixed-case>A</fixed-case>bstract <fixed-case>M</fixed-case>eaning <fixed-case>R</fixed-case>epresentation: Annotation of a General Corpus</title>
       <author><first>Shira</first><last>Wein</last></author>
-      <abstract>Abstract Abstract Meaning Representation (AMR), originally designed for English, has been adapted to a number of languages to facilitate cross-lingual semantic representation and analysis. We build on previous work and present the first sizable, general annotation project for Spanish AMR. We release a detailed set of annotation guidelines and a corpus of 486 gold-annotated sentences spanning multiple genres from an existing, cross-lingual AMR corpus. Our work constitutes the second largest non-English gold AMR corpus to date. Fine-tuning an AMR to-Spanish generation model with our annotations results in a BERTScore improvement of 8.8%, demonstrating initial utility of our work.</abstract>
+      <author><first>Lucia</first><last>Donatelli</last></author>
+      <author><first>Ethan</first><last>Ricker</last></author>
+      <author><first>Calvin</first><last>Engstrom</last></author>
+      <author><first>Alex</first><last>Nelson</last></author>
+      <author><first>Leonie</first><last>Harter</last></author>
+      <author><first>Nathan</first><last>Schneider</last></author>
+      <abstract>Abstract Meaning Representation (AMR), originally designed for English, has been adapted to a number of languages to facilitate cross-lingual semantic representation and analysis. We build on previous work and present the first sizable, general annotation project for Spanish AMR. We release a detailed set of annotation guidelines and a corpus of 486 gold-annotated sentences spanning multiple genres from an existing, cross-lingual AMR corpus. Our work constitutes the second largest non-English gold AMR corpus to date. Fine-tuning an AMR to-Spanish generation model with our annotations results in a BERTScore improvement of 8.8%, demonstrating initial utility of our work.</abstract>
       <url hash="b8ab1c04">2022.nejlt-1.6</url>
       <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.4462</doi>
       <bibkey>wein-2022-spanish</bibkey>


### PR DESCRIPTION
Author had accidentally delisted a few authors in an issue export - adding these manually 