### PR TITLE
Update 2024.bea.xml for paper 2024.bea-1.55

### DIFF
--- a/data/xml/2024.bea.xml
+++ b/data/xml/2024.bea.xml
@@ -612,7 +612,7 @@
       <bibkey>dutilleul-etal-2024-isep</bibkey>
     </paper>
     <paper id="55">
-      <title>Machine Translation for Lexical Complexity Prediction and Lexical Simplification</title>
+      <title>Archaeology at MLSP 2024: Machine Translation for Lexical Complexity Prediction and Lexical Simplification</title>
       <author><first>Petru</first><last>Cristea</last><affiliation>University of Bucharest</affiliation></author>
       <author><first>Sergiu</first><last>Nisioi</last><affiliation>Human Language Technologies Research Center, University of Bucharest</affiliation></author>
       <pages>610-617</pages>


### PR DESCRIPTION
The paper title metadata does not match the title in the PDF.

The authors corrected the title in the PDF and added a missing prefix for the shared task team name, but they did not update this information on Softconf. As a result, it was missing during the Softconf export when the proceedings were compiled.

For reference, see the PDF: https://aclanthology.org/2024.bea-1.55.pdf

For more details, see the issue: https://github.com/acl-org/acl-anthology/issues/3622
