### PR TITLE
Voynich upper-cased

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -12071,6 +12071,7 @@ Voronezhskaya oblast'
 Võrumaa
 Vosges
 Votic
+Voynich
 Vrancea
 Vraneštica
 Vransko

--- a/data/xml/2020.lt4hala.xml
+++ b/data/xml/2020.lt4hala.xml
@@ -125,7 +125,7 @@
       <bibkey>azar-etal-2020-thesaurus</bibkey>
     </paper>
     <paper id="11">
-      <title>Word Probability Findings in the Voynich Manuscript</title>
+      <title>Word Probability Findings in the <fixed-case>V</fixed-case>oynich Manuscript</title>
       <author><first>Colin</first><last>Layfield</last></author>
       <author><first>Lonneke</first><last>van der Plas</last></author>
       <author><first>Michael</first><last>Rosner</last></author>

--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -2612,7 +2612,7 @@
       <bibkey>sayeed-etal-2011-crowdsourcing</bibkey>
     </paper>
     <paper id="11">
-      <title>What We Know About The Voynich Manuscript</title>
+      <title>What We Know About The <fixed-case>V</fixed-case>oynich Manuscript</title>
       <author><first>Sravana</first><last>Reddy</last></author>
       <author><first>Kevin</first><last>Knight</last></author>
       <pages>78–86</pages>


### PR DESCRIPTION
`Voynich` upper-cased for all instances found. Also updated the true-list.