### PR TITLE
Update Github Workflows

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -18,6 +18,6 @@ jobs:
       run: sudo apt-get update
     - name: install other deps
       run: sudo apt-get install -y jing bibutils openssh-client rsync libyaml-dev libpython3-dev
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: build
       run: make check site

--- a/.github/workflows/paperswithcode.yml
+++ b/.github/workflows/paperswithcode.yml
@@ -41,8 +41,8 @@ jobs:
       name: Check if PR should be created
       if: steps.update-pwc-metadata.conclusion == 'success'
       run: |
-        echo "::set-output name=commits-this-week::"$(git log --author='acl-pwc-bot' --after=$(date --date='6 days ago' +%Y-%m-%d) --oneline | wc -l)
-        echo "::set-output name=lines-changed::"$(git diff --cached --numstat data/xml/*xml | awk 'BEGIN {s=0} {s+=$1; s+=$2} END {print s}' -)
+        echo "commits-this-week="$(git log --author='acl-pwc-bot' --after=$(date --date='6 days ago' +%Y-%m-%d) --oneline | wc -l) >> $GITHUB_OUTPUT
+        echo "lines-changed="$(git diff --cached --numstat data/xml/*xml | awk 'BEGIN {s=0} {s+=$1; s+=$2} END {print s}' -) >> $GITHUB_OUTPUT
 
     - uses: peter-evans/create-pull-request@v3
       id: create-pr

--- a/.github/workflows/paperswithcode.yml
+++ b/.github/workflows/paperswithcode.yml
@@ -21,7 +21,7 @@ jobs:
       run: sudo apt-get install -y jing bibutils openssh-client rsync libyaml-dev libpython3-dev python3-lxml
 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: Checkout master branch
       with:
         ref: master

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,7 @@ jobs:
         mkdir -p $HOME/.ssh/
         echo "$SSH_KEY" > $HOME/.ssh/id_rsa
         chmod 600 $HOME/.ssh/id_rsa
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: fetch master branch
       run: |
         git fetch origin master

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,11 +42,11 @@ jobs:
         python -m pip install lxml
     - name: extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: list volumes
       shell: bash
-      run: echo "##[set-output name=volumes;]$(git diff --name-only $GITHUB_REF origin/master | python ./bin/volumes_from_diff.py https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}/volumes)"
+      run: echo "volumes=$(git diff --name-only $GITHUB_REF origin/master | python ./bin/volumes_from_diff.py https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}/volumes)" >> $GITHUB_OUTPUT
       id: list_volumes
 #    - name: list volumes debug
 #      shell: bash

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   preview:
+    if: github.repository == 'acl-org/acl-anthology'
     runs-on: ubuntu-22.04
     steps:
     - name: install hugo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ concurrency: publish
 
 jobs:
   publish-aclanthology:
+    if: github.repository == 'acl-org/acl-anthology'
     runs-on: ubuntu-22.04
     steps:
     - name: install hugo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         mkdir -p $HOME/.ssh/
         echo "$SSH_KEY" > $HOME/.ssh/id_rsa
         chmod 600 $HOME/.ssh/id_rsa
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: build
       env:
         ANTHOLOGY_PREFIX: https://aclanthology.org


### PR DESCRIPTION
1. Updates `actions/checkout` to `@v3` because older versions are raising a deprecation warning due to Node.js 12.
2. Replaces `::set-output` commands because [they are deprecated and will start failing on June 1st, 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
3. Adds a check if we're in the `acl-org/acl-anthology` repo to the `preview` and `publish` workflows, which will stop Github from attempting to run them in forks of this repo (which fails, but is annoying).
