### PR TITLE
Added Gonçal Garcés with name variants

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -2985,6 +2985,12 @@
 - canonical: {first: Radovan, last: Garabík}
   variants:
   - {first: Radovan, last: Garabik}
+- canonical: {first: Gonçal V., last: Garcés Díaz-Munío}
+  orcid: 0000-0002-2594-5858
+  variants:
+  - {first: Gonçal, last: Garcés Díaz-Munío}
+  - {first: Gonzalo, last: Garcés Díaz-Munío}
+  - {first: Gonzalo V., last: Garcés Díaz-Munío}
 - canonical: {first: Fernando, last: Garcia}
   variants:
   - {first: Fernando, last: García-Granada}


### PR DESCRIPTION
name_variants.yaml: Added Gonçal Garcés with name variants
- Merging https://aclanthology.org/people/g/goncal-v-garces-diaz-munio/ and https://aclanthology.org/people/g/goncal-garces-diaz-munio/
- ORCID: https://orcid.org/0000-0002-2594-5858
- Academic website: https://www.upv.es/pls/oalu/sic_person.Info?p_alias=gogardia&P_IDIOMA=i