### PR TITLE
Fixed casing in `irvine-etal-2012-processing` (W12)

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -8667,6 +8667,7 @@ Paiwan
 Pakaásnovos
 Pakanha
 Pakistan
+Pakistani
 Pakistan Sign Language
 Paktiyā
 Paktīkā

--- a/data/xml/W12.xml
+++ b/data/xml/W12.xml
@@ -3119,7 +3119,7 @@
       <bibkey>bergsma-etal-2012-language</bibkey>
     </paper>
     <paper id="9">
-      <title>Processing Informal, <fixed-case>R</fixed-case>omanized Pakistani Text Messages</title>
+      <title>Processing Informal, <fixed-case>R</fixed-case>omanized <fixed-case>P</fixed-case>akistani Text Messages</title>
       <author><first>Ann</first><last>Irvine</last></author>
       <author><first>Jonathan</first><last>Weese</last></author>
       <author><first>Chris</first><last>Callison-Burch</last></author>


### PR DESCRIPTION
Fixed casing in a single entry (`irvine-etal-2012-processing`) in W12.xml and updated the `truelist`.
