### PR TITLE
Editor, Venue and Abstract fixes for SDP 2025 proceedings

### DIFF
--- a/data/xml/2025.sdp.xml
+++ b/data/xml/2025.sdp.xml
@@ -5,13 +5,13 @@
       <booktitle>Proceedings of the Fifth Workshop on Scholarly Document Processing (SDP 2025)</booktitle>
       <editor><first>Tirthankar</first><last>Ghosal</last></editor>
       <editor><first>Philipp</first><last>Mayr</last></editor>
-      <editor><first>Anita</first><last>De Waard</last></editor>
-      <editor><first>Aakanksha</first><last>Naik</last></editor>
       <editor><first>Amanpreet</first><last>Singh</last></editor>
-      <editor><first>Dayne</first><last>Freitag</last></editor>
+      <editor><first>Aakanksha</first><last>Naik</last></editor>
       <editor><first>Georg</first><last>Rehm</last></editor>
-      <editor><first>Sonja</first><last>Schimmler</last></editor>
+      <editor><first>Dayne</first><last>Freitag</last></editor>
       <editor><first>Dan</first><last>Li</last></editor>
+      <editor><first>Sonja</first><last>Schimmler</last></editor>
+      <editor><first>Anita</first><last>De Waard</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Vienna, Austria</address>
       <month>July</month>


### PR DESCRIPTION
We (SDP 2025 chairs) realized the following issues with the workshop proceedings:
i) Venue is Venice, Austria instead of Vienna, Austria
ii) The editor list only has one instead of all the chairs
iii) The abstract contains inconsistencies compared to the proceedings pdf.

URLs with issues:
-- https://aclanthology.org/2025.sdp-1.0/
-- https://aclanthology.org/2025.sdp-1.1/


This PR is to fix those issues.

Thanks

