### PR TITLE
Clean up venue metadata & expand venue pages

### DIFF
--- a/bin/create_hugo_pages.py
+++ b/bin/create_hugo_pages.py
@@ -165,6 +165,8 @@ def create_venues(srcdir, clean=False):
                 "acronym": venue_data["acronym"],
                 "title": venue_data["name"],
             }
+            if "url" in venue_data:
+                yaml_data["venue_url"] = venue_data["url"]
             yaml.dump(yaml_data, default_flow_style=False, stream=f)
             print("---", file=f)
 

--- a/bin/create_hugo_yaml.py
+++ b/bin/create_hugo_yaml.py
@@ -159,7 +159,7 @@ def export_anthology(anthology, outdir, clean=False, dryrun=False):
             )
             data["volumes_by_year"][year] = filtered_volumes
         if not data["volumes_by_year"]:
-            log.warn(f"Venue '{main_venue}' has no volumes associated with it")
+            log.warning(f"Venue '{main_venue}' has no volumes associated with it")
 
         data["years"] = sorted(list(data["years"]))
 

--- a/bin/create_hugo_yaml.py
+++ b/bin/create_hugo_yaml.py
@@ -158,6 +158,8 @@ def export_anthology(anthology, outdir, clean=False, dryrun=False):
                 filter(lambda k: volumes[k]["year"] == year, data["volumes"])
             )
             data["volumes_by_year"][year] = filtered_volumes
+        if not data["volumes_by_year"]:
+            log.warn(f"Venue '{main_venue}' has no volumes associated with it")
 
         data["years"] = sorted(list(data["years"]))
 

--- a/data/xml/2022.flp.xml
+++ b/data/xml/2022.flp.xml
@@ -14,7 +14,7 @@
       <month>December</month>
       <year>2022</year>
       <url hash="531392d8">2022.flp-1</url>
-      <venue>flp</venue>
+      <venue>figlang</venue>
     </meta>
     <frontmatter>
       <url hash="316aef8f">2022.flp-1.0</url>

--- a/data/yaml/venues/all.yaml
+++ b/data/yaml/venues/all.yaml
@@ -1,4 +1,0 @@
-acronym: all
-name: 'The Joint Conference of the 59th Annual Meeting of the Association for Computational
-  Linguistics and the 11th International Joint Conference on Natural Language Processing:
-  System Demonstrations'

--- a/data/yaml/venues/alvr.yaml
+++ b/data/yaml/venues/alvr.yaml
@@ -1,4 +1,4 @@
 acronym: ALVR
 is_acl: true
-name: The Workshop on Advances in Language and Vision Research
+name: Workshop on Advances in Language and Vision Research
 url: https://alvr-workshop.github.io/

--- a/data/yaml/venues/autosimtrans.yaml
+++ b/data/yaml/venues/autosimtrans.yaml
@@ -1,4 +1,4 @@
 acronym: AutoSimTrans
 is_acl: true
-name: The Workshop on Automatic Simultaneous Translation
+name: Workshop on Automatic Simultaneous Translation
 url: https://autosimtrans.github.io/

--- a/data/yaml/venues/bppf.yaml
+++ b/data/yaml/venues/bppf.yaml
@@ -1,2 +1,2 @@
 acronym: BPPF
-name: '1st Workshop on Benchmarking: Past, Present and Future'
+name: 'Workshop on Benchmarking: Past, Present and Future'

--- a/data/yaml/venues/ccl.yaml
+++ b/data/yaml/venues/ccl.yaml
@@ -1,4 +1,4 @@
 acronym: CCL
 is_toplevel: true
-name: The Chinese National Conference on Computational Linguistics
+name: Chinese National Conference on Computational Linguistics
 url: http://cips-cl.org

--- a/data/yaml/venues/ccurl.yaml
+++ b/data/yaml/venues/ccurl.yaml
@@ -1,2 +1,0 @@
-acronym: CCURL
-name: Collaboration and Computing for Under-Resourced Languages Workshop

--- a/data/yaml/venues/clasp.yaml
+++ b/data/yaml/venues/clasp.yaml
@@ -1,2 +1,2 @@
 acronym: CLASP
-name: The CLASP Conference on (Dis)embodiment
+name: CLASP Conference on (Dis)embodiment

--- a/data/yaml/venues/computel.yaml
+++ b/data/yaml/venues/computel.yaml
@@ -1,4 +1,3 @@
 acronym: ComputEL
-name: The Workshop on the Use of Computational Methods in the Study of Endangered
-  Languages
+name: Workshop on the Use of Computational Methods in the Study of Endangered Languages
 url: https://computel-workshop.org

--- a/data/yaml/venues/cxgsnlp.yaml
+++ b/data/yaml/venues/cxgsnlp.yaml
@@ -1,2 +1,2 @@
 acronym: CxGsNLP
-name: Workshop on Construction Grammars and NLP (CxGs+NLP, GURT/SyntaxFest 2023)
+name: Workshop on Construction Grammars and NLP

--- a/data/yaml/venues/dash.yaml
+++ b/data/yaml/venues/dash.yaml
@@ -1,2 +1,2 @@
 acronym: DaSH
-name: 'Second Workshop on Data Science with Human in the Loop: Language Advances'
+name: 'Workshop on Data Science with Human in the Loop: Language Advances'

--- a/data/yaml/venues/dialdoc.yaml
+++ b/data/yaml/venues/dialdoc.yaml
@@ -1,3 +1,2 @@
 acronym: dialdoc
-name: 1st Workshop on Document-grounded Dialogue and Conversational Question Answering
-  (DialDoc 2021)
+name: Workshop on Document-grounded Dialogue and Conversational Question Answering

--- a/data/yaml/venues/disrpt.yaml
+++ b/data/yaml/venues/disrpt.yaml
@@ -1,2 +1,2 @@
 acronym: DISRPT
-name: 2nd Shared Task on Discourse Relation Parsing and Treebanking (DISRPT 2021)
+name: Shared Task on Discourse Relation Parsing and Treebanking

--- a/data/yaml/venues/ecnlp.yaml
+++ b/data/yaml/venues/ecnlp.yaml
@@ -1,3 +1,3 @@
 acronym: ECNLP
-name: The Workshop on e-Commerce and NLP
+name: Workshop on e-Commerce and NLP
 url: https://sites.google.com/view/ecnlp/

--- a/data/yaml/venues/econlp.yaml
+++ b/data/yaml/venues/econlp.yaml
@@ -1,2 +1,2 @@
 acronym: ECONLP
-name: Third Workshop on Economics and Natural Language Processing
+name: Workshop on Economics and Natural Language Processing

--- a/data/yaml/venues/eval4nlp.yaml
+++ b/data/yaml/venues/eval4nlp.yaml
@@ -1,2 +1,2 @@
 acronym: Eval4NLP
-name: The Workshop on Evaluation and Comparison of NLP Systems
+name: Workshop on Evaluation and Comparison of NLP Systems

--- a/data/yaml/venues/fieldmatters.yaml
+++ b/data/yaml/venues/fieldmatters.yaml
@@ -1,2 +1,2 @@
 acronym: FieldMatters
-name: workshop on NLP applications to field linguistics
+name: Workshop on NLP Applications to Field Linguistics

--- a/data/yaml/venues/flp.yaml
+++ b/data/yaml/venues/flp.yaml
@@ -1,2 +1,0 @@
-acronym: FLP
-name: Workshop on Figurative Language Processing

--- a/data/yaml/venues/gem.yaml
+++ b/data/yaml/venues/gem.yaml
@@ -1,2 +1,2 @@
 acronym: GEM
-name: 1st Workshop on Natural Language Generation, Evaluation, and Metrics
+name: Workshop on Natural Language Generation, Evaluation, and Metrics

--- a/data/yaml/venues/germeval.yaml
+++ b/data/yaml/venues/germeval.yaml
@@ -1,3 +1,3 @@
 acronym: GermEval
-name: GermEval 2021 Shared Task
+name: GermEval Shared Task
 url: https://germeval2021toxic.github.io/SharedTask/

--- a/data/yaml/venues/hcinlp.yaml
+++ b/data/yaml/venues/hcinlp.yaml
@@ -1,2 +1,2 @@
 acronym: HCINLP
-name: Workshop on Bridging Human--Computer Interaction and Natural Language Processing
+name: Workshop on Bridging Human–Computer Interaction and Natural Language Processing

--- a/data/yaml/venues/hlt.yaml
+++ b/data/yaml/venues/hlt.yaml
@@ -1,4 +1,4 @@
 acronym: HLT
 is_toplevel: true
-name: Human Language Technology Conf.
+name: Human Language Technology Conference
 oldstyle_letter: H

--- a/data/yaml/venues/humeval.yaml
+++ b/data/yaml/venues/humeval.yaml
@@ -1,3 +1,3 @@
 acronym: HumEval
-name: The Workshop on Human Evaluation of NLP Systems
+name: Workshop on Human Evaluation of NLP Systems
 url: https://humeval.github.io/

--- a/data/yaml/venues/lantern.yaml
+++ b/data/yaml/venues/lantern.yaml
@@ -1,2 +1,2 @@
 acronym: LANTERN
-name: 'The Workshop Beyond Vision and LANguage: inTEgrating Real-world kNowledge'
+name: 'Workshop Beyond Vision and LANguage: inTEgrating Real-world kNowledge'

--- a/data/yaml/venues/lchange.yaml
+++ b/data/yaml/venues/lchange.yaml
@@ -1,3 +1,2 @@
 acronym: LChange
-name: The 2nd  International  Workshop  on  Computational  Approaches  to  Historical  Language
-  Change 2021
+name: International Workshop on Computational Approaches to Historical Language Change

--- a/data/yaml/venues/maiworkshop.yaml
+++ b/data/yaml/venues/maiworkshop.yaml
@@ -1,2 +1,2 @@
 acronym: maiworkshop
-name: Third Workshop on Multimodal Artificial Intelligence
+name: Workshop on Multimodal Artificial Intelligence

--- a/data/yaml/venues/mia.yaml
+++ b/data/yaml/venues/mia.yaml
@@ -1,2 +1,2 @@
 acronym: MIA
-name: Workshop on Multilingual Information Access (MIA)
+name: Workshop on Multilingual Information Access

--- a/data/yaml/venues/mmsr.yaml
+++ b/data/yaml/venues/mmsr.yaml
@@ -1,2 +1,2 @@
 acronym: MMSR
-name: Workshop on Multimodal Semantic Representations (MMSR)
+name: Workshop on Multimodal Semantic Representations

--- a/data/yaml/venues/mmtlrl.yaml
+++ b/data/yaml/venues/mmtlrl.yaml
@@ -1,2 +1,2 @@
 acronym: MMTLRL
-name: Workshop on Multimodal Machine Translation for Low Resource Languages (MMTLRL-2021)
+name: Workshop on Multimodal Machine Translation for Low Resource Languages

--- a/data/yaml/venues/mrl.yaml
+++ b/data/yaml/venues/mrl.yaml
@@ -1,2 +1,2 @@
 acronym: MRL
-name: The 1st Workshop on Multilingual Representation Learning
+name: Workshop on Multilingual Representation Learning

--- a/data/yaml/venues/mrqa.yaml
+++ b/data/yaml/venues/mrqa.yaml
@@ -1,2 +1,2 @@
 acronym: MRQA
-name: Proceedings of the 3rd Workshop on Machine Reading for Question Answering
+name: Workshop on Machine Reading for Question Answering

--- a/data/yaml/venues/muc.yaml
+++ b/data/yaml/venues/muc.yaml
@@ -1,4 +1,4 @@
 acronym: MUC
 is_toplevel: true
-name: Message Understanding Conf.
+name: Message Understanding Conference
 oldstyle_letter: M

--- a/data/yaml/venues/naloma.yaml
+++ b/data/yaml/venues/naloma.yaml
@@ -1,2 +1,2 @@
 acronym: NALOMA
-name: Workshop on Natural Logic Meets Machine Learning (NALOMA)
+name: Workshop on Natural Logic Meets Machine Learning

--- a/data/yaml/venues/newsum.yaml
+++ b/data/yaml/venues/newsum.yaml
@@ -1,2 +1,2 @@
 acronym: newsum
-name: The Third Workshop on New Frontiers in Summarization (NewSum 2021)
+name: Workshop on New Frontiers in Summarization

--- a/data/yaml/venues/nli.yaml
+++ b/data/yaml/venues/nli.yaml
@@ -1,3 +1,3 @@
 acronym: NLI
 is_acl: true
-name: The Workshop on Natural Language Interfaces
+name: Workshop on Natural Language Interfaces

--- a/data/yaml/venues/nllp.yaml
+++ b/data/yaml/venues/nllp.yaml
@@ -1,2 +1,2 @@
 acronym: NLLP
-name: Proceedings of the Natural Legal Language Processing Workshop 2021
+name: Natural Legal Language Processing Workshop

--- a/data/yaml/venues/nlp4convai.yaml
+++ b/data/yaml/venues/nlp4convai.yaml
@@ -1,4 +1,4 @@
 acronym: NLP4ConvAI
 is_acl: true
-name: The Workshop on Natural Language Processing for Conversational AI
+name: Workshop on Natural Language Processing for Conversational AI
 url: https://sites.google.com/view/2ndnlp4convai/home

--- a/data/yaml/venues/nlpmc.yaml
+++ b/data/yaml/venues/nlpmc.yaml
@@ -1,4 +1,4 @@
 acronym: NLPMC
 is_acl: true
-name: The Workshop on NLP for Medical Conversations
+name: Workshop on NLP for Medical Conversations
 url: https://sites.google.com/view/nlp4medicalconversations/

--- a/data/yaml/venues/nmt.yaml
+++ b/data/yaml/venues/nmt.yaml
@@ -1,3 +1,0 @@
-acronym: NMT
-is_acl: true
-name: Workshop on Neural Machine Translation

--- a/data/yaml/venues/nsurl.yaml
+++ b/data/yaml/venues/nsurl.yaml
@@ -1,2 +1,2 @@
 acronym: NSURL
-name: The International Workshop on NLP Solutions for Under Resourced Languages
+name: International Workshop on NLP Solutions for Under Resourced Languages

--- a/data/yaml/venues/nuse.yaml
+++ b/data/yaml/venues/nuse.yaml
@@ -1,4 +1,4 @@
 acronym: NUSE
 is_acl: true
-name: The Workshop on Narrative Understanding, Storylines, and Events
+name: Workshop on Narrative Understanding, Storylines, and Events
 url: https://sites.google.com/view/nuse

--- a/data/yaml/venues/ranlpstud.yaml
+++ b/data/yaml/venues/ranlpstud.yaml
@@ -1,2 +1,0 @@
-acronym: RANLPStud
-name: Student Research Workshop Associated with RANLP 2021

--- a/data/yaml/venues/rapid.yaml
+++ b/data/yaml/venues/rapid.yaml
@@ -1,4 +1,4 @@
 acronym: RaPID
-name: The RaPID Workshop - Resources and ProcessIng of linguistic, para-linguistic
+name: RaPID Workshop - Resources and ProcessIng of linguistic, para-linguistic
   and extra-linguistic Data from people with various forms of cognitive/psychiatric/developmental
   impairments

--- a/data/yaml/venues/splurobonlp.yaml
+++ b/data/yaml/venues/splurobonlp.yaml
@@ -1,3 +1,3 @@
 acronym: splurobonlp
-name: Second International Combined Workshop on Spatial Language Understanding and
+name: International Combined Workshop on Spatial Language Understanding and
   Grounded Communication for Robotics

--- a/data/yaml/venues/spnlp21.yaml
+++ b/data/yaml/venues/spnlp21.yaml
@@ -1,2 +1,0 @@
-acronym: SPNLP21
-name: 5th Workshop on Structured Prediction for NLP

--- a/data/yaml/venues/srw.yaml
+++ b/data/yaml/venues/srw.yaml
@@ -1,2 +1,0 @@
-acronym: SRW
-name: ACL-IJCNLP 2021 Student Research Workshop

--- a/data/yaml/venues/suki.yaml
+++ b/data/yaml/venues/suki.yaml
@@ -1,2 +1,2 @@
 acronym: SUKI
-name: Workshop on Structured and Unstructured Knowledge Integration (SUKI)
+name: Workshop on Structured and Unstructured Knowledge Integration

--- a/data/yaml/venues/tu.yaml
+++ b/data/yaml/venues/tu.yaml
@@ -1,2 +1,2 @@
 acronym: TU
-name: Workshop On Transcript Understanding
+name: Workshop on Transcript Understanding

--- a/data/yaml/venues/tutorials.yaml
+++ b/data/yaml/venues/tutorials.yaml
@@ -1,4 +1,0 @@
-acronym: tutorials
-name: 'Proceedings of the 59th Annual Meeting of the Association for Computational
-  Linguistics and the 11th International Joint Conference on Natural Language Processing:
-  Tutorial Abstracts'

--- a/data/yaml/venues/unimplicit.yaml
+++ b/data/yaml/venues/unimplicit.yaml
@@ -1,3 +1,2 @@
 acronym: unimplicit
-name: Proceedings of the 1st Workshop on Understanding Implicit and Underspecified
-  Language (UnImplicit 2021)
+name: Workshop on Understanding Implicit and Underspecified Language

--- a/data/yaml/venues/wit.yaml
+++ b/data/yaml/venues/wit.yaml
@@ -1,2 +1,2 @@
 acronym: WIT
-name: Workshop On Deriving Insights From User-Generated Text
+name: Workshop on Deriving Insights From User-Generated Text

--- a/data/yaml/venues/wnu.yaml
+++ b/data/yaml/venues/wnu.yaml
@@ -1,2 +1,2 @@
 acronym: WNU
-name: Workshop of Narrative Understanding (WNU2022)
+name: Workshop of Narrative Understanding

--- a/data/yaml/venues/woah.yaml
+++ b/data/yaml/venues/woah.yaml
@@ -1,2 +1,2 @@
 acronym: WOAH
-name: Fifth Workshop on Online Abuse and Harms
+name: Workshop on Online Abuse and Harms

--- a/data/yaml/venues/wosp.yaml
+++ b/data/yaml/venues/wosp.yaml
@@ -1,3 +1,3 @@
 acronym: WOSP
-name: The International Workshop on Mining Scientific Publications
+name: International Workshop on Mining Scientific Publications
 url: https://wosp.core.ac.uk/jcdl2020/index.html

--- a/hugo/layouts/venues/li.html
+++ b/hugo/layouts/venues/li.html
@@ -1,0 +1,10 @@
+<li>
+  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+  <span class="badge badge-secondary align-middle ml-1">{{ .Params.acronym }}</span>
+  {{ $venue := index .Site.Data.venues .Params.venue }}
+  {{ $volumes := slice }}
+  {{ range $year := index $venue "years" }}
+    {{ $volumes = $volumes | append (index $venue "volumes_by_year" $year) }}
+  {{ end }}
+  <span class="badge badge-info align-middle ml-1">{{ len $volumes }}&nbsp;{{ cond (gt (len $volumes) 1) "volumes" "volume" }}</span>
+</li>

--- a/hugo/layouts/venues/section.html
+++ b/hugo/layouts/venues/section.html
@@ -1,0 +1,20 @@
+{{ define "meta" }}
+<meta name="robots" content="noindex, nofollow">
+{{ end }}
+
+{{ define "main" }}
+<main aria-role="main">
+  <h2 id="title">{{ .Title }}</h2>
+  <hr />
+
+  {{ .Content }}
+
+  {{ with .Params.render_pagelist }}
+  <ul>
+    {{ range $.Pages }}
+      {{ .Render "li" }}
+    {{ end }}
+  </ul>
+  {{ end }}
+</main>
+{{ end }}

--- a/hugo/layouts/venues/single.html
+++ b/hugo/layouts/venues/single.html
@@ -5,6 +5,22 @@
   </h2>
   <hr />
 
+  <div class="row acl-paper-details">
+    <div class="col">
+    <dl>
+      <dt>Acronym:</dt>
+      <dd>{{ .Params.acronym }}</dd>
+      <dt>Venue ID:</dt>
+      <dd>{{ .Params.venue }}</dd>
+      {{ with .Params.venue_url }}
+      <dt>URL:</dt>
+      <dd><a href="{{ . }}">{{ . }}</a></dd>
+      {{ end }}
+    </dl>
+    </div>
+  </div>
+  <hr />
+
   {{ $venue := index .Site.Data.venues .Params.venue }}
   <div>
     {{ range $year := sort (index $venue "years") "value" "desc" }}


### PR DESCRIPTION
I went through the [list of all venues](https://aclanthology.org/venues/) and did some (hopefully uncontroversial) clean-up:

1. Removed numbers, years, acronyms from venue names
2. Deleted venues that had no associated volumes, as they still show up on the website (e.g. [`all`](https://aclanthology.org/venues/all/))
3. Standardized some names (remove initial "The", fix some casing, expand "Conf." to "Conference")

I'm also wondering if we should standardize workshop venues to always have "Workshop" in the title, because [most of them do](https://aclanthology.org/venues/), but many do not ([`aespen`](https://aclanthology.org/venues/aespen/), [`blackboxnlp`](https://aclanthology.org/venues/blackboxnlp/), [`nespnlp`](https://aclanthology.org/venues/nespnlp/), ...). But that's probably not a trivial change, so I didn't consider it here.

Finally, I made some small changes to site templates:

1. Show acronym, ID, and URL (if given) on the venue pages
2. Add some badges to the venue list page