### PR TITLE
Fix NEJLT metadata

### DIFF
--- a/data/xml/2021.nejlt.xml
+++ b/data/xml/2021.nejlt.xml
@@ -1,14 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <collection id="2021.nejlt">
-  <volume id="1" ingest-date="2023-02-23" type="proceedings">
+  <volume id="1" ingest-date="2023-02-23" type="journal">
     <meta>
       <booktitle>Northern European Journal of Language Technology, Volume 7</booktitle>
       <editor><first>Leon</first><last>Derczynski</last></editor>
-      <publisher>Northern European Association of Language Technology</publisher>
-      <address>Copenhagen, Denmark</address>
+      <publisher>Linköping University Electronic Press</publisher>
+      <address>Linköping, Sweden</address>
       <doi>https://doi.org/10.3384/nejlt.2000-1533.7.1</doi>
       <year>2021</year>
       <venue>nejlt</venue>
+      <journal-volume>7</journal-volume>
     </meta>
     <frontmatter>
       <url hash="bacc4a15">2021.nejlt-1.0</url>

--- a/data/xml/2021.nejlt.xml
+++ b/data/xml/2021.nejlt.xml
@@ -6,7 +6,7 @@
       <editor><first>Leon</first><last>Derczynski</last></editor>
       <publisher>Linköping University Electronic Press</publisher>
       <address>Linköping, Sweden</address>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.7.1</doi>
+      <doi>10.3384/nejlt.2000-1533.7.1</doi>
       <year>2021</year>
       <venue>nejlt</venue>
       <journal-volume>7</journal-volume>
@@ -19,7 +19,7 @@
       <title>6 Questions for Socially Aware Language Technologies</title>
       <author><first>Diyi</first><last>Yang</last></author>
       <url hash="2f7a22b3">2021.nejlt-1.1</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2021.3874</doi>
+      <doi>10.3384/nejlt.2000-1533.2021.3874</doi>
       <bibkey>yang-2021-6</bibkey>
     </paper>
     <paper id="2">
@@ -28,7 +28,7 @@
       <author><first>Therese Lindström</first><last>Tiedemann</last></author>
       <author><first>Elena</first><last>Volodina</last></author>
       <url hash="d11d6f22">2021.nejlt-1.2</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2021.3128</doi>
+      <doi>10.3384/nejlt.2000-1533.2021.3128</doi>
       <bibkey>alfter-etal-2021-crowdsourcing</bibkey>
     </paper>
   </volume>

--- a/data/xml/2022.nejlt.xml
+++ b/data/xml/2022.nejlt.xml
@@ -6,7 +6,7 @@
       <editor><first>Leon</first><last>Derczynski</last></editor>
       <publisher>Linköping University Electronic Press</publisher>
       <address>Linköping, Sweden</address>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.8.1</doi>
+      <doi>10.3384/nejlt.2000-1533.8.1</doi>
       <url hash="b4654b54">2022.nejlt-1</url>
       <year>2022</year>
       <venue>nejlt</venue>
@@ -17,7 +17,7 @@
       <author><first>Leon</first><last>Derczynski</last></author>
       <abstract>An introduction to the Northern European Journal of Language Technology in 2022</abstract>
       <url hash="e8b71a2c">2022.nejlt-1.1</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.4617</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.4617</doi>
       <bibkey>derczynski-2022-foreword</bibkey>
     </paper>
     <paper id="2">
@@ -30,7 +30,7 @@
       <author><first>Nancy</first><last>Fulda</last></author>
       <abstract>A variety of NLP applications use word2vec skip-gram, GloVe, and fastText word embeddings. These models learn two sets of embedding vectors, but most practitioners use only one of them, or alternately an unweighted sum of both. This is the first study to systematically explore a range of linear combinations between the first and second embedding sets. We evaluate these combinations on a set of six NLP benchmarks including IR, POS-tagging, and sentence similarity. We show that the default embedding combinations are often suboptimal and demonstrate 1.0-8.0% improvements. Notably, GloVes default unweighted sum is its least effective combination across tasks. We provide a theoretical basis for weighting one set of embeddings more than the other according to the algorithm and task. We apply our findings to improve accuracy in applications of cross-lingual alignment and navigational knowledge by up to 15.2%.</abstract>
       <url hash="ec6f2a64">2022.nejlt-1.2</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.4438</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.4438</doi>
       <bibkey>robinson-etal-2022-task</bibkey>
     </paper>
     <paper id="3">
@@ -39,7 +39,7 @@
       <author><first>Emily M.</first><last>Bender</last></author>
       <abstract>We present a grammar inference system that leverages linguistic knowledge recorded in the form of annotations in interlinear glossed text (IGT) and in a meta-grammar engineering system (the LinGO Grammar Matrix customization system) to automatically produce machine-readable HPSG grammars. Building on prior work to handle the inference of lexical classes, stems, affixes and position classes, and preliminary work on inferring case systems and word order, we introduce an integrated grammar inference system that covers a wide range of fundamental linguistic phenomena. System development was guided by 27 geneologically and geographically diverse languages, and we test the system’s cross-linguistic generalizability on an additional 5 held-out languages, using datasets provided by field linguists. Our system out-performs three baseline systems in increasing coverage while limiting ambiguity and producing richer semantic representations, while also producing richer representations than previous work in grammar inference.</abstract>
       <url hash="da808536">2022.nejlt-1.3</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.4017</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.4017</doi>
       <bibkey>howell-bender-2022-building</bibkey>
     </paper>
     <paper id="4">
@@ -49,7 +49,7 @@
       <author><first>Sebastian</first><last>Padó</last></author>
       <abstract>In recent years, there has been an increasing awareness that many NLP systems incorporate biases of various types (e.g., regarding gender or race) which can have significant negative consequences. At the same time, the techniques used to statistically analyze such biases are still relatively simple. Typically, studies test for the presence of a significant difference between two levels of a single bias variable (e.g., male vs. female) without attention to potential confounders, and do not quantify the importance of the bias variable. This article proposes to analyze bias in the output of NLP systems using multivariate regression models. They provide a robust and more informative alternative which (a) generalizes to multiple bias variables, (b) can take covariates into account, (c) can be combined with measures of effect size to quantify the size of bias. Jointly, these effects contribute to a more robust statistical analysis of bias that can be used to diagnose system behavior and extract informative examples. We demonstrate the benefits of our method by analyzing a range of current NLP models on one regression and one classification tasks (emotion intensity prediction and coreference resolution, respectively).</abstract>
       <url hash="d70ddadb">2022.nejlt-1.4</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.3505</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.3505</doi>
       <bibkey>dayanik-etal-2022-analysis</bibkey>
     </paper>
     <paper id="5">
@@ -58,7 +58,7 @@
       <author><first>Riza</first><last>Batista-Navarro</last></author>
       <abstract>Legislative debate transcripts provide citizens with information about the activities of their elected representatives, but are difficult for people to process. We propose the novel task of policy-focused stance detection, in which both the policy proposals under debate and the position of the speakers towards those proposals are identified. We adapt a previously existing dataset to include manual annotations of policy preferences, an established schema from political science. We evaluate a range of approaches to the automatic classification of policy preferences and speech sentiment polarity, including transformer-based text representations and a multi-task learning paradigm. We find that it is possible to identify the policies under discussion using features derived from the speeches, and that incorporating motion-dependent debate modelling, previously used to classify speech sentiment, also improves performance in the classification of policy preferences. We analyse the output of the best performing system, finding that discriminating features for the task are highly domain-specific, and that speeches that address policy preferences proposed by members of the same party can be among the most difficult to predict.</abstract>
       <url hash="45e6c84c">2022.nejlt-1.5</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.3454</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.3454</doi>
       <bibkey>abercrombie-batista-navarro-2022-policy</bibkey>
     </paper>
     <paper id="6">
@@ -72,7 +72,7 @@
       <author><first>Nathan</first><last>Schneider</last></author>
       <abstract>Abstract Meaning Representation (AMR), originally designed for English, has been adapted to a number of languages to facilitate cross-lingual semantic representation and analysis. We build on previous work and present the first sizable, general annotation project for Spanish AMR. We release a detailed set of annotation guidelines and a corpus of 486 gold-annotated sentences spanning multiple genres from an existing, cross-lingual AMR corpus. Our work constitutes the second largest non-English gold AMR corpus to date. Fine-tuning an AMR to-Spanish generation model with our annotations results in a BERTScore improvement of 8.8%, demonstrating initial utility of our work.</abstract>
       <url hash="b8ab1c04">2022.nejlt-1.6</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.4462</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.4462</doi>
       <bibkey>wein-2022-spanish</bibkey>
     </paper>
     <paper id="7">
@@ -83,7 +83,7 @@
       <author><first>Yonatan</first><last>Belinkov</last></author>
       <abstract>Most linguistic studies of Judeo-Arabic, the ensemble of dialects spoken and written by Jews in Arab lands, are qualitative in nature and rely on laborious manual annotation work, and are therefore limited in scale. In this work, we develop automatic methods for morpho-syntactic tagging of Algerian Judeo-Arabic texts published by Algerian Jews in the 19th–20th centuries, based on a linguistically tagged corpus. First, we describe our semi-automatic approach for preprocessing these texts. Then, we experiment with both an off-the-shelf morphological tagger and several specially designed neural network taggers. Finally, we perform a real-world evaluation of new texts that were never tagged before in comparison with human expert annotators. Our experimental results demonstrate that these methods can dramatically speed up and improve the linguistic research pipeline, enabling linguists to study these dialects on a much greater scale.</abstract>
       <url hash="7988c04e">2022.nejlt-1.7</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.4315</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.4315</doi>
       <bibkey>tirosh-becker-etal-2022-part</bibkey>
     </paper>
     <paper id="8">
@@ -91,7 +91,7 @@
       <author><first>Jussi</first><last>Karlgren</last></author>
       <abstract>The study presented in this paper demonstrates how transcribed podcast material differs with respect to lexical content from other collections of English language data: editorial text, social media, both long form and microblogs, dialogue from movie scripts, and transcribed phone conversations. Most of the recorded differences are as might be expected, reflecting known or assumed difference between spoken and written language, between dialogue and soliloquy, and between scripted formal and unscripted informal language use. Most notably, podcast material, compared to the hitherto typical training sets from editorial media, is characterised by being in the present tense, and with a much higher incidence of pronouns, interjections, and negations. These characteristics are, unsurprisingly, largely shared with social media texts. Where podcast material differs from social media material is in its attitudinal content, with many more amplifiers and much less negative attitude than in blog texts. This variation, besides being of philological interest, has ramifications for computational work. Information access for material which is not primarily topical should be designed to be sensitive to such variation that defines the data set itself and discriminates items within it. In general, training sets for language models are a non-trivial parameter which are likely to show effects both expected and unexpected when applied to data from other sources and the characteristics and provenance of data used to train a model should be listed on the label as a minimal form of downstream consumer protection.</abstract>
       <url hash="6b2c2093">2022.nejlt-1.8</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.3566</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.3566</doi>
       <bibkey>karlgren-2022-lexical</bibkey>
     </paper>
     <paper id="9">
@@ -101,7 +101,7 @@
       <author><first>Lilja</first><last>Øvrelid</last></author>
       <abstract>We present a qualitative analysis of the (potentially erroneous) outputs of contextualized embedding-based methods for detecting diachronic semantic change. First, we introduce an ensemble method outperforming previously described contextualized approaches. This method is used as a basis for an in-depth analysis of the degrees of semantic change predicted for English words across 5 decades. Our findings show that contextualized methods can often predict high change scores for words which are not undergoing any real diachronic semantic shift in the lexicographic sense of the term (or at least the status of these shifts is questionable). Such challenging cases are discussed in detail with examples, and their linguistic categorization is proposed. Our conclusion is that pre-trained contextualized language models are prone to confound changes in lexicographic senses and changes in contextual variance, which naturally stem from their distributional nature, but is different from the types of issues observed in methods based on static embeddings. Additionally, they often merge together syntactic and semantic aspects of lexical entities. We propose a range of possible future solutions to these issues.</abstract>
       <url hash="db015b96">2022.nejlt-1.9</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2022.3478</doi>
+      <doi>10.3384/nejlt.2000-1533.2022.3478</doi>
       <bibkey>kutuzov-etal-2022-contextualized</bibkey>
     </paper>
   </volume>

--- a/data/xml/2022.nejlt.xml
+++ b/data/xml/2022.nejlt.xml
@@ -1,15 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <collection id="2022.nejlt">
-  <volume id="1" ingest-date="2023-03-03" type="proceedings">
+  <volume id="1" ingest-date="2023-03-03" type="journal">
     <meta>
       <booktitle>Northern European Journal of Language Technology, Volume 8</booktitle>
       <editor><first>Leon</first><last>Derczynski</last></editor>
-      <publisher>Northern European Association of Language Technology</publisher>
-      <address>Copenhagen, Denmark</address>
+      <publisher>Linköping University Electronic Press</publisher>
+      <address>Linköping, Sweden</address>
       <doi>https://doi.org/10.3384/nejlt.2000-1533.8.1</doi>
       <url hash="b4654b54">2022.nejlt-1</url>
       <year>2022</year>
       <venue>nejlt</venue>
+      <journal-volume>8</journal-volume>
     </meta>
     <paper id="1">
       <title>Foreword to <fixed-case>NEJLT</fixed-case> Volume 8, 2022</title>

--- a/data/xml/2023.nejlt.xml
+++ b/data/xml/2023.nejlt.xml
@@ -6,7 +6,7 @@
       <editor><first>Leon</first><last>Derczynski</last></editor>
       <publisher>Linköping University Electronic Press</publisher>
       <address>Linköping, Sweden</address>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.9.1</doi>
+      <doi>10.3384/nejlt.2000-1533.9.1</doi>
       <year>2023</year>
       <url hash="9c75cf6f">2023.nejlt-1</url>
       <venue>nejlt</venue>
@@ -17,7 +17,7 @@
       <author><first>Emiel</first><last>van Miltenburg</last></author>
       <abstract>This is a proposal for publishing resource papers as registered reports in the Northern European Journal of Language Technology. The idea is that authors write a data collection plan with a full data statement, to the extent that it can be written before data collection starts. Once the proposal is approved, publication of the final resource paper is guaranteed, as long as the data collection plan is followed (modulo reasonable changes due to unforeseen circumstances). This proposal changes the reviewing process from an antagonistic to a collaborative enterprise, and hopefully encourages NLP resources to develop and publish more high-quality datasets. The key advantage of this proposal is that it helps to promote responsible resource development (through constructive peer review) and to avoid research waste.</abstract>
       <url hash="083f4d3e">2023.nejlt-1.1</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4884</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4884</doi>
       <bibkey>van-miltenburg-2023-resource</bibkey>
     </paper>
     <paper id="2">
@@ -30,7 +30,7 @@
       <author><first>Joakim</first><last>Nivre</last></author>
       <abstract>Multiword expressions (MWEs) are challenging and pervasive phenomena whose idiosyncratic properties show notably at the levels of lexicon, morphology, and syntax. Thus, they should best be annotated jointly with morphosyntax. We discuss two multilingual initiatives, Universal Dependencies and PARSEME, addressing these annotation layers in cross-lingually unified ways. We compare the annotation principles of these initiatives with respect to MWEs, and we put forward a roadmap towards their gradual unification. The expected outcomes are more consistent treebanking and higher universality in modeling idiosyncrasy.</abstract>
       <url hash="85bcb4cc">2023.nejlt-1.2</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4453</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4453</doi>
       <bibkey>savary-etal-2023-parseme-meets</bibkey>
     </paper>
     <paper id="3">
@@ -47,7 +47,7 @@
       <author><first>Luou</first><last>Wen</last></author>
       <abstract>Earlier research has shown that few studies in Natural Language Generation (NLG) evaluate their system outputs using an error analysis, despite known limitations of automatic evaluation metrics and human ratings. This position paper takes the stance that error analyses should be encouraged, and discusses several ways to do so. This paper is based on our shared experience as authors as well as a survey we distributed as a means of public consultation. We provide an overview of existing barriers to carrying out error analyses, and propose changes to improve error reporting in the NLG literature.</abstract>
       <url hash="327030d4">2023.nejlt-1.3</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4529</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4529</doi>
       <bibkey>van-miltenburg-etal-2023-barriers</bibkey>
     </paper>
     <paper id="4">
@@ -59,7 +59,7 @@
       <author><first>Thiusius Rajeeth</first><last>Savarimuthu</last></author>
       <abstract>In natural language processing, benchmarks are used to track progress and identify useful models. Currently, no benchmark for Danish clinical word embeddings exists. This paper describes the development of a Danish benchmark for clinical word embeddings. The clinical benchmark consists of ten datasets: eight intrinsic and two extrinsic. Moreover, we evaluate word embeddings trained on text from the clinical domain, general practitioner domain and general domain on the established benchmark. All the intrinsic tasks of the benchmark are publicly available.</abstract>
       <url hash="37b6c8b5">2023.nejlt-1.4</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4132</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4132</doi>
       <bibkey>laursen-etal-2023-benchmark</bibkey>
     </paper>
     <paper id="5">
@@ -191,7 +191,7 @@
       <author><first>Yue</first><last>Zhang</last></author>
       <abstract>Data augmentation is an important method for evaluating the robustness of and enhancing the diversity of training data for natural language processing (NLP) models. In this paper, we present NL-Augmenter, a new participatory Python-based natural language (NL) augmentation framework which supports the creation of transformations (modifications to the data) and filters (data splits according to specific features). We describe the framework and an initial set of 117 transformations and 23 filters for a variety of NL tasks annotated with noisy descriptive tags. The transformations incorporate noise, intentional and accidental human mistakes, socio-linguistic variation, semantically-valid style, syntax changes, as well as artificial constructs that are unambiguous to humans. We demonstrate the efficacy of NL-Augmenter by using its transformations to analyze the robustness of popular language models. We find different models to be differently challenged on different tasks, with quasi-systematic score decreases. The infrastructure, datacards, and robustness evaluation results are publicly available on GitHub for the benefit of researchers working on paraphrase generation, robustness analysis, and low-resource NLP.</abstract>
       <url hash="d6cd4f93">2023.nejlt-1.5</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4725</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4725</doi>
       <bibkey>dhole-etal-2023-nl</bibkey>
     </paper>
     <paper id="6">
@@ -201,7 +201,7 @@
       <author><first>Sebastian</first><last>Padó</last></author>
       <abstract>Emotions, which are responses to salient events, can be realized in text implicitly, for instance with mere references to facts (e.g., “That was the beginning of a long war”). Interpreting affective meanings thus relies on the readers background knowledge, but that is hardly modeled in computational emotion analysis. Much work in the field is focused on the word level and treats individual lexical units as the fundamental emotion cues in written communication. We shift our attention to word relations. We leverage Frame Semantics, a prominent theory for the description of predicate-argument structures, which matches the study of emotions: frames build on a “semantics of understanding” whose assumptions rely precisely on peoples world knowledge. Our overarching question is whether and to what extent the events that are represented by frames possess an emotion meaning. To carry out a large corpus-based correspondence analysis, we automatically annotate texts with emotions as well as with FrameNet frames and roles, and we analyze the correlations between them. Our main finding is that substantial groups of frames have an emotional import. With an extensive qualitative analysis, we show that they capture several properties of emotions that are purported by theories from psychology. These observations boost insights on the two strands of research that we bring together: emotion analysis can profit from the event-based perspective of frame semantics; in return, frame semantics gains a better grip of its position vis-à-vis emotions, an integral part of word meanings.</abstract>
       <url hash="84200429">2023.nejlt-1.6</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4361</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4361</doi>
       <bibkey>troiano-etal-2023-relationship</bibkey>
     </paper>
     <paper id="7">
@@ -211,7 +211,7 @@
       <author><first>Frank</first><last>Drewes</last></author>
       <abstract>Document clustering is frequently used in applications of natural language processing, e.g. to classify news articles or creating topic models. In this paper, we study document clustering with the common clustering pipeline that includes vectorization with BERT or Doc2Vec, dimension reduction with PCA or UMAP, and clustering with K-Means or HDBSCAN. We discuss the inter- actions of the different components in the pipeline, parameter settings, and how to determine an appropriate number of dimensions. The results suggest that BERT embeddings combined with UMAP dimension reduction to no less than 15 dimensions provides a good basis for clustering, regardless of the specific clustering algorithm used. Moreover, while UMAP performed better than PCA in our experiments, tuning the UMAP settings showed little impact on the overall performance. Hence, we recommend configuring UMAP so as to optimize its time efficiency. According to our topic model evaluation, the combination of BERT and UMAP, also used in BERTopic, performs best. A topic model based on this pipeline typically benefits from a large number of clusters.</abstract>
       <url hash="e575bfd7">2023.nejlt-1.7</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4396</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4396</doi>
       <bibkey>eklund-etal-2023-empirical</bibkey>
     </paper>
     <paper id="8">
@@ -221,7 +221,7 @@
       <author><first>Roman</first><last>Klinger</last></author>
       <abstract>People differ fundamentally in what motivates them to pursue a goal and how they approach it. For instance, some people seek growth and show eagerness, whereas others prefer security and are vigilant. The concept of regulatory focus is employed in psychology, to explain and predict this goal-directed behavior of humans underpinned by two unique motivational systems – the promotion and the prevention system. Traditionally, text analysis methods using closed-vocabularies are employed to assess the distinctive linguistic patterns associated with the two systems. From an NLP perspective, automatically detecting the regulatory focus of individuals from text provides valuable insights into the behavioral inclinations of the author, finding its applications in areas like marketing or health communication. However, the concept never made an impactful debut in computational linguistics research. To bridge this gap we introduce the novel task of regulatory focus classification from text and present two complementary German datasets – (1) experimentally generated event descriptions and (2) manually annotated short social media texts used for evaluating the generalizability of models on real-world data. First, we conduct a correlation analysis to verify if the linguistic footprints of regulatory focus reported in psychology studies are observable and to what extent in our datasets. For automatic classification, we compare closed-vocabulary-based analyses with a state-of-the-art BERT-based text classification model and observe that the latter outperforms lexicon-based approaches on experimental data and is notably better on out-of-domain Twitter data.</abstract>
       <url hash="22c11089">2023.nejlt-1.8</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4561</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4561</doi>
       <bibkey>velutharambath-etal-2023-prevention</bibkey>
     </paper>
     <paper id="9">
@@ -230,7 +230,7 @@
       <author><first>Tae-Bin</first><last>Ha</last></author>
       <abstract>Generative Adversarial Networks (GAN) is a model for data synthesis, which creates plausible data through the competition of generator and discriminator. Although GAN application to image synthesis is extensively studied, it has inherent limitations to natural language generation. Because natural language is composed of discrete tokens, a generator has difficulty updating its gradient through backpropagation; therefore, most text-GAN studies generate sentences starting with a random token based on a reward system. Thus, the generators of previous studies are pre-trained in an autoregressive way before adversarial training, causing data memorization that synthesized sentences reproduce the training data. In this paper, we synthesize sentences using a framework similar to the original GAN. More specifically, we propose Text Embedding Space Generative Adversarial Networks (TESGAN) which generate continuous text embedding spaces instead of discrete tokens to solve the gradient backpropagation problem. Furthermore, TESGAN conducts unsupervised learning which does not directly refer to the text of the training data to overcome the data memorization issue. By adopting this novel method, TESGAN can synthesize new sentences, showing the potential of unsupervised learning for text synthesis. We expect to see extended research combining Large Language Models with a new perspective of viewing text as an continuous space.</abstract>
       <url hash="7ea2dd46">2023.nejlt-1.9</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4855</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4855</doi>
       <bibkey>lee-ha-2023-unsupervised</bibkey>
     </paper>
     <paper id="10">
@@ -239,7 +239,7 @@
       <author><first>Dmytro</first><last>Kalpakchi</last></author>
       <abstract>In this article we present the first dataset of multiple choice questions for assessing reading comprehension in Ukrainian. The dataset is based on the texts from the Ukrainian national tests for reading comprehension, and the MCQs themselves are created semi-automatically in three stages. The first stage was to use GPT-3 to generate the MCQs zero-shot, the second stage was to select MCQs of sufficient quality and revise the ones with minor errors, whereas the final stage was to expand the dataset with the MCQs written manually. The dataset is created by the Ukrainian language native speakers, one of whom is also a language teacher. The resulting corpus has slightly more than 900 MCQs, of which only 43 MCQs could be kept as they were generated by GPT-3.</abstract>
       <url hash="4c30412f">2023.nejlt-1.10</url>
-      <doi>https://doi.org/10.3384/nejlt.2000-1533.2023.4939</doi>
+      <doi>10.3384/nejlt.2000-1533.2023.4939</doi>
       <bibkey>zyrianova-kalpakchi-2023-qua</bibkey>
     </paper>
   </volume>

--- a/data/xml/2023.nejlt.xml
+++ b/data/xml/2023.nejlt.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <collection id="2023.nejlt">
-  <volume id="1" ingest-date="2024-08-06" type="proceedings">
+  <volume id="1" ingest-date="2024-08-06" type="journal">
     <meta>
       <booktitle>Northern European Journal of Language Technology, Volume 9</booktitle>
       <editor><first>Leon</first><last>Derczynski</last></editor>
@@ -10,6 +10,7 @@
       <year>2023</year>
       <url hash="9c75cf6f">2023.nejlt-1</url>
       <venue>nejlt</venue>
+      <journal-volume>9</journal-volume>
     </meta>
     <paper id="1">
       <title>Resource papers as registered reports: a proposal</title>

--- a/data/xml/2024.nejlt.xml
+++ b/data/xml/2024.nejlt.xml
@@ -8,6 +8,7 @@
       <address>Linköping, Sweden</address>
       <month>December</month>
       <year>2024</year>
+      <doi>10.3384/nejlt.2000-1533.10.1</doi>
       <url hash="4082ecf8">2024.nejlt-1</url>
       <venue>nejlt</venue>
       <journal-volume>10</journal-volume>
@@ -22,6 +23,7 @@
       <pages>1-13</pages>
       <abstract>Finetuning is a useful method for adapting Transformer-based text encoders to new tasks but can be computationally expensive for structured prediction tasks that require tuning at the token level. Furthermore, finetuning is inherently inefficient in updating all base model parameters, which prevents parameter sharing across tasks. To address these issues, we propose a method for efficient task adaptation of frozen Transformer encoders based on the local contribution of their intermediate layers to token representations. Our adapter uses a novel attention mechanism to aggregate intermediate layers and tailor the resulting representations to a target task. Experiments on several structured prediction tasks demonstrate that our method outperforms previous approaches, retaining over 99% of the finetuning performance at a fraction of the training cost. Our proposed method offers an efficient solution for adapting frozen Transformer encoders to new tasks, improving performance and enabling parameter sharing across different tasks.</abstract>
       <url hash="9b919104">2024.nejlt-1.1</url>
+      <doi>10.3384/nejlt.2000-1533.2024.4932</doi>
       <bibkey>basirat-2024-efficient</bibkey>
     </paper>
     <paper id="2">
@@ -31,6 +33,7 @@
       <author><first>Rebekah</first><last>Baglini</last><affiliation>Aarhus University</affiliation></author>
       <pages>14-29</pages>
       <abstract>Named entity recognition is an important application within Danish NLP, essential within both industry and research. However, Danish NER is inhibited by a lack coverage across domains and entity types. As a consequence, no current models are capable of fine-grained named entity recognition, nor have they been evaluated for potential generalizability issues across datasets and domains. To alleviate these limitations, this paper introduces: 1) DANSK: a named entity dataset providing for high-granularity tagging as well as within-domain evaluation of models across a diverse set of domains; 2) and three generalizable models with fine-grained annotation available in DaCy 2.6.0; and 3) an evaluation of current state-of-the-art models’ ability to generalize across domains. The evaluation of existing and new models revealed notable performance discrepancies across domains, which should be addressed within the field. Shortcomings of the annotation quality of the dataset and its impact on model training and evaluation are also discussed. Despite these limitations, we advocate for the use of the new dataset DANSK alongside further work on generalizability within Danish NER.</abstract>
+      <doi>10.3384/nejlt.2000-1533.2024.5249</doi>
       <url hash="9ea5374c">2024.nejlt-1.2</url>
       <bibkey>enevoldsen-etal-2024-dansk</bibkey>
     </paper>
@@ -43,6 +46,7 @@
       <author><first>Verena</first><last>Rieser</last></author>
       <pages>30-49</pages>
       <abstract>Counterspeech offers direct rebuttals to hateful speech by challenging perpetrators of hate and showing support to targets of abuse. It provides a promising alternative to more contentious measures, such as content moderation and deplatforming, by contributing a greater amount of positive online speech rather than attempting to mitigate harmful content through removal. Advances in the development of large language models mean that the process of producing counterspeech could be made more efficient by automating its generation, which would enable large-scale online campaigns. However, we currently lack a systematic understanding of several important factors relating to the efficacy of counterspeech for hate mitigation, such as which types of counterspeech are most effective, what are the optimal conditions for implementation, and which specific effects of hate it can best ameliorate. This paper aims to fill this gap by systematically reviewing counterspeech research in the social sciences and comparing methodologies and findings with natural language processing (NLP) and computer science efforts in automatic counterspeech generation. By taking this multi-disciplinary view, we identify promising future directions in both fields.</abstract>
+      <doi>10.3384/nejlt.2000-1533.2024.5203</doi>
       <url hash="4dc31916">2024.nejlt-1.3</url>
       <bibkey>chung-etal-2024-understanding</bibkey>
     </paper>
@@ -68,6 +72,7 @@
       <author><first>Yacine</first><last>Jernite</last></author>
       <pages>50-77</pages>
       <abstract>Contemporary large-scale data collection efforts have prioritized the amount of data collected to improve large language models (LLM). This quantitative approach has resulted in concerns for the rights of data subjects represented in data collections. This concern is exacerbated by a lack of documentation and analysis tools, making it difficult to interrogate these collections. Mindful of these pitfalls, we present a methodology for documentation-first, human-centered data collection. We apply this approach in an effort to train a multilingual LLM. We identify a geographically diverse set of target language groups (Arabic varieties, Basque, Chinese varieties, Catalan, English, French, Indic languages, Indonesian, Niger-Congo languages, Portuguese, Spanish, and Vietnamese, as well as programming languages) for which to collect metadata on potential data sources. We structure this effort by developing an online catalogue in English as a tool for gathering metadata through public hackathons. We present our tool and analyses of the resulting resource metadata, including distributions over languages, regions, and resource types, and discuss our lessons learned.</abstract>
+      <doi>10.3384/nejlt.2000-1533.2024.5217</doi>
       <url hash="cc57a878">2024.nejlt-1.4</url>
       <bibkey>mcmillan-major-etal-2024-documenting</bibkey>
     </paper>
@@ -76,6 +81,7 @@
       <author><first>Matúš</first><last>Pikuliak</last><affiliation>Kempelen Institute of Intelligent Technologies</affiliation></author>
       <pages>78-85</pages>
       <abstract>We are at a curious point in time where our ability to build language models (LMs) has outpaced our ability to analyze them. We do not really know how to reliably determine their capabilities, biases, dangers, knowledge, and so on. The benchmarks we have are often overly specific, do not generalize well, and are susceptible to data leakage. Recently, I have noticed a trend of using self-report studies, such as various polls and questionnaires originally designed for humans, to analyze the properties of LMs. I think that this approach can easily lead to false results, which can be quite dangerous considering the current discussions on AI safety, governance, and regulation. To illustrate my point, I will delve deeper into several papers that employ self-report methodologies and I will try to highlight some of their weaknesses.</abstract>
+      <doi>10.3384/nejlt.2000-1533.2024.5000</doi>
       <url hash="03ec9a16">2024.nejlt-1.5</url>
       <bibkey>pikuliak-2024-using</bibkey>
     </paper>
@@ -85,6 +91,7 @@
       <author><first>Johan</first><last>Boye</last><affiliation>KTH Royal Institute of Technology</affiliation></author>
       <pages>86-105</pages>
       <abstract>Multiple-choice questions (MCQs) provide a widely used means of assessing reading comprehension. The automatic generation of such MCQs is a challenging language-technological problem that also has interesting educational applications. This article presents several methods for automatically producing reading comprehension questions MCQs from Swedish text. Unlike previous approaches, we construct models to generate the whole MCQ in one go, rather than using a pipeline architecture. Furthermore, we propose a two-stage method for evaluating the quality of the generated MCQs, first evaluating on carefully designed single-sentence texts, and then on texts from the SFI national exams. An extensive evaluation of the MCQ-generating capabilities of 12 different models, using this two-stage scheme, reveals that GPT-based models surpass smaller models that have been fine-tuned using small-scale datasets on this specific problem.</abstract>
+      <doi>10.3384/nejlt.2000-1533.2024.4886</doi>
       <url hash="d9829f86">2024.nejlt-1.6</url>
       <bibkey>kalpakchi-boye-2024-generation</bibkey>
     </paper>

--- a/data/xml/2024.nejlt.xml
+++ b/data/xml/2024.nejlt.xml
@@ -1,15 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <collection id="2024.nejlt">
-  <volume id="1" ingest-date="2025-01-08" type="proceedings">
+  <volume id="1" ingest-date="2025-01-08" type="journal">
     <meta>
       <booktitle>Northern European Journal of Language Technology, Volume 10</booktitle>
       <editor><first>Marcel</first><last>Bollmann</last></editor>
       <publisher>Linköping University Electronic Press</publisher>
       <address>Linköping, Sweden</address>
-      <month>March</month>
+      <month>December</month>
       <year>2024</year>
       <url hash="4082ecf8">2024.nejlt-1</url>
       <venue>nejlt</venue>
+      <journal-volume>10</journal-volume>
     </meta>
     <frontmatter>
       <url hash="d6dbcb7f">2024.nejlt-1.0</url>


### PR DESCRIPTION
- Marks NEJLT volumes as 'journal'
- Adds 'journal-volume'
- Fixes publisher (NEALT is not a publisher; Linköping E-Press is)
- Fix DOI fields (2021–2023)
- Add DOIs (2024; oversight in my adaption of ACLPUB2 ...)
