### PR TITLE
fixed names for publication 953

### DIFF
--- a/data/xml/2023.emnlp.xml
+++ b/data/xml/2023.emnlp.xml
@@ -12404,11 +12404,11 @@
     </paper>
     <paper id="953">
       <title>Automatic Transcription of Handwritten Old <fixed-case>O</fixed-case>ccitan Language</title>
-      <author><first>Esteban</first><last>Arias</last></author>
+      <author><first>Esteban</first><last>Garces Arias</last></author>
       <author><first>Vallari</first><last>Pai</last></author>
       <author><first>Matthias</first><last>Schöffel</last></author>
       <author><first>Christian</first><last>Heumann</last></author>
-      <author><first>Matthias</first><last>Aenmacher</last></author>
+      <author><first>Matthias</first><last>Aßenmacher</last></author>
       <pages>15416-15439</pages>
       <abstract>While existing neural network-based approaches have shown promising results in Handwritten Text Recognition (HTR) for high-resource languages and standardized/machine-written text, their application to low-resource languages often presents challenges, resulting in reduced effectiveness. In this paper, we propose an innovative HTR approach that leverages the Transformer architecture for recognizing handwritten Old Occitan language. Given the limited availability of data, which comprises only word pairs of graphical variants and lemmas, we develop and rely on elaborate data augmentation techniques for both text and image data. Our model combines a custom-trained Swin image encoder with a BERT text decoder, which we pre-train using a large-scale augmented synthetic data set and fine-tune on the small human-labeled data set. Experimental results reveal that our approach surpasses the performance of current state-of-the-art models for Old Occitan HTR, including open-source Transformer-based models such as a fine-tuned TrOCR and commercial applications like Google Cloud Vision. To nurture further research and development, we make our models, data sets, and code publicly available.</abstract>
       <url hash="ead68866">2023.emnlp-main.953</url>


### PR DESCRIPTION
For Esteban the middle name "Garces" was missing, and for Matthias the last name was spelled wrong. We fixed this.