### PR TITLE
booktitle formatting + added frontmatter blocks for issues 2 and 3

### DIFF
--- a/data/xml/2011.tal.xml
+++ b/data/xml/2011.tal.xml
@@ -2,7 +2,7 @@
 <collection id="2011.tal">
   <volume id="1" ingest-date="2023-02-23">
     <meta>
-      <booktitle>Traitement Automatique des Langues 2011 Volume 52 Numéro 1</booktitle>
+      <booktitle>Traitement Automatique des Langues, Volume 52, Numéro 1 : Varia [Varia]</booktitle>
       <editor><first>Éric</first><last>Villemonte de La Clergerie</last></editor>
       <editor><first>Béatrice</first><last>Daille</last></editor>
       <editor><first>Yves</first><last>Lepage</last></editor>
@@ -13,7 +13,7 @@
       <venue>tal</venue>
     </meta>
     <frontmatter>
-      <bibkey>tal-2011-traitement</bibkey>
+      <bibkey>tal-2011-52-1</bibkey>
     </frontmatter>
     <paper id="1">
       <title>Enrichissement de lexiques sémantiques approvisionnés par les foules : le système <fixed-case>WISIGOTH</fixed-case> appliqué à <fixed-case>W</fixed-case>iktionary [Enrichment of crowdsourced semantic networks: The <fixed-case>WISIGOTH</fixed-case> system applied to <fixed-case>W</fixed-case>iktionary]</title>
@@ -80,7 +80,7 @@
   </volume>
   <volume id="2" ingest-date="2023-02-10">
     <meta>
-      <booktitle>Traitement Automatique des Langues 2011 Volume 52 Numéro 2</booktitle>
+      <booktitle>Traitement Automatique des Langues, Volume 52, Numéro 2 : Vers la morphologie et au-delà [Toward Morphology and beyond]</booktitle>
       <editor><first>Nabil</first><last>Hathout</last></editor>
       <editor><first>Fiammetta</first><last>Namer</last></editor>
       <publisher>ATALA (Association pour le Traitement Automatique des Langues)</publisher>
@@ -88,6 +88,9 @@
       <year>2011</year>
       <venue>tal</venue>
     </meta>
+    <frontmatter>
+      <bibkey>tal-2011-52-2</bibkey>
+    </frontmatter>
     <paper id="1">
       <title>Préface [Foreword]</title>
       <author><first>Nabil</first><last>Hathout</last></author>
@@ -147,7 +150,7 @@
   </volume>
   <volume id="3" ingest-date="2023-02-26">
     <meta>
-      <booktitle>Traitement Automatique des Langues 2011 Volume 52 Numéro 3</booktitle>
+      <booktitle>Traitement Automatique des Langues, Volume 52, Numéro 3 : Ressources linguistiques libres [Free Language Resources]</booktitle>
       <editor><first>Nuria</first><last>Bel</last></editor>
       <editor><first>Benoît</first><last>Sagot</last></editor>
       <publisher>ATALA (Association pour le Traitement Automatique des Langues)</publisher>
@@ -155,6 +158,9 @@
       <year>2011</year>
       <venue>tal</venue>
     </meta>
+    <frontmatter>
+      <bibkey>tal-2011-52-3</bibkey>
+    </frontmatter>
     <paper id="1">
       <title>Introduction - Ressources linguistiques libres [Foreword - Free Language Resources]</title>
       <author><first>Nuria</first><last>Bel</last></author>


### PR DESCRIPTION
- Manual reformatting of booktitle to get homogenous formats across tal volumes (cf. #2431)
- added frontmatter blocks for issues 2 and 3, cf. the frontmatter block for issue 1 was added but not for 2 and 3
- modification of bibkey of frontmatter to avoid getting the same bibkey for the 3 issues of the 2011 volume
