### PR TITLE
Small performance improvement: Switch urllib with simpler check

### DIFF
--- a/bin/anthology/utils.py
+++ b/bin/anthology/utils.py
@@ -22,7 +22,6 @@ import requests
 import shutil
 
 from lxml import etree
-from urllib.parse import urlparse
 from xml.sax.saxutils import escape as xml_escape
 from typing import Tuple, Optional
 from zlib import crc32
@@ -300,20 +299,20 @@ def infer_url(filename, template=data.CANONICAL_URL_TEMPLATE):
         "{}" in template or "%s" in template
     ), "template has no substitution text; did you pass a prefix by mistake?"
 
-    if urlparse(filename).netloc:
+    if "://" in filename:
         return filename
     return template.format(filename)
 
 
 def infer_attachment_url(filename, parent_id=None):
-    if urlparse(filename).netloc:
+    if "://" in filename:
         return filename
     # Otherwise, treat it as an internal filename
     if parent_id is not None and not filename.startswith(parent_id):
         logging.error(
             f"attachment must begin with paper ID '{parent_id}', but is '{filename}'"
         )
-    return infer_url(filename, data.ATTACHMENT_TEMPLATE)
+    return data.ATTACHMENT_TEMPLATE.format(filename)
 
 
 def infer_year(collection_id):


### PR DESCRIPTION
Reduces instantiation time from 9.005s to 8.480s on my system, should be functionally equivalent for our purposes, and is the fastest version I could think of as tested with pyperf:

```bash
$ pyperf timeit --setup 'from urllib.parse import urlparse' 'bool(urlparse("https://foobar.com/badabing.pdf").netloc)' 
.....................  
Mean +- std dev: 600 ns +- 6 ns

$ pyperf timeit '"https://foobar.com/badabing.pdf".startswith("http")' 
.....................  
Mean +- std dev: 40.0 ns +- 1.7 ns

$ pyperf timeit '"://" in "https://foobar.com/badabing.pdf"'
.....................  
Mean +- std dev: 13.5 ns +- 0.1 ns
```