### PR TITLE
Remove software attachment for 2024.emnlp-main.605

### DIFF
--- a/data/xml/2024.emnlp.xml
+++ b/data/xml/2024.emnlp.xml
@@ -7841,7 +7841,6 @@
       <pages>10838-10851</pages>
       <abstract>Incorrect student answers can become valuable learning opportunities, provided that the student understands where they went wrong and why. To this end, rather than being given the correct answer, students should receive elaborated feedback on how to correct a mistake on their own. Highlighting the complex demands that the generation of such feedback places on a model’s input utilization abilities, we propose two extensions to the training pipeline. Firstly, we employ a KL regularization term between a standard and enriched input format to achieve more targeted input representations. Secondly, we add a preference optimization step to encourage student answer-adaptive feedback generation. The effectiveness of those extensions is underlined by a significant increase in model performance of 3.3 METEOR points. We go beyond traditional surface form-based metrics to assess two important dimensions of feedback quality, i.e., faithfulness and informativeness. Hereby, we are the first to propose an automatic metric measuring the degree to which feedback divulges the correct answer, that we call Informativeness Index <tex-math>I^2</tex-math>. We verify in how far each metric captures feedback quality.</abstract>
       <url hash="eca0f750">2024.emnlp-main.605</url>
-      <attachment type="software" hash="bbcc06e9">2024.emnlp-main.605.software.zip</attachment>
       <bibkey>liermann-etal-2024-insightful</bibkey>
     </paper>
     <paper id="606">


### PR DESCRIPTION
I am one of the authors of the paper "[More Insightful Feedback for Tutoring: Enhancing Generation Mechanisms and Automatic Evaluation](https://aclanthology.org/2024.emnlp-main.605.pdf)", 2024.emnlp-main.605.

The currently attached software is a preliminary version provided for review purposes only, we will provide an adapted version on github that meets company standards (linked in paper pdf). Therefore, we would like to request that the current software attachment is removed from the ACL anthology.