### PR TITLE
Metadata correction to name in IWSLT 2024

### DIFF
--- a/data/xml/2024.iwslt.xml
+++ b/data/xml/2024.iwslt.xml
@@ -32,7 +32,7 @@
       <author><first>Barry</first><last>Haddow</last><affiliation>U. Edinburgh</affiliation></author>
       <author><first>Dávid</first><last>Javorský</last><affiliation>Charles U.</affiliation></author>
       <author><first>Mateusz</first><last>Krubiński</last><affiliation>Charles U.</affiliation></author>
-      <author><first>Tsz</first><last>Kim Lam</last><affiliation>U. Edinburgh</affiliation></author>
+      <author><first>Tsz Kin</first><last>Lam</last><affiliation>U. Edinburgh</affiliation></author>
       <author><first>Xutai</first><last>Ma</last><affiliation>Meta</affiliation></author>
       <author><first>Prashant</first><last>Mathur</last><affiliation>Amazon</affiliation></author>
       <author><first>Evgeny</first><last>Matusov</last><affiliation>AppTek</affiliation></author>
@@ -264,7 +264,7 @@
     </paper>
     <paper id="16">
       <title>Compact Speech Translation Models via Discrete Speech Units Pretraining</title>
-      <author><first>Tsz</first><last>Kin Lam</last><affiliation>The University of Edinburgh</affiliation></author>
+      <author><first>Tsz Kin</first><last>Lam</last><affiliation>The University of Edinburgh</affiliation></author>
       <author><first>Alexandra</first><last>Birch</last><affiliation>University of Edinburgh</affiliation></author>
       <author><first>Barry</first><last>Haddow</last><affiliation>University of Edinburgh</affiliation></author>
       <pages>114-124</pages>


### PR DESCRIPTION
Metadata corrections to one name on two papers in IWSLT 2024 ([1](https://aclanthology.org/2024.iwslt-1.1/) and [16](https://aclanthology.org/2024.iwslt-1.16/))