### PR TITLE
Reverted change to FinNLP

### DIFF
--- a/data/xml/2023.finnlp.xml
+++ b/data/xml/2023.finnlp.xml
@@ -1,145 +1,207 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <collection id="2023.finnlp">
-  <volume id="1" ingest-date="2024-01-18" type="proceedings">
+  <volume id="1" ingest-date="2023-09-04" type="proceedings">
     <meta>
-      <booktitle>Proceedings of the ART of Safety: Workshop on Adversarial testing and Red-Teaming for generative AI</booktitle>
-      <publisher>Association for Computational Linguistics</publisher>
-      <address>Bali, Indonesia</address>
-      <month>November</month>
+      <booktitle>Proceedings of the Fifth Workshop on Financial Technology and Natural Language Processing and the Second Multimodal AI For Financial Forecasting</booktitle>
+      <editor><first>Chung-Chi</first><last>Chen</last></editor>
+      <editor><first>Hiroya</first><last>Takamura</last></editor>
+      <editor><first>Puneet</first><last>Mathur</last></editor>
+      <editor><first>Remit</first><last>Sawhney</last></editor>
+      <editor><first>Hen-Hsen</first><last>Huang</last></editor>
+      <editor><first>Hsin-Hsi</first><last>Chen</last></editor>
+      <publisher>-</publisher>
+      <address>Macao</address>
+      <month>20 August</month>
       <year>2023</year>
+      <url hash="ec235596">2023.finnlp-1</url>
       <venue>finnlp</venue>
+      <venue>ws</venue>
     </meta>
     <frontmatter>
-      <url hash="817e94f6">2023.finnlp-1.0</url>
-      <bibkey>finnlp-2023-art</bibkey>
+      <url hash="85ab0e1b">2023.finnlp-1.0</url>
+      <bibkey>finnlp-2023-financial</bibkey>
     </frontmatter>
     <paper id="1">
-      <title>Red Teaming for Large Language Models At Scale: Tackling Hallucinations on Mathematics Tasks</title>
-      <author><first>Aleksander</first><last>Buszydlik</last></author>
-      <author><first>Karol</first><last>Dobiczek</last></author>
-      <author><first>Michał Teodor</first><last>Okoń</last></author>
-      <author><first>Konrad</first><last>Skublicki</last></author>
-      <author><first>Philip</first><last>Lippmann</last></author>
-      <author><first>Jie</first><last>Yang</last></author>
-      <pages>1–10</pages>
-      <url hash="00ee6f7b">2023.finnlp-1.1</url>
-      <bibkey>buszydlik-etal-2023-red-teaming</bibkey>
+      <title>Model-Agnostic Meta-Learning for Natural Language Understanding Tasks in Finance</title>
+      <author><first>Bixing</first><last>Yan</last></author>
+      <author><first>Shaoling</first><last>Chen</last></author>
+      <author><first>Yuxuan</first><last>He</last></author>
+      <author><first>Zhihan</first><last>Li</last></author>
+      <pages>1–12</pages>
+      <url hash="7e7e40ba">2023.finnlp-1.1</url>
+      <bibkey>yan-etal-2023-model</bibkey>
     </paper>
     <paper id="2">
-      <title>Student-Teacher Prompting for Red Teaming to Improve Guardrails</title>
-      <author><first>Rodrigo</first><last>Revilla Llaca</last></author>
-      <author><first>Victoria</first><last>Leskoschek</last></author>
-      <author><first>Vitor</first><last>Costa Paiva</last></author>
-      <author><first>Cătălin</first><last>Lupău</last></author>
-      <author><first>Philip</first><last>Lippmann</last></author>
-      <author><first>Jie</first><last>Yang</last></author>
-      <pages>11–23</pages>
-      <url hash="0f072087">2023.finnlp-1.2</url>
-      <bibkey>revilla-llaca-etal-2023-student-teacher</bibkey>
+      <title><fixed-case>C</fixed-case>hat<fixed-case>GPT</fixed-case> as Data Augmentation for Compositional Generalization: A Case Study in Open Intent Detection</title>
+      <author><first>Yihao</first><last>Fang</last></author>
+      <author><first>Xianzhi</first><last>Li</last></author>
+      <author><first>Stephen</first><last>Thomas</last></author>
+      <author><first>Xiaodan</first><last>Zhu</last></author>
+      <pages>13–33</pages>
+      <url hash="affe7a9d">2023.finnlp-1.2</url>
+      <bibkey>fang-etal-2023-chatgpt</bibkey>
     </paper>
     <paper id="3">
-      <title>Distilling Adversarial Prompts from Safety Benchmarks: Report for the Adversarial Nibbler Challenge</title>
-      <author><first>Manuel</first><last>Brack</last></author>
-      <author><first>Patrick</first><last>Schramowski</last></author>
-      <author><first>Kristian</first><last>Kersting</last></author>
-      <pages>24–28</pages>
-      <url hash="6c2cbed4">2023.finnlp-1.3</url>
-      <bibkey>brack-etal-2023-distilling-adversarial</bibkey>
+      <title>Beyond Classification: Financial Reasoning in State-of-the-Art Language Models</title>
+      <author><first>Guijin</first><last>Son</last></author>
+      <author><first>Hanearl</first><last>Jung</last></author>
+      <author><first>Moonjeong</first><last>Hahm</last></author>
+      <author><first>Keonju</first><last>Na</last></author>
+      <author><first>Sol</first><last>Jin</last></author>
+      <pages>34–44</pages>
+      <url hash="bd3b1301">2023.finnlp-1.3</url>
+      <bibkey>son-etal-2023-beyond</bibkey>
     </paper>
     <paper id="4">
-      <title>Audit Report Coverage Assessment using Sentence Classification</title>
-      <author><first>Sushodhan</first><last>Vaishampayan</last></author>
-      <author><first>Nitin</first><last>Ramrakhiyani</last></author>
-      <author><first>Sachin</first><last>Pawar</last></author>
-      <author><first>Aditi</first><last>Pawde</last></author>
-      <author><first>Manoj</first><last>Apte</last></author>
-      <author><first>Girish</first><last>Palshikar</last></author>
-      <pages>31–41</pages>
-      <url hash="ee238be2">2023.finnlp-1.4</url>
-      <bibkey>vaishampayan-etal-2023-audit</bibkey>
+      <title>Textual Evidence Extraction for <fixed-case>ESG</fixed-case> Scores</title>
+      <author><first>Naoki</first><last>Kannan</last></author>
+      <author><first>Yohei</first><last>Seki</last></author>
+      <pages>45–54</pages>
+      <url hash="892bbe05">2023.finnlp-1.4</url>
+      <bibkey>kannan-seki-2023-textual</bibkey>
     </paper>
     <paper id="5">
-      <title><fixed-case>GPT</fixed-case>-<fixed-case>F</fixed-case>in<fixed-case>RE</fixed-case>: In-context Learning for Financial Relation Extraction using Large Language Models</title>
-      <author><first>Pawan</first><last>Rajpoot</last></author>
-      <author><first>Ankur</first><last>Parikh</last></author>
-      <pages>42–45</pages>
-      <url hash="dfec2792">2023.finnlp-1.5</url>
-      <bibkey>rajpoot-parikh-2023-gpt</bibkey>
+      <title>A Scalable and Adaptive System to Infer the Industry Sectors of Companies: Prompt + Model Tuning of Generative Language Models</title>
+      <author><first>Lele</first><last>Cao</last></author>
+      <author><first>Vilhelm</first><last>von Ehrenheim</last></author>
+      <author><first>Astrid</first><last>Berghult</last></author>
+      <author><first>Cecilia</first><last>Henje</last></author>
+      <author><first>Richard Anselmo</first><last>Stahl</last></author>
+      <author><first>Joar</first><last>Wandborg</last></author>
+      <author><first>Sebastian</first><last>Stan</last></author>
+      <author><first>Armin</first><last>Catovic</last></author>
+      <author><first>Erik</first><last>Ferm</last></author>
+      <author><first>Hannes</first><last>Ingelhag</last></author>
+      <pages>55–62</pages>
+      <url hash="b571538d">2023.finnlp-1.5</url>
+      <bibkey>cao-etal-2023-scalable</bibkey>
     </paper>
     <paper id="6">
-      <title>Multi-Lingual <fixed-case>ESG</fixed-case> Impact Type Identification</title>
+      <title>Using Deep Learning to Find the Next Unicorn: A Practical Synthesis on Optimization Target, Feature Selection, Data Split and Evaluation Strategy</title>
+      <author><first>Lele</first><last>Cao</last></author>
+      <author><first>Vilhelm</first><last>von Ehrenheim</last></author>
+      <author><first>Sebastian</first><last>Stan</last></author>
+      <author><first>Xiaoxue</first><last>Li</last></author>
+      <author><first>Alexandra</first><last>Lutz</last></author>
+      <pages>63–73</pages>
+      <url hash="e47e20ef">2023.finnlp-1.6</url>
+      <bibkey>loukas-etal-2023-using</bibkey>
+    </paper>
+    <paper id="7">
+      <title>Breaking the Bank with <fixed-case>C</fixed-case>hat<fixed-case>GPT</fixed-case>: Few-Shot Text Classification for Finance</title>
+      <author><first>Lefteris</first><last>Loukas</last></author>
+      <author><first>Ilias</first><last>Stogiannidis</last></author>
+      <author><first>Prodromos</first><last>Malakasiotis</last></author>
+      <author><first>Stavros</first><last>Vassos</last></author>
+      <pages>74–80</pages>
+      <url hash="52094c5a">2023.finnlp-1.7</url>
+      <bibkey>liang-etal-2023-breaking</bibkey>
+    </paper>
+    <paper id="8">
+      <title><fixed-case>D</fixed-case>e<fixed-case>R</fixed-case>isk: An Effective Deep Learning Framework for Credit Risk Prediction over Real-World Financial Data</title>
+      <author><first>Yancheng</first><last>Liang</last></author>
+      <author><first>Jiajie</first><last>Zhang</last></author>
+      <author><first>Hui</first><last>Li</last></author>
+      <author><first>Xiaochen</first><last>Liu</last></author>
+      <author><first>Yi</first><last>Hu</last></author>
+      <author><first>Yong</first><last>Wu</last></author>
+      <author><first>Jiaoyao</first><last>Zhang</last></author>
+      <author><first>Yongyan</first><last>Liu</last></author>
+      <author><first>Yi</first><last>Wu</last></author>
+      <pages>81–93</pages>
+      <url hash="4885bf3d">2023.finnlp-1.8</url>
+      <bibkey>lambruschini-etal-2023-derisk</bibkey>
+    </paper>
+    <paper id="9">
+      <title>Reducing tokenizer’s tokens per word ratio in Financial domain with <fixed-case>T</fixed-case>-<fixed-case>M</fixed-case>u<fixed-case>F</fixed-case>in <fixed-case>BERT</fixed-case> Tokenizer</title>
+      <author><first>Braulio Blanco</first><last>Lambruschini</last></author>
+      <author><first>Patricia</first><last>Becerra-Sanchez</last></author>
+      <author><first>Mats</first><last>Brorsson</last></author>
+      <author><first>Maciej</first><last>Zurad</last></author>
+      <pages>94–103</pages>
+      <url hash="4a89bfbf">2023.finnlp-1.9</url>
+      <bibkey>gopalakrishnan-etal-2023-reducing</bibkey>
+    </paper>
+    <paper id="10">
+      <title><fixed-case>L</fixed-case>o<fixed-case>KI</fixed-case>:Money Laundering Report Generation via Logical Table-to-Text using Meta Learning</title>
+      <author><first>Harika</first><last>Cm</last></author>
+      <author><first>Debasmita</first><last>Das</last></author>
+      <author><first>Ram Ganesh</first><last>V</last></author>
+      <author><first>Rajesh Kumar</first><last>Ranjan</last></author>
+      <author><first>Siddhartha</first><last>Asthana</last></author>
+      <pages>104–110</pages>
+      <url hash="fb740e73">2023.finnlp-1.10</url>
+      <bibkey>cm-etal-2023-loki</bibkey>
+    </paper>
+    <paper id="11">
+      <title>Multi-Lingual <fixed-case>ESG</fixed-case> Issue Identification</title>
       <author><first>Chung-Chi</first><last>Chen</last></author>
       <author><first>Yu-Min</first><last>Tseng</last></author>
       <author><first>Juyeon</first><last>Kang</last></author>
       <author><first>Anaïs</first><last>Lhuissier</last></author>
-      <author><first>Yohei</first><last>Seki</last></author>
       <author><first>Min-Yuh</first><last>Day</last></author>
       <author><first>Teng-Tsai</first><last>Tu</last></author>
       <author><first>Hsin-Hsi</first><last>Chen</last></author>
-      <pages>46–50</pages>
-      <url hash="ee7d37fa">2023.finnlp-1.6</url>
+      <pages>111–115</pages>
+      <url hash="198cbdc5">2023.finnlp-1.11</url>
       <bibkey>chen-etal-2023-multi-lingual</bibkey>
     </paper>
-    <paper id="7">
-      <title>Identifying <fixed-case>ESG</fixed-case> Impact with Key Information</title>
-      <author><first>Le</first><last>Qiu</last></author>
-      <author><first>Bo</first><last>Peng</last></author>
-      <author><first>Jinghang</first><last>Gu</last></author>
-      <author><first>Yu-Yin</first><last>Hsu</last></author>
-      <author><first>Emmanuele</first><last>Chersoni</last></author>
-      <pages>51–56</pages>
-      <url hash="82505bd2">2023.finnlp-1.7</url>
-      <bibkey>qiu-etal-2023-identifying</bibkey>
-    </paper>
-    <paper id="8">
-      <title>A low resource framework for Multi-lingual <fixed-case>ESG</fixed-case> Impact Type Identification</title>
-      <author><first>Harsha</first><last>Vardhan</last></author>
-      <author><first>Sohom</first><last>Ghosh</last></author>
-      <author><first>Ponnurangam</first><last>Kumaraguru</last></author>
-      <author><first>Sudip</first><last>Naskar</last></author>
-      <pages>57–61</pages>
-      <url hash="b6a68497">2023.finnlp-1.8</url>
-      <bibkey>vardhan-etal-2023-low</bibkey>
-    </paper>
-    <paper id="9">
-      <title><fixed-case>GPT</fixed-case>-based Solution for <fixed-case>ESG</fixed-case> Impact Type Identification</title>
-      <author><first>Anna</first><last>Polyanskaya</last></author>
-      <author><first>Lucas Fernández</first><last>Brillet</last></author>
-      <pages>62–65</pages>
-      <url hash="dce664e2">2023.finnlp-1.9</url>
-      <bibkey>polyanskaya-brillet-2023-gpt</bibkey>
-    </paper>
-    <paper id="10">
-      <title>The Risk and Opportunity of Data Augmentation and Translation for <fixed-case>ESG</fixed-case> News Impact Identification with Language Models</title>
-      <author><first>Yosef Ardhito</first><last>Winatmoko</last></author>
-      <author><first>Ali</first><last>Septiandri</last></author>
-      <pages>66–71</pages>
-      <url hash="a55e183c">2023.finnlp-1.10</url>
-      <bibkey>winatmoko-septiandri-2023-risk</bibkey>
-    </paper>
-    <paper id="11">
-      <title><fixed-case>ESG</fixed-case> Impact Type Classification: Leveraging Strategic Prompt Engineering and <fixed-case>LLM</fixed-case> Fine-Tuning</title>
-      <author><first>Soumya</first><last>Mishra</last></author>
-      <pages>72–78</pages>
-      <url hash="62ca74af">2023.finnlp-1.11</url>
-      <bibkey>mishra-2023-esg</bibkey>
-    </paper>
     <paper id="12">
-      <title>Exploring Knowledge Composition for <fixed-case>ESG</fixed-case> Impact Type Determination</title>
-      <author><first>Fabian</first><last>Billert</last></author>
-      <author><first>Stefan</first><last>Conrad</last></author>
-      <pages>79–83</pages>
-      <url hash="e91b8fb2">2023.finnlp-1.12</url>
-      <bibkey>billert-conrad-2023-exploring</bibkey>
+      <title>Leveraging Contrastive Learning with <fixed-case>BERT</fixed-case> for <fixed-case>ESG</fixed-case> Issue Identification</title>
+      <author><first>Weiwei</first><last>Wang</last></author>
+      <author><first>Wenyang</first><last>Wei</last></author>
+      <author><first>Qingyuan</first><last>Song</last></author>
+      <author><first>Yansong</first><last>Wang</last></author>
+      <pages>116–120</pages>
+      <url hash="9063a775">2023.finnlp-1.12</url>
+      <bibkey>wang-etal-2023-leveraging</bibkey>
     </paper>
     <paper id="13">
-      <title>Enhancing <fixed-case>ESG</fixed-case> Impact Type Identification through Early Fusion and Multilingual Models</title>
-      <author><first>Hariram</first><last>Veeramani</last></author>
-      <author><first>Surendrabikram</first><last>Thapa</last></author>
-      <author><first>Usman</first><last>Naseem</last></author>
-      <pages>84–90</pages>
-      <url hash="b3004d60">2023.finnlp-1.13</url>
-      <bibkey>veeramani-etal-2023-enhancing</bibkey>
+      <title>Leveraging <fixed-case>BERT</fixed-case> Language Models for Multi-Lingual <fixed-case>ESG</fixed-case> Issue Identification</title>
+      <author><first>Elvys Linhares</first><last>Pontes</last></author>
+      <author><first>Mohamed</first><last>Benjannet</last></author>
+      <author><first>Lam Kim</first><last>Ming</last></author>
+      <pages>121–126</pages>
+      <url hash="58e0bb35">2023.finnlp-1.13</url>
+      <bibkey>pontes-etal-2023-leveraging</bibkey>
+    </paper>
+    <paper id="14">
+      <title><fixed-case>E</fixed-case>a<fixed-case>S</fixed-case>y<fixed-case>G</fixed-case>uide : <fixed-case>ESG</fixed-case> Issue Identification Framework leveraging Abilities of Generative Large Language Models</title>
+      <author><first>Hanwool</first><last>Lee</last></author>
+      <author><first>Jonghyun</first><last>Choi</last></author>
+      <author><first>Sohyeon</first><last>Kwon</last></author>
+      <author><first>Sungbum</first><last>Jung</last></author>
+      <pages>127–132</pages>
+      <url hash="62b6a728">2023.finnlp-1.14</url>
+      <bibkey>lee-etal-2023-easyguide</bibkey>
+    </paper>
+    <paper id="15">
+      <title>Jetsons at the <fixed-case>F</fixed-case>in<fixed-case>NLP</fixed-case>-2023: Using Synthetic Data and Transfer Learning for Multilingual <fixed-case>ESG</fixed-case> Issue Classification</title>
+      <author><first>Parker</first><last>Glenn</last></author>
+      <author><first>Alolika</first><last>Gon</last></author>
+      <author><first>Nikhil</first><last>Kohli</last></author>
+      <author><first>Sihan</first><last>Zha</last></author>
+      <author><first>Parag Pravin</first><last>Dakle</last></author>
+      <author><first>Preethi</first><last>Raghavan</last></author>
+      <pages>133–139</pages>
+      <url hash="26917b58">2023.finnlp-1.15</url>
+      <bibkey>glenn-etal-2023-jetsons</bibkey>
+    </paper>
+    <paper id="16">
+      <title><fixed-case>HKESG</fixed-case> at the <fixed-case>ML</fixed-case>-<fixed-case>ESG</fixed-case> Task: Exploring Transformer Representations for Multilingual <fixed-case>ESG</fixed-case> Issue Identification</title>
+      <author><first>Ivan</first><last>Mashkin</last></author>
+      <author><first>Emmanuele</first><last>Chersoni</last></author>
+      <pages>140–145</pages>
+      <url hash="595f9fbe">2023.finnlp-1.16</url>
+      <bibkey>mashkin-chersoni-2023-hkesg</bibkey>
+    </paper>
+    <paper id="17">
+      <title>Team <fixed-case>HHU</fixed-case> at the <fixed-case>F</fixed-case>in<fixed-case>NLP</fixed-case>-2023 <fixed-case>ML</fixed-case>-<fixed-case>ESG</fixed-case> Task: A Multi-Model Approach to <fixed-case>ESG</fixed-case>-Key-Issue Classification</title>
+      <author><first>Fabian</first><last>Billert</last></author>
+      <author><first>Stefan</first><last>Conrad</last></author>
+      <pages>146–150</pages>
+      <url hash="b2688ba5">2023.finnlp-1.17</url>
+      <bibkey>billert-conrad-2023-team</bibkey>
     </paper>
   </volume>
 </collection>

--- a/data/xml/2023.ijcnlp.xml
+++ b/data/xml/2023.ijcnlp.xml
@@ -1385,7 +1385,6 @@
       <volume-id>2023.sealp-1</volume-id>
       <volume-id>2023.socialnlp-1</volume-id>
       <volume-id>2023.artofsafety-1</volume-id>
-      <volume-id>2023.finnlp-1</volume-id>
       <volume-id>2023.nlint-1</volume-id>
       <volume-id>2023.nlpmc-1</volume-id>
       <volume-id>2023.wiesp-1</volume-id>


### PR DESCRIPTION
FinNLP was accidentally overwritten with another workshop. This reverts that.

It appears that FinNLP might have had two meetings in 2023.