### PR TITLE
Fix tex-math to unicode serialization

### DIFF
--- a/bin/anthology/texmath.py
+++ b/bin/anthology/texmath.py
@@ -230,4 +230,4 @@ class TexMath:
         HTML tags afterwards.
         """
         element = self.to_html(element)
-        return etree.tostring(element, encoding="unicode", method="text")
+        return etree.tostring(element, encoding="unicode", method="text", with_tail=False)

--- a/tests/test_tex_math.py
+++ b/tests/test_tex_math.py
@@ -263,6 +263,8 @@ def test_unicode(inp, out):
     element = etree.fromstring(f"<span>{inp}</span>")
     math_element = element.find(".//tex-math")
     actual_out = texmath.to_unicode(math_element)
+    if math_element.tail:
+        actual_out += math_element.tail
     assert actual_out == out
 
 


### PR DESCRIPTION
When converting `<tex-math>` expressions to Unicode, the tail (= text after the closing tag) gets serialized twice.

Examples:
- https://aclanthology.org/2022.aacl-main.66/
- https://aclanthology.org/2022.findings-acl.24/
- https://aclanthology.org/2023.findings-emnlp.1054/ (closes #3004)

Note that the paper title heading on the page is correct, because that one uses the HTML conversion, whereas the duplication can be seen in the preformatted citation strings and also the HTML page title itself.

This bug must have existed ever since we introduced `<tex-math>` five years ago ...