### PR TITLE
Update author page URIs

### DIFF
--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -353,7 +353,7 @@ def export_people(anthology, builddir, dryrun):
         task = progress.add_task("Exporting people...", total=ppl_count)
 
         # Here begins the actual serialization
-        people = defaultdict(dict)
+        people = {}
         for person_id, person in anthology.people.items():
             cname = person.canonical_name
             papers = sorted(
@@ -399,13 +399,12 @@ def export_people(anthology, builddir, dryrun):
             similar = anthology.people.similar.subset(person_id)
             if len(similar) > 1:
                 data["similar"] = list(similar - {person_id})
-            people[person_id[0]][person_id] = data
+            people[person_id] = data
             progress.update(task, advance=1)
 
         if not dryrun:
-            for first_letter, people_list in people.items():
-                with open(f"{builddir}/data/people/{first_letter}.json", "wb") as f:
-                    f.write(ENCODER.encode(people_list))
+            with open(f"{builddir}/data/people.json", "wb") as f:
+                f.write(ENCODER.encode(people))
             progress.update(task, advance=100)
 
 

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -33,7 +33,7 @@ Options:
 """
 
 from docopt import docopt
-from collections import Counter, defaultdict
+from collections import Counter
 from functools import cache
 import logging as log
 import msgspec

--- a/hugo/content/people/_content.gotmpl
+++ b/hugo/content/people/_content.gotmpl
@@ -1,12 +1,10 @@
-{{ range $first_letter, $people := .Site.Data.people }}
-   {{ range $person_id, $person := $people }}
-      {{ $page := dict
-         "kind" "page"
-         "path" (printf "%s/%s" $first_letter $person_id)
-         "slug" $person_id
-         "params" (dict "name" $person_id "lastname" $person.last)
-         "title" $person.full
-      }}
-      {{ $.AddPage $page }}
-   {{ end }}
+{{ range $person_id, $person := .Site.Data.people }}
+   {{ $page := dict
+      "kind" "page"
+      "path" $person_id
+      "slug" $person_id
+      "params" (dict "name" $person_id "lastname" $person.last)
+      "title" $person.full
+   }}
+   {{ $.AddPage $page }}
 {{ end }}

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -3,8 +3,7 @@
 {{ $paper := index (index .Site.Data.papers $volume_id) .Params.anthology_id }}
   <meta content="{{ $paper.title }}" name="citation_title" >
 {{ range $paper.author }}
-  {{ $first_letter := slicestr .id 0 1 }}
-  <meta content="{{ (index $.Site.Data.people $first_letter .id).full }}" name="citation_author" >
+  <meta content="{{ (index $.Site.Data.people .id).full }}" name="citation_author" >
 {{ end }}
 {{ with $paper.parent_volume_id }}
   {{ $volume := index $.Site.Data.volumes . }}

--- a/hugo/layouts/partials/author_link.html
+++ b/hugo/layouts/partials/author_link.html
@@ -8,7 +8,6 @@
         - person: A dict with key "id" (the ID of the person to link to, e.g., "hector-martinez-alonso"), and optional key "full" (a variant spelling)
         - class (optional): CSS classes for the link
 */}}
-{{ $first_letter := slicestr .person.id 0 1 }}
-{{ $entry := index .ctx.Site.Data.people $first_letter .person.id }}
-{{ $link_to := printf "/people/%s/%s" $first_letter .person.id }}
+{{ $entry := index .ctx.Site.Data.people .person.id }}
+{{ $link_to := printf "/people/%s" .person.id }}
 <a href="{{ relref .ctx $link_to }}"{{ with .class }} class="{{ . }}"{{ end }}>{{ if isset .person "full" }}{{ .person.full }}{{ else }}{{ $entry.full }}{{ end }}</a>

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -1,6 +1,5 @@
 {{ define "main" }}
-{{ $first_letter := slicestr .Params.name 0 1 }}
-{{ $person := index .Site.Data.people $first_letter .Params.name }}
+{{ $person := index .Site.Data.people .Params.name }}
 <section id="main">
   <h2 id="title">
     <!-- {{- .Title -}} -->
@@ -24,7 +23,7 @@
     {{ $len := (len .) }}
     {{ range $index, $sim_id := . }}
     {{ trim (partial "author_link.html" (dict "ctx" $ "person" (dict "id" $sim_id))) " \n" | safeHTML }}
-    {{ $sim_person := index $.Site.Data.people (slicestr $sim_id 0 1) $sim_id }}{{ with $sim_person.comment }}({{.}}){{ end }}{{ if ne (add $index 1) $len }}, {{ end }}
+    {{ $sim_person := index $.Site.Data.people $sim_id }}{{ with $sim_person.comment }}({{.}}){{ end }}{{ if ne (add $index 1) $len }}, {{ end }}
     {{ end }}
   </p>
   {{ end }}

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -79,7 +79,7 @@ RewriteRule ^thumb/(.*)$ anthology-files/thumb/$1 [L,NC]
 # Author pages. A request for the old-style URL /people/m/matt-post should give a 301 redirect
 # to /people/matt-post. Note that this works for any letter prefix, but this can't be avoided
 # since the pattern-match can't match source side.
-RewriteRule ^people/[a-z]/([a-z0-9])([\-a-z0-9]+)/?$ people/$1$2/ [R=301,L,NC]
+RewriteRule ^people/[a-z]/([\-a-z0-9]+)/?$ people/$1/ [R=301,L,NC]
 
 # Videos
 ## match old-style URLs, e.g., /N13-1001.mp4 -> anthology-files/videos/N/N13-1001.mp4

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -77,8 +77,9 @@ RewriteRule ^files/(.*)$ anthology-files/files/$1 [L,NC]
 # Thumbnails (e.g., /thumb/P17-1069.jpg loads anthology-files/thumb/P17-1069.jpg)
 RewriteRule ^thumb/(.*)$ anthology-files/thumb/$1 [L,NC]
 
-# Author pages (e.g., people/arya-d-mccarthy loads people/a/arya-d-mccarthy)
-RewriteRule ^people/([a-z])([\-a-z0-9]*)$ people/$1/$1$2/ [L,NC]
+# Author pages. A request for the old-style URL /people/m/matt-post should give a 301 redirect
+# to /people/matt-post.
+RewriteRule ^people/([a-z])/$1([\-a-z0-9]*)$ people/$1/$1$2/ [R=301,L,NC]
 
 # Videos
 ## match old-style URLs, e.g., /N13-1001.mp4 -> anthology-files/videos/N/N13-1001.mp4

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -20,8 +20,9 @@ AddDefaultCharset utf-8
 ErrorDocument 404 /ANTHOLOGYDIR/404.html
 
 RewriteEngine On
+# This allows prefixes to work for previews (preview.aclanthology.org/ANTHOLOGYDIR))
+RewriteBase /ANTHOLOGYDIR
 
-#
 # EXTERNAL REDIRECTIONS
 #
 # These rules contain external redirections: to HTTPS, to the canonical URLs, and others.
@@ -32,7 +33,6 @@ RewriteCond %{HTTPS} !=on [OR]
 RewriteCond %{HTTP_HOST} acl\.ldc\.upenn\.edu [OR]
 RewriteCond %{HTTP_HOST} www\.aclanthology\.org [NC]
 RewriteRule ^(.*)$ https://aclanthology.org/$1 [R=301,L]
-
 
 ## Nested file paths
 # Redirect old nested file paths (e.g., P/P17/P17-1069.pdf -> https://www.aclweb.org/anthology/P17-1069.pdf)
@@ -46,7 +46,6 @@ RewriteRule ^[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})(/|\.[a-z]+)?$ htt
 RewriteCond %{HTTP_HOST} ^aclanthology\.org$
 RewriteRule ^papers/[A-Za-z]/[A-Za-z]\d{2}/([A-Za-z])(\d{2})\-(\d{4})/?$ https://aclanthology.org/$1$2-$3 [R=301,L]
 
-#
 # INTERNAL RETRIEVALS
 #
 # These rules take valid external URLS (which are often virtual targets) and retrieve their target.
@@ -78,8 +77,9 @@ RewriteRule ^files/(.*)$ anthology-files/files/$1 [L,NC]
 RewriteRule ^thumb/(.*)$ anthology-files/thumb/$1 [L,NC]
 
 # Author pages. A request for the old-style URL /people/m/matt-post should give a 301 redirect
-# to /people/matt-post.
-RewriteRule ^people/([a-z])/$1([\-a-z0-9]*)$ people/$1/$1$2/ [R=301,L,NC]
+# to /people/matt-post. Note that this works for any letter prefix, but this can't be avoided
+# since the pattern-match can't match source side.
+RewriteRule ^people/[a-z]/([a-z0-9])([\-a-z0-9]+)/?$ people/$1$2/ [R=301,L,NC]
 
 # Videos
 ## match old-style URLs, e.g., /N13-1001.mp4 -> anthology-files/videos/N/N13-1001.mp4


### PR DESCRIPTION
The current canonical author url is `/people/{letter}/{letter}{rest-of-slug}`. This removes the middle portion which is no longer necessary, resulting in a cleaner look. We give 301 redirects from the prior page.

@mbollmann do you have a minute to help me with the Hugo portion here? 

Closes #5627.