### PR TITLE
Update naming "Jan Wahle" -> "Jan Philip Wahle"

### DIFF
--- a/data/xml/2023.emnlp.xml
+++ b/data/xml/2023.emnlp.xml
@@ -9703,7 +9703,7 @@
     </paper>
     <paper id="746">
       <title>Paraphrase Types for Generation and Detection</title>
-      <author><first>Jan</first><last>Wahle</last></author>
+      <author><first>Jan Philip</first><last>Wahle</last></author>
       <author><first>Bela</first><last>Gipp</last></author>
       <author><first>Terry</first><last>Ruas</last></author>
       <pages>12148-12164</pages>
@@ -10317,7 +10317,7 @@
     </paper>
     <paper id="797">
       <title>We are Who We Cite: Bridges of Influence Between Natural Language Processing and Other Academic Fields</title>
-      <author><first>Jan</first><last>Wahle</last></author>
+      <author><first>Jan Philip</first><last>Wahle</last></author>
       <author><first>Terry</first><last>Ruas</last></author>
       <author><first>Mohamed</first><last>Abdalla</last></author>
       <author><first>Bela</first><last>Gipp</last></author>


### PR DESCRIPTION
This PR solves a naming error in EMNLP 2023 for my full name with a middle name (as opposed to just a first name). This way, the EMNLP 2023 articles will show in my [author profile](https://aclanthology.org/people/j/jan-philip-wahle/) instead of a [new author profile](https://aclanthology.org/people/j/jan-wahle/).  
