### PR TITLE
Update 2023.eval4nlp.xml, correct author names

### DIFF
--- a/data/xml/2023.eval4nlp.xml
+++ b/data/xml/2023.eval4nlp.xml
@@ -3,7 +3,13 @@
   <volume id="1" ingest-date="2024-02-28" type="proceedings">
     <meta>
       <booktitle>Proceedings of the 4th Workshop on Evaluation and Comparison of NLP Systems</booktitle>
-      <editor><first>John</first><last>Walker</last></editor>
+      <editor><first>Daniel</first><last>Deutsch</last></editor>
+      <editor><first>Rotem</first><last>Dror</last></editor>
+      <editor><first>Steffen</first><last>Eger</last></editor>
+      <editor><first>Yang</first><last>Gao</last></editor>
+      <editor><first>Christoph</first><last>Leiter</last></editor>
+      <editor><first>Juri</first><last>Opitz</last></editor>
+      <editor><first>Andreas</first><last>Rücklé</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Bali, Indonesia</address>
       <month>November</month>


### PR DESCRIPTION
There's a hallucinated author name in Eval4NLP 2023 xml. This PR corrects the author names