### PR TITLE
Bump Hugo version from 0.108.0 to 0.118.2

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: install hugo
-      run: wget https://github.com/gohugoio/hugo/releases/download/v0.108.0/hugo_extended_0.108.0_linux-amd64.deb && sudo dpkg -i hugo_extended*.deb
+      run: wget https://github.com/gohugoio/hugo/releases/download/v0.118.2/hugo_extended_0.118.2_linux-amd64.deb && sudo dpkg -i hugo_extended*.deb
     - name: update
       run: sudo apt-get update
     - name: install other deps

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: install hugo
-      run: wget https://github.com/gohugoio/hugo/releases/download/v0.108.0/hugo_extended_0.108.0_linux-amd64.deb && sudo dpkg -i hugo_extended*.deb
+      run: wget https://github.com/gohugoio/hugo/releases/download/v0.118.2/hugo_extended_0.118.2_linux-amd64.deb && sudo dpkg -i hugo_extended*.deb
     - name: update
       run: sudo apt-get update
     - name: install other deps

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: install hugo
-      run: wget https://github.com/gohugoio/hugo/releases/download/v0.108.0/hugo_extended_0.108.0_linux-amd64.deb && sudo dpkg -i hugo_extended*.deb
+      run: wget https://github.com/gohugoio/hugo/releases/download/v0.118.2/hugo_extended_0.118.2_linux-amd64.deb && sudo dpkg -i hugo_extended*.deb
     - name: update
       run: sudo apt-get update
     - name: install other deps

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ endif
 #######################################################
 
 # hugo version check
-HUGO_VERSION_MIN=58
+HUGO_VERSION_MIN=114
 HUGO_VERSION=$(shell hugo version | sed 's/^.* v0\.\(.*\)\..*/\1/')
 HUGO_VERSION_TOO_LOW:=$(shell [[ $(HUGO_VERSION_MIN) -gt $(HUGO_VERSION) ]] && echo true)
 ifeq ($(HUGO_VERSION_TOO_LOW),true)

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,8 @@ build/.hugo: build/.static build/.pages build/.bibtex build/.mods build/.endnote
 	         -d website/$(ANTHOLOGYDIR) \
 		 -e $(HUGO_ENV) \
 	         --cleanDestinationDir \
-	         --minify
+	         --minify \
+		 --logLevel=info
 	@cd build/website/$(ANTHOLOGYDIR) \
 	    && ln -s $(ANTHOLOGYFILES) anthology-files \
 	    && perl -i -pe 's|ANTHOLOGYDIR|$(ANTHOLOGYDIR)|g' .htaccess


### PR DESCRIPTION
No breaking changes for us, but I added `--logLevel=info` to the Hugo invocation, and set the minimum required Hugo version to 0.114.x because that's when the `--logLevel` flag was introduced. I think it's fine to require a somewhat recent version even though the website technically builds with older versions.
