### PR TITLE
Add middle initial to metadata that is in pdf

### DIFF
--- a/data/xml/2024.eacl.xml
+++ b/data/xml/2024.eacl.xml
@@ -149,7 +149,7 @@
     <paper id="11">
       <title>A Comparative Multidimensional Analysis of Empathetic Systems</title>
       <author><first>Andrew</first><last>Lee</last><affiliation>University of Michigan</affiliation></author>
-      <author><first>Jonathan</first><last>Kummerfeld</last><affiliation>University of Sydney</affiliation></author>
+      <author><first>Jonathan K.</first><last>Kummerfeld</last><affiliation>University of Sydney</affiliation></author>
       <author><first>Larry</first><last>Ann</last><affiliation>University of Michigan</affiliation></author>
       <author><first>Rada</first><last>Mihalcea</last><affiliation>University of Michigan</affiliation></author>
       <pages>179-189</pages>


### PR DESCRIPTION
My name is 'Jonathan K. Kummerfeld' in the pdf, but not in the metadata. See:

https://aclanthology.org/2024.eacl-long.11/
and
https://aclanthology.org/2024.eacl-long.11.pdf

This PR fixes the metadata.
