### PR TITLE
update metadata 2023.nlposs-1.2 and 2024.mrl-1.11

### DIFF
--- a/data/xml/2023.nlposs.xml
+++ b/data/xml/2023.nlposs.xml
@@ -31,11 +31,12 @@
     </paper>
     <paper id="2">
       <title><fixed-case>J</fixed-case>ina Embeddings: A Novel Set of High-Performance Sentence Embedding Models</title>
-      <author><first>Michael</first><last>Günther</last></author>
-      <author><first>Georgios</first><last>Mastrapas</last></author>
-      <author><first>Bo</first><last>Wang</last></author>
+      <author><first>Michael</first><last>Günther</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Louis</first><last>Milliken</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Jonathan</first><last>Geuter</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Georgios</first><last>Mastrapas</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Bo</first><last>Wang</last><affiliation>Jina AI</affiliation></author>
       <author><first>Han</first><last>Xiao</last><affiliation>Jina AI</affiliation></author>
-      <author><first>Jonathan</first><last>Geuter</last></author>
       <pages>8-18</pages>
       <abstract>Jina Embeddings constitutes a set of high-performance sentence embedding models adept at translating textual inputs into numerical representations, capturing the semantics of the text. These models excel in applications like dense retrieval and semantic textual similarity. This paper details the development of Jina Embeddings, starting with the creation of high-quality pairwise and triplet datasets.It underlines the crucial role of data cleaning in dataset preparation, offers in-depth insights into the model training process, and concludes with a comprehensive performance evaluation using the Massive Text Embedding Benchmark (MTEB). Furthermore, to increase the model’s awareness of grammatical negation, we construct a novel training and evaluation dataset of negated and non-negated statements, which we make publicly available to the community.</abstract>
       <url hash="bb731c1e">2023.nlposs-1.2</url>

--- a/data/xml/2024.mrl.xml
+++ b/data/xml/2024.mrl.xml
@@ -136,9 +136,16 @@
     </paper>
     <paper id="11">
       <title><fixed-case>J</fixed-case>ina-<fixed-case>C</fixed-case>ol<fixed-case>BERT</fixed-case>-v2: A General-Purpose Multilingual Late Interaction Retriever</title>
+      <author><first>Rohan</first><last>Jha</last><affiliation>The University of Texas at Austin</affiliation></author>
+      <author><first>Bo</first><last>Wang</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Michael</first><last>Günther</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Georgios</first><last>Mastrapas</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Saba</first><last>Sturua</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Isabelle</first><last>Mohr</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Andreas</first><last>Koukounas</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Mohammad Kalim</first><last>Wang</last><affiliation>Jina AI</affiliation></author>
+      <author><first>Nan</first><last>Wang</last><affiliation>Jina AI</affiliation></author>
       <author><first>Han</first><last>Xiao</last><affiliation>Jina AI</affiliation></author>
-      <author><first>Bo</first><last>Wang</last></author>
-      <author><first>Rohan</first><last>Jha</last></author>
       <pages>159-166</pages>
       <abstract>Multi-vector dense models, such as ColBERT, have proven highly effective in information retrieval. ColBERT’s late interaction scoring approximates the joint query-document attention seen in cross-encoders while maintaining inference efficiency closer to traditional dense retrieval models, thanks to its bi-encoder architecture and recent optimizations in indexing and search. In this paper, we introduce a novel architecture and a training framework to support long context window and multilingual retrieval. Leveraging Matryoshka Representation Loss, we further demonstrate that the reducing the embedding dimensionality from 128 to 64 has insignificant impact on the model’s retrieval performance and cut storage requirements by up to 50%. Our new model, Jina-ColBERT-v2, demonstrates strong performance across a range of English and multilingual retrieval tasks,</abstract>
       <url hash="0e17920e">2024.mrl-1.11</url>


### PR DESCRIPTION
This PR changes the author information in the metadata of two papers to be consistent with the PDFs
Implements changes requested in #4068 and #4069 