### PR TITLE
CCL 2023: Fixed the problem of spelling error of the author's name

### DIFF
--- a/data/xml/2023.ccl.xml
+++ b/data/xml/2023.ccl.xml
@@ -611,10 +611,10 @@
     </paper>
     <paper id="47">
       <title>古汉语通假字资源库的构建及应用研究(The Construction and Application of an <fixed-case>A</fixed-case>ncient <fixed-case>C</fixed-case>hinese Language Resource on Tongjiazi)</title>
-      <author><first>Wang</first><last>Zaoji</last><variant script="latn"><first>兆基</first><last>王</last></variant></author>
-      <author><first>Zhang</first><last>Shirui</last><variant script="latn"><first>诗睿</first><last>张</last></variant></author>
-      <author><first>Zhang</first><last>Xuetao</last><variant script="latn"><first>学涛</first><last>张</last></variant></author>
-      <author><first>Hu</first><last>Renfen</last><variant script="latn"><first>韧奋</first><last>胡</last></variant></author>
+      <author><first>Zhaoji</first><last>Wang</last><variant script="hani"><first>兆基</first><last>王</last></variant></author>
+      <author><first>Shirui</first><last>Zhang</last><variant script="hani"><first>诗睿</first><last>张</last></variant></author>
+      <author><first>Xuetao</first><last>Zhang</last><variant script="hani"><first>学涛</first><last>张</last></variant></author>
+      <author><first>Renfen</first><last>Hu</last><variant script="hani"><first>韧奋</first><last>胡</last></variant></author>
       <pages>535–546</pages>
       <abstract>“古籍文本中的文字通假现象较为常见,这不仅为人理解文意造成了困难,也是古汉语信息处理面临的一项重要挑战。为了服务于通假字的人工判别和机器处理,本文构建并开源了一个多维度的通假字资源库,包括语料库、知识库和评测数据集三个子库。其中,语料库收录11000余条包含通假现象详细标注的语料;知识库以汉字为节点,通假和形声关系为边,从字音、字形、字义多个角度对通假字与正字的属性进行加工,共包含4185个字节点和8350对关联信息;评测数据集面向古汉语信息处理需求,支持通假字检测和正字识别两个子任务的评测,收录评测数据19678条。在此基础上,本文搭建了通假字自动识别的系列基线模型,并结合试验结果分析了影响通假字自动识别的因素与改进方法。进一步地,本文探讨了该资源库在古籍整理、人文研究和文言文教学中的应用。”</abstract>
       <url hash="7a154b27">2023.ccl-1.47</url>


### PR DESCRIPTION
**Fixed the problem of spelling error of the author's name.**

**The metadata currently displayed on the ACL Anthology is incorrect**, as shown in the following figure.

<img width="1197" alt="image" src="https://github.com/acl-org/acl-anthology/assets/6050869/682b9cab-2ddc-4a9e-8ec0-8743e4d3541a">

**The correct author name is as follows**, as it appears in the paper:

<img width="545" alt="image" src="https://github.com/acl-org/acl-anthology/assets/6050869/2698699f-f5de-4d33-9df3-cb0546da7ae5">

<img width="646" alt="image" src="https://github.com/acl-org/acl-anthology/assets/6050869/bbd6061a-2ebc-4ede-b998-53b2e8fb30e5">
