### PR TITLE
Shorten "Fix metadata" to "Fix data" in documentation and script

### DIFF
--- a/.github/ISSUE_TEMPLATE/99-bulk-metadata-correction.yml
+++ b/.github/ISSUE_TEMPLATE/99-bulk-metadata-correction.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        **This form is not meant to be used manually.** Instead, it is activated by clicking the yellow "Fix metadata" button found on each paper page in the Anthology (e.g., https://aclanthology.org/K17-1003/). Clicking this button displays a UI tool for modifying the title, abstract, and author list. Submission of that form will automatically populate the title above and data block below.
+        **This form is not meant to be used manually.** Instead, it is activated by clicking the yellow "Fix data" button found on each paper page in the Anthology (e.g., https://aclanthology.org/K17-1003/). Clicking this button displays a UI tool for modifying the title, abstract, and author list. Submission of that form will automatically populate the title above and data block below.
   - type: markdown
     attributes:
       value: >

--- a/bin/process_bulk_metadata.py
+++ b/bin/process_bulk_metadata.py
@@ -44,7 +44,7 @@ from anthology.utils import deconstruct_anthology_id, indent, make_simple_elemen
 
 close_old_issue_comment = """### ⓘ Notice
 
-The Anthology has implemented a new, semi-automated workflow to better handle metadata corrections. We are closing this issue, and invite you to resubmit your request using our new workflow. Please visit your paper page ([{anthology_id}]({url})) and click the yellow 'Fix metadata' button. This will guide you through the new process step by step."""
+The Anthology has implemented a new, semi-automated workflow to better handle metadata corrections. We are closing this issue, and invite you to resubmit your request using our new workflow. Please visit your paper page ([{anthology_id}]({url})) and click the yellow 'Fix data' button. This will guide you through the new process step by step."""
 
 
 class AnthologyMetadataUpdater:

--- a/hugo/content/faq/corrections.md
+++ b/hugo/content/faq/corrections.md
@@ -3,7 +3,7 @@ Title: How can I submit corrections to papers?
 weight: 1
 ---
 
-Metadata (title, author list, and abstract) can be corrected by clicking on the yellow "Fix metadata" button on any paper page in the Anthology (e.g., [K17-1003](https://aclanthology.org/K17-1003/)). This will present you with a modal dialog that upon submission will instantiate an issue template in the Anthology Github repository.
+Metadata (title, author list, and abstract) can be corrected by clicking on the yellow "Fix data" button on any paper page in the Anthology (e.g., [K17-1003](https://aclanthology.org/K17-1003/)). This will present you with a modal dialog that upon submission will instantiate an issue template in the Anthology Github repository.
 
 The Anthology treats PDFs as the authoritative source of information, so metadata corrections should conform to the information in the PDF.
 

--- a/hugo/content/info/corrections.md
+++ b/hugo/content/info/corrections.md
@@ -35,7 +35,7 @@ Please note that **the Anthology treats PDFs as authoritative**. This means that
 
 A request to change paper metadata can be submitted in two ways.
 
-- Navigate to the paper's page in the ACL Anthology (e.g., [K17-1003](https://aclanthology.org/K17-1003/)). From there, click the yellow "Fix metadata" button. This will display a dialog that you can use to correct the title and abstract and fix issues with the author list.
+- Navigate to the paper's page in the ACL Anthology (e.g., [K17-1003](https://aclanthology.org/K17-1003/)). From there, click the yellow "Fix data" button. This will display a dialog that you can use to correct the title and abstract and fix issues with the author list.
 
   Submitting this form will create a Github issue with a JSON data block. This will then be validated by Anthology staff, and processed by a semi-automatic bulk corrections script on a weekly basis.
 

--- a/hugo/content/posts/2024-12-27-new-metadata-workflow.md
+++ b/hugo/content/posts/2024-12-27-new-metadata-workflow.md
@@ -8,7 +8,7 @@ After proceedings are published, authors often discover errors in the paper meta
 
 <img src="/images/2024-12-27/many-requests.png" alt="Accumulating issues" style="width:50%;" />
 
-We are therefore happy to announce a new simplified workflow that we hope will reduce effort and processing time. This workflow introduces a yellow "Fix metadata" button on each paper page in the Anthology. Clicking on this button will display a dialog allowing for easy manipulation of the title, author list, and abstract. Upon submission, this dialog will lead the submitter to the creation of a structured Github issue for the correction. The user needs only to submit the issue, and leave the rest to Anthology staff.
+We are therefore happy to announce a new simplified workflow that we hope will reduce effort and processing time. This workflow introduces a yellow "Fix data" button on each paper page in the Anthology. Clicking on this button will display a dialog allowing for easy manipulation of the title, author list, and abstract. Upon submission, this dialog will lead the submitter to the creation of a structured Github issue for the correction. The user needs only to submit the issue, and leave the rest to Anthology staff.
 
 <img src="/images/2024-12-27/dialog.png" alt="Metadata correction dialog" style="width:50%;" />
 


### PR DESCRIPTION
Per #4229, the button was renamed in 055e8c3. This PR targets documentation pages mentioning the feature.