### PR TITLE
Update 2024.sigtyp.xml: Correcting author name as requested by author

### DIFF
--- a/data/xml/2024.sigtyp.xml
+++ b/data/xml/2024.sigtyp.xml
@@ -50,7 +50,7 @@
     </paper>
     <paper id="3">
       <title>A New Dataset for Tonal and Segmental Dialectometry from the <fixed-case>Y</fixed-case>ue- and Pinghua-Speaking Area</title>
-      <author><first>Ho</first><last>Sung</last><affiliation>Leiden University</affiliation></author>
+      <author><first>Ho Wang Matthew</first><last>Sung</last><affiliation>Leiden University</affiliation></author>
       <author><first>Jelena</first><last>Prokic</last><affiliation>Universiteit Leiden</affiliation></author>
       <author><first>Yiya</first><last>Chen</last><affiliation>Leiden University</affiliation></author>
       <pages>25-36</pages>


### PR DESCRIPTION
Correcting the first name of author Ho Wang Matthew Sung. The author emailed us to report that "Ho Wang Matthew" is the correct first name. The XML had incorrectly truncated to "Ho" at export from OpenReview.
