### PR TITLE
Restore human readability and add header

### DIFF
--- a/bin/create_bibtex.py
+++ b/bin/create_bibtex.py
@@ -74,16 +74,14 @@ def create_bibtex(anthology, trgdir, limit=0, clean=False) -> None:
     ) as file_anthology, gzip.open(
         "{}/anthology+abstracts.bib.gz".format(trgdir), "wt", encoding="utf-8"
     ) as file_anthology_with_abstracts:
-        # Add a header to the consolidated bibfiles
+        # Add a header to each consolidated bibfile
         for outfh in file_anthology_raw, file_anthology, file_anthology_with_abstracts:
-            # get basename with extension
-            os.path.basename(outfh.name)
             print(
                 f"% https://aclanthology.org/{Path(outfh.name).name} generated on {datetime.date.today().isoformat()}\n",
                 file=outfh,
             )
 
-        # Add some shortcuts to the consolidated bib file
+        # Add some shortcuts to the uncompressed consolidated bib file
         print(
             "@string{acl = {Association for Computational Linguistics}}",
             file=file_anthology_raw,
@@ -116,9 +114,9 @@ def create_bibtex(anthology, trgdir, limit=0, clean=False) -> None:
                         print(concise_contents, file=file_volume)
                         print(concise_contents, file=file_anthology)
 
-                        # Space saver (https://github.com/acl-org/acl-anthology/issues/3016)
+                        # Space saver (https://github.com/acl-org/acl-anthology/issues/3016) for the
+                        # uncompressed consolidated bibfile.
                         # Replace verbose text with abbreviations to get the file under 50 MB for Overleaf
-
                         concise_contents = concise_contents.replace(
                             'publisher = "Association for Computational Linguistics",',
                             "publisher = acl,",
@@ -159,7 +157,7 @@ def create_bibtex(anthology, trgdir, limit=0, clean=False) -> None:
                                 concise_contents,
                             )
 
-                        # Remove newlines, indentations, and double-spaces around author separators
+                        # Convert spaces to tabs to save a bit of space
                         concise_contents = re.sub(r"\n    ", "\n\t", concise_contents)
 
                         print(concise_contents, file=file_anthology_raw)

--- a/bin/create_bibtex.py
+++ b/bin/create_bibtex.py
@@ -28,11 +28,14 @@ Options:
 """
 
 import re
-from docopt import docopt
-from tqdm import tqdm
 import gzip
 import logging as log
 import os
+import datetime
+
+from docopt import docopt
+from tqdm import tqdm
+from pathlib import Path
 
 from anthology import Anthology
 from anthology.utils import SeverityTracker, deconstruct_anthology_id, infer_year
@@ -71,6 +74,15 @@ def create_bibtex(anthology, trgdir, limit=0, clean=False) -> None:
     ) as file_anthology, gzip.open(
         "{}/anthology+abstracts.bib.gz".format(trgdir), "wt", encoding="utf-8"
     ) as file_anthology_with_abstracts:
+        # Add a header to the consolidated bibfiles
+        for outfh in file_anthology_raw, file_anthology, file_anthology_with_abstracts:
+            # get basename with extension
+            os.path.basename(outfh.name)
+            print(
+                f"% https://aclanthology.org/{Path(outfh.name).name} generated on {datetime.date.today().isoformat()}\n",
+                file=outfh,
+            )
+
         # Add some shortcuts to the consolidated bib file
         print(
             "@string{acl = {Association for Computational Linguistics}}",
@@ -148,7 +160,7 @@ def create_bibtex(anthology, trgdir, limit=0, clean=False) -> None:
                             )
 
                         # Remove newlines, indentations, and double-spaces around author separators
-                        concise_contents = re.sub(r"\s+", " ", concise_contents)
+                        concise_contents = re.sub(r"\n    ", "\n\t", concise_contents)
 
                         print(concise_contents, file=file_anthology_raw)
 


### PR DESCRIPTION
This restores human readability to the anthology.bib file while keeping the file size under 50 MB (#3016). It also adds a comment containing the bib file URL and the date it was generated.