### PR TITLE
Update co-author metadata 2024.ml4al.xml

### DIFF
--- a/data/xml/2024.ml4al.xml
+++ b/data/xml/2024.ml4al.xml
@@ -195,8 +195,8 @@
       <title>“Gotta catch ‘em all!”: Retrieving people in <fixed-case>A</fixed-case>ncient <fixed-case>G</fixed-case>reek texts combining transformer models and domain knowledge</title>
       <author><first>Marijke</first><last>Beersmans</last><affiliation>KU Leuven</affiliation></author>
       <author><first>Alek</first><last>Keersmaekers</last><affiliation>KU Leuven</affiliation></author>
-      <author><first>Evelien</first><last>Graaf</last><affiliation>KU Leuven</affiliation></author>
-      <author><first>Tim</first><last>Van De Cruys</last><affiliation>KU Leuven</affiliation></author>
+      <author><first>Evelien</first><last>de Graaf</last><affiliation>KU Leuven</affiliation></author>
+      <author><first>Tim</first><last>Van de Cruys</last><affiliation>KU Leuven</affiliation></author>
       <author><first>Mark</first><last>Depauw</last><affiliation>KU Leuven</affiliation></author>
       <author><first>Margherita</first><last>Fantoli</last><affiliation>KU Leuven</affiliation></author>
       <pages>152-164</pages>


### PR DESCRIPTION
fixed minor misspellings to co-author names:
Evelien Graaf --> Evelien de Graaf
Tim Van De Cruys --> Tim Van de Cruys

(Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)
