### PR TITLE
add GWC events in the siglex

### DIFF
--- a/data/yaml/sigs/siglex.yaml
+++ b/data/yaml/sigs/siglex.yaml
@@ -15,6 +15,7 @@ Meetings:
     - 2021.mwe-1 # Proceedings of the 17th Workshop on Multiword Expressions (MWE 2021)
     - 2021.semeval-1 # Proceedings of the 15th International Workshop on Semantic Evaluation (SemEval-2021)
     - 2021.starsem-1 # Proceedings of *SEM 2021: The Tenth Joint Conference on Lexical and Computational Semantics
+    - 2021.gwc-1 # Proceedings of the 11th Global Wordnet Conference
   - 2020:
     - 2020.cogalex-1 # Proceedings of the Workshop on the Cognitive Aspects of the Lexicon
     - 2020.semeval-1 # Proceedings of the Fourteenth Workshop on Semantic Evaluation
@@ -24,10 +25,12 @@ Meetings:
     - S19-1 # *SEM
     - S19-2 # SemEval
     - W19-51 # Joint Workshop on Multiword Expressions and Wordnet
+    - 2019.gwc-1 # Proceedings of the 10th Global Wordnet Conference
   - 2018:
     - S18-1 # SemEval
     - S18-2 # *Sem
     - W18-49 # LAW-MWE-CxG-2018
+    - 2018.gwc-1 # Proceedings of the 9th Global Wordnet Conference
   - 2017:
     - S17-1 # *Sem
     - S17-2 # SemEval
@@ -37,6 +40,7 @@ Meetings:
     - S16-2 # *Sem
     - W16-18 # MWE
     - W16-53 # Proceedings of the 5th Workshop on Cognitive Aspects of the Lexicon
+    - 2016.gwc-1 # Proceedings of the 8th Global WordNet Conference
   - 2015:
     - S15-1 # *Sem
     - S15-2 # *SemEval
@@ -50,6 +54,7 @@ Meetings:
     - S14-2 # SemEval
     - W14-05 # CogACLL
     - W14-08 # MWE
+    - W14-01 # Proceedings of the Seventh Global Wordnet Conference
   - 2013:
     - S13-1 # *Sem
     - S13-2 # SemEval


### PR DESCRIPTION

> The SIGLEX Board agreed that SIGLEX should endorse the Global Wordnet Conferences, both the current ones and the past ones, retroactively. 

I am adding the list of past GWC events to the siglex page.