### PR TITLE
Fix author name & affiliation in 2023.acl-long.314

### DIFF
--- a/data/xml/2023.acl.xml
+++ b/data/xml/2023.acl.xml
@@ -3807,7 +3807,7 @@
     </paper>
     <paper id="314">
       <title>Free Lunch: Robust Cross-Lingual Transfer via Model Checkpoint Averaging</title>
-      <author><first>Fabian</first><last>Schmidt</last><affiliation>University of Wuerzburg</affiliation></author>
+      <author><first>Fabian David</first><last>Schmidt</last><affiliation>University of Würzburg</affiliation></author>
       <author><first>Ivan</first><last>Vulić</last><affiliation>University of Cambridge</affiliation></author>
       <author><first>Goran</first><last>Glavaš</last><affiliation>University of Würzburg</affiliation></author>
       <pages>5712-5730</pages>


### PR DESCRIPTION
Anthology id: 2023.acl-long.314
Corrects the name and affiliation of my long paper accepted to conference proceedings of ACL.

Apologies, I forgot to add my second name (which I use in academic contexts to distinguish my otherwise rather common German name) when maintaining my profile Softconf, where I believe this issue ultimately stems from. This should also resolve two different authors on ACL Anthology (Fabian David Schmidt vs Fabian Schmidt) and unify Google Scholar indexing. I hope to fix is in the right place.

Thanks in advance!