### PR TITLE
Update author name in 2024.wassa.xml for paper 38

### DIFF
--- a/data/xml/2024.wassa.xml
+++ b/data/xml/2024.wassa.xml
@@ -405,7 +405,7 @@
       <title><fixed-case>WASSA</fixed-case> 2024 Shared Task: Enhancing Emotional Intelligence with Prompts</title>
       <author><first>Svetlana</first><last>Churina</last></author>
       <author><first>Preetika</first><last>Verma</last></author>
-      <author><first>Suchismita1510.tripathy@gmail.com</first><last>Suchismita1510.tripathy@gmail.com</last><affiliation>NA</affiliation></author>
+      <author><first>Suchismita</first><last>Tripathy</last></author>
       <pages>425-429</pages>
       <abstract>This paper describes the system for the last-min-submittion team in WASSA-2024 Shared Task 1:Empathy Detection and Emotion Classification. This task aims at developing models which can predict the empathy, emotion, and emotional polarity. This system achieved relatively goodresults on the competition’s official leaderboard.The code of this system is available here.</abstract>
       <url hash="f792865b">2024.wassa-1.38</url>


### PR DESCRIPTION
Updating the xml entry for a paper submitted by my team for WASSA 2024 in Bangkok, Thailand. Modifying author's name listed in the xml entry to actual first and last name (entry instead includes email ID as both first and last name). 
