### PR TITLE
Correction to 2023 LoResMT Submission 1.9

### DIFF
--- a/data/xml/2023.loresmt.xml
+++ b/data/xml/2023.loresmt.xml
@@ -125,7 +125,7 @@
       <author><first>Peter</first><last>Ohue</last><affiliation>University of Ibadan, Nigeria</affiliation></author>
       <author><first>Michael</first><last>Pham</last><affiliation>Swarthmore</affiliation></author>
       <author><first>Abdoulaye</first><last>Sako</last><affiliation>RobotsMali</affiliation></author>
-      <author><first>Sokhar</first><last>Samb</last><affiliation>Dakar American University of Science & Technology, Senegal</affiliation></author>
+      <author><first>Sokhar</first><last>Samb</last><affiliation>Dakar American University of Science and Technology, Senegal</affiliation></author>
       <author><first>Yaya</first><last>Sy</last><affiliation>Independent, previously Université Paris-Cité</affiliation></author>
       <author><first>Tharindu Cyril</first><last>Weerasooriya</last><affiliation>Rochester Institute of Technology, USA</affiliation></author>
       <author><first>Yacine</first><last>Zahidi</last><affiliation>Orange Silicon Valley</affiliation></author>

--- a/data/xml/2023.loresmt.xml
+++ b/data/xml/2023.loresmt.xml
@@ -110,8 +110,8 @@
     <paper id="9">
       <title>Findings from the <fixed-case>B</fixed-case>ambara - <fixed-case>F</fixed-case>rench Machine Translation Competition (<fixed-case>BFMT</fixed-case> 2023)</title>
       <author><first>Ninoh</first><last>Agostinho Da Silva</last><affiliation>Independent, previously Université Paris-Cité</affiliation></author>
-      <author><first>Tunde</first><last>Ajayi</last><affiliation>Independent</affiliation></author>
-      <author><first>Alex</first><last>Antonov</last><affiliation>Chuvash Language Laboratory, Yandex</affiliation></author>
+      <author><first>Tunde Oluwaseyi</first><last>Ajayi</last><affiliation>Insight Centre for Data Analytics, Masakhane</affiliation></author>
+      <author><first>Alexander</first><last>Antonov</last><affiliation>Chuvash Language Laboratory, Yandex</affiliation></author>
       <author><first>Panga</first><last>Azazia Kamate</last><affiliation>RobotsMali</affiliation></author>
       <author><first>Moussa</first><last>Coulibaly</last><affiliation>RobotsMali</affiliation></author>
       <author><first>Mason</first><last>Del Rio</last><affiliation>Orange</affiliation></author>
@@ -119,6 +119,17 @@
       <author><first>Sebastian</first><last>Diarra</last><affiliation>RobotsMali</affiliation></author>
       <author><first>Chris</first><last>Emezue</last><affiliation>Mila Quebec AI Institute, Lanfrica, Masakhane, Technical University of Munich</affiliation></author>
       <author><first>Joel</first><last>Hamilcaro</last><affiliation>Independent, previously Université Paris-Cité</affiliation></author>
+      <author><first>Christopher M.</first><last>Homan</last><affiliation>Rochester Institute of Technology, USA</affiliation></author>
+      <author><first>Alexander</first><last>Most</last><affiliation>Montana State University,USA</affiliation></author>
+      <author><first>Joseph</first><last>Mwatukange</last><affiliation>Meyabase Platforms</affiliation></author>
+      <author><first>Peter</first><last>Ohue</last><affiliation>University of Ibadan, Nigeria</affiliation></author>
+      <author><first>Michael</first><last>Pham</last><affiliation>Swarthmore</affiliation></author>
+      <author><first>Abdoulaye</first><last>Sako</last><affiliation>RobotsMali</affiliation></author>
+      <author><first>Sokhar</first><last>Samb</last><affiliation>Dakar American University of Science & Technology, Senegal</affiliation></author>
+      <author><first>Yaya</first><last>Sy</last><affiliation>Independent, previously Université Paris-Cité</affiliation></author>
+      <author><first>Tharindu Cyril</first><last>Weerasooriya</last><affiliation>Rochester Institute of Technology, USA</affiliation></author>
+      <author><first>Yacine</first><last>Zahidi</last><affiliation>Orange Silicon Valley</affiliation></author>
+      <author><first>Sarah</first><last>Luger</last><affiliation>Orange Silicon Valley</affiliation></author>
       <pages>110-122</pages>
       <abstract>Orange Silicon Valley hosted a low-resource machine translation (MT) competition with monetary prizes. The goals of the competition were to raise awareness of the challenges in the low-resource MT domain, improve MT algorithms and data strategies, and support MT expertise development in the regions where people speak Bambara and other low-resource languages. The participants built Bambara to French and French to Bambara machine translation systems using data provided by the organizers and additional data resources shared amongst the competitors. This paper details each team’s different approaches and motivation for ongoing work in Bambara and the broader low-resource machine translation domain.</abstract>
       <url hash="bf5522ee">2023.loresmt-1.9</url>


### PR DESCRIPTION
Corrections to the metadata for missing authors and author information from the PDF that shows up on anthology. Only the first 10 authors shows up on Anthology, this PR includes the rest. 

https://aclanthology.org/2023.loresmt-1.9/