### PR TITLE
2018.tal : booktitle formatting + added frontmatter for issues 2 and 3

### DIFF
--- a/data/xml/2018.tal.xml
+++ b/data/xml/2018.tal.xml
@@ -2,7 +2,7 @@
 <collection id="2018.tal">
   <volume id="1" ingest-date="2023-02-23">
     <meta>
-      <booktitle>Traitement Automatique des Langues 2018 Volume 59 Numéro 1</booktitle>
+      <booktitle>Traitement Automatique des Langues, Volume 59, Numéro 1 : Varia [Varia]</booktitle>
       <editor><first>Emmanuel</first><last>Morin</last></editor>
       <editor><first>Sophie</first><last>Rosset</last></editor>
       <editor><first>Pascale</first><last>Sébillot</last></editor>
@@ -13,7 +13,7 @@
       <venue>tal</venue>
     </meta>
     <frontmatter>
-      <bibkey>tal-2018-traitement</bibkey>
+      <bibkey>tal-2018-59-1</bibkey>
     </frontmatter>
     <paper id="1">
       <title>Une approche mathématique de la notion de structure syntaxique : raisonner en termes de connexions plutôt que d’unités [A mathematical approach of the notion of syntactic structure: reasoning in terms of connections rather than units]</title>
@@ -46,7 +46,7 @@
   </volume>
   <volume id="2" ingest-date="2023-02-09">
     <meta>
-      <booktitle>Traitement Automatique des Langues 2018 Volume 59 Numéro 2</booktitle>
+      <booktitle>Traitement Automatique des Langues, Volume 59, Numéro 2 : Apprentissage profond pour le traitement automatique des langues [Deep Learning for natural language processing>]</booktitle>
       <editor><first>Alexandre</first><last>Allauzen</last></editor>
       <editor><first>Hinrich</first><last>Schütze</last></editor>
       <publisher>ATALA (Association pour le Traitement Automatique des Langues)</publisher>
@@ -55,6 +55,9 @@
       <url hash="1797456d">2018.tal-2</url>
       <venue>tal</venue>
     </meta>
+    <frontmatter>
+      <bibkey>tal-2018-59-2</bibkey>
+    </frontmatter>
     <paper id="1">
       <title>Apprentissage profond pour le traitement automatique des langues [Deep Learning for Natural Language Processing]</title>
       <author><first>Alexandre</first><last>Allauzen</last></author>
@@ -98,7 +101,7 @@
   </volume>
   <volume id="3" ingest-date="2023-02-10">
     <meta>
-      <booktitle>Traitement Automatique des Langues 2018 Volume 59 Numéro 3</booktitle>
+      <booktitle>Traitement Automatique des Langues, Volume 59, Numéro 3 : Traitement automatique des langues peu dotées [NLP for Under-Resourced Languages]</booktitle>
       <editor><first>Delphine</first><last>Bernhard</last></editor>
       <editor><first>Claudia</first><last>Soria</last></editor>
       <publisher>ATALA (Association pour le Traitement Automatique des Langues)</publisher>
@@ -107,6 +110,9 @@
       <url hash="bdec150d">2018.tal-3</url>
       <venue>tal</venue>
     </meta>
+    <frontmatter>
+      <bibkey>tal-2018-59-3</bibkey>
+    </frontmatter>
     <paper id="1">
       <title>Traitement automatique des langues peu dotées [<fixed-case>NLP</fixed-case> for Under-Resourced Languages]</title>
       <author><first>Delphine</first><last>Bernhard</last></author>


### PR DESCRIPTION
Same modifications as #2464 but for 2018.tal volume
This aims at having homogenous booktitle formatting for 2011.tal, 2018.tal, and the pending volumes 2017, 2019, 2020 and 2021,
cf. https://preview.aclanthology.org/continued-tal-ingestion/venues/tal/ and #2431 
