### PR TITLE
Removed comments

### DIFF
--- a/bin/anthology/utils.py
+++ b/bin/anthology/utils.py
@@ -433,9 +433,6 @@ def parse_element(
         return attrib
 
     for element in xml_element:
-        if element.tag is etree.Comment:
-            continue
-
         # parse value
         tag = element.tag.lower()
         if tag in dont_parse_elements:

--- a/data/xml/2023.ws.xml
+++ b/data/xml/2023.ws.xml
@@ -2,8 +2,7 @@
 <collection id="2023.ws">
   <event id="ws-2023">
     <colocated>
-      <!-- Unsorted -->
-      <volume-id>2023.computel-1</volume-id>
+      <volume-id note="unsorted">2023.computel-1</volume-id>
       <volume-id>2023.wsc-csdh</volume-id>
       <volume-id>2023.depling-1</volume-id>
       <volume-id>2023.cxgsnlp-1</volume-id>
@@ -11,8 +10,7 @@
       <volume-id>2023.udw-1</volume-id>
       <volume-id>2023.resourceful-1</volume-id>
       <volume-id>2023.nlp4call-1</volume-id>
-      <!-- EACL 2023 -->
-      <volume-id>2023.bsnlp-1</volume-id>
+      <volume-id note="eacl">2023.bsnlp-1</volume-id>
       <volume-id>2023.c3nlp-1</volume-id>
       <volume-id>2023.fever-1</volume-id>
       <volume-id>2023.fieldmatters-1</volume-id>
@@ -24,8 +22,7 @@
       <volume-id>2023.sigtyp-1</volume-id>
       <volume-id>2023.unlp-1</volume-id>
       <volume-id>2023.vardial-1</volume-id>
-      <!-- ACL 2023 -->
-      <volume-id>2023.americasnlp-1</volume-id>
+      <volume-id note="acl">2023.americasnlp-1</volume-id>
       <volume-id>2023.bea-1</volume-id>
       <volume-id>2023.bionlp-1</volume-id>
       <volume-id>2023.cawl-1</volume-id>

--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -144,7 +144,7 @@ Event = element event {
    & element links { url* }?
    & Talk*
    & element colocated {
-       element volume-id { text }*
+       element volume-id { attribute note { xsd:string }?, text }*
      }?
  )
 }


### PR DESCRIPTION
I removed comments from the XML and the Python code that permitted skipping them when parsing. In its place, I added a "note" attribute to `<volume-id>` to help sort workshops. Would this work or does it also complicate things?