### PR TITLE
Fix metadata - add middle initial

### DIFF
--- a/data/xml/2023.emnlp.xml
+++ b/data/xml/2023.emnlp.xml
@@ -13039,7 +13039,7 @@
       <author><first>Zheng</first><last>Zhang</last></author>
       <author><first>Zheng</first><last>Ning</last></author>
       <author><first>Toby</first><last>Li</last></author>
-      <author><first>Jonathan</first><last>Kummerfeld</last></author>
+      <author><first>Jonathan K.</first><last>Kummerfeld</last></author>
       <author><first>Tianyi</first><last>Zhang</last></author>
       <pages>16149-16166</pages>
       <abstract>Relational databases play an important role in business, science, and more. However, many users cannot fully unleash the analytical power of relational databases, because they are not familiar with database languages such as SQL. Many techniques have been proposed to automatically generate SQL from natural language, but they suffer from two issues: (1) they still make many mistakes, particularly for complex queries, and (2) they do not provide a flexible way for non-expert users to validate and refine incorrect queries. To address these issues, we introduce a new interaction mechanism that allows users to directly edit a step-by-step explanation of a query to fix errors. Our experiments on multiple datasets, as well as a user study with 24 participants, demonstrate that our approach can achieve better performance than multiple SOTA approaches. Our code and datasets are available at https://github.com/magic-YuanTian/STEPS.</abstract>


### PR DESCRIPTION
This adds my middle initial to the metadata. Note that my middle initial does appear in the paper pdf:

https://aclanthology.org/2023.emnlp-main.1004.pdf
