### PR TITLE
fixed the typo in the LoResMT 2024 title (the The as the)

### DIFF
--- a/data/xml/2024.loresmt.xml
+++ b/data/xml/2024.loresmt.xml
@@ -2,7 +2,7 @@
 <collection id="2024.loresmt">
   <volume id="1" ingest-date="2024-07-26" type="proceedings">
     <meta>
-      <booktitle>Proceedings of the The Seventh Workshop on Technologies for Machine Translation of Low-Resource Languages (LoResMT 2024)</booktitle>
+      <booktitle>Proceedings of the Seventh Workshop on Technologies for Machine Translation of Low-Resource Languages (LoResMT 2024)</booktitle>
       <editor><first>Atul Kr.</first><last>Ojha</last></editor>
       <editor><first>Chao-hong</first><last>Liu</last></editor>
       <editor><first>Ekaterina</first><last>Vylomova</last></editor>


### PR DESCRIPTION
I fixed the typo in the title. 
"Proceedings of the The Seventh ..." >> "Proceedings of the Seventh ...

