### PR TITLE
Rename NAACL to "Nations of the Americas Chapter..."

### DIFF
--- a/data/yaml/venues/naacl.yaml
+++ b/data/yaml/venues/naacl.yaml
@@ -1,5 +1,5 @@
 acronym: NAACL
 is_acl: true
 is_toplevel: true
-name: North American Chapter of the Association for Computational Linguistics
+name: Nations of the Americas Chapter of the Association for Computational Linguistics
 oldstyle_letter: N


### PR DESCRIPTION
Similar to #5572, NAACL was recently renamed to the "Nations of the Americas Chapter..." ([Source](https://naacl.org/posts/2024-10-24-Name-Change-Announcement)).

The latest volume names are fine; only the ACL Anthology header needs to be updated.
See: https://aclanthology.org/events/naacl-2025/

As in #5572, modifying the venue name in the YAML file will also change previous editions.

Thank you for your continuous efforts!