### PR TITLE
Add NoDaLiDa to front page

### DIFF
--- a/data/yaml/venues/nodalida.yaml
+++ b/data/yaml/venues/nodalida.yaml
@@ -1,2 +1,4 @@
 acronym: NoDaLiDa
 name: Nordic Conference of Computational Linguistics
+is_acl: false
+is_toplevel: true


### PR DESCRIPTION
This PR adds the [NoDaLiDa conference](https://aclanthology.org/venues/nodalida/) to the front page. Given the long history of the conference and that it is still active, I believe this is warranted.

(I am on the exec board of NEALT, which organizes NoDaLiDa, and this was brought up at a board meeting.)