### PR TITLE
fix: author name for 2023.findings-emnlp.815

### DIFF
--- a/data/xml/2023.findings.xml
+++ b/data/xml/2023.findings.xml
@@ -24828,7 +24828,7 @@
     </paper>
     <paper id="815">
       <title>One For All &amp; All For One: Bypassing Hyperparameter Tuning with Model Averaging for Cross-Lingual Transfer</title>
-      <author><first>Fabian</first><last>Schmidt</last></author>
+      <author><first>Fabian David</first><last>Schmidt</last></author>
       <author><first>Ivan</first><last>Vulić</last></author>
       <author><first>Goran</first><last>Glavaš</last></author>
       <pages>12186-12193</pages>


### PR DESCRIPTION
Anthology id: 2023.findings-emnlp.815
Adds the second name for my short paper accepted to findings of EMNLP to remain consistent with my remaining papers on ACL-Anthology.