### PR TITLE
Undo schema change introduced by #5650

### DIFF
--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -7,9 +7,6 @@ url = element url {
 }
 fixed-case = element fixed-case { MarkupText }
 tex-math = element tex-math { text }
-a = element a {
-  attribute href { xsd:anyURI } & text
-}
 MarkupText = (text | b | i | url | fixed-case | tex-math)+
 
 first = element first { xsd:string { pattern="(\S(.*\S)?)?" } }

--- a/data/xml/schema.rnc
+++ b/data/xml/schema.rnc
@@ -7,7 +7,7 @@ url = element url {
 }
 fixed-case = element fixed-case { MarkupText }
 tex-math = element tex-math { text }
-MarkupText = (text | b | i | url | fixed-case | tex-math)+
+MarkupText = (text | b | i | url | fixed-case | tex-math )+
 
 first = element first { xsd:string { pattern="(\S(.*\S)?)?" } }
 last = element last { xsd:string { pattern="\S(.*\S)?" } }


### PR DESCRIPTION
This causes integration tests on the Python library to fail otherwise due to a schema mismatch.
