### PR TITLE
Update name_variants.yaml

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -10746,3 +10746,10 @@
 - canonical: {first: Marten, last: Düring}
   comment: May refer to several people
   id: marten-during
+- canonical: {first: Steven, last: Wilson}
+  variants:
+  - {first: Steven R., last: Wilson}
+  - {first: Steven R, last: Wilson}
+  - {first: Steve, last: Wilson}
+  - {first: Steve R., last: Wilson}
+  - {first: Steve R, last: Wilson}


### PR DESCRIPTION
The following author pages should be merged:
https://aclanthology.org/people/s/steven-wilson/
https://aclanthology.org/people/s/steve-r-wilson/
https://aclanthology.org/people/s/steven-r-wilson/

Name variants to capture all of these are being suggested.

(Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)
