### PR TITLE
Addition of missing author

### DIFF
--- a/data/xml/2023.nlposs.xml
+++ b/data/xml/2023.nlposs.xml
@@ -46,6 +46,7 @@
     <paper id="3">
       <title>Deepparse : An Extendable, and Fine-Tunable State-Of-The-Art Library for Parsing Multinational Street Addresses</title>
       <author><first>David</first><last>Beauchemin</last></author>
+      <author><first>Marouane</first><last>Yassine</last></author>
       <pages>19-24</pages>
       <abstract>Segmenting an address into meaningful components, also known as address parsing, is an essential step in many applications from record linkage to geocoding and package delivery. Consequently, a lot of work has been dedicated to develop accurate address parsing techniques, with machine learning and neural network methods leading the state-of-the-art scoreboard. However, most of the work on address parsing has been confined to academic endeavours with little availability of free and easy-to-use open-source solutions.This paper presents Deepparse, a Python open-source, extendable, fine-tunable address parsing solution under LGPL-3.0 licence to parse multinational addresses using state-of-the-art deep learning algorithms and evaluated on over 60 countries. It can parse addresses written in any language and use any address standard. The pre-trained model achieves average 99% parsing accuracies on the countries used for training with no pre-processing nor post-processing needed. Moreover, the library supports fine-tuning with new data to generate a custom address parser.</abstract>
       <url hash="811daf70">2023.nlposs-1.3</url>


### PR DESCRIPTION
This PR adds an author's name which seems to have been left out of the metadata of the _2023.nlposs-1.3_ paper. The author's name is present in the PDF but not in the metadata.
