### PR TITLE
Correcting variations on first name to reflect pdf contents for author Chris Jenkins

### DIFF
--- a/data/xml/2023.emnlp.xml
+++ b/data/xml/2023.emnlp.xml
@@ -13990,7 +13990,7 @@
     </paper>
     <paper id="1002">
       <title>To Split or Not to Split: Composing Compounds in Contextual Vector Spaces</title>
-      <author><first>Christopher</first><last>Jenkins</last></author>
+      <author><first>Chris</first><last>Jenkins</last></author>
       <author><first>Filip</first><last>Miletic</last></author>
       <author><first>Sabine</first><last>Schulte im Walde</last></author>
       <pages>16131-16136</pages>

--- a/data/xml/2024.lrec.xml
+++ b/data/xml/2024.lrec.xml
@@ -17782,7 +17782,7 @@
       <title>What Can Diachronic Contexts and Topics Tell Us about the Present-Day Compositionality of <fixed-case>E</fixed-case>nglish Noun Compounds?</title>
       <author><first>Samin</first><last>Mahdizadeh Sani</last></author>
       <author><first>Malak</first><last>Rassem</last></author>
-      <author><first>Chris W.</first><last>Jenkins</last></author>
+      <author><first>Chris</first><last>Jenkins</last></author>
       <author><first>Filip</first><last>Miletić</last></author>
       <author><first>Sabine</first><last>Schulte im Walde</last></author>
       <pages>17449–17458</pages>


### PR DESCRIPTION
The goal of this edit is to collapse these two ACL Anthology pages:

https://aclanthology.org/people/c/christopher-jenkins/
and
https://aclanthology.org/people/c/chris-w-jenkins/

into this one:
https://aclanthology.org/people/c/chris-jenkins/

which reflects the contents of the pdfs in all cases

Thanks!
