### PR TITLE
metadata correction issue JSON: store strings of old/new full author lists for easy comparison

### DIFF
--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -281,8 +281,8 @@
     const newAuthorString = JSON.stringify(newAuthors);
     if (newAuthorString != oldAuthorString) {
       updatedParams.authors = newAuthors;
-      updatedParam.authors0 = paper_params.authors.map((x) => x.first + "  " + x.last).join(" | ");
-      updatedParam.authors1 = newAuthors.map((x) => x.first + "  " + x.last).join(" | ");
+      updatedParams.authors0 = paper_params.authors.map((x) => x.first + "  " + x.last).join(" | ");
+      updatedParams.authors1 = newAuthors.map((x) => x.first + "  " + x.last).join(" | ");
     }
 
     if (Object.keys(updatedParams).length === 1) {

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -281,8 +281,8 @@
     const newAuthorString = JSON.stringify(newAuthors);
     if (newAuthorString != oldAuthorString) {
       updatedParams.authors = newAuthors;
-      updatedParams.authors0 = paper_params.authors.map((x) => x.first + "  " + x.last).join(" | ");
-      updatedParams.authors1 = newAuthors.map((x) => x.first + "  " + x.last).join(" | ");
+      updatedParams.authors_old = paper_params.authors.map((x) => x.first + "  " + x.last).join(" | ");
+      updatedParams.authors_new = newAuthors.map((x) => x.first + "  " + x.last).join(" | ");
     }
 
     if (Object.keys(updatedParams).length === 1) {

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -281,6 +281,8 @@
     const newAuthorString = JSON.stringify(newAuthors);
     if (newAuthorString != oldAuthorString) {
       updatedParams.authors = newAuthors;
+      updatedParam.authors0 = paper_params.authors.map((x) => x.first + "  " + x.last).join(" | ");
+      updatedParam.authors1 = newAuthors.map((x) => x.first + "  " + x.last).join(" | ");
     }
 
     if (Object.keys(updatedParams).length === 1) {


### PR DESCRIPTION

<img width="805" alt="image" src="https://github.com/user-attachments/assets/c6e602b1-9aea-47eb-a40f-699127523f68" />

I think these 2 strings will just be ignored when the bulk processing happens. But they are good for readability.