### PR TITLE
amend title metadata in 2022.nejlt-1.4

### DIFF
--- a/data/xml/2022.nejlt.xml
+++ b/data/xml/2022.nejlt.xml
@@ -42,7 +42,7 @@
       <bibkey>howell-bender-2022-building</bibkey>
     </paper>
     <paper id="4">
-      <title>Analysis of Bias in <fixed-case>NLP</fixed-case> Models With Regression and Effect Sizes</title>
+      <title>Bias Identification and Attribution in <fixed-case>NLP</fixed-case> Models With Regression and Effect Sizes</title>
       <author><first>Erenay</first><last>Dayanik</last></author>
       <author><first>Ngoc Thang</first><last>Vu</last></author>
       <author><first>Sebastian</first><last>Padó</last></author>


### PR DESCRIPTION
Author metadata was out of sync with paper title in this article, amended the relevant line