### PR TITLE
Merge NLP4PosImpact with NLP4PI, fixes #2482

### DIFF
--- a/data/xml/2021.nlp4posimpact.xml
+++ b/data/xml/2021.nlp4posimpact.xml
@@ -14,7 +14,7 @@
       <month>August</month>
       <year>2021</year>
       <url hash="2a2e6a54">2021.nlp4posimpact-1</url>
-      <venue>nlp4posimpact</venue>
+      <venue>nlp4pi</venue>
     </meta>
     <frontmatter>
       <url hash="4789defb">2021.nlp4posimpact-1.0</url>

--- a/data/yaml/venues/nlp4posimpact.yaml
+++ b/data/yaml/venues/nlp4posimpact.yaml
@@ -1,2 +1,0 @@
-acronym: NLP4PosImpact
-name: 1st Workshop on NLP for Positive Impact


### PR DESCRIPTION
Removes duplicate venue, keeping the shorter and more recent acronym.