### PR TITLE
Update 2024.bea.xml for paper 2024.bea-1.51

### DIFF
--- a/data/xml/2024.bea.xml
+++ b/data/xml/2024.bea.xml
@@ -573,6 +573,18 @@
       <author><first>Akio</first><last>Hayakawa</last><affiliation>Universitat Pompeu Fabra</affiliation></author>
       <author><first>Andrea</first><last>Horbach</last><affiliation>Universität Hildesheim</affiliation></author>
       <author><first>Anna</first><last>Huelsing</last><affiliation>University of Hildesheim</affiliation></author>
+      <author><first>Yusuke</first><last>Ide</last><affiliation>Nara Institute of Science and Technology</affiliation></author>
+      <author><first>Joseph Marvin</first><last>Imperial</last><affiliation>University of Bath</affiliation></author>
+      <author><first>Adam</first><last>Nohejl</last><affiliation>Nara Institute of Science and Technology</affiliation></author>
+      <author><first>Kai</first><last>North</last><affiliation>George Mason University</affiliation></author>
+      <author><first>Laura</first><last>Occhipinti</last><affiliation>University of Bologna</affiliation></author>
+      <author><first>Nelson</first><last>Peréz Rojas</last><affiliation>Tecnológico de Costa Rica</affiliation></author>
+      <author><first>Nishat</first><last>Raihan</last><affiliation>George Mason University</affiliation></author>
+      <author><first>Tharindu</first><last>Ranasinghe</last><affiliation>Aston University</affiliation></author>
+      <author><first>Martin</first><last>Solis Salazar</last><affiliation>Tecnológico de Costa Rica</affiliation></author>
+      <author><first>Sanja</first><last>Štajner</last><affiliation>Independent Researcher</affiliation></author>
+      <author><first>Marcos</first><last>Zampieri</last><affiliation>George Mason University</affiliation></author>
+      <author><first>Horacio</first><last>Saggion</last><affiliation>Universitat Pompeu Fabra</affiliation></author>
       <pages>571-589</pages>
       <abstract>We report the findings of the 2024 Multilingual Lexical Simplification Pipeline shared task. We released a new dataset comprising 5,927 instances of lexical complexity prediction and lexical simplification on common contexts across 10 languages, split into trial (300) and test (5,627). 10 teams participated across 2 tracks and 10 languages with 233 runs evaluated across all systems. Five teams participated in all languages for the lexical complexity prediction task and 4 teams participated in all languages for the lexical simplification task. Teams employed a range of strategies, making use of open and closed source large language models for lexical simplification, as well as feature-based approaches for lexical complexity prediction. The highest scoring team on the combined multilingual data was able to obtain a Pearson’s correlation of 0.6241 and an ACC@1@Top1 of 0.3772, both demonstrating that there is still room for improvement on two difficult sub-tasks of the lexical simplification pipeline.</abstract>
       <url hash="3a258e99">2024.bea-1.51</url>


### PR DESCRIPTION
The author list was truncated to the first 10 authors due to a bug in the aclpub2 tool.

For reference, see the PDF: https://aclanthology.org/2024.bea-1.51.pdf

For more details, see the issue: [#3621](https://github.com/acl-org/acl-anthology/issues/3621) 

The cause of this issue can be found in the aclpub2 GitHub repository, specifically in this issue: https://github.com/rycolab/aclpub2/issues/173 and this pull request: https://github.com/rycolab/aclpub2/pull/174

Although the issue was raised and the corrected version was forwarded to the NAACL 2024 publication chairs (past the proceedings deadline), it was not updated in the ACL Anthology.
