### PR TITLE
Add namespace to PageMap in sitemap

### DIFF
--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -23,7 +23,7 @@
         {{ if (hasPrefix . "https://aclanthology.org") }}
         <url>
           <loc>{{ . }}</loc>
-          <PageMap>
+          <PageMap xmlns="http://www.google.com/schemas/sitemap-pagemap/1.0">
             <DataObject type="metatags">
               <Attribute name="citation_publication_date" value="{{ $volume.meta_date }}"/>
             </DataObject>


### PR DESCRIPTION
Re #2611 and #2605, and based on an error I'm seeing in the Google Search Console, the `<PageMap>` tag in the sitemap needs to [declare its XML namespace](https://developers.google.com/custom-search/docs/structured_data#addtositemap).