### PR TITLE
Fix breaking ruff changes

### DIFF
--- a/bin/fixedcase/protect.py
+++ b/bin/fixedcase/protect.py
@@ -11,6 +11,7 @@ import lxml.etree as ET
 import sys
 import copy
 import itertools
+from nltk.tokenize.treebank import TreebankWordDetokenizer
 
 # ruff: noqa: F403, F405
 if __name__ == "__main__":

--- a/bin/latex_to_unicode.py
+++ b/bin/latex_to_unicode.py
@@ -4,6 +4,7 @@ import logging
 import collections
 import copy
 import re
+import latexcodec  # noqa: F401
 import codecs
 import lxml.etree as etree
 

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -9,7 +9,7 @@ latexcodec>=1.0.7
 lxml>=4.2.0
 nltk
 pre-commit
-pybtex==0.22.2
+pybtex~=0.24.0
 PyPDF2
 pytest
 pytest-cov


### PR DESCRIPTION
Fix breaking changes introduced by #2449 

1. `import latexcodec` is a "magic" import that automatically registers codecs without any additional function call.
2. The missing NLTK import is a result of star imports used in the `fixedcase/` scripts (`from common import *`), which is probably a textbook example of why they should be avoided :)

I also bumped up the version of `pybtex` because the listed version is incompatible with Python 3.10+ due to deprecated imports.