### PR TITLE
Fixed bad hyphenation in `ahmed-etal-2011-challenges`.

### DIFF
--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -6690,7 +6690,7 @@
       <bibkey>ws-2011-advances</bibkey>
     </frontmatter>
     <paper id="1">
-      <title>Challenges in Designing Input Method Editors for <fixed-case>I</fixed-case>ndian Lan-guages: The Role of Word-Origin and Context</title>
+      <title>Challenges in Designing Input Method Editors for <fixed-case>I</fixed-case>ndian Languages: The Role of Word-Origin and Context</title>
       <author><first>Umair Z</first><last>Ahmed</last></author>
       <author><first>Kalika</first><last>Bali</last></author>
       <author><first>Monojit</first><last>Choudhury</last></author>


### PR DESCRIPTION
Removed redundant hyphen in `ahmed-etal-2011-challenges`.
