### PR TITLE
Remove upper-case ISBN from XML schema

### DIFF
--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -106,7 +106,7 @@ Meta = element meta {
    & element month { text }?
    & element year { xsd:gYear }?
    & element volume { xsd:positiveInteger }?
-   & (element ISBN { xsd:NMTOKEN } | element isbn { xsd:NMTOKEN })?
+   & element isbn { xsd:NMTOKEN }?
    & url-with-checksum?
    & element doi { xsd:anyURI }?
    & element venue { text }+


### PR DESCRIPTION
Tiny change that disallows `<ISBN>` in the XML in favor of `<isbn>`.

Zero instances of the upper-case version currently exist in our XML, so there's no good reason to keep this potential for inconsistency around.
