### PR TITLE
Add more rules for LaTeX quote conversion

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
 - MarkupText can now be instantiated from strings (potentially) containing LaTeX markup.
   - This reimplements functionality used at ingestion time previously found in `bin/latex_to_unicode.py`.
+
+### Changed
+
+- MarkupText: Typographic quotes now convert to/from LaTeX quotes more consistently.
 
 ## [0.5.2] — 2025-05-16
 

--- a/python/tests/text/markuptext_test.py
+++ b/python/tests/text/markuptext_test.py
@@ -106,6 +106,30 @@ test_cases_markup = (
         },
     ),
     (
+        'This "very <b>bold</b>" assumption',
+        {
+            "text": 'This "very bold" assumption',
+            "html": 'This "very <b>bold</b>" assumption',
+            "latex": "This ``very \\textbf{bold}'' assumption",
+        },
+    ),
+    (  # Typographic quotes get turned into normal LaTeX quotes as well
+        "This “very normal” assumption",
+        {
+            "text": "This “very normal” assumption",
+            "html": "This “very normal” assumption",
+            "latex": "This ``very normal'' assumption",
+        },
+    ),
+    (
+        "This “very <b>bold</b>” assumption",
+        {
+            "text": "This “very bold” assumption",
+            "html": "This “very <b>bold</b>” assumption",
+            "latex": "This ``very \\textbf{bold}'' assumption",
+        },
+    ),
+    (  # Special characters should always be in braces for BibTeX export
         "Äöøéÿőßû–",
         {
             "text": "Äöøéÿőßû–",
@@ -282,12 +306,20 @@ test_cases_markup_from_latex = (
         "ħĦ",
     ),
     (
-        "\\textquotesingle \\textquotedblleft \\textquotedblright",
-        "'“”",
+        "\\textquotesingle \\textquotedblleft \\textquotedblright \\textquoteleft \\textquoteright",
+        "'“”‘’",
     ),
     (
-        "\\$42 x`x",
-        "$42 x`x",  # TODO: latex_to_unicode.py converts ` to ‘ but I'm not sure why
+        "\\$42",
+        "$42",
+    ),
+    (  # LaTeX quotes should be turned into typographic quotes
+        "``Double'' quotes ``within'' text and \\textbf{``markup''}",
+        "“Double” quotes “within” text and <b>“markup”</b>",
+    ),
+    (
+        "`Single' quotes `within' text and \\textbf{`markup'}",
+        "‘Single’ quotes ‘within’ text and <b>‘markup’</b>",
     ),
     (  # Non-ASCII characters should remain unchanged
         "陳大文",


### PR DESCRIPTION
Addresses #5320 by explicitly converting to/from LaTeX quotes (` `` '' ` and `` ` ' ``) if possible, instead of using `\textquotedblleft` etc.