### PR TITLE
Fixed capitalization (Alemannic, Standard German, Nynorsk)

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -338,6 +338,7 @@ Alberta
 Alcozauca Mixtec
 Alege
 Alekano
+Alemannic
 Alergian
 Alessandria
 Aleut
@@ -10646,6 +10647,7 @@ Stackoverflow
 Staffordshire
 Standard Arabic
 Standard Estonian
+Standard German
 Standard Latvian
 Standard Malay
 Standard Moroccan Tamazight

--- a/data/xml/2019.gwc.xml
+++ b/data/xml/2019.gwc.xml
@@ -43,7 +43,7 @@
       <bibkey>loukachevitch-parkhomenko-2019-thesaurus</bibkey>
     </paper>
     <paper id="4">
-      <title>Including <fixed-case>S</fixed-case>wiss Standard <fixed-case>G</fixed-case>erman in <fixed-case>G</fixed-case>erma<fixed-case>N</fixed-case>et</title>
+      <title>Including <fixed-case>S</fixed-case>wiss <fixed-case>S</fixed-case>tandard <fixed-case>G</fixed-case>erman in <fixed-case>G</fixed-case>erma<fixed-case>N</fixed-case>et</title>
       <author><first>Eva</first><last>Huber</last></author>
       <author><first>Erhard</first><last>Hinrichs</last></author>
       <pages>24–32</pages>

--- a/data/xml/2022.eamt.xml
+++ b/data/xml/2022.eamt.xml
@@ -443,7 +443,7 @@
       <bibkey>kaldeli-etal-2022-europeana</bibkey>
     </paper>
     <paper id="40">
-      <title>The <fixed-case>PASSAGE</fixed-case> project : Standard <fixed-case>G</fixed-case>erman Subtitling of <fixed-case>S</fixed-case>wiss <fixed-case>G</fixed-case>erman <fixed-case>TV</fixed-case> content</title>
+      <title>The <fixed-case>PASSAGE</fixed-case> project : <fixed-case>S</fixed-case>tandard <fixed-case>G</fixed-case>erman Subtitling of <fixed-case>S</fixed-case>wiss <fixed-case>G</fixed-case>erman <fixed-case>TV</fixed-case> content</title>
       <author><first>Pierrette</first><last>Bouillon</last></author>
       <author><first>Johanna</first><last>Gerlach</last></author>
       <author><first>Jonathan</first><last>Mutal</last></author>

--- a/data/xml/2022.lrec.xml
+++ b/data/xml/2022.lrec.xml
@@ -4306,7 +4306,7 @@
       <bibkey>pritzen-etal-2022-multitask</bibkey>
     </paper>
     <paper id="347">
-      <title><fixed-case>SDS</fixed-case>-200: A <fixed-case>S</fixed-case>wiss <fixed-case>G</fixed-case>erman Speech to Standard <fixed-case>G</fixed-case>erman Text Corpus</title>
+      <title><fixed-case>SDS</fixed-case>-200: A <fixed-case>S</fixed-case>wiss <fixed-case>G</fixed-case>erman Speech to <fixed-case>S</fixed-case>tandard <fixed-case>G</fixed-case>erman Text Corpus</title>
       <author><first>Michel</first><last>Plüss</last></author>
       <author><first>Manuela</first><last>Hürlimann</last></author>
       <author><first>Marc</first><last>Cuny</last></author>

--- a/data/xml/2022.sigul.xml
+++ b/data/xml/2022.sigul.xml
@@ -193,7 +193,7 @@
       <bibkey>resiandi-etal-2022-neural</bibkey>
     </paper>
     <paper id="17">
-      <title>Machine Translation from Standard <fixed-case>G</fixed-case>erman to Alemannic Dialects</title>
+      <title>Machine Translation from <fixed-case>S</fixed-case>tandard <fixed-case>G</fixed-case>erman to Alemannic Dialects</title>
       <author><first>Louisa</first><last>Lambrecht</last></author>
       <author><first>Felix</first><last>Schneider</last></author>
       <author><first>Alexander</first><last>Waibel</last></author>

--- a/data/xml/2022.slpat.xml
+++ b/data/xml/2022.slpat.xml
@@ -73,7 +73,7 @@
       <doi>10.18653/v1/2022.slpat-1.4</doi>
     </paper>
     <paper id="5">
-      <title>Producing Standard <fixed-case>G</fixed-case>erman Subtitles for <fixed-case>S</fixed-case>wiss <fixed-case>G</fixed-case>erman <fixed-case>TV</fixed-case> Content</title>
+      <title>Producing <fixed-case>S</fixed-case>tandard <fixed-case>G</fixed-case>erman Subtitles for <fixed-case>S</fixed-case>wiss <fixed-case>G</fixed-case>erman <fixed-case>TV</fixed-case> Content</title>
       <author><first>Johanna</first><last>Gerlach</last></author>
       <author><first>Jonathan</first><last>Mutal</last></author>
       <author><first>Bouillon</first><last>Pierrette</last></author>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -268,7 +268,7 @@
       <bibkey>ws-2017-nordic</bibkey>
     </frontmatter>
     <paper id="1">
-      <title>Joint <fixed-case>UD</fixed-case> Parsing of <fixed-case>N</fixed-case>orwegian <fixed-case>B</fixed-case>okmål and Nynorsk</title>
+      <title>Joint <fixed-case>UD</fixed-case> Parsing of <fixed-case>N</fixed-case>orwegian <fixed-case>B</fixed-case>okmål and <fixed-case>N</fixed-case>ynorsk</title>
       <author><first>Erik</first><last>Velldal</last></author>
       <author><first>Lilja</first><last>Øvrelid</last></author>
       <author><first>Petter</first><last>Hohle</last></author>


### PR DESCRIPTION
Hi again! Similarly to my previous PR (#2451), I would like to request updates to the capitalization list, this time for {A}lemannic and {S}tandard {G}erman (analogously to _Standard Estonian_, _Standard Malay_, etc., which are already in `fixedcase/truelist`). This affects the following papers (whose metadata I've edited accordingly): [2022.sigul-1.17](https://aclanthology.org/2022.sigul-1.17/), [2022.lrec-1.347](https://aclanthology.org/2022.lrec-1.347/), [2022.eamt-1.40](https://aclanthology.org/2022.eamt-1.40/), [2022.slpat-1.5](https://aclanthology.org/2022.slpat-1.5/), [2019.gwc-1.4](https://aclanthology.org/2019.gwc-1.4/).

(I also fixed the metadata for {N}ynorsk in the title for [W17-0201](https://aclanthology.org/W17-0201/), which I didn't do in my previous PR.)