### PR TITLE
[2024.emnlp-main.213] Adjust the title of 2024.emnlp-main.213 to make it match to the PDF

### DIFF
--- a/data/xml/2024.emnlp.xml
+++ b/data/xml/2024.emnlp.xml
@@ -2758,7 +2758,7 @@
       <bibkey>cao-2024-learn</bibkey>
     </paper>
     <paper id="213">
-      <title><fixed-case>VGB</fixed-case>ench: A Comprehensive Benchmark of Vector Graphics Understanding and Generation for Large Language Models</title>
+      <title><fixed-case>VGB</fixed-case>ench: Evaluating Large Language Models on Vector Graphics Understanding and Generation</title>
       <author><first>Bocheng</first><last>Zou</last></author>
       <author><first>Mu</first><last>Cai</last><affiliation>Department of Computer Science, University of Wisconsin, Madison</affiliation></author>
       <author><first>Jianrui</first><last>Zhang</last></author>


### PR DESCRIPTION
The title of our work in the ACL system doesn't match the title in our PDF, https://aclanthology.org/2024.emnlp-main.213.pdf

The title in the PDF is "VGBench: Evaluating Large Language Models on Vector Graphics Understanding and Generation", however the title in the ACL system is "VGBench: A Comprehensive Benchmark of Vector Graphics Understanding and Generation for Large Language Models". The title in the PDF is the correct one.