### PR TITLE
Fix proceedings name AMTA 2024

### DIFF
--- a/data/xml/2024.amta.xml
+++ b/data/xml/2024.amta.xml
@@ -239,7 +239,7 @@
   </volume>
   <volume id="presentations" ingest-date="2024-09-27" type="proceedings">
     <meta>
-      <booktitle>Proceedings of the 16th Conference of the Association for Machine Translation in the Americas (Volume 2: User Track)</booktitle>
+      <booktitle>Proceedings of the 16th Conference of the Association for Machine Translation in the Americas (Volume 2: Presentations)</booktitle>
       <editor><first>Marianna</first><last>Martindale</last></editor>
       <editor><first>Janice</first><last>Campbell</last></editor>
       <editor><first>Konstantin</first><last>Savenkov</last></editor>


### PR DESCRIPTION
As requested in #3818 by I have changed the proceedings title from `... (Volume 2: User Track)` to `... (Volume 2: Presentations)`.