### PR TITLE
Adapt Papers with Code integration script to use Python library

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [UNRELEASED]
+
+### Changed
+
+- `PapersWithCodeReference.code` will now always correctly be `None` if neither name or URL for a code repository are given, instead of `(None, '')` which was previously possible.
+
 ## [0.5.3] — 2025-06-22
 
 This release adds more functionality for ingesting new proceedings and modifying existing data.

--- a/python/acl_anthology/collections/paper.py
+++ b/python/acl_anthology/collections/paper.py
@@ -300,9 +300,7 @@ class Paper:
     language: Optional[str] = field(default=None, repr=False)
     note: Optional[str] = field(default=None, repr=False)
     pages: Optional[str] = field(default=None, repr=False)
-    paperswithcode: Optional[PapersWithCodeReference] = field(
-        default=None, on_setattr=attrs.setters.frozen, repr=False
-    )
+    paperswithcode: Optional[PapersWithCodeReference] = field(default=None, repr=False)
     pdf: Optional[PDFReference] = field(default=None, repr=False)
     type: PaperType = field(default=PaperType.PAPER, repr=False, converter=PaperType)
 

--- a/python/acl_anthology/files.py
+++ b/python/acl_anthology/files.py
@@ -212,7 +212,7 @@ class PapersWithCodeReference:
         pwc_tuple = (elem.text, elem.get("url", ""))
         if elem.tag == "pwccode":
             self.community_code = xsd_boolean(elem.get("additional", ""))
-            self.code = pwc_tuple
+            self.code = pwc_tuple if any(pwc_tuple) else None
         elif elem.tag == "pwcdataset":
             self.datasets.append(pwc_tuple)
         else:  # pragma: no cover
@@ -226,15 +226,19 @@ class PapersWithCodeReference:
             A serialization of all PapersWithCode information as a list of corresponding XML tags in the Anthology XML format.
         """
         elements = []
-        if self.code is not None:
-            args = [self.code[0]] if self.code[0] is not None else []
-            elements.append(
-                E.pwccode(
-                    *args,
-                    url=self.code[1],
-                    additional=str(self.community_code).lower(),
+        if self.code or self.community_code:
+            additional = str(self.community_code).lower()
+            if self.code is None:
+                elements.append(E.pwccode(url="", additional=additional))
+            else:
+                args = [self.code[0]] if self.code[0] is not None else []
+                elements.append(
+                    E.pwccode(
+                        *args,
+                        url=self.code[1],
+                        additional=additional,
+                    )
                 )
-            )
         for dataset in self.datasets:
             args = [dataset[0]] if dataset[0] is not None else []
             elements.append(E.pwcdataset(*args, url=dataset[1]))

--- a/python/tests/files_test.py
+++ b/python/tests/files_test.py
@@ -110,7 +110,7 @@ test_cases_pwc = (
     (
         # This happens, so it needs to be handled
         ('<pwccode url="" additional="true"/>',),
-        (None, ""),
+        None,
         True,
         [],
     ),


### PR DESCRIPTION
Adapts `ingest_pwc.py` to use the Python library rather than modify XML directly.

Targets `python-dev` since the v0.5.3 changes are not merged into master yet, and this also introduces some small modifications to the library.

Resolves #5473 (after the script is run at least once on master).