### PR TITLE
Add variations of first name into name_variants.yaml

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -4457,6 +4457,9 @@
 - canonical: {first: Rafael - Michael, last: Karampatsis}
   variants:
   - {first: Rafael Michael, last: Karampatsis}
+- canonical: {first: Amir Hossein, last: Kargaran}
+  variants:
+  - {first: Amir, last: Kargaran}
 - canonical: {first: David R., last: Karger}
   variants:
   - {first: David, last: Karger}


### PR DESCRIPTION
I have 2 acl profiles, as mentioed in this [issue#3353](https://github.com/acl-org/acl-anthology/issues/3353).
I don't mind publishing in both names as long as i can keep the acl profiles merged (with middle name and without):

https://aclanthology.org/people/a/amir-hossein-kargaran/ (default)
https://aclanthology.org/people/a/amir-kargaran/

affiliation: LMU Munich

I made the changes to reflect this.
