### PR TITLE
Fix wrong PDFs for AMTA 2006 panels

### DIFF
--- a/data/xml/2006.amta.xml
+++ b/data/xml/2006.amta.xml
@@ -396,37 +396,37 @@
       <venue>amta</venue>
     </meta>
     <frontmatter>
-      <url hash="a59e7206">2006.amta-panels.0</url>
+      <url hash="a59e7206">2006.amta-panel1.0</url>
       <bibkey>amta-2006-association-machine</bibkey>
     </frontmatter>
     <paper id="1">
       <title>Meadan global dialogue</title>
       <author><first>Ed</first><last>Bice</last></author>
-      <url hash="c9024543">2006.amta-panels.1</url>
+      <url hash="c9024543">2006.amta-panel1.1</url>
       <bibkey>bice-2006-meadan</bibkey>
     </paper>
     <paper id="2">
       <title>The social impact of online <fixed-case>MT</fixed-case></title>
       <author><first>Federico</first><last>Gaspari</last></author>
-      <url hash="ad58c3ef">2006.amta-panels.2</url>
+      <url hash="ad58c3ef">2006.amta-panel1.2</url>
       <bibkey>gaspari-2006-social</bibkey>
     </paper>
     <paper id="3">
       <title>Social impact of <fixed-case>MT</fixed-case></title>
       <author><first>Jennifer</first><last>DeCamp</last></author>
-      <url hash="137ab447">2006.amta-panels.3</url>
+      <url hash="137ab447">2006.amta-panel1.3</url>
       <bibkey>decamp-2006-social</bibkey>
     </paper>
     <paper id="4">
       <title><fixed-case>MT</fixed-case> for social impact</title>
       <author><first>Michael</first><last>McCord</last></author>
-      <url hash="5522b165">2006.amta-panels.4</url>
+      <url hash="5522b165">2006.amta-panel1.4</url>
       <bibkey>mccord-2006-mt</bibkey>
     </paper>
     <paper id="5">
       <title>The social impact of translation via <fixed-case>SMS</fixed-case></title>
       <author><first>Rami B.</first><last>Safadi</last></author>
-      <url hash="920a3c98">2006.amta-panels.5</url>
+      <url hash="920a3c98">2006.amta-panel1.5</url>
       <bibkey>safadi-2006-social</bibkey>
     </paper>
   </volume>
@@ -440,38 +440,38 @@
       <venue>amta</venue>
     </meta>
     <frontmatter>
-      <url hash="3b3937c7">2006.amta-panels.0</url>
+      <url hash="3b3937c7">2006.amta-panel2.0</url>
       <bibkey>amta-2006-association-machine-translation</bibkey>
     </frontmatter>
     <paper id="1">
       <title>Presentation</title>
       <author><first>Jaime</first><last>Carbonell</last></author>
-      <url hash="e1ccdfad">2006.amta-panels.1</url>
+      <url hash="e1ccdfad">2006.amta-panel2.1</url>
       <bibkey>carbonell-2006-presentation</bibkey>
     </paper>
     <paper id="2">
       <title>Presentation</title>
       <author><first>Nizar</first><last>Habash</last></author>
-      <url hash="7e2753bb">2006.amta-panels.2</url>
+      <url hash="7e2753bb">2006.amta-panel2.2</url>
       <bibkey>habash-2006-presentation</bibkey>
     </paper>
     <paper id="3">
       <title>Statistical machine translation and hybrid machine translation</title>
       <author><first>Philipp</first><last>Koehn</last></author>
-      <url hash="d458c82c">2006.amta-panels.3</url>
+      <url hash="d458c82c">2006.amta-panel2.3</url>
       <bibkey>koehn-2006-statistical</bibkey>
     </paper>
     <paper id="4">
       <title>Combining interlingua with <fixed-case>SMT</fixed-case></title>
       <author><first>Stephanie</first><last>Seneff</last></author>
-      <url hash="4e7596e7">2006.amta-panels.4</url>
+      <url hash="4e7596e7">2006.amta-panel2.4</url>
       <bibkey>seneff-2006-combining</bibkey>
     </paper>
     <paper id="5">
       <title>First strategies for integrating hybrid approaches into established systems</title>
       <author><first>Jean</first><last>Senellart</last></author>
       <author><first>John S.</first><last>White</last></author>
-      <url hash="03c4e9f2">2006.amta-panels.5</url>
+      <url hash="03c4e9f2">2006.amta-panel2.5</url>
       <bibkey>senellart-white-2006-first</bibkey>
     </paper>
   </volume>


### PR DESCRIPTION
Fixes identical URL issues for the two AMTA 2006 panels. Closes #4155.