### PR TITLE
Metadata correction for author name: Ekaterina Artemova

### DIFF
--- a/data/xml/2022.inlg.xml
+++ b/data/xml/2022.inlg.xml
@@ -33,7 +33,7 @@
       <title>Template-based Approach to Zero-shot Intent Recognition</title>
       <author><first>Dmitry</first><last>Lamanov</last></author>
       <author><first>Pavel</first><last>Burnyshev</last></author>
-      <author><first>Katya</first><last>Artemova</last></author>
+      <author><first>Ekaterina</first><last>Artemova</last></author>
       <author><first>Valentin</first><last>Malykh</last></author>
       <author><first>Andrey</first><last>Bout</last></author>
       <author><first>Irina</first><last>Piontkovskaya</last></author>

--- a/data/xml/2022.semeval.xml
+++ b/data/xml/2022.semeval.xml
@@ -2822,7 +2822,7 @@
       <author><first>Amina</first><last>Miftahova</last></author>
       <author><first>Alexander</first><last>Pugachev</last></author>
       <author><first>Artem</first><last>Skiba</last></author>
-      <author><first>Katya</first><last>Artemova</last></author>
+      <author><first>Ekaterina</first><last>Artemova</last></author>
       <author><first>Tatiana</first><last>Batura</last></author>
       <author><first>Pavel</first><last>Braslavski</last></author>
       <author><first>Vladimir</first><last>Ivanov</last></author>

--- a/data/xml/2023.nodalida.xml
+++ b/data/xml/2023.nodalida.xml
@@ -430,7 +430,7 @@
     </paper>
     <paper id="39">
       <title>Low-resource Bilingual Dialect Lexicon Induction with Large Language Models</title>
-      <author><first>Katya</first><last>Artemova</last><affiliation>Ludwig-Maximilians-Universität München</affiliation></author>
+      <author><first>Ekaterina</first><last>Artemova</last><affiliation>Ludwig-Maximilians-Universität München</affiliation></author>
       <author><first>Barbara</first><last>Plank</last><affiliation>Ludwig-Maximilians-Universität München and IT University of Copenhagen</affiliation></author>
       <pages>371-385</pages>
       <abstract>Bilingual word lexicons map words in one language to their synonyms in another language. Numerous papers have explored bilingual lexicon induction (BLI) in high-resource scenarios, framing a typical pipeline that consists of two steps: (i) unsupervised bitext mining and (ii) unsupervised word alignment. At the core of those steps are pre-trained large language models (LLMs).In this paper we present the analysis of the BLI pipeline for German and two of its dialects, Bavarian and Alemannic. This setup poses a number of unique challenges, attributed to the scarceness of resources, relatedness of the languages and lack of standardization in the orthography of dialects. We analyze the BLI outputs with respect to word frequency and the pairwise edit distance. Finally, we release an evaluation dataset consisting of manual annotations for 1K bilingual word pairs labeled according to their semantic similarity.</abstract>


### PR DESCRIPTION
### Confirm that this is a metadata correction
* [x]  I want to file corrections to make the metadata match the PDF file hosted on the ACL Anthology.

### Anthology ID
 - 2023.nodalida.xml
 - 2022.semeval.xml
 - 2022.inlg.xml

### Type of Paper Metadata Correction
* [ ]  Paper Title
* [ ]  Paper Abstract
* [x]  Author Name(s)

### Correction to Paper Title
_No response_

### Correction to Paper Abstract
_No response_

### Correction to Author Name(s)
Katya Artemova to Ekaterina Artemova 

I request the merging of two profiles in ACL Anthology, both associated with Ekaterina Artemova. While her papers in the PDF files are under Ekaterina Artemova, those submitted via OpenReview were published under the nickname Katya, leading to a separate profile.


