### PR TITLE
Add check that collection ID matches filename

### DIFF
--- a/python/acl_anthology/collections/collection.py
+++ b/python/acl_anthology/collections/collection.py
@@ -133,7 +133,8 @@ class Collection(SlottedDict[Volume]):
         log.debug(f"Parsing XML data file: {self.path}")
         current_volume = cast(Volume, None)  # noqa: F841
         for _, element in etree.iterparse(
-            self.path, tag=("meta", "frontmatter", "paper", "volume", "event")
+            self.path,
+            tag=("meta", "frontmatter", "paper", "volume", "event", "collection"),
         ):
             discard_element = True
             if (
@@ -150,6 +151,11 @@ class Collection(SlottedDict[Volume]):
             elif element.tag == "event":
                 self._set_event_from_xml(element)
                 element.clear()
+            elif element.tag == "collection":
+                if element.get("id") != self.id:
+                    raise ValueError(
+                        f"File {self.path} contains Collection '{element.get('id')}'"
+                    )
             else:
                 # Keep element around; should only apply to <event><meta> ...
                 discard_element = False

--- a/python/tests/collections/collection_test.py
+++ b/python/tests/collections/collection_test.py
@@ -68,6 +68,14 @@ def test_collection_load(
         assert collection.get_event() is None
 
 
+def test_collection_load_id_mismatch(collection_index, datadir):
+    collection = Collection(
+        "2019.emnlp", parent=collection_index, path=datadir / "xml" / "2022.acl.xml"
+    )
+    with pytest.raises(ValueError):
+        collection.load()
+
+
 @pytest.mark.parametrize("filename", test_cases_xml_roundtrip)
 def test_collection_validate_schema(collection_index, datadir, filename):
     infile = datadir / "xml" / filename


### PR DESCRIPTION
Adds an explicit check for the implicit assumption we currently make that XML filenames must match the collection IDs they contain.

Should prevent issue like #4458 
