### PR TITLE
Update name_variants.yaml

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -9642,6 +9642,13 @@
   - {first: Sarah E., last: Vieweg}
 - canonical: {first: Marina, last: Vigário}
   id: marina-vigario
+- canonical: {first: Jacob Hoover, last: Vigly}
+  id: jacob-hoover-vigly
+  variants:
+  - {first: Jacob Louis, last: Hoover}
+  - {first: Jacob L., last: Hoover}
+  - {first: Jacob, last: Hoover}
+  - {first: Jacob, last: Vigly}
 - canonical: {first: K., last: Vijay-Shanker}
   id: k-vijay-shanker
   variants:


### PR DESCRIPTION
Consolidate two name variants, and update canonical name to be new legal name.

Currently there are two name pages which refer to the same person (I published under two variants of name)
- [Jacob **Hoover**](https://aclanthology.org/people/j/jacob-hoover/)
- [Jacob Louis **Hoover**](https://aclanthology.org/people/j/jacob-louis-hoover/)
These should both be under the new legal name (and future publications will be under this new name):
- Jacob Hoover **Vigly**

See issue: #4484 