### PR TITLE
expose/differentiate author page corrections as a separate issue from paper metadata corrections

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-name-correction.yml
+++ b/.github/ISSUE_TEMPLATE/02-name-correction.yml
@@ -13,7 +13,7 @@ body:
         For cases where an individual has published under multiple name variants, submitting a pull request
         that modifies [`name_variants.yaml`](https://github.com/acl-org/acl-anthology/blob/master/data/yaml/name_variants.yaml)
         directly will expedite the process. If an author name listed for a paper does not match
-        what is in the PDF, use the "Fix data" button on the paper page,
+        what is in the PDF, instead use the "Fix data" button on the paper page,
         which will help automate the correction. Thanks!
   - type: textarea
     id: name_pages_affected

--- a/.github/ISSUE_TEMPLATE/02-name-correction.yml
+++ b/.github/ISSUE_TEMPLATE/02-name-correction.yml
@@ -1,6 +1,6 @@
-name: Correction to Author Metadata
+name: Correction to Author Page
 description: Fix issues with author pages.
-title: "Author Metadata: {replace with author name}"
+title: "Author Page: {replace with author name}"
 labels: ["correction", "metadata"]
 assignees:
   - anthology-assist
@@ -8,11 +8,13 @@ body:
   - type: markdown
     attributes:
       value: >
-        This form will report author metadata issues to Anthology staff.
-        For simple cases (where paper metadata in the [XML](https://github.com/acl-org/acl-anthology/tree/master/data/xml)
-        record doesn't match the PDF, or
-        [`name_variants.yaml`](https://github.com/acl-org/acl-anthology/blob/master/data/yaml/name_variants.yaml) needs modification),
-        submitting a __pull request__ instead will expedite the process. Thanks!
+        This form will report issues with author pages—for example, if a name needs to be disambiguated,
+        or if two versions of a name should be mapped to the same individual.
+        For cases where an individual has published under multiple name variants, submitting a pull request
+        that modifies [`name_variants.yaml`](https://github.com/acl-org/acl-anthology/blob/master/data/yaml/name_variants.yaml)
+        directly will expedite the process. If an author name listed for a paper does not match
+        what is in the PDF, use the "Fix data" button on the paper page,
+        which will help automate the correction. Thanks!
   - type: textarea
     id: name_pages_affected
     attributes:

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -362,7 +362,7 @@
         <div class="modal-footer d-flex align-items-center">
           <div class="form-check mb-0">
             <input type="checkbox" class="form-check-input" id="pdfCorrectionCheck">
-            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF. If paper metadata matches the PDF, but the grouping of papers into author pages is incorrect, please file an <a href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Metadata%3A+%7Breplace+with+author+name%7D">author page correction</a> instead.</label>
+            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF. If paper metadata matches the PDF, but the grouping of papers into author pages is incorrect, please file an <a href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+%7Breplace+with+author+name%7D">author page correction</a> instead.</label>
           </div>
           <button type="button" class="btn btn-primary" onclick="submitMetadataCorrection()">Submit</button>
         </div>

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -362,7 +362,7 @@
         <div class="modal-footer d-flex align-items-center">
           <div class="form-check mb-0">
             <input type="checkbox" class="form-check-input" id="pdfCorrectionCheck">
-            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF. If paper metadata matches the PDF, but the grouping of papers into author pages is incorrect, please file an <a href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+%7Breplace+with+author+name%7D">author page correction</a> instead.</label>
+            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF. If paper metadata matches the PDF, but the paper should be linked to a different author page, please file an <a href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+%7Breplace+with+author+name%7D">author page correction</a> instead.</label>
           </div>
           <button type="button" class="btn btn-primary" onclick="submitMetadataCorrection()">Submit</button>
         </div>

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -362,7 +362,7 @@
         <div class="modal-footer d-flex align-items-center">
           <div class="form-check mb-0">
             <input type="checkbox" class="form-check-input" id="pdfCorrectionCheck">
-            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF</label>
+            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF. If paper metadata matches the PDF, but the grouping of papers into author pages is incorrect, file an <a href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Metadata%3A+%7Breplace+with+author+name%7D">author page correction</a> instead.</label>
           </div>
           <button type="button" class="btn btn-primary" onclick="submitMetadataCorrection()">Submit</button>
         </div>

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -362,7 +362,7 @@
         <div class="modal-footer d-flex align-items-center">
           <div class="form-check mb-0">
             <input type="checkbox" class="form-check-input" id="pdfCorrectionCheck">
-            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF. If paper metadata matches the PDF, but the grouping of papers into author pages is incorrect, file an <a href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Metadata%3A+%7Breplace+with+author+name%7D">author page correction</a> instead.</label>
+            <label class="form-check-label" for="pdfCorrectionCheck">ALL author names, the title, and the abstract match the PDF. If paper metadata matches the PDF, but the grouping of papers into author pages is incorrect, please file an <a href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Metadata%3A+%7Breplace+with+author+name%7D">author page correction</a> instead.</label>
           </div>
           <button type="button" class="btn btn-primary" onclick="submitMetadataCorrection()">Submit</button>
         </div>

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -339,7 +339,7 @@
         </div>
         <div class="modal-body">
           <form id="metadataForm">
-            <div class="alert alert-info" role="alert">
+            <div class="alert alert-warning" role="alert">
               <b>Important</b>: The Anthology treat PDFs as authoritative. Please use this form only to correct data that is out of line with the PDF. See <a href="https://aclanthology.org/info/corrections/">our corrections guidelines</a> if you need to change the PDF.
             </div>
             <div class="mb-3">

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -119,7 +119,7 @@
         </div>
       </div>
 
-      <a class="btn btn-warning btn-lg btn-secondary btn-block mb-2" title="Correct problems with the author page" href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+{replace+with+author+name}">
+      <a class="btn btn-warning btn-lg btn-secondary btn-block mb-2" title="Correct problems with the author page" href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+{{ .Params.name }}">
         <span class="d-none d-sm-inline"><i class="fas fa-edit"></i></span>
         <span class="pl-md-2">Fix data</span>
       </a>

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -119,7 +119,7 @@
         </div>
       </div>
 
-      <a class="btn btn-warning btn-lg btn-secondary btn-block mb-2" href=# title="Correct problems with the author page" href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+{replace+with+author+name}">
+      <a class="btn btn-warning btn-lg btn-secondary btn-block mb-2" title="Correct problems with the author page" href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+{replace+with+author+name}">
         <span class="d-none d-sm-inline"><i class="fas fa-edit"></i></span>
         <span class="pl-md-2">Fix data</span>
       </a>

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -118,6 +118,11 @@
           </div>
         </div>
       </div>
+
+      <a class="btn btn-warning btn-lg btn-secondary btn-block mb-2" href=# title="Correct problems with the author page" href="https://github.com/acl-org/acl-anthology/issues/new?assignees=anthology-assist&labels=correction%2Cmetadata&projects=&template=02-name-correction.yml&title=Author+Page%3A+{replace+with+author+name}">
+        <span class="d-none d-sm-inline"><i class="fas fa-edit"></i></span>
+        <span class="pl-md-2">Fix data</span>
+      </a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Some people are using the metadata fix dialog to try to address author grouping issues that are not due to paper-level problems. This PR attempts to bring clarity by:

- Renaming the title of the issue type from "author metadata" to "author page"
   * I don't know if there is any downstream automation that will be affected. I did not modify anything in the form itself.
- Explaining in the paper metadata dialog that author page issues should be addressed separately
- Explaining the difference in the author page issue template
- Adding a "Fix data" button to author pages that links to the issue template

In the future we may want to create a dialog for author pages to give us the data in a structured format. The most common issue seems to be name variants that need to be grouped together under the same individual.