### PR TITLE
fixed metadata for my name in 2024 wassa paper

### DIFF
--- a/data/xml/2024.wassa.xml
+++ b/data/xml/2024.wassa.xml
@@ -33,11 +33,11 @@
     <paper id="2">
       <title><fixed-case>SEC</fixed-case>: Context-Aware Metric Learning for Efficient Emotion Recognition in Conversation</title>
       <author><first>Barbara</first><last>Gendron</last><affiliation>University of Lorraine</affiliation></author>
-      <author><first>GaelGuibon</first><last>GaelGuibon</last><affiliation>University of Lorraine</affiliation></author>
+      <author><first>Gaël</first><last>Guibon</last><affiliation>University of Lorraine</affiliation></author>
       <pages>11-22</pages>
       <abstract>The advent of deep learning models has made a considerable contribution to the achievement of Emotion Recognition in Conversation (ERC). However, this task still remains an important challenge due to the plurality and subjectivity of human emotions. Previous work on ERC provides predictive models using mostly graph-based conversation representations. In this work, we propose a way to model the conversational context that we incorporate into a metric learning training strategy, with a two-step process. This allows us to perform ERC in a flexible classification scenario and end up with a lightweight yet efficient model. Using metric learning through a Siamese Network architecture, we achieve 57.71 in macro F1 score for emotion classification in conversation on DailyDialog dataset, which outperforms the related work. This state-of-the-art result is promising in terms of the use of metric learning for emotion recognition, yet perfectible compared to the micro F1 score obtained.</abstract>
       <url hash="a4798b58">2024.wassa-1.2</url>
-      <bibkey>gendron-gaelguibon-2024-sec</bibkey>
+      <bibkey>gendron-guibon-2024-sec</bibkey>
     </paper>
     <paper id="3">
       <title>Modeling Complex Interactions in Long Documents for Aspect-Based Sentiment Analysis</title>


### PR DESCRIPTION
My name was wrongly put in our WASSA 2024 paper. Here is a fix with my correct name. It may also be necessary to change it in the bibtex if it is not generated from this XML file. Thank you
