### PR TITLE
Fix retracted display for papers whose titles start with an lxml child

### DIFF
--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -183,11 +183,8 @@ class Paper:
         if (
             "retracted" in paper.attrib
             and "xml_title" in paper.attrib
-            and paper.attrib["xml_title"].text is not None
         ):
-            paper.attrib["xml_title"].text = (
-                "[RETRACTED] " + paper.attrib["xml_title"].text
-            )
+            paper.add_prefix_to_title("[RETRACTED] ")
 
         if "removed" in paper.attrib and paper.attrib["removed"] is None:
             paper.attrib["removed"] = " "
@@ -306,6 +303,13 @@ class Paper:
             return self.attrib[name]
         except KeyError:
             return default
+
+    def add_prefix_to_title(self, prefix):
+        """Add a prefix to the title of the paper. 
+        The attrib is an lxml Element object."""
+        if self.attrib["xml_title"].text is None:
+            self.attrib["xml_title"].text = ""
+        self.attrib["xml_title"].text = prefix + self.attrib["xml_title"].text
 
     def get_title(self, form="xml"):
         """Returns the paper title, optionally formatting it.

--- a/bin/anthology/papers.py
+++ b/bin/anthology/papers.py
@@ -180,10 +180,7 @@ class Paper:
             paper.attrib["retracted"] = " "
 
         # Adjust the title for retracted papers
-        if (
-            "retracted" in paper.attrib
-            and "xml_title" in paper.attrib
-        ):
+        if "retracted" in paper.attrib and "xml_title" in paper.attrib:
             paper.add_prefix_to_title("[RETRACTED] ")
 
         if "removed" in paper.attrib and paper.attrib["removed"] is None:
@@ -305,7 +302,7 @@ class Paper:
             return default
 
     def add_prefix_to_title(self, prefix):
-        """Add a prefix to the title of the paper. 
+        """Add a prefix to the title of the paper.
         The attrib is an lxml Element object."""
         if self.attrib["xml_title"].text is None:
             self.attrib["xml_title"].text = ""


### PR DESCRIPTION
Retracted papers whose title starts with a child (e.g., `<fixed-case>`) were not getting the "[RETRACTED]" prefix. This fixes that problem.