### PR TITLE
Data fixes: first/last name tags (in XML), joint key (in YAML)

### DIFF
--- a/data/xml/2022.amta.xml
+++ b/data/xml/2022.amta.xml
@@ -132,12 +132,12 @@
     </paper>
     <paper id="10">
       <title>On the Effectiveness of Quasi Character-Level Models for Machine Translation</title>
-      <author><first>Salvador</first><last>Carrión-Ponz</last></author>
+      <author><first>Salvador</first><last>Carrión</last></author>
       <author><first>Francisco</first><last>Casacuberta</last></author>
       <pages>131-143</pages>
       <url hash="b53f65d5">2022.amta-research.10</url>
       <abstract>Neural Machine Translation (NMT) models often use subword-level vocabularies to deal with rare or unknown words. Although some studies have shown the effectiveness of purely character-based models, these approaches have resulted in highly expensive models in computational terms. In this work, we explore the benefits of quasi-character-level models for very low-resource languages and their ability to mitigate the effects of the catastrophic forgetting problem. First, we conduct an empirical study on the efficacy of these models, as a function of the vocabulary and training set size, for a range of languages, domains, and architectures. Next, we study the ability of these models to mitigate the effects of catastrophic forgetting in machine translation. Our work suggests that quasi-character-level models have practically the same generalization capabilities as character-based models but at lower computational costs. Furthermore, they appear to help achieve greater consistency between domains than standard subword-level models, although the catastrophic forgetting problem is not mitigated.</abstract>
-      <bibkey>carrion-ponz-casacuberta-2022-effectiveness</bibkey>
+      <bibkey>carrion-casacuberta-2022-effectiveness</bibkey>
     </paper>
     <paper id="11">
       <title>Improving Translation of Out Of Vocabulary Words using Bilingual Lexicon Induction in Low-Resource Machine Translation</title>
@@ -174,12 +174,12 @@
     </paper>
     <paper id="14">
       <title>Few-Shot Regularization to Tackle Catastrophic Forgetting in Multilingual Machine Translation</title>
-      <author><first>Salvador Carrión-Ponz</first><last/></author>
+      <author><first>Salvador</first><last>Carrión</last></author>
       <author><first>Francisco</first><last>Casacuberta</last></author>
       <pages>188-199</pages>
       <url hash="fd8d6bcf">2022.amta-research.14</url>
       <abstract>Increasing the number of tasks supported by a machine learning model without forgetting previously learned tasks is the goal of any lifelong learning system. In this work, we study how to mitigate the effects of the catastrophic forgetting problem to sequentially train a multilingual neural machine translation model using minimal past information. First, we describe the catastrophic forgetting phenomenon as a function of the number of tasks learned (language pairs) and the ratios of past data used during the learning of the new task. Next, we explore the importance of applying oversampling strategies for scenarios where only minimal amounts of past data are available. Finally, we derive a new loss function that minimizes the forgetting of previously learned tasks by actively re-weighting past samples and penalizing weights that deviate too much from the original model. Our work suggests that by using minimal amounts of past data and a simple regularization function, we can significantly mitigate the effects of the catastrophic forgetting phenomenon without increasing the computational costs.</abstract>
-      <bibkey>-casacuberta-2022-shot</bibkey>
+      <bibkey>carrion-casacuberta-2022-shot</bibkey>
     </paper>
     <paper id="15">
       <title>Quantized <fixed-case>W</fixed-case>asserstein <fixed-case>P</fixed-case>rocrustes Alignment of Word Embedding Spaces</title>

--- a/data/xml/2023.clinicalnlp.xml
+++ b/data/xml/2023.clinicalnlp.xml
@@ -73,7 +73,7 @@
     <paper id="5">
       <title>Investigating Massive Multilingual Pre-Trained Machine Translation Models for Clinical Domain via Transfer Learning</title>
       <author><first>Lifeng</first><last>Han</last></author>
-      <author><first>Gleb</first><last/></author>
+      <author><first>Gleb</first><last>Erofeev</last></author>
       <author><first>Irina</first><last>Sorokina</last></author>
       <author><first>Serge</first><last>Gladkoff</last><affiliation>Logrus Global AI Lab</affiliation></author>
       <author><first>Goran</first><last>Nenadic</last><affiliation>University of Manchester</affiliation></author>

--- a/data/xml/O06.xml
+++ b/data/xml/O06.xml
@@ -452,9 +452,8 @@
     </paper>
     <paper id="6">
       <title>Author and Subject Index</title>
-      <author><first/><last/></author>
       <url hash="a30782a7">O06-5006</url>
-      <bibkey>-2006-author</bibkey>
+      <bibkey>nn-2006-author</bibkey>
     </paper>
   </volume>
 </collection>

--- a/data/xml/O08.xml
+++ b/data/xml/O08.xml
@@ -173,7 +173,6 @@
     <meta>
       <booktitle><fixed-case>ROCLING</fixed-case> 2008 Poster Papers</booktitle>
       <url hash="8f542c20">O08-2</url>
-      <editor><first/><last/></editor>
       <publisher>The Association for Computational Linguistics and Chinese Language Processing (ACLCLP)</publisher>
       <address>Taipei, Taiwan</address>
       <month>September</month>

--- a/data/xml/O09.xml
+++ b/data/xml/O09.xml
@@ -203,7 +203,6 @@
     <meta>
       <booktitle><fixed-case>ROCLING</fixed-case> 2009 Poster Papers</booktitle>
       <url hash="53ed6dba">O09-2</url>
-      <editor><first/><last/></editor>
       <publisher>The Association for Computational Linguistics and Chinese Language Processing (ACLCLP)</publisher>
       <address>Taichung, Taiwan</address>
       <month>September</month>

--- a/data/xml/O93.xml
+++ b/data/xml/O93.xml
@@ -107,7 +107,6 @@
     <meta>
       <booktitle><fixed-case>ROCLING</fixed-case> 1993 Short Papers</booktitle>
       <url hash="e26ec674">O93-2</url>
-      <editor><first/><last/></editor>
       <publisher>The Association for Computational Linguistics and Chinese Language Processing (ACLCLP)</publisher>
       <address>Nantou, Taiwan</address>
       <month>September</month>

--- a/data/xml/O94.xml
+++ b/data/xml/O94.xml
@@ -115,7 +115,6 @@
     <meta>
       <booktitle><fixed-case>ROCLING</fixed-case> 1994 Poster Papers</booktitle>
       <url hash="8e82f9a2">O94-2</url>
-      <editor><first/><last/></editor>
       <publisher>The Association for Computational Linguistics and Chinese Language Processing (ACLCLP)</publisher>
       <address>Hsinchu, Taiwan</address>
       <month>August</month>

--- a/data/xml/O95.xml
+++ b/data/xml/O95.xml
@@ -114,7 +114,6 @@
     <meta>
       <booktitle><fixed-case>ROCLING</fixed-case> 1995 Poster Papers</booktitle>
       <url hash="d6182d8e">O95-2</url>
-      <editor><first/><last/></editor>
       <publisher>The Association for Computational Linguistics and Chinese Language Processing (ACLCLP)</publisher>
       <address>Taoyuan, Taiwan</address>
       <month>August</month>

--- a/data/xml/O97.xml
+++ b/data/xml/O97.xml
@@ -248,7 +248,6 @@
     <meta>
       <booktitle><fixed-case>ROCLING</fixed-case> 1997 Poster Papers</booktitle>
       <url hash="52b04dc2">O97-2</url>
-      <editor><first/><last/></editor>
       <publisher>The Association for Computational Linguistics and Chinese Language Processing (ACLCLP)</publisher>
       <address>Taipei, Taiwan</address>
       <month>August</month>

--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -9,8 +9,8 @@ fixed-case = element fixed-case { MarkupText }
 tex-math = element tex-math { text }
 MarkupText = (text | b | i | url | fixed-case | tex-math )+
 
-first = element first { text }
-last = element last { text }
+first = element first { xsd:string { pattern="(\S(.*\S)?)?" } }
+last = element last { xsd:string { pattern="\S(.*\S)?" } }
 affiliation = element affiliation { text }
 orcid = element orcid { text }
 google-scholar = element google-scholar{ text }

--- a/data/yaml/venues/iwclul.yaml
+++ b/data/yaml/venues/iwclul.yaml
@@ -1,4 +1,3 @@
 acronym: IWCLUL
 is_acl: true
-joint: WS
 name: International Workshop on Computational Linguistics for Uralic Languages

--- a/data/yaml/venues/konvens.yaml
+++ b/data/yaml/venues/konvens.yaml
@@ -1,5 +1,4 @@
 acronym: KONVENS
 is_toplevel: true
-joint: WS
 name: Conference on Natural Language Processing
 url: https://konvens.org/site/


### PR DESCRIPTION
- Enforce that `<last>` name cannot be empty
- Fix instances of empty `<last>` name tags
- Enforce that `<first>` and `<last>` must start/end with non-whitespace character
- Remove two spurious "joint" keys from venue YAML files

Closes #2725 