### PR TITLE
Use fixed case for Nynorsk and Low Saxon

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -6409,6 +6409,7 @@ Lovech
 Lovrenc na Pohorju
 Low German
 Low Prussian Dialect
+Low Saxon
 Lower Burdekin
 Lower Chehalis
 Lower Grand Valley Dani
@@ -8322,6 +8323,7 @@ Nyíregyháza
 Nyishi
 Nyiyaparli
 Nymburk
+Nynorsk
 Nyokon
 Nyole
 Nyong

--- a/data/xml/2009.freeopmt.xml
+++ b/data/xml/2009.freeopmt.xml
@@ -65,7 +65,7 @@
       <bibkey>tyers-nordfalk-2009-shallow</bibkey>
     </paper>
     <paper id="7">
-      <title>Reuse of free resources in machine translation between Nynorsk and <fixed-case>B</fixed-case>okmål</title>
+      <title>Reuse of free resources in machine translation between <fixed-case>N</fixed-case>ynorsk and <fixed-case>B</fixed-case>okmål</title>
       <author><first>Kevin</first><last>Unhammer</last></author>
       <author><first>Trond</first><last>Trosterud</last></author>
       <pages>35-42</pages>

--- a/data/xml/2020.vardial.xml
+++ b/data/xml/2020.vardial.xml
@@ -48,7 +48,7 @@
       <bibkey>nigmatulina-etal-2020-asr</bibkey>
     </paper>
     <paper id="3">
-      <title><fixed-case>LSDC</fixed-case> - A comprehensive dataset for Low <fixed-case>S</fixed-case>axon Dialect Classification</title>
+      <title><fixed-case>LSDC</fixed-case> - A comprehensive dataset for <fixed-case>L</fixed-case>ow <fixed-case>S</fixed-case>axon Dialect Classification</title>
       <author><first>Janine</first><last>Siewert</last></author>
       <author><first>Yves</first><last>Scherrer</last></author>
       <author><first>Martijn</first><last>Wieling</last></author>

--- a/data/xml/2021.konvens.xml
+++ b/data/xml/2021.konvens.xml
@@ -260,7 +260,7 @@
       <bibkey>oguz-etal-2021-wordguess</bibkey>
     </paper>
     <paper id="25">
-      <title>Towards a balanced annotated Low <fixed-case>S</fixed-case>axon dataset for diachronic investigation of dialectal variation</title>
+      <title>Towards a balanced annotated <fixed-case>L</fixed-case>ow <fixed-case>S</fixed-case>axon dataset for diachronic investigation of dialectal variation</title>
       <author><first>Janine</first><last>Siewert</last></author>
       <author><first>Yves</first><last>Scherrer</last></author>
       <author><first>Jörg</first><last>Tiedemann</last></author>


### PR DESCRIPTION
Hi! I'd like to add {N}ynorsk and {L}ow {S}axon to the list of words with fixed capitalization. 
I updated the list of capitalized words and edited the title metadata for [2009.freeopmt-1.7](https://aclanthology.org/2009.freeopmt-1.7/), [2020.vardial-1.3](https://aclanthology.org/2020.vardial-1.3/) and [2021.konvens-1.25](https://aclanthology.org/2021.konvens-1.25/) accordingly, but wasn't able to locate the metadata file for [W17-0201](https://aclanthology.org/W17-0201/).