### PR TITLE
[WIP] Display plenary talks on event page

### DIFF
--- a/bin/anthology/events.py
+++ b/bin/anthology/events.py
@@ -54,6 +54,7 @@ class EventIndex:
                 "year": year,
                 "title": f"{venue_name} ({year})",
                 "links": [],
+                "talks": [],
                 "volumes": [],
             }
 
@@ -70,6 +71,8 @@ class EventIndex:
             list_elements=["url", "volume-id"],
             dont_parse_elements=["meta", "links", "colocated"],
         )
+        # parse_element does not play nicely with "talk" so add here
+        event_data["talk"] = event_xml.findall("talk")
 
         # copy over on top of default values
         for key, value in event_data.items():
@@ -107,11 +110,21 @@ class EventIndex:
                 ):
                     self.register_volume(volume_id, event_id)
 
+            elif key == "talk":
+                for talk in value:
+                    parsed_talk = parse_element(talk, list_elements=["speaker"])
+                    self.events[event_id]["talks"].append(
+                        {
+                            "title": parsed_talk["xml_title"].text,
+                            "speaker": parsed_talk["speaker"],
+                            "video": parsed_talk["video"],
+                        }
+                    )   
+
             else:
                 # all other keys
                 self.events[event_id][key] = value
 
-        # print(event_id, self.events[event_id])
 
     def register_volume(self, volume: str, event_id: str):
         """

--- a/bin/anthology/utils.py
+++ b/bin/anthology/utils.py
@@ -461,7 +461,7 @@ def parse_element(
                 "type": element.get("type", "attachment"),
                 "url": element.text,
             }
-        elif tag in ("author", "editor"):
+        elif tag in ("author", "editor", "speaker"):
             id_ = element.attrib.get("id", None)
             value = (PersonName.from_element(element), id_)
         elif tag == "erratum":


### PR DESCRIPTION
**Note:** this is very much a work in progress!

### Summary
This pull request aims to display plenary talks (e.g., (e.g., [these](https://github.com/acl-org/acl-anthology/blob/c7127b85f4f6979410f05424b0d6a3785ef3af38/data/xml/2022.acl.xml#L12303-L12322) from ACL 2022) on the relevant event pages. Currently, some plenary talks are stored in `data/xml` but are not displayed on the website.

### Display strategy
The exact method for displaying these talks is still under consideration. One option is to list the talks below the existing Website and Handbook links on the event page (see e.g., [ACL 2022](https://aclanthology.org/events/acl-2022/)). Another option is to link to a dedicated page where all talks are collected.

Additionally, each talk should have a dedicated landing page, similar to how papers are presented, including the ability to cite the talk.

### Rough roadmap
- [x] Store talks in `class EventIndex` when available.
- [ ] Store talks in Hugo data folders when running `bin/create_hugo_yaml.py`.
- [ ] create a Hugo layout for talks in `hugo/layouts/talks`.
- [ ] Ensure talks are generated during website build (modify `bin/create_hugo_pages.py`)
- [ ] Add all available talks that are stored on the server (currently only `2022.acl.xml` includes talks)