### PR TITLE
Fixed typo (liang-etal-2020-xglue at EMNLP 2020).

### DIFF
--- a/data/xml/2020.emnlp.xml
+++ b/data/xml/2020.emnlp.xml
@@ -7261,7 +7261,7 @@
       <pwccode url="https://github.com/thompsonb/vecalign" additional="false">thompsonb/vecalign</pwccode>
     </paper>
     <paper id="484">
-      <title><fixed-case>XGLUE</fixed-case>: A New Benchmark Datasetfor Cross-lingual Pre-training, Understanding and Generation</title>
+      <title><fixed-case>XGLUE</fixed-case>: A New Benchmark Dataset for Cross-lingual Pre-training, Understanding and Generation</title>
       <author><first>Yaobo</first><last>Liang</last></author>
       <author><first>Nan</first><last>Duan</last></author>
       <author><first>Yeyun</first><last>Gong</last></author>


### PR DESCRIPTION
Fix typo in the title of `liang-etal-2020-xglue`.