### PR TITLE
Use doi.org instead of dx.doi.org

### DIFF
--- a/bin/anthology/data.py
+++ b/bin/anthology/data.py
@@ -81,7 +81,7 @@ DONT_PARSE_ELEMENTS = (
 )
 
 # Constants associated with DOI assignation
-DOI_URL_PREFIX = "https://dx.doi.org/"
+DOI_URL_PREFIX = "https://doi.org/"
 DOI_PREFIX = "10.18653/v1/"
 
 # Default ingestion date (= unknown)

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -206,7 +206,7 @@
       <dt>URL:</dt>
       <dd><a href="{{ $paper.url }}">{{ $paper.url }}</a></dd>
       <dt>DOI:</dt>
-      <dd>{{ with $paper.doi }}<a href="http://dx.doi.org/{{ . }}" title="To the current version of the paper by DOI">{{ . }}</a>{{ end }}</dd>
+      <dd>{{ with $paper.doi }}<a href="https://doi.org/{{ . }}" title="To the current version of the paper by DOI">{{ . }}</a>{{ end }}</dd>
       {{ range $paper.award }}
       <dt>Award:</dt>
       <dd><i class="fas fa-award"></i>&nbsp;{{ . }}</dd>

--- a/hugo/layouts/volumes/single.html
+++ b/hugo/layouts/volumes/single.html
@@ -70,7 +70,7 @@
       <dt>URL:</dt>
       <dd><a href="{{ $paper.url }}">{{ $paper.url }}</a></dd>
       <dt>DOI:</dt>
-      <dd>{{ with $paper.doi }}<a href="http://dx.doi.org/{{ . }}" title="To the current version of the paper by DOI">{{ . }}</a>{{ end }}</dd>
+      <dd>{{ with $paper.doi }}<a href="https://doi.org/{{ . }}" title="To the current version of the paper by DOI">{{ . }}</a>{{ end }}</dd>
       <!--
       <dt>Bibtype:</dt>
       <dd>{{ with $paper.bibtype }}{{ . }}{{ end }}</dd>


### PR DESCRIPTION
Since 2017, DOI has changed their URL prefix from `http://dx.doi.org/` to `https://doi.org/`. This pull request updates the URLs in the ACL Anthology, making the links simpler, shorter, and more secure.

- https://www.doi.org/the-identifier/resources/factsheets/doi-resolution-documentation
- https://www.crossref.org/display-guidelines/