### PR TITLE
add missing authors to eacl-main.57

### DIFF
--- a/data/xml/2023.eacl.xml
+++ b/data/xml/2023.eacl.xml
@@ -664,7 +664,7 @@
       <author><first>David</first><last>Moeljadi</last><affiliation>Kanda University of International Studies</affiliation></author>
       <author><first>Radityo Eko</first><last>Prasojo</last><affiliation>Pitik.id</affiliation></author>
       <author><first>Pascale</first><last>Fung</last><affiliation>Hong Kong University of Science and Technology</affiliation></author>
-      <author><first>Timothy</first>Baldwin<last></last><affiliation>Mbzuai</affiliation></author>
+      <author><first>Timothy</first><last>Baldwin</last><affiliation>Mbzuai</affiliation></author>
       <author><first>Jey Han</first><last>Lau</last><affiliation>University of Melbourne</affiliation></author>
       <author><first>Rico</first><last>Sennrich</last><affiliation>University of Zurich</affiliation></author>
       <author><first>Sebastian</first><last>Ruder</last><affiliation>Google Research</affiliation></author>

--- a/data/xml/2023.eacl.xml
+++ b/data/xml/2023.eacl.xml
@@ -664,6 +664,10 @@
       <author><first>David</first><last>Moeljadi</last><affiliation>Kanda University of International Studies</affiliation></author>
       <author><first>Radityo Eko</first><last>Prasojo</last><affiliation>Pitik.id</affiliation></author>
       <author><first>Pascale</first><last>Fung</last><affiliation>Hong Kong University of Science and Technology</affiliation></author>
+      <author><first>Timothy</first>Baldwin<last></last><affiliation>Mbzuai</affiliation></author>
+      <author><first>Jey Han</first><last>Lau</last><affiliation>University of Melbourne</affiliation></author>
+      <author><first>Rico</first><last>Sennrich</last><affiliation>University of Zurich</affiliation></author>
+      <author><first>Sebastian</first><last>Ruder</last><affiliation>Google Research</affiliation></author>
       <pages>815-834</pages>
       <abstract>Natural language processing (NLP) has a significant impact on society via technologies such as machine translation and search engines. Despite its success, NLP technology is only widely available for high-resource languages such as English and Chinese, while it remains inaccessible to many languages due to the unavailability of data resources and benchmarks. In this work, we focus on developing resources for languages in Indonesia. Despite being the second most linguistically diverse country, most languages in Indonesia are categorized as endangered and some are even extinct. We develop the first-ever parallel resource for 10 low-resource languages in Indonesia. Our resource includes sentiment and machine translation datasets, and bilingual lexicons. We provide extensive analyses and describe challenges for creating such resources. We hope this work can spark NLP research on Indonesian and other underrepresented languages.</abstract>
       <url hash="222ef034">2023.eacl-main.57</url>


### PR DESCRIPTION
eacl-main.57 only lists the first 10 out of 14 authors.

I fixed this in a pull request, but it might be worth checking if there was some issue with the ingestion scripts that also affects other papers, because all 14 authors are present in softconf.