### PR TITLE
Update 2024.jeptalnrecital.xml

### DIFF
--- a/data/xml/2024.jeptalnrecital.xml
+++ b/data/xml/2024.jeptalnrecital.xml
@@ -1190,7 +1190,7 @@
       <bibkey>hunter-etal-2024-meeting</bibkey>
     </paper>
     <paper id="36">
-      <title><fixed-case>MODEL</fixed-case>: Large Language Models for Spontaneous <fixed-case>F</fixed-case>rench Dialogue</title>
+      <title><fixed-case>C</fixed-case>laire: Large Language Models for Spontaneous <fixed-case>F</fixed-case>rench Dialogue</title>
       <author><first>Jérôme</first><last>Louradour</last></author>
       <author><first>Julie</first><last>Hunter</last></author>
       <author><first>Ismaïl</first><last>Harrando</last></author>


### PR DESCRIPTION
Correct Paper Metadata: {2024.jeptalnrecital-taln.36}

The title from
**MODEL**: Large Language Models for Spontaneous French Dialogue
to
**Claire**: Large Language Models for Spontaneous French Dialogue

https://aclanthology.org/2024.jeptalnrecital-taln.36/
