### PR TITLE
Fix: Remove 'ws' tag from findings volumes

### DIFF
--- a/data/xml/2025.findings.xml
+++ b/data/xml/2025.findings.xml
@@ -6414,7 +6414,6 @@
       <month>July</month>
       <year>2025</year>
       <venue>findings</venue>
-      <venue>ws</venue>
       <isbn>979-8-89176-256-5</isbn>
     </meta>
     <frontmatter>


### PR DESCRIPTION
Removes the ws tag from "findings" volumes. This was missed in the initial fix for tutorials (see [#5449](https://github.com/acl-org/acl-anthology/pull/5449#issuecomment-3089275500)).