### PR TITLE
Don't overwrite canonical names that are explicitly defined in variants list

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Bugfix: Converting a `<texmath>` expression to Unicode no longer serializes the tail of the XML tag, but only the TeX math expression itself.
+- Bugfix: Heuristic scoring of name variants will no longer overwrite canonical names that are explicitly defined in `name_variants.yaml`.
 
 ## [0.4.3] — 2023-11-05
 

--- a/python/acl_anthology/people/index.py
+++ b/python/acl_anthology/people/index.py
@@ -250,7 +250,9 @@ class PersonIndex(SlottedDict[Person]):
                 person = self.data[pid]
                 # If the name scores higher than the current canonical one, we
                 # also assume we should set this as the canonical one
-                if name.score() > person.canonical_name.score():
+                if (not person.is_explicit) and (
+                    name.score() > person.canonical_name.score()
+                ):
                     person.set_canonical_name(name)
                 else:
                     person.add_name(name)
@@ -316,6 +318,7 @@ class PersonIndex(SlottedDict[Person]):
                 parent=self.parent,
                 names=names,
                 comment=entry.get("comment", None),
+                is_explicit=True,
             )
             # ...and add it to the index
             self.add_person(person)

--- a/python/acl_anthology/people/person.py
+++ b/python/acl_anthology/people/person.py
@@ -34,6 +34,8 @@ class Person:
         names: A list of names under which this person has published.
         item_ids: A set of volume and/or paper IDs this person has authored or edited.
         comment: A comment for disambiguation purposes; can be stored in `name_variants.yaml`.
+        is_explicit: True if this person is explicitly defined in the metadata
+            (i.e. `name_variants.yaml`), rather than implicitly created.
     """
 
     id: str
@@ -43,6 +45,7 @@ class Person:
         factory=set, repr=lambda x: f"<set of {len(x)} AnthologyIDTuple objects>"
     )
     comment: Optional[str] = field(default=None)
+    is_explicit: Optional[bool] = field(default=False)
 
     @property
     def canonical_name(self) -> Name:

--- a/python/tests/people/personindex_test.py
+++ b/python/tests/people/personindex_test.py
@@ -128,8 +128,9 @@ def test_get_or_create_person_with_explicit_canonical_name(index):
     ns1 = NameSpecification(Name("Emily", "Prud’hommeaux"))
     # This one is not, but scores higher according to our heuristics
     ns2 = NameSpecification(Name("Emily", "Prud’Hommeaux"))
-    assert ns2.name.score() > ns1.name.score(), \
-        "This test assumes that `ns2` will score higher than `ns1`."
+    assert (
+        ns2.name.score() > ns1.name.score()
+    ), "This test assumes that `ns2` will score higher than `ns1`."
     person1 = index.get_or_create_person(ns1)
     person2 = index.get_or_create_person(ns2)
     assert person1 is person2

--- a/python/tests/people/personindex_test.py
+++ b/python/tests/people/personindex_test.py
@@ -122,6 +122,23 @@ def test_get_or_create_person_with_name_merging(index):
     assert person2.canonical_name == ns2.name
 
 
+def test_get_or_create_person_with_explicit_canonical_name(index):
+    index._load_variant_list()
+    # This name is defined as canonical in the variants list
+    ns1 = NameSpecification(Name("Emily", "Prud’hommeaux"))
+    # This one is not, but scores higher according to our heuristics
+    ns2 = NameSpecification(Name("Emily", "Prud’Hommeaux"))
+    assert ns2.name.score() > ns1.name.score(), \
+        "This test assumes that `ns2` will score higher than `ns1`."
+    person1 = index.get_or_create_person(ns1)
+    person2 = index.get_or_create_person(ns2)
+    assert person1 is person2
+    assert person2.has_name(ns1.name)
+    assert person2.has_name(ns2.name)
+    # Canonical name should still be the one defined in variants list
+    assert person2.canonical_name == ns1.name
+
+
 def test_similar_names_defined_in_variant_list(index):
     index._load_variant_list()
     similar = index.similar.subset("pranav-a")

--- a/python/tests/toy_anthology/yaml/name_variants.yaml
+++ b/python/tests/toy_anthology/yaml/name_variants.yaml
@@ -27,3 +27,7 @@
   variants:
   - {first: Susan, last: Warwick-Armstrong}
   - {first: Susan, last: Warwick}
+- canonical: {first: Emily, last: Prud’hommeaux}
+  variants:
+  - {first: Emily T., last: Prud’hommeaux}
+  - {first: Emily, last: Prud'hommeaux}


### PR DESCRIPTION
Fixes a bug that could see canonical names defined in `name_variants.yaml` being overwritten by other name variants that scored higher according to our heuristics, and adds a test for it.