### PR TITLE
Fix author name: Guillermo Segura Gómez → Guillermo Segura-Gómez in 2…

### DIFF
--- a/data/xml/2025.semeval.xml
+++ b/data/xml/2025.semeval.xml
@@ -2329,7 +2329,7 @@
     </paper>
     <paper id="218">
       <title><fixed-case>NLP</fixed-case>-Cimat at <fixed-case>S</fixed-case>em<fixed-case>E</fixed-case>val-2025 Task 11: Prompt Optimization for <fixed-case>LLM</fixed-case>s via Genetic Algorithms and Systematic Mutation applied on Emotion Detection</title>
-      <author><first>Guillermo</first><last>Segura Gómez</last><affiliation>Centro de Investigación en Matemáticas</affiliation></author>
+      <author><first>Guillermo</first><last>Segura-Gómez</last><affiliation>Centro de Investigación en Matemáticas</affiliation></author>
       <author><first>Adrian Pastor</first><last>Lopez Monroy</last><affiliation>Mathematics Research Center CIMAT</affiliation></author>
       <author><first>Fernando</first><last>Sanchez - Vega</last><affiliation>Center for Mathematical Research (CIMAT)</affiliation></author>
       <author><first>Alejandro</first><last>Rosales Pérez</last><affiliation>Center for Research in Mathematics CIMAT</affiliation></author>


### PR DESCRIPTION
This PR updates the metadata for paper 2025.semeval-1.218: "Guillermo Segura Gómez" → "Guillermo Segura-Gómez".

The PDF already shows "Guillermo Segura-Gómez", so this change aligns the XML metadata with the published paper.
