### PR TITLE
fixed 2023.emnlp-main.552 title in metadata

### DIFF
--- a/data/xml/2023.emnlp.xml
+++ b/data/xml/2023.emnlp.xml
@@ -7717,7 +7717,7 @@
       <video href="2023.emnlp-main.551.mp4"/>
     </paper>
     <paper id="552">
-      <title>Exploring Linguistic Probes for Morphological Inflection</title>
+      <title>Exploring Linguistic Probes for Morphological Generalization</title>
       <author><first>Jordan</first><last>Kodner</last></author>
       <author><first>Salam</first><last>Khalifa</last></author>
       <author><first>Sarah Ruth Brogden</first><last>Payne</last></author>


### PR DESCRIPTION
Paper: 2023.emnlp-main.552 had the wrong title in the metadata, so it was showing a different title on the aclanthology page than the actual paper title. This is only a metadata issue, so no pdf needs to be uploaded.
