### PR TITLE
Author name correction in 2022.findings-emnlp.391

### DIFF
--- a/data/xml/2022.findings.xml
+++ b/data/xml/2022.findings.xml
@@ -14367,7 +14367,7 @@ Faster and Smaller Speech Translation without Quality Compromise</title>
       <author><first>Hyundong</first><last>Cho</last></author>
       <author><first>Chinnadhurai</first><last>Sankar</last></author>
       <author><first>Christopher</first><last>Lin</last></author>
-      <author><first>Kaushik</first><last>Sadagopan</last></author>
+      <author><first>Kaushik Ram</first><last>Sadagopan</last></author>
       <author><first>Shahin</first><last>Shayandeh</last></author>
       <author><first>Asli</first><last>Celikyilmaz</last></author>
       <author><first>Jonathan</first><last>May</last></author>


### PR DESCRIPTION
This is the actual paper: https://aclanthology.org/2022.findings-emnlp.391.pdf

You can see that the name "Kaushik Ram Sadagopan" in the pdf is not reflected correctly.
