### PR TITLE
 Fix issue  #2920: Paper Metadata: 2023.findings-emnlp.512 

### DIFF
--- a/data/xml/2023.findings.xml
+++ b/data/xml/2023.findings.xml
@@ -20438,13 +20438,13 @@
       <bibkey>li-etal-2023-evaluating-dependencies</bibkey>
     </paper>
     <paper id="512">
-      <title>Effects of Human Adversarial and Affable Samples on <fixed-case>BERT</fixed-case> Generalizability</title>
+      <title>Effects of Human Adversarial and Affable Samples on <fixed-case>BERT</fixed-case> Generalization</title>
       <author><first>Aparna</first><last>Elangovan</last></author>
       <author><first>Estrid</first><last>He</last></author>
       <author><first>Yuan</first><last>Li</last></author>
       <author><first>Karin</first><last>Verspoor</last></author>
       <pages>7637-7649</pages>
-      <abstract>BERT-based models have had strong performance on leaderboards, yet have been demonstrably worse in real-world settings requiring generalization. Limited quantities of training data is considered a key impediment to achieving generalizability in machine learning. In this paper, we examine the impact of training data quality, not quantity, on a model’s generalizability. We consider two characteristics of training data: the portion of human-adversarial (h-adversarial) samples, i.e. sample pairs with seemingly minor differences but different ground-truth labels, and human-affable (h-affable) training samples, i.e. sample pairs with minor differences but the same ground-truth label. We find that for a fixed size of training samples, having 10-30% h-adversarial instances improves the precision, and therefore F_1, by up to 20 points in the tasks of text classification and relation extraction. Increasing h-adversarials beyond this range can result in performance plateaus or even degradation. In contrast, h-affables may not contribute to a model’s generalizability and may even degrade generalization performance.</abstract>
+      <abstract>BERT-based models have had strong performance on leaderboards, yet have been demonstrably worse in real-world settings requiring generalization. Limited quantities of training data is considered a key impediment to achieving generalizability in machine learning. In this paper, we examine the impact of training data quality, not quantity, on a model’s generalizability. We consider two characteristics of training data: the portion of human-adversarial (h-adversarial), i.e. sample pairs with seemingly minor differences but different ground-truth labels, and human-affable (h-affable) training samples, i.e. sample pairs with minor differences but the same ground-truth label. We find that for a fixed size of training samples, as a rule of thumb, having 10-30% h-adversarial instances improves the precision, and therefore F1, by up to 20 points in the tasks of text classification and relation extraction. Increasing h-adversarials beyond this range can result in performance plateaus or even degradation. In contrast, h-affables may not contribute to a model’s generalizability and may even degrade generalization performance.</abstract>
       <url hash="a1402183">2023.findings-emnlp.512</url>
       <bibkey>elangovan-etal-2023-effects</bibkey>
     </paper>


### PR DESCRIPTION
This is to fix the metadata associated with paper 2023.findings-emnlp.512, issue [https://github.com/acl-org/acl-anthology/issues/2920](https://github.com/acl-org/acl-anthology/issues/2920). 

The title was changed from: 

OLD: "Effects of Human Adversarial and Affable Samples on <fixed-case>BERT</fixed-case> Generalizability" 
NEW: "Effects of Human Adversarial and Affable Samples on <fixed-case>BERT</fixed-case> Generalization".

The abstract was also slightly changed to reflect the pdf.
