### PR TITLE
Don't index preview builds (closes #2425)

### DIFF
--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    {{ if hasPrefix .Site.BaseURL "https://preview.aclanthology.org" }}
+    <meta name="robots" content="noindex, nofollow">
+    {{ end }}
 
     <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
     {{ "<!--[if IEMobile]>" | safeHTML }}


### PR DESCRIPTION
Uses the same mechanism as 9c7eed2 to include a `<meta name="robots" content="noindex, nofollow">` tag on every page if the build is for a preview branch.

I wonder if we should also additionally have a `robots.txt` that we push to the server in the `preview` target of the Makefile?