### PR TITLE
Update Freda Shi name variants.

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -10713,3 +10713,9 @@
   - {first: Eddie A., last: Santos}
   - {first: Eddie, last: Antonio Santos}
   - {first: Eddie, last: Santos}
+- canonical: {first: Freda, last: Shi}
+  id: freda-shi
+  orcid: 0009-0009-5697-449X
+  variants:
+  - {first: Haoyue, last: Shi}
+  - {first: Haoyue Freda, last: Shi}


### PR DESCRIPTION
I used to publish under Haoyue Shi before 2022 and then switched to Freda Shi. 
This PR includes my name variants.