### PR TITLE
Correcting and adding info to NLP-OSS workshop 2023 (`2023.nlposs.xml`)

### DIFF
--- a/data/xml/2023.nlposs.xml
+++ b/data/xml/2023.nlposs.xml
@@ -288,9 +288,8 @@
     </paper>
     <paper id="26">
       <title><fixed-case>SEA</fixed-case>-<fixed-case>LION</fixed-case> (<fixed-case>S</fixed-case>outheast <fixed-case>A</fixed-case>sian Languages In One Network): A Family of <fixed-case>S</fixed-case>outheast <fixed-case>A</fixed-case>sian Language Models</title>
-      <author><first>William</first><last>Tjhi</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>David</first><last>Ong</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Peerat</first><last>Limkonchotiwat</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
+      <author><first>David</first><last>Ong</last><affiliation>AI Singapore</affiliation></author>
+      <author><first>Peerat</first><last>Limkonchotiwat</last><affiliation>Vidyasirimedhi Institute of Science and Technology, Thailand</affiliation></author>
       <pages>245-245</pages>
       <abstract>Abstract. (not necessary)</abstract>
       <url hash="632dc5a1">2023.nlposs-1.26</url>
@@ -298,18 +297,18 @@
     </paper>
     <paper id="27">
       <title>trl<fixed-case>X</fixed-case>: A Framework for Large Scale Open Source <fixed-case>RLHF</fixed-case></title>
-      <author><first>Louis</first><last>Castricato</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
+      <author><first>Louis</first><last>Castricato</last><affiliation>EleutherAI</affiliation></author>
       <pages>246-246</pages>
-      <abstract>Abstract. (not necessary)</abstract>
+      <abstract>Reinforcement learning from human feedback (RLHF) utilizes human feedback to better align large language models with human preferences via online optimization against a learned reward model. Current RLHF paradigms rely on Proximal Policy Optimization (PPO), which quickly becomes a challenge to implement and scale up to large architectures. To address this difficulty we created the trlX library as a feature-complete open-source framework for RLHF fine-tuning of models up to and exceeding 70 billion parameters. We implemented support for multiple types of distributed training including distributed data parallel, model sharded, as well as tensor, sequential, and pipeline parallelism.</abstract>
       <url hash="b8184f0c">2023.nlposs-1.27</url>
       <bibkey>castricato-2023-trlx</bibkey>
     </paper>
     <paper id="28">
       <title>Towards Explainable and Accessible <fixed-case>AI</fixed-case></title>
-      <author><first>Brandon</first><last>Duderstadt</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Yuvanesh</first><last>Anand</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
+      <author><first>Brandon</first><last>Duderstadt</last><affiliation>Nomic AI</affiliation></author>
+      <author><first>Yuvanesh</first><last>Anand</last><affiliation>Virginia Institute of Technology & Nomic AI</affiliation></author>
       <pages>247-247</pages>
-      <abstract>Abstract. (not necessary)</abstract>
+      <abstract>Large language models (LLMs) have recently achieved human-level performance on a range of professional and academic benchmarks. Unfortunately, the explainability and accessibility of these models has lagged behind their performance. State-of-the-art LLMs require costly infrastructure, are only accessible via rate-limited, geo-locked, and censored web interfaces, and lack publicly available code and technical reports. Moreover, the lack of tooling for understanding the massive datasets used to train and produced by LLMs presents a critical challenge for explainability research. This talk will be an overview of Nomic AI’s efforts to address these challenges through its two core initiatives: GPT4All and Atlas</abstract>
       <url hash="5f8b67d2">2023.nlposs-1.28</url>
       <bibkey>duderstadt-anand-2023-towards</bibkey>
     </paper>

--- a/data/xml/2023.nlposs.xml
+++ b/data/xml/2023.nlposs.xml
@@ -274,15 +274,14 @@
     </paper>
     <paper id="25">
       <title>The Vault: A Comprehensive Multilingual Dataset for Advancing Code Understanding and Generation</title>
-      <author><first>Dung Nguyen</first><last>Manh</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Nam Le</first><last>Hai</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Anh T. V.</first><last>Dau</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Anh Minh</first><last>Nguyen</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Khanh</first><last>Nghiem</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Jin</first><last>Guo</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
-      <author><first>Nghi D. Q.</first><last>Bui</last><affiliation>Online University (can leave it as it will not shown)</affiliation></author>
+      <author><first>Dung Nguyen</first><last>Manh</last></author>
+      <author><first>Nam Le</first><last>Hai</last></author>
+      <author><first>Anh T. V.</first><last>Dau</last></author>
+      <author><first>Anh Minh</first><last>Nguyen</last></author>
+      <author><first>Khanh</first><last>Nghiem</last></author>
+      <author><first>Jin</first><last>Guo</last></author>
+      <author><first>Nghi D. Q.</first><last>Bui</last></author>
       <pages>219-244</pages>
-      <abstract>Abstract. (not necessary)</abstract>
       <url hash="ac0cae15">2023.nlposs-1.25</url>
       <bibkey>manh-etal-2023-vault</bibkey>
     </paper>
@@ -291,7 +290,6 @@
       <author><first>David</first><last>Ong</last><affiliation>AI Singapore</affiliation></author>
       <author><first>Peerat</first><last>Limkonchotiwat</last><affiliation>Vidyasirimedhi Institute of Science and Technology, Thailand</affiliation></author>
       <pages>245-245</pages>
-      <abstract>Abstract. (not necessary)</abstract>
       <url hash="632dc5a1">2023.nlposs-1.26</url>
       <bibkey>tjhi-etal-2023-sea</bibkey>
     </paper>
@@ -306,8 +304,7 @@
     <paper id="28">
       <title>Towards Explainable and Accessible <fixed-case>AI</fixed-case></title>
       <author><first>Brandon</first><last>Duderstadt</last><affiliation>Nomic AI</affiliation></author>
-      <author><first>Yuvanesh</first><last>Anand</last><affiliation>Virginia Institute of Technology &amp; Nomic 
-AI</affiliation></author>
+      <author><first>Yuvanesh</first><last>Anand</last><affiliation>Virginia Institute of Technology &amp; Nomic AI</affiliation></author>
       <pages>247-247</pages>
       <abstract>Large language models (LLMs) have recently achieved human-level performance on a range of professional and academic benchmarks. Unfortunately, the explainability and accessibility of these models has lagged behind their performance. State-of-the-art LLMs require costly infrastructure, are only accessible via rate-limited, geo-locked, and censored web interfaces, and lack publicly available code and technical reports. Moreover, the lack of tooling for understanding the massive datasets used to train and produced by LLMs presents a critical challenge for explainability research. This talk will be an overview of Nomic AI’s efforts to address these challenges through its two core initiatives: GPT4All and Atlas</abstract>
       <url hash="5f8b67d2">2023.nlposs-1.28</url>

--- a/data/xml/2023.nlposs.xml
+++ b/data/xml/2023.nlposs.xml
@@ -306,7 +306,8 @@
     <paper id="28">
       <title>Towards Explainable and Accessible <fixed-case>AI</fixed-case></title>
       <author><first>Brandon</first><last>Duderstadt</last><affiliation>Nomic AI</affiliation></author>
-      <author><first>Yuvanesh</first><last>Anand</last><affiliation>Virginia Institute of Technology & Nomic AI</affiliation></author>
+      <author><first>Yuvanesh</first><last>Anand</last><affiliation>Virginia Institute of Technology &amp; Nomic 
+AI</affiliation></author>
       <pages>247-247</pages>
       <abstract>Large language models (LLMs) have recently achieved human-level performance on a range of professional and academic benchmarks. Unfortunately, the explainability and accessibility of these models has lagged behind their performance. State-of-the-art LLMs require costly infrastructure, are only accessible via rate-limited, geo-locked, and censored web interfaces, and lack publicly available code and technical reports. Moreover, the lack of tooling for understanding the massive datasets used to train and produced by LLMs presents a critical challenge for explainability research. This talk will be an overview of Nomic AI’s efforts to address these challenges through its two core initiatives: GPT4All and Atlas</abstract>
       <url hash="5f8b67d2">2023.nlposs-1.28</url>


### PR DESCRIPTION
- Removed additional authors from https://aclanthology.org/2023.nlposs-1.26/ 
- Added abstracts to the invited talks.

