### PR TITLE
Fixed casing for `kunchukuttan-etal-2021-large`

### DIFF
--- a/data/xml/2021.eacl.xml
+++ b/data/xml/2021.eacl.xml
@@ -4065,7 +4065,7 @@
       <pwccode url="https://github.com/ximenina/theturningpoint" additional="false">ximenina/theturningpoint</pwccode>
     </paper>
     <paper id="303">
-      <title>A Large-scale Evaluation of Neural Machine Transliteration for Indic Languages</title>
+      <title>A Large-scale Evaluation of Neural Machine Transliteration for <fixed-case>I</fixed-case>ndic Languages</title>
       <author><first>Anoop</first><last>Kunchukuttan</last></author>
       <author><first>Siddharth</first><last>Jain</last></author>
       <author><first>Rahul</first><last>Kejriwal</last></author>


### PR DESCRIPTION
As usual, "Indic" was lowercase.
