### PR TITLE
Correct author name (mine) to bring in line with PDF

### DIFF
--- a/data/xml/2022.iwslt.xml
+++ b/data/xml/2022.iwslt.xml
@@ -388,7 +388,7 @@
       <author><first>Javier</first><last>Jorge Cano</last></author>
       <author><first>Alejandro</first><last>Pérez-González-de-Martos</last></author>
       <author><first>Adrián</first><last>Giménez Pastor</last></author>
-      <author><first>Gonçal</first><last>Garcés Díaz-Munío</last></author>
+      <author><first>Gonçal V.</first><last>Garcés Díaz-Munío</last></author>
       <author><first>Pau</first><last>Baquero-Arnal</last></author>
       <author><first>Joan Albert</first><last>Silvestre-Cerdà</last></author>
       <author><first>Jorge</first><last>Civera Saiz</last></author>


### PR DESCRIPTION
Correct author name (mine) to bring in line with PDF:
Added middle name as in PDF https://aclanthology.org/2022.iwslt-1.22.pdf
``<first>Gonçal</first>`` -> ``<first>Gonçal V.</first>``