### PR TITLE
Update 2024.textgraphs.xml

### DIFF
--- a/data/xml/2024.textgraphs.xml
+++ b/data/xml/2024.textgraphs.xml
@@ -4,15 +4,15 @@
     <meta>
       <booktitle>Proceedings of TextGraphs-17: Graph-based Methods for Natural Language Processing</booktitle>
       <editor><first>Dmitry</first><last>Ustalov</last></editor>
-      <editor><first>Alexander</first><last>Pachenko</last></editor>
       <editor><first>Yanjun</first><last>Gao</last></editor>
+      <editor><first>Alexander</first><last>Pachenko</last></editor>
+      <editor><first>Elena</first><last>Tutubalina</last></editor>
       <editor><first>Irina</first><last>Nikishina</last></editor>
       <editor><first>Arti</first><last>Ramesh</last></editor>
       <editor><first>Andrey</first><last>Sakhovskiy</last></editor>
-      <editor><first>Elena</first><last>Tutubalina</last></editor>
-      <editor><first>Gerald</first><last>Penn</last></editor>
-      <editor><first>Gerald</first><last>Valentino</last></editor>
       <editor><first>Ricardo</first><last>Usbeck</last></editor>
+      <editor><first>Gerald</first><last>Penn</last></editor>
+      <editor><first>Marco</first><last>Valentino</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Bangkok, Thailand</address>
       <month>August</month>


### PR DESCRIPTION
I am submitting this PR on behalf of the TextGraphs-17 workshop organizing committee.

1. We noticed that the ACL Anthology entry does not match the order to editors in the proceedings: https://aclanthology.org/2024.textgraphs-1.0.pdf
2. Also, there was an unfortunate typo: `Marco Valentino`, not `Gerald Valentino`

This PR fixes both issues.