### PR TITLE
Add 2 missing workshops to LREC-COLING 2024

### DIFF
--- a/data/xml/2024.coling.xml
+++ b/data/xml/2024.coling.xml
@@ -10,6 +10,7 @@
       <url type="website">https://lrec-coling-2024.org</url>
     </links>
     <colocated>
+      <volume-id>2024.bucc-1</volume-id>
       <volume-id>2024.cawl-1</volume-id>
       <volume-id>2024.cl4health-1</volume-id>
       <volume-id>2024.cogalex-1</volume-id>
@@ -40,6 +41,7 @@
       <volume-id>2024.rfp-1</volume-id>
       <volume-id>2024.safety4convai-1</volume-id>
       <volume-id>2024.sigul-1</volume-id>
+      <volume-id>2024.signlang-1</volume-id>
       <volume-id>2024.tdle-1</volume-id>
       <volume-id>2024.trac-1</volume-id>
       <volume-id>2024.unlp-1</volume-id>

--- a/data/xml/2024.lrec.xml
+++ b/data/xml/2024.lrec.xml
@@ -18389,6 +18389,7 @@
       <url type="website">https://lrec-coling-2024.org</url>
     </links>
     <colocated>
+      <volume-id>2024.bucc-1</volume-id>
       <volume-id>2024.cawl-1</volume-id>
       <volume-id>2024.cl4health-1</volume-id>
       <volume-id>2024.cogalex-1</volume-id>
@@ -18419,6 +18420,7 @@
       <volume-id>2024.rfp-1</volume-id>
       <volume-id>2024.safety4convai-1</volume-id>
       <volume-id>2024.sigul-1</volume-id>
+      <volume-id>2024.signlang-1</volume-id>
       <volume-id>2024.tdle-1</volume-id>
       <volume-id>2024.trac-1</volume-id>
       <volume-id>2024.unlp-1</volume-id>


### PR DESCRIPTION
The LREC-COLING 2024 workshops [signlang](https://aclanthology.org/volumes/2024.signlang-1/) and [BUCC](https://aclanthology.org/volumes/2024.bucc-1/) were ingested, but not listed in the volumes of the [lrec-2024](https://aclanthology.org/events/lrec-2024/) and [coling-2024](https://aclanthology.org/events/coling-2024/) events (see #3175). This corrects that.