### PR TITLE
Rename WMT to "Conference on Machine Translation"

### DIFF
--- a/data/yaml/venues/wmt.yaml
+++ b/data/yaml/venues/wmt.yaml
@@ -1,4 +1,4 @@
 acronym: WMT
 is_acl: true
 is_toplevel: true
-name: Workshop on Statistical Machine Translation
+name: Conference on Machine Translation


### PR DESCRIPTION
WMT has been renamed to "Conference on Machine Translation" 10 years ago, though it keeps the abbreviation for historical reasons. The current name can be [checked here](https://www2.statmt.org/wmt25/).

The ACL Anthology refers to it as _Workshop on Statistical Machine Translation_, which is incorrect. Example where this happens is here: https://aclanthology.org/events/wmt-2024/

My understanding is that by changing the venue name in the YAML file, the name will change also in previous editions. Still, it might be more correct to use the "new" name.