### PR TITLE
Title and abstract correction for Anthology ID: 2024.acl-long.748

### DIFF
--- a/data/xml/2024.acl.xml
+++ b/data/xml/2024.acl.xml
@@ -9692,7 +9692,7 @@
       <bibkey>maharana-etal-2024-evaluating</bibkey>
     </paper>
     <paper id="748">
-      <title>Prototypical Reward Network for Data-Efficient Model Alignment</title>
+      <title>Prototypical Reward Network for Data-Efficient RLHF</title>
       <author><first>Jinghan</first><last>Zhang</last><affiliation>Portland State University</affiliation></author>
       <author><first>Xiting</first><last>Wang</last><affiliation>Renmin University of China</affiliation></author>
       <author><first>Yiqiao</first><last>Jin</last></author>
@@ -9700,7 +9700,7 @@
       <author><first>Xinhao</first><last>Zhang</last><affiliation>Portland State University</affiliation></author>
       <author><first>Kunpeng</first><last>Liu</last><affiliation>Portland State University</affiliation></author>
       <pages>13871-13884</pages>
-      <abstract>The reward model for Reinforcement Learning from Human Feedback (RLHF) has proven effective in fine-tuning Large Language Models (LLMs). This paper explores enhancing RLHF with Prototypical Networks to improve reward models. We propose a framework utilizing Prototypical Networks to enhance reward models under limited human feedback, enabling more stable and reliable structural learning from fewer samples. This enhances the model’s adaptability and accuracy in interpreting human preferences. Our experiments demonstrate that this approach significantly improves the performance of reward models and LLMs in human feedback tasks, surpassing traditional methods, especially in data-limited scenarios.</abstract>
+      <abstract>The reward model for Reinforcement Learning from Human Feedback (RLHF) has proven effective in fine-tuning Large Language Models (LLMs). Notably, collecting human feedback for RLHF can be resource-intensive and lead to scalability issues for LLMs and complex tasks. Our proposed framework Proto-RM leverages prototypical networks to enhance reward models under limited human feedback. By enabling stable and reliable structural learning from fewer samples, Proto-RM significantly enhances LLMs' adaptability and accuracy in interpreting human preferences. Extensive experiments on various datasets demonstrate that Proto-RM significantly improves the performance of reward models and LLMs in human feedback tasks, achieving comparable and usually better results than traditional methods, while requiring significantly less data in data-limited scenarios. This research offers a promising direction for enhancing the efficiency of reward models and optimizing the fine-tuning of language models under restricted feedback conditions.</abstract>
       <url hash="f45d9850">2024.acl-long.748</url>
       <bibkey>zhang-etal-2024-prototypical</bibkey>
     </paper>

--- a/data/xml/2024.acl.xml
+++ b/data/xml/2024.acl.xml
@@ -9695,7 +9695,7 @@
       <title>Prototypical Reward Network for Data-Efficient RLHF</title>
       <author><first>Jinghan</first><last>Zhang</last><affiliation>Portland State University</affiliation></author>
       <author><first>Xiting</first><last>Wang</last><affiliation>Renmin University of China</affiliation></author>
-      <author><first>Yiqiao</first><last>Jin</last></author>
+      <author><first>Yiqiao</first><last>Jin</last><affiliation>Georgia Institute of Technology</affiliation></author>
       <author><first>Changyu</first><last>Chen</last><affiliation>Renmin University of China</affiliation></author>
       <author><first>Xinhao</first><last>Zhang</last><affiliation>Portland State University</affiliation></author>
       <author><first>Kunpeng</first><last>Liu</last><affiliation>Portland State University</affiliation></author>


### PR DESCRIPTION
I am the author of the paper with Anthology ID: 2024.acl-long.748. Requesting updates to both the title and abstract of paper ID: 2024.acl-long.748 to ensure they match the PDF content. The current system title, “Prototypical Reward Network for Data-Efficient Model Alignment,” should be updated to “Prototypical Reward Network for Data-Efficient RLHF.” Additionally, the abstract needs alignment with the PDF to maintain accuracy and coherence.
