### PR TITLE
Restore contrib table; update documentation

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -5,3 +5,8 @@ staticDir = ["static", "data-export"]
 
 [permalinks]
   papers = "/:filename/"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true  # allow HTML in MD files

--- a/hugo/content/info/contrib.md
+++ b/hugo/content/info/contrib.md
@@ -120,7 +120,9 @@ For both current and legacy events, it is good practice for the organizers to at
 
 ### ISBN Numbers
 
-If you need to assign ISBN numbers, please provide the exact titles of each volume to be assigned an ISBN and forward this information to Priscilla Rasmussen, ACL Business Manager.
+If you plan to publish or print your proceedings, you will need an ISBN.
+The ACL can provide these for *ACL conferences.
+Please provide the exact titles of each volume to be assigned an ISBN and send this information to [Jennifer Rachford](acl.rachford@gmail.com), the ACL Business Manager.
 
 ### Errata and Corrections
 

--- a/hugo/content/info/contrib.md
+++ b/hugo/content/info/contrib.md
@@ -2,7 +2,7 @@
 Title: Information for Submitters
 linktitle: Submitting
 subtitle: General information on submitting proceedings to the ACL Anthology (for event chairs)
-date: "2021-04-18"
+date: "2023-06-21"
 ---
 
 This page contains general information about submitting the proceedings of a conference to the ACL Anthology.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,3 @@ skip-string-normalization = true
 [tool.ruff]
 ignore = ['E501']  # "Line too long" is black's job
 target-version = 'py38'
-
-[markup.goldmark.renderer]
-  unsafe = true  # Allow HTML in md files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ skip-string-normalization = true
 [tool.ruff]
 ignore = ['E501']  # "Line too long" is black's job
 target-version = 'py38'
+
+[markup.goldmark.renderer]
+  unsafe = true  # Allow HTML in md files


### PR DESCRIPTION
It seems that we have been deleting a huge HTML table with deadlines since we upgraded past hugo 0.60.

https://aclanthology.org/info/contrib/

This PR will also include other doc updates.