### PR TITLE
Add Github link to navbar

### DIFF
--- a/hugo/content/faq/feedback.md
+++ b/hugo/content/faq/feedback.md
@@ -4,5 +4,6 @@ weight: 1
 ---
 
 We welcome your feedback!
-The most convenient way for us to receive it is for you to [create a new issue on our Github issues page](https://github.com/acl-org/acl-anthology/issues/), or to add a new comment to our [feedback mega-thread](https://github.com/acl-org/acl-anthology/issues/170).
+The most convenient way for us to receive it is for you to [create a new issue on our Github issues page](https://github.com/acl-org/acl-anthology/issues/).
+This is also the method most likely to generate the fastest response, since it can be seen by anyone on the volunteer team.
 If you prefer, you are also invited to [email the Anthology director](mailto:anthology@aclweb.org).

--- a/hugo/content/faq/related-work.md
+++ b/hugo/content/faq/related-work.md
@@ -6,7 +6,7 @@ weight: 5
 The following papers provide overviews of the Anthology infrastructure at different points in time:
 
 - [Two Decades of the ACL Anthology: Development, Impact, and Open Challenges](https://aclanthology.org/2023.nlposs-1.10) (Bollmann et al., NLPOSS-WS 2023).
-- [The ACL Anthology: Current State and Future Directions](https://aclanthology.org/W18-2504) (Gildea et al., NLPOSS 2018). 
+- [The ACL Anthology: Current State and Future Directions](https://aclanthology.org/W18-2504) (Gildea et al., NLPOSS 2018).
   It is now out of date, but helped direct changes to the Anthology that occurred in 2019.
 
 There are also many papers that make use of the Anthology's data.

--- a/hugo/content/faq/related-work.md
+++ b/hugo/content/faq/related-work.md
@@ -3,19 +3,19 @@ Title: What other resources are there based on the ACL Anthology?
 weight: 5
 ---
 
-The [ACL Anthology Reference Corpus](http://acl-arc.comp.nus.edu.sg/) provides **plain text and other metadata** for a controlled subset of the ACL Anthology.
+The following papers provide overviews of the Anthology infrastructure at different points in time:
 
-The following people have written reflections on the ACL Anthology:
+- [Two Decades of the ACL Anthology: Development, Impact, and Open Challenges](https://aclanthology.org/2023.nlposs-1.10) (Bollmann et al., NLPOSS-WS 2023).
+- [The ACL Anthology: Current State and Future Directions](https://aclanthology.org/W18-2504) (Gildea et al., NLPOSS 2018). 
+  It is now out of date, but helped direct changes to the Anthology that occurred in 2019.
 
-+ [Aravind Joshi]({{< relref "reflections-aj.md" >}})
-+ [Karen Spärck Jones]({{< relref "reflections-ksj.md" >}})
+There are also many papers that make use of the Anthology's data.
+Here we highlight a few:
 
-A 2018 paper gave a technical description of the Anthology at the time:
+- [On Forgetting to Cite Older Papers: An Analysis of the ACL Anthology](https://aclanthology.org/2020.acl-main.699) (Bollmann & Elliott, ACL 2020)
+- [NLP Scholar: An Interactive Visual Explorer for Natural Language Processing Literature](https://aclanthology.org/2020.acl-demos.27) (Mohammad, ACL 2020)
+- [Mining Scientific Terms and their Definitions: A Study of the ACL Anthology](https://aclanthology.org/D13-1073) (Jin et al., EMNLP 2013)
+- [The ACL Anthology Reference Corpus: A Reference Dataset for Bibliographic Research in Computational Linguistics](http://www.lrec-conf.org/proceedings/lrec2008/pdf/445_paper.pdf) (Bird et al., LREC 2008).
+  This work provided **plain text and other metadata** for a controlled subset of the ACL Anthology.
 
-> [The ACL Anthology: Current State and Future Directions](https://aclanthology.org/W18-2504/)
-> Daniel Gildea, Min-Yen Kan, Nitin Madnani, Christoph Teichmann, Martin Villalba
-> Proceedings of Workshop for NLP Open Source Software (NLP-OSS)
-
-It is now out of date, but helped direct changes to the Anthology that occurred in 2019.
-
-Many other [publications based on the ACL Anthology](https://www.semanticscholar.org/search?q=acl+anthology) exist.
+Many other publications based on the ACL Anthology exist, which you [may be able to find by searching](https://www.semanticscholar.org/search?q=acl+anthology).

--- a/hugo/layouts/partials/header_navbar.html
+++ b/hugo/layouts/partials/header_navbar.html
@@ -20,7 +20,7 @@
         <a class="nav-link" href={{ relref . "/info/contrib.md" }}>Submissions<span class="sr-only">(current)</span></a>
       </li>
     </ul>
-    <form class="form-inline my-2 my-lg-0" action={{"/search/?" | relURL}} method=get>
+    <form class="form-inline my-2 my-lg-0 flex-nowrap" action={{"/search/?" | relURL}} method=get>
       <input id=acl-search-box class="form-control mr-sm-2" name=q type=search placeholder=Search... aria-label=Search>
       <button class="btn btn-outline-primary" type=submit><i class="fas fa-search"></i></button>
     </form>

--- a/hugo/layouts/partials/header_navbar.html
+++ b/hugo/layouts/partials/header_navbar.html
@@ -9,7 +9,7 @@
   </button>
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav mr-auto">
+    <ul class="navbar-nav flex-grow-1 pr-md-2">
       <li class="nav-item">
         <a class="nav-link" href={{ relref . "/faq" }}>FAQ<span class="sr-only">(current)</span></a>
       </li>
@@ -18,6 +18,9 @@
       </li>
       <li class="nav-item">
         <a class="nav-link" href={{ relref . "/info/contrib.md" }}>Submissions<span class="sr-only">(current)</span></a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://github.com/acl-org/acl-anthology/"><i class="fab fa-github pr-1"></i>Find us on Github</a>
       </li>
     </ul>
     <form class="form-inline my-2 my-lg-0 flex-nowrap" action={{"/search/?" | relURL}} method=get>

--- a/hugo/layouts/partials/header_navbar.html
+++ b/hugo/layouts/partials/header_navbar.html
@@ -2,7 +2,7 @@
   <div id="navbar-container" class="container">
   <a class="navbar-brand" href={{ "/" | relURL}}>
     <img src={{ "/images/acl-logo.svg" | relURL}} width=56 alt="ACL Logo">
-    <span class="d-none d-md-inline pl-md-2">ACL Anthology</span>
+    <span class="d-inline pl-2">ACL Anthology</span>
   </a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/hugo/layouts/partials/header_navbar.html
+++ b/hugo/layouts/partials/header_navbar.html
@@ -20,7 +20,7 @@
         <a class="nav-link" href={{ relref . "/info/contrib.md" }}>Submissions<span class="sr-only">(current)</span></a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://github.com/acl-org/acl-anthology/"><i class="fab fa-github pr-1"></i>Find us on Github</a>
+        <a class="nav-link" href="https://github.com/acl-org/acl-anthology/"><i class="fab fa-github pr-1"></i>Github</a>
       </li>
     </ul>
     <form class="form-inline my-2 my-lg-0 flex-nowrap" action={{"/search/?" | relURL}} method=get>


### PR DESCRIPTION
I propose to add a prominent link to our Github repo to the website's navbar, in order to make it easier to discover.

We could make a button on the front page as well (analogous to the BibTeX download buttons), but I thought this would be nicer.