### PR TITLE
Fix name mismatch by changing "Terry Lima Ruas" -> "Terry Ruas" in paper 2023.acl-long.734

### DIFF
--- a/data/xml/2023.acl.xml
+++ b/data/xml/2023.acl.xml
@@ -9830,7 +9830,7 @@
       <title>The Elephant in the Room: Analyzing the Presence of Big Tech in Natural Language Processing Research</title>
       <author><first>Mohamed</first><last>Abdalla</last><affiliation>University of Toronto</affiliation></author>
       <author><first>Jan Philip</first><last>Wahle</last><affiliation>University of Göttingen</affiliation></author>
-      <author><first>Terry</first><last>Lima Ruas</last><affiliation>University of Göttingen</affiliation></author>
+      <author><first>Terry</first><last>Ruas</last><affiliation>University of Göttingen</affiliation></author>
       <author><first>Aurélie</first><last>Névéol</last><affiliation>Université Paris Saclay, CNRS, LISN</affiliation></author>
       <author><first>Fanny</first><last>Ducel</last><affiliation>Sorbonne Universite, LORIA</affiliation></author>
       <author><first>Saif</first><last>Mohammad</last><affiliation>NRC</affiliation></author>


### PR DESCRIPTION
The following publication has the wrong name of one of our collaborators:
**DOI:** 10.18653/v1/2023.acl-long.734 
**Paper title:** The Elephant in the Room: Analyzing the Presence of Big Tech in Natural Language Processing Research

The correct author's name is **Terry Ruas**.
The wrong one (in the paper's metadata) is **Terry Lima Ruas**.

This leads to the problem of showing the profile for [Terry Lima Ruas](https://aclanthology.org/people/t/terry-lima-ruas/) with just this **one** paper while the author has multiple papers in the ACL Anthology under [Terry Ruas](https://aclanthology.org/people/t/terry-ruas/).

The pull requests change the name in the publication from "Terry Lima Ruas" -> "Terry Ruas"

I am linking @truas to confirm.