### PR TITLE
feat: update name variants

### DIFF
--- a/data/xml/2022.acl.xml
+++ b/data/xml/2022.acl.xml
@@ -11364,7 +11364,7 @@ in the Case of Unambiguous Gender</title>
     </paper>
     <paper id="11">
       <title>Combine to Describe: Evaluating Compositional Generalization in Image Captioning</title>
-      <author><first>George</first><last>Pantazopoulos</last></author>
+      <author><first>Georgios</first><last>Pantazopoulos</last></author>
       <author><first>Alessandro</first><last>Suglia</last></author>
       <author><first>Arash</first><last>Eshghi</last></author>
       <pages>115-131</pages>

--- a/data/xml/2022.sigdial.xml
+++ b/data/xml/2022.sigdial.xml
@@ -886,7 +886,7 @@
       <author><first>Alessandro</first><last>Suglia</last></author>
       <author><first>Bhathiya</first><last>Hemanthage</last></author>
       <author><first>Malvina</first><last>Nikandrou</last></author>
-      <author><first>George</first><last>Pantazopoulos</last></author>
+      <author><first>Georgios</first><last>Pantazopoulos</last></author>
       <author><first>Amit</first><last>Parekh</last></author>
       <author><first>Arash</first><last>Eshghi</last></author>
       <author><first>Claudio</first><last>Greco</last></author>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -10619,3 +10619,7 @@
   id: mathew-huerta-enochian
   variants:
   - {first: Mathew John, last: Huerta-Enochian}
+- canonical: {first: Georgios, last: Pantazopoulos}
+  id: georgios-pantazopoulos
+  variants:
+    - {first: George, last: Pantazopoulos}

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -10619,7 +10619,3 @@
   id: mathew-huerta-enochian
   variants:
   - {first: Mathew John, last: Huerta-Enochian}
-- canonical: {first: Georgios, last: Pantazopoulos}
-  id: georgios-pantazopoulos
-  variants:
-    - {first: George, last: Pantazopoulos}


### PR DESCRIPTION
(Similar to https://github.com/acl-org/acl-anthology/pull/3551)

I have two ACL profiles:
https://aclanthology.org/people/g/georgios-pantazopoulos/ (default)
https://aclanthology.org/people/g/george-pantazopoulos/ 

I would like to merge the two ACL profiles and being able to publish with both first name variants