### PR TITLE
Add bulk metadata correction template

### DIFF
--- a/.github/ISSUE_TEMPLATE/99-bulk-metadata-correction.yml
+++ b/.github/ISSUE_TEMPLATE/99-bulk-metadata-correction.yml
@@ -1,0 +1,21 @@
+name: Bulk Correction to Paper Metadata
+description: Fix typos or errors in a paper's title, abstract, or author names.
+labels: ["correction", "metadata"]
+assignees:
+  - anthology-assist
+body:
+  - type: markdown
+    attributes:
+      value: >
+        This form will list the title, abstract, and authors in structured YAML. You can manipulate this YAML to make corrections, such as adjusting a title, correcting an author name, adding a missing author, or reordering names. After verification from Anthology staff, these corrections will be applied in weekly batches and made live.
+  - type: textarea
+    id: data
+    attributes:
+      label: YAML code block
+      description: Please make corrections below.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** If you request an author name correction for yourself, please also make sure that your name is correctly entered into Softconf/OpenReview for any future publications, as this is where we obtain the author names from.


### PR DESCRIPTION
Unfortunately YAML-based issues templates need to be under `master` to be tested. This will be used by #4146.