### PR TITLE
Don't register co-editors for non-volume items

### DIFF
--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -309,18 +309,17 @@ class AnthologyIndex:
                 if not self._fast_load:
                     self._id_to_used[id_].add(name)
 
-                if not dummy:
+                if not dummy and (role == "author" or paper.is_volume):
                     # Register paper
                     self.id_to_papers[id_][role].append(paper.full_id)
                     if not self._fast_load:
                         self.name_to_papers[name][explicit].append(paper.full_id)
                         # Register co-author(s)
-                        if role == "author" or paper.is_volume:
-                            for co_name, co_id in paper.get(role):
-                                if co_id is None:
-                                    co_id = self.resolve_name(co_name)["id"]
-                                if co_id != id_:
-                                    self._coauthors[id_][co_id] += 1
+                        for co_name, co_id in paper.get(role):
+                            if co_id is None:
+                                co_id = self.resolve_name(co_name)["id"]
+                            if co_id != id_:
+                                self._coauthors[id_][co_id] += 1
 
     @property
     def id_to_used(self):

--- a/bin/anthology/index.py
+++ b/bin/anthology/index.py
@@ -315,11 +315,12 @@ class AnthologyIndex:
                     if not self._fast_load:
                         self.name_to_papers[name][explicit].append(paper.full_id)
                         # Register co-author(s)
-                        for co_name, co_id in paper.get(role):
-                            if co_id is None:
-                                co_id = self.resolve_name(co_name)["id"]
-                            if co_id != id_:
-                                self._coauthors[id_][co_id] += 1
+                        if role == "author" or paper.is_volume:
+                            for co_name, co_id in paper.get(role):
+                                if co_id is None:
+                                    co_id = self.resolve_name(co_name)["id"]
+                                if co_id != id_:
+                                    self._coauthors[id_][co_id] += 1
 
     @property
     def id_to_used(self):

--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -503,6 +503,8 @@ class Paper:
         return self.attrib.items()
 
     def iter_people(self):
-        for role in ("author", "editor"):
-            for name, id_ in self.get(role, []):
-                yield (name, id_, role)
+        for name, id_ in self.get("author", []):
+            yield (name, id_, "author")
+        if self.is_volume:
+            for name, id_ in self.get("editor", []):
+                yield (name, id_, "editor")


### PR DESCRIPTION
Attempts to fix #2863.

The way author/editor assignment is handled is currently terrible, and the way editors are added to papers without affecting author pages and paper counts feels like a terrible hack. In [the new library](https://github.com/mbollmann/acl-anthology-py/), there is already a clear distinction between information given explicitly in the XML vs. being implicitly inferred, so this should hopefully improve in the future.
