### PR TITLE
MarkupText improvements & save_all()

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,7 @@ This release implements the new [name resolution and author ID logic](https://gi
 
 ### Added
 
+- Anthology now provides `save_all()` to conveniently save all data files.  The library tracks modifications to collection objects to only write XML files that have actually changed.
 - NameSpecification now provides an `orcid` field.
 - Person:
   - Now provides `orcid`, `degree`, `disable_name_matching`, and `similar_ids` fields that correspond to the respective fields in the new `people.yaml`.
@@ -17,6 +18,8 @@ This release implements the new [name resolution and author ID logic](https://gi
   - Now also keeps a mapping of name slugs to (verified) person IDs, via `slugs_to_verified_ids` (mostly for internal use).
   - Added `ingest_namespec()` to implement the [matching logic on ingestion](https://github.com/acl-org/acl-anthology/wiki/Author-Page-Plan#ingestion) of new volumes.
   - Added `create_person()` to instantiate a new Person and add it to the index.
+- MarkupText now provides a `from_()` class method that calls the appropriate builder method, using heuristic markup parsing if instantiated from a string.
+- MarkupText now supports some common string methods, such as `__contains__`, `endswith`, `startswith`.
 
 ### Changed
 
@@ -28,6 +31,8 @@ This release implements the new [name resolution and author ID logic](https://gi
   - Changed the previously experimental `save()` function to serialize the `people.yaml` file.
 - Person now stores names as tuples of `(Name, NameLink)`, the latter of which indicates if the name was explicitly defined in `people.yaml` or inferred by the name resolution logic (e.g. via slug matching).  As a consequence, `Person.names` can no longer be modified in-place; use `Person.add_name()`, `Person.remove_name()`, or the setter of `Person.names`.
 - Setting a canonical name for a Person changed from `.set_canonical_name()` to `Person.canonical_name = ...`
+- Attributes that expect a MarkupText, such as `Volume.title` or `Paper.abstract`, can now be set to a string, in which case the string will be automatically converted to MarkupText, including markup parsing.
+- EventLinkingType renamed to EventLink.
 
 ## [0.5.3] — 2025-06-22
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -20,6 +20,7 @@ This release implements the new [name resolution and author ID logic](https://gi
   - Added `PersonIndex.create` to instantiate a new Person and add it to the index.
 - MarkupText now provides a `from_()` class method that calls the appropriate builder method, using heuristic markup parsing if instantiated from a string.
 - MarkupText now supports some common string methods, such as `__contains__`, `endswith`, `startswith`.
+- Venues can now be created via `VenueIndex.create()`.
 
 ### Changed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -17,7 +17,7 @@ This release implements the new [name resolution and author ID logic](https://gi
   - Now also indexes Person objects by ORCID, and provides `by_orcid` and `get_by_orcid()`.
   - Now also keeps a mapping of name slugs to (verified) person IDs, via `slugs_to_verified_ids` (mostly for internal use).
   - Added `ingest_namespec()` to implement the [matching logic on ingestion](https://github.com/acl-org/acl-anthology/wiki/Author-Page-Plan#ingestion) of new volumes.
-  - Added `create_person()` to instantiate a new Person and add it to the index.
+  - Added `PersonIndex.create` to instantiate a new Person and add it to the index.
 - MarkupText now provides a `from_()` class method that calls the appropriate builder method, using heuristic markup parsing if instantiated from a string.
 - MarkupText now supports some common string methods, such as `__contains__`, `endswith`, `startswith`.
 

--- a/python/acl_anthology/anthology.py
+++ b/python/acl_anthology/anthology.py
@@ -180,6 +180,20 @@ class Anthology:
             )
         return self
 
+    def save_all(self) -> Self:
+        """Save all Anthology data files."""
+        for collection in self.collections.values():
+            if collection.is_modified:
+                collection.save()
+        self.people.save()
+        self.venues.save()
+        warnings.warn(
+            UserWarning(
+                "SIG metadata is not yet automatically saved.  Call `.sigs.save()` manually if you need this."
+            )
+        )
+        return self
+
     def reset_indices(self) -> Self:
         """Reset all non-collection indices.
 

--- a/python/acl_anthology/collections/__init__.py
+++ b/python/acl_anthology/collections/__init__.py
@@ -18,7 +18,7 @@ from .bibkeys import BibkeyIndex
 from .eventindex import EventIndex
 from .event import Event, Talk
 from .volume import Volume
-from .types import EventLinkingType, PaperDeletionType, PaperType, VolumeType
+from .types import EventLink, PaperDeletionType, PaperType, VolumeType
 from .paper import Paper
 
 
@@ -28,7 +28,7 @@ __all__ = [
     "CollectionIndex",
     "Event",
     "EventIndex",
-    "EventLinkingType",
+    "EventLink",
     "Paper",
     "PaperDeletionType",
     "PaperType",

--- a/python/acl_anthology/collections/collection.py
+++ b/python/acl_anthology/collections/collection.py
@@ -202,6 +202,7 @@ class Collection(SlottedDict[Volume]):
             self.root.people._add_to_index(volume.editors, volume.full_id_tuple)
 
         self.data[id] = volume
+        self.is_modified = True
         return volume
 
     def create_event(
@@ -244,6 +245,7 @@ class Collection(SlottedDict[Volume]):
             **kwargs,
         )
         self.root.events._add_to_index(self.event)
+        self.is_modified = True
         return self.event
 
     def load(self) -> None:
@@ -297,6 +299,7 @@ class Collection(SlottedDict[Volume]):
             ] + self.event.colocated_ids
 
         self.is_data_loaded = True
+        self.is_modified = False
 
     def save(self, path: Optional[StrPath] = None, minimal_diff: bool = True) -> None:
         """Saves this collection as an XML file.

--- a/python/acl_anthology/collections/collection.py
+++ b/python/acl_anthology/collections/collection.py
@@ -63,6 +63,7 @@ class Collection(SlottedDict[Volume]):
     Attributes: Non-Init Attributes:
         event: An event represented by this collection.
         is_data_loaded: A flag indicating whether the XML file has already been loaded.
+        is_modified: A flag indicating whether any of the data in this collection has been modified after loading.
     """
 
     id: str = field(converter=int_to_str)
@@ -75,6 +76,7 @@ class Collection(SlottedDict[Volume]):
         validator=v.optional(v.instance_of(Event)),
     )
     is_data_loaded: bool = field(init=False, repr=True, default=False)
+    is_modified: bool = field(init=False, repr=False, default=False)
 
     @id.validator
     def _check_id(self, _: Any, value: str) -> None:

--- a/python/acl_anthology/collections/collection.py
+++ b/python/acl_anthology/collections/collection.py
@@ -148,7 +148,7 @@ class Collection(SlottedDict[Volume]):
     def create_volume(
         self,
         id: str,
-        title: MarkupText,
+        title: MarkupText | str,
         year: Optional[str] = None,
         type: VolumeType = VolumeType.PROCEEDINGS,
         **kwargs: Any,
@@ -157,7 +157,7 @@ class Collection(SlottedDict[Volume]):
 
         Parameters:
             id: The ID of the new volume.
-            title: The title of the new volume.
+            title: The title of the new volume.  If given as a string, it will be [heuristically parsed for markup][acl_anthology.text.markuptext.MarkupText.from_].
             year: The year of the new volume (optional); if None, will infer the year from this collection's ID.
             type: Whether this is a journal or proceedings volume; defaults to [VolumeType.PROCEEDINGS][acl_anthology.collections.types.VolumeType].
             **kwargs: Any valid list or optional attribute of [Volume][acl_anthology.collections.volume.Volume].

--- a/python/acl_anthology/collections/collection.py
+++ b/python/acl_anthology/collections/collection.py
@@ -33,7 +33,7 @@ from ..utils.ids import infer_year, is_valid_collection_id
 from ..utils.logging import get_logger
 from ..utils import xml
 from .event import Event
-from .types import EventLinkingType, VolumeType
+from .types import EventLink, VolumeType
 from .volume import Volume
 from .paper import Paper
 
@@ -290,11 +290,11 @@ class Collection(SlottedDict[Volume]):
         if self.event is not None:
             # Events are implicitly linked to volumes defined in the same collection
             self.event.colocated_ids = [
-                (volume.full_id_tuple, EventLinkingType.INFERRED)
+                (volume.full_id_tuple, EventLink.INFERRED)
                 for volume in self.data.values()
                 # Edge case: in case the <colocated> block lists a volume in
                 # the same collection, don't add it twice
-                if (volume.full_id_tuple, EventLinkingType.EXPLICIT)
+                if (volume.full_id_tuple, EventLink.EXPLICIT)
                 not in self.event.colocated_ids
             ] + self.event.colocated_ids
 

--- a/python/acl_anthology/collections/event.py
+++ b/python/acl_anthology/collections/event.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from attrs import define, field, validators as v
+from attrs import define, field, converters, validators as v
 from lxml import etree
 from lxml.builder import E
 from typing import Any, Iterator, Optional, TYPE_CHECKING
@@ -24,7 +24,7 @@ from .types import EventLinkingType
 from ..constants import RE_EVENT_ID
 from ..files import EventFileReference
 from ..people import NameSpecification
-from ..text import MarkupText
+from ..text import MarkupText, to_markuptext
 from ..utils.attrs import auto_validate_types
 from ..utils.ids import AnthologyID, AnthologyIDTuple, parse_id, build_id_from_tuple
 
@@ -44,7 +44,7 @@ class Talk:
         attachments: Links to attachments for this talk. The dictionary key specifies the type of attachment (e.g., "video" or "slides").
     """
 
-    title: MarkupText = field()
+    title: MarkupText = field(converter=to_markuptext)
     type: Optional[str] = field(default=None)
     speakers: list[NameSpecification] = field(factory=list)
     attachments: dict[str, EventFileReference] = field(factory=dict)
@@ -128,7 +128,9 @@ class Event:
         ),
     )
 
-    title: Optional[MarkupText] = field(default=None)
+    title: Optional[MarkupText] = field(
+        default=None, converter=converters.optional(to_markuptext)
+    )
     location: Optional[str] = field(default=None)
     dates: Optional[str] = field(default=None)
 

--- a/python/acl_anthology/collections/eventindex.py
+++ b/python/acl_anthology/collections/eventindex.py
@@ -24,7 +24,7 @@ from ..text import MarkupText
 from ..utils.ids import AnthologyID, AnthologyIDTuple, parse_id
 from ..utils.logging import get_logger
 from .event import Event
-from .types import EventLinkingType
+from .types import EventLink
 from .volume import Volume
 
 if TYPE_CHECKING:
@@ -124,12 +124,12 @@ class EventIndex(SlottedDict[Event]):
                                 event_id,
                                 collection,
                                 is_explicit=False,
-                                colocated_ids=[(volume_fid, EventLinkingType.INFERRED)],
+                                colocated_ids=[(volume_fid, EventLink.INFERRED)],
                                 title=MarkupText.from_string(event_name),
                             )
                         else:
                             # Add implicit connection to existing event
-                            event.add_colocated(volume_fid, EventLinkingType.INFERRED)
+                            event.add_colocated(volume_fid, EventLink.INFERRED)
                         self.reverse[volume_fid].add(event_id)
             except Exception as exc:
                 log.exception(exc)

--- a/python/acl_anthology/collections/index.py
+++ b/python/acl_anthology/collections/index.py
@@ -91,6 +91,7 @@ class CollectionIndex(SlottedDict[Collection]):
             path=self.parent.datadir / "xml" / f"{id}.xml",
         )
         collection.is_data_loaded = True
+        collection.is_modified = True
         self.data[id] = collection
 
         return collection

--- a/python/acl_anthology/collections/paper.py
+++ b/python/acl_anthology/collections/paper.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import attrs
-from attrs import define, field, validators as v
+from attrs import define, field, converters, validators as v
 import datetime
 from functools import cached_property
 import langcodes
@@ -34,7 +34,7 @@ from ..files import (
     VideoReference,
 )
 from ..people import NameSpecification
-from ..text import MarkupText
+from ..text import MarkupText, to_markuptext
 from ..utils.attrs import auto_validate_types, date_to_str, int_to_str
 from ..utils.citation import citeproc_render_html, render_acl_citation
 from ..utils.ids import build_id, is_valid_item_id, AnthologyIDTuple
@@ -257,7 +257,7 @@ class Paper:
     bibkey: str = field(
         on_setattr=attrs.setters.pipe(attrs.setters.validate, _update_bibkey_index),
     )
-    title: MarkupText = field()
+    title: MarkupText = field(converter=to_markuptext)
 
     attachments: list[tuple[str, AttachmentReference]] = field(
         factory=list,
@@ -289,7 +289,9 @@ class Paper:
     )
     videos: list[VideoReference] = field(factory=list, repr=False)
 
-    abstract: Optional[MarkupText] = field(default=None)
+    abstract: Optional[MarkupText] = field(
+        default=None, converter=converters.optional(to_markuptext)
+    )
     deletion: Optional[PaperDeletionNotice] = field(
         default=None, repr=False, validator=v.optional(v.instance_of(PaperDeletionNotice))
     )

--- a/python/acl_anthology/collections/paper.py
+++ b/python/acl_anthology/collections/paper.py
@@ -296,7 +296,12 @@ class Paper:
         default=None, repr=False, validator=v.optional(v.instance_of(PaperDeletionNotice))
     )
     doi: Optional[str] = field(default=None, repr=False)
-    ingest_date: Optional[str] = field(default=None, repr=False)
+    ingest_date: Optional[str] = field(
+        default=None,
+        repr=False,
+        converter=date_to_str,
+        validator=v.optional(v.matches_re(constants.RE_ISO_DATE)),
+    )
     issue: Optional[str] = field(default=None, repr=False)
     journal: Optional[str] = field(default=None, repr=False)
     language: Optional[str] = field(default=None, repr=False)

--- a/python/acl_anthology/collections/types.py
+++ b/python/acl_anthology/collections/types.py
@@ -15,7 +15,7 @@
 from enum import Enum
 
 
-class EventLinkingType(Enum):
+class EventLink(Enum):
     """How a volume ID was connected to an Event."""
 
     EXPLICIT = "explicit"

--- a/python/acl_anthology/constants.py
+++ b/python/acl_anthology/constants.py
@@ -29,5 +29,8 @@ UNKNOWN_INGEST_DATE = date(1900, 1, 1)
 RE_EVENT_ID = r"^[a-z0-9]+-[0-9]{4}$"
 """A regular expression matching a valid event ID."""
 
+RE_VENUE_ID = r"^[a-z][a-z0-9]+$"
+"""A regular expression matching a valid venue ID."""
+
 RE_ISO_DATE = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
 """A regular expression matching a date in ISO format."""

--- a/python/acl_anthology/people/index.py
+++ b/python/acl_anthology/people/index.py
@@ -346,7 +346,7 @@ class PersonIndex(SlottedDict[Person]):
             if is_verified_person_id(pid):
                 self._slugs_to_verified_ids[name.slugify()].add(pid)
 
-    def create_person(
+    def create(
         self,
         id: str,
         names: list[Name],

--- a/python/acl_anthology/sigs.py
+++ b/python/acl_anthology/sigs.py
@@ -209,6 +209,11 @@ class SIGIndex(SlottedDict[SIG]):
 
         self.is_data_loaded = True
 
+    def save(self) -> None:
+        """Save all SIG metadata to `sigs/*.yaml` files."""
+        for sig in self.values():
+            sig.save()
+
     def by_volume(self, volume: Volume | AnthologyID) -> list[SIG]:
         """Find SIGs associated with a volume."""
         if not self.is_data_loaded:

--- a/python/acl_anthology/text/__init__.py
+++ b/python/acl_anthology/text/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .markuptext import MarkupText
+from .markuptext import MarkupText, to_markuptext
 from .stopwords import StopWords
 from .texmath import TexMath
 
 
-__all__ = ["MarkupText", "StopWords", "TexMath"]
+__all__ = ["MarkupText", "StopWords", "TexMath", "to_markuptext"]

--- a/python/acl_anthology/utils/attrs.py
+++ b/python/acl_anthology/utils/attrs.py
@@ -19,16 +19,29 @@ from __future__ import annotations
 import attrs
 from attrs import validators
 import datetime
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, TypeVar, TYPE_CHECKING
 import re
 
 from .ids import AnthologyIDTuple
 
+if TYPE_CHECKING:
+    from ..collections import Paper, Volume, Event
+
 
 RE_WRAPPED_TYPE = re.compile(r"^([^\[]*)\[(.*)\]$")
+T = TypeVar("T")
+
+
+def track_modifications(
+    obj: Paper | Volume | Event, attr: attrs.Attribute[Any], value: T
+) -> T:
+    if attr.name != "parent":
+        obj.collection.is_modified = True
+    return value
 
 
 def validate_anthology_id_tuple(cls: Any, attr: attrs.Attribute[Any], value: Any) -> None:
+    """Validate that an AnthologyIDTuple has the correct format."""
     if (
         isinstance(value, tuple)
         and len(value) == 3

--- a/python/acl_anthology/venues.py
+++ b/python/acl_anthology/venues.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from attrs import define, field, validators as v, asdict
 from pathlib import Path
-from typing import Iterator, Optional, TYPE_CHECKING
+from typing import Any, Iterator, Optional, TYPE_CHECKING
 import yaml
 
 try:
@@ -26,6 +26,7 @@ except ImportError:  # pragma: no cover
 
 from .utils.attrs import auto_validate_types
 from .utils.ids import AnthologyIDTuple, build_id_from_tuple
+from .constants import RE_VENUE_ID
 from .containers import SlottedDict
 
 if TYPE_CHECKING:
@@ -51,7 +52,7 @@ class Venue:
         url: A website URL for the venue.
     """
 
-    id: str = field(converter=str)
+    id: str = field(converter=str, validator=v.matches_re(RE_VENUE_ID))
     parent: Anthology = field(repr=False, eq=False)
     acronym: str = field(converter=str)
     name: str = field(converter=str)
@@ -134,7 +135,7 @@ class VenueIndex(SlottedDict[Venue]):
     is_data_loaded: bool = field(init=False, repr=True, default=False)
 
     def load(self) -> None:
-        """Loads and parses the `venues/*.yaml` files.
+        """Load and parse the `venues/*.yaml` files.
 
         Raises:
             KeyError: If a mandatory key is missing in a YAML file.
@@ -149,8 +150,36 @@ class VenueIndex(SlottedDict[Venue]):
         self.build()
         self.is_data_loaded = True
 
+    def create(self, id: str, acronym: str, name: str, **kwargs: Any) -> Venue:
+        """Create a new venue and add it to the index.
+
+        Parameters:
+            id: The ID of the new venue.
+            acronym: The acronym of the new venue.
+            name: The name of the new venue.
+            **kwargs: Any valid optional attribute of [Venue][acl_anthology.venues.Venue], with the exception of `path`, which is automatically set based on the venue ID, as well as `item_ids` and `oldstyle_letter`, which cannot be set.
+
+        Returns:
+            The created [Venue][acl_anthology.venues.Venue] object.
+
+        Raises:
+            KeyError: If an invalid attribute is supplied in `**kwargs`.
+        """
+        if "item_ids" in kwargs:
+            raise KeyError(
+                "Cannot specify `item_ids` for Venue; add its ID to the volume(s) instead."
+            )
+        if "oldstyle_letter" in kwargs:
+            raise KeyError("Cannot specify a new venue with an old-style letter.")
+
+        kwargs["parent"] = self.parent
+        kwargs["path"] = self.parent.datadir / "yaml" / "venues" / f"{id}.yaml"
+        venue = Venue(id=id, acronym=acronym, name=name, **kwargs)
+        self.data[id] = venue
+        return venue
+
     def reset(self) -> None:
-        """Resets the index."""
+        """Reset the index."""
         self.data = {}
         self.is_data_loaded = False
 

--- a/python/docs/guide/modifying-data.md
+++ b/python/docs/guide/modifying-data.md
@@ -336,7 +336,11 @@ the gory details), it's best to ensure that:
 
 ### Connecting to venues and SIGs
 
-Volumes can be connected to venues by modifying the volume's `venue_ids` list. {==TODO: adding new venues==}
+Volumes can be connected to venues by modifying the volume's `venue_ids` list.
+New venues can be added by calling
+[`VenueIndex.create()`][acl_anthology.venues.VenueIndex.create], which will also
+create a corresponding YAML file upon saving.  Afterwards, the ID used when
+instantiating the venue can be used in a volume's `venue_ids`.
 
 {==TODO: connecting to SIGs; we may want to refactor how SIGs are represented before introducing this functionality.==}
 

--- a/python/docs/guide/modifying-data.md
+++ b/python/docs/guide/modifying-data.md
@@ -156,7 +156,7 @@ A person can be _explicit_ (has an entry in `people.yaml`) or _inferred_ (was in
 Manually creating a new person (that will get saved to `people.yaml` and can
 have an ORCID and other metadata) can be done in two ways:
 
-1. By calling [`PersonIndex.create_person()`][acl_anthology.people.index.PersonIndex.create_person].  The returned Person is _not_ linked to any papers/volumes, but you can set their ID afterwards on name specifications.
+1. By calling [`PersonIndex.create()`][acl_anthology.people.index.PersonIndex.create].  The returned Person is _not_ linked to any papers/volumes, but you can set their ID afterwards on name specifications.
 
 2. By calling [`make_explicit()`][acl_anthology.people.person.Person.make_explicit] on a currently _inferred_ person.  This will not only add this person to the database, but also **set their ID on all papers/volumes** currently associated with them.
 
@@ -174,7 +174,7 @@ have an ORCID and other metadata) can be done in two ways:
 
 **Situation:** A person `p1` is currently associated with papers/volumes that actually belong to different people, who just happened to publish under the same name.  We want to create a new person instance for the other author with the same name.
 
-1. Call [`anthology.people.create_person()`][acl_anthology.people.index.PersonIndex.create_person] for all persons who do not have an explicit ID yet, giving all the names that can refer to this person.  Also supply the ORCID when calling this function, if it is known.
+1. Call [`anthology.people.create()`][acl_anthology.people.index.PersonIndex.create] for all persons who do not have an explicit ID yet, giving all the names that can refer to this person.  Also supply the ORCID when calling this function, if it is known.
 
 2. For each person, iterate through the papers that actually belong to them and update the name specification that currently resolves to `p1` by setting the explicit ID of the correct newly-created person.  {==TODO: Same as above: It's currently a bit tricky to find the _name specification_ referring to a person; should add a function for this.==}
 
@@ -290,7 +290,7 @@ NameSpecification(Name("Marcel", "Bollmann"), orcid="0000-0003-2598-8150")
 If an ORCID is supplied, the NameSpecification also needs to have an explicit ID
 referring to an entry in `people.yaml`.  **The library can add an ID
 automatically** as long as you supply the author/editor list to the `create_`
-function, so there is typically **no need to call `create_person()`** during
+function, so there is typically **no need to call `create()`** during
 ingestion!
 
 !!! example

--- a/python/docs/guide/types-of-metadata.md
+++ b/python/docs/guide/types-of-metadata.md
@@ -26,6 +26,9 @@ paper.attachments      # is {}
 paper.language         # is None
 ```
 
+When modifying metadata fields, most of them will [perform input validation
+and/or conversion](modifying-data.md#modifying-publications).
+
 ## Markup text
 
 Two of the most common field types, **titles** and **abstracts**, can contain
@@ -43,7 +46,15 @@ This means that such metadata fields don't contain strings, but rather
 MarkupText('S<span class="tex-math"><sup>4</sup></span>-Tuning: A Simple Cross-lingual Sub-network Tuning Method')
 ```
 
-To work with these as Unicode strings, you need to explicitly convert them:
+For convenience, they support a limited subset of string methods, for example:
+
+```pycon
+>>> paper.title.startswith("S")  # True
+>>> "Tuning" in paper.title      # True
+```
+
+If MarkupText is converted to a string, any containing markup will be discarded:
+
 ```pycon
 >>> str(paper.title)
 'S4-Tuning: A Simple Cross-lingual Sub-network Tuning Method'

--- a/python/tests/collections/collection_test.py
+++ b/python/tests/collections/collection_test.py
@@ -143,11 +143,12 @@ def test_collection_create_volume_implicit(collection_index):
     collection = collection_index.get("2022.acl")
     volume = collection.create_volume(
         "keynotes",
-        title=MarkupText.from_string("Keynotes from ACL 2022"),
+        title="Keynotes from ACL 2022",
     )
     assert volume.id in collection
     assert volume.year == "2022"
     assert volume.id == "keynotes"
+    assert volume.title == "Keynotes from ACL 2022"
     assert volume.full_id == "2022.acl-keynotes"
     assert volume.type == VolumeType.PROCEEDINGS
 
@@ -165,10 +166,17 @@ def test_collection_create_volume_explicit(collection_index):
     assert volume.id in collection
     assert volume.year == "1989"
     assert volume.id == "99"
+    assert volume.title == "Special Issue"
     assert volume.full_id == "1989.cl-99"
     assert volume.type == VolumeType.JOURNAL
     assert volume.journal_issue == "99"
     assert "cl" in volume.venue_ids
+
+
+def test_collection_create_volume_should_parse_markup(collection_index):
+    collection = collection_index.get("2022.acl")
+    volume = collection.create_volume("infinity", title="Special issue on $\\infty$")
+    assert volume.title.as_text() == "Special issue on ∞"
 
 
 def test_collection_create_volume_should_fail_in_oldstyle_volumes(collection_index):

--- a/python/tests/collections/collection_test.py
+++ b/python/tests/collections/collection_test.py
@@ -83,6 +83,7 @@ def test_collection_load(
         assert collection.get_event() is not None
     else:
         assert collection.get_event() is None
+    assert not collection.is_modified
 
 
 @pytest.mark.filterwarnings(
@@ -141,10 +142,12 @@ def test_collection_roundtrip_save(
 
 def test_collection_create_volume_implicit(collection_index):
     collection = collection_index.get("2022.acl")
+    assert not collection.is_modified
     volume = collection.create_volume(
         "keynotes",
         title="Keynotes from ACL 2022",
     )
+    assert collection.is_modified
     assert volume.id in collection
     assert volume.year == "2022"
     assert volume.id == "keynotes"
@@ -155,6 +158,7 @@ def test_collection_create_volume_implicit(collection_index):
 
 def test_collection_create_volume_explicit(collection_index):
     collection = collection_index.get("1989.cl")
+    assert not collection.is_modified
     volume = collection.create_volume(
         id="99",
         title=MarkupText.from_string("Special Issue"),
@@ -163,6 +167,7 @@ def test_collection_create_volume_explicit(collection_index):
         journal_issue="99",
         venue_ids=["cl"],
     )
+    assert collection.is_modified
     assert volume.id in collection
     assert volume.year == "1989"
     assert volume.id == "99"
@@ -344,9 +349,11 @@ def test_collection_create_event_oldstyle_ids(collection_index):
 
 def test_collection_create_event_newstyle_ids(collection_index):
     collection = collection_index.get("1989.cl")
+    assert not collection.is_modified
 
     # For new-style ID collections, an explicit event ID is not required
     event = collection.create_event()
+    assert collection.is_modified
     assert event.id == "cl-1989"
 
     # Trying to create yet another event in the same collection should raise

--- a/python/tests/collections/collection_test.py
+++ b/python/tests/collections/collection_test.py
@@ -21,7 +21,7 @@ from acl_anthology import Anthology
 from acl_anthology.collections import (
     Collection,
     CollectionIndex,
-    EventLinkingType,
+    EventLink,
     VolumeType,
 )
 from acl_anthology.people import NameSpecification
@@ -265,7 +265,7 @@ def test_collection_create_volume_should_create_event(anthology, pre_load, reset
 
     # New implicit event should exist in the event index
     assert "acl-2000" in anthology.events
-    assert (volume.full_id_tuple, EventLinkingType.INFERRED) in anthology.events[
+    assert (volume.full_id_tuple, EventLink.INFERRED) in anthology.events[
         "acl-2000"
     ].colocated_ids
     assert volume.full_id_tuple in anthology.events.reverse
@@ -298,7 +298,7 @@ def test_collection_create_volume_should_update_event(anthology, pre_load, reset
 
     # New volume should be added to existing event
     assert "acl-2022" in anthology.events
-    assert (volume.full_id_tuple, EventLinkingType.INFERRED) in anthology.events[
+    assert (volume.full_id_tuple, EventLink.INFERRED) in anthology.events[
         "acl-2022"
     ].colocated_ids
     assert volume.full_id_tuple in anthology.events.reverse
@@ -372,7 +372,7 @@ def test_collection_create_event_should_update_eventindex(pre_load, anthology):
     if pre_load:
         # Volume should automatically have been added
         assert event.colocated_ids == [
-            (collection.get("1").full_id_tuple, EventLinkingType.INFERRED)
+            (collection.get("1").full_id_tuple, EventLink.INFERRED)
         ]
     else:
         # If event index wasn't loaded, it's not

--- a/python/tests/collections/collectionindex_test.py
+++ b/python/tests/collections/collectionindex_test.py
@@ -39,6 +39,7 @@ def test_collectionindex_create_collection(anthology_stub):
     assert collection.id == "2099.acl"
     assert collection.parent is index
     assert collection.id in index
+    assert collection.is_modified
 
 
 def test_collectionindex_create_collection_should_raise_with_oldstyle_ids(anthology_stub):

--- a/python/tests/collections/event_test.py
+++ b/python/tests/collections/event_test.py
@@ -16,7 +16,7 @@ import pytest
 from attrs import define
 from lxml import etree
 
-from acl_anthology.collections import Event, EventLinkingType, Talk
+from acl_anthology.collections import Event, EventLink, Talk
 from acl_anthology.files import EventFileReference
 from acl_anthology.text import MarkupText
 from acl_anthology.utils.xml import indent
@@ -91,9 +91,9 @@ def test_event_all_attribs():
         location="Online",
         dates="August 17-19, 2023",
         colocated_ids=[
-            (("2023.foobar", "1", None), EventLinkingType.EXPLICIT),
-            (("2023.baz", "1", None), EventLinkingType.EXPLICIT),
-            (("2023.asdf", "1", None), EventLinkingType.EXPLICIT),
+            (("2023.foobar", "1", None), EventLink.EXPLICIT),
+            (("2023.baz", "1", None), EventLink.EXPLICIT),
+            (("2023.asdf", "1", None), EventLink.EXPLICIT),
         ],
         talks=[Talk("Invited talk")],
         links={"Website": EventFileReference("http://foobar.com")},
@@ -108,10 +108,10 @@ def test_event_to_xml_dont_list_colocated_volumes_of_parent():
         id="li-2023",
         parent=CollectionStub("2023.li"),
         colocated_ids=[
-            (("2023.baz", "1", None), EventLinkingType.EXPLICIT),
-            (("2023.li", "main", None), EventLinkingType.INFERRED),
-            (("2023.li", "side", None), EventLinkingType.INFERRED),
-            (("2023.ling", "1", None), EventLinkingType.EXPLICIT),
+            (("2023.baz", "1", None), EventLink.EXPLICIT),
+            (("2023.li", "main", None), EventLink.INFERRED),
+            (("2023.li", "side", None), EventLink.INFERRED),
+            (("2023.ling", "1", None), EventLink.EXPLICIT),
         ],
     )
     out = event.to_xml()
@@ -171,7 +171,7 @@ def test_event_add_colocated(anthology):
     # Adding colocated volume should update Event & EventIndex
     event.add_colocated(volume)
     assert len(event.colocated_ids) == 2
-    assert (volume.full_id_tuple, EventLinkingType.EXPLICIT) in event.colocated_ids
+    assert (volume.full_id_tuple, EventLink.EXPLICIT) in event.colocated_ids
     assert event in anthology.events.by_volume(volume)
     assert event.collection.is_modified
 

--- a/python/tests/collections/event_test.py
+++ b/python/tests/collections/event_test.py
@@ -95,7 +95,7 @@ def test_event_all_attribs():
             (("2023.baz", "1", None), EventLinkingType.EXPLICIT),
             (("2023.asdf", "1", None), EventLinkingType.EXPLICIT),
         ],
-        talks=[Talk(MarkupText.from_string("Invited talk"))],
+        talks=[Talk("Invited talk")],
         links={"Website": EventFileReference("http://foobar.com")},
     )
     assert event.collection_id == "2023.li"

--- a/python/tests/collections/event_test.py
+++ b/python/tests/collections/event_test.py
@@ -152,9 +152,20 @@ def test_event_volumes(anthology):
         list(anthology.events.get("acl-2022").volumes())
 
 
+@pytest.mark.parametrize(
+    "attr_name", ("id", "colocated_ids", "links", "talks", "title", "location", "dates")
+)
+def test_event_setattr_sets_collection_is_modified(anthology, attr_name):
+    event = anthology.events.get("lrec-2006")
+    assert not event.collection.is_modified
+    setattr(event, attr_name, getattr(event, attr_name))
+    assert event.collection.is_modified
+
+
 def test_event_add_colocated(anthology):
     event = anthology.events.get("lrec-2006")
     assert len(event.colocated_ids) == 1
+    assert not event.collection.is_modified
     volume = anthology.get_volume("J89-1")
 
     # Adding colocated volume should update Event & EventIndex
@@ -162,6 +173,7 @@ def test_event_add_colocated(anthology):
     assert len(event.colocated_ids) == 2
     assert (volume.full_id_tuple, EventLinkingType.EXPLICIT) in event.colocated_ids
     assert event in anthology.events.by_volume(volume)
+    assert event.collection.is_modified
 
     # Adding the same volume a second time shouldn't change anything
     event.add_colocated(volume)

--- a/python/tests/collections/eventindex_test.py
+++ b/python/tests/collections/eventindex_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from acl_anthology.collections import EventIndex, EventLinkingType
+from acl_anthology.collections import EventIndex, EventLink
 
 
 def test_all_defined_events(anthology):
@@ -40,9 +40,7 @@ def test_implicit_event_data(anthology):
     )
     assert event.location is None
     assert event.dates is None
-    assert event.colocated_ids == [
-        (("2022.naloma", "1", None), EventLinkingType.INFERRED)
-    ]
+    assert event.colocated_ids == [(("2022.naloma", "1", None), EventLink.INFERRED)]
 
 
 def test_implicit_and_explicit_event_data(anthology):
@@ -52,8 +50,8 @@ def test_implicit_and_explicit_event_data(anthology):
     assert event.location is None
     assert event.dates is None
     assert event.colocated_ids == [
-        (("2022.nonexistant", "1", None), EventLinkingType.EXPLICIT),
-        (("2022.naloma", "1", None), EventLinkingType.INFERRED),
+        (("2022.nonexistant", "1", None), EventLink.EXPLICIT),
+        (("2022.naloma", "1", None), EventLink.INFERRED),
     ]
 
 
@@ -75,15 +73,15 @@ def test_explicit_event_data(anthology):
     assert event.location == "Dublin, Ireland"
     assert event.dates == "May 22–27, 2022"
     assert event.colocated_ids == [
-        (("2022.acl", "long", None), EventLinkingType.INFERRED),
-        (("2022.acl", "short", None), EventLinkingType.INFERRED),
-        (("2022.acl", "srw", None), EventLinkingType.INFERRED),
-        (("2022.acl", "demo", None), EventLinkingType.INFERRED),
-        (("2022.acl", "tutorials", None), EventLinkingType.INFERRED),
-        (("2022.findings", "acl", None), EventLinkingType.EXPLICIT),
-        (("2022.bigscience", "1", None), EventLinkingType.EXPLICIT),
-        (("2022.naloma", "1", None), EventLinkingType.EXPLICIT),
-        (("2022.wit", "1", None), EventLinkingType.EXPLICIT),
+        (("2022.acl", "long", None), EventLink.INFERRED),
+        (("2022.acl", "short", None), EventLink.INFERRED),
+        (("2022.acl", "srw", None), EventLink.INFERRED),
+        (("2022.acl", "demo", None), EventLink.INFERRED),
+        (("2022.acl", "tutorials", None), EventLink.INFERRED),
+        (("2022.findings", "acl", None), EventLink.EXPLICIT),
+        (("2022.bigscience", "1", None), EventLink.EXPLICIT),
+        (("2022.naloma", "1", None), EventLink.EXPLICIT),
+        (("2022.wit", "1", None), EventLink.EXPLICIT),
     ]
 
 

--- a/python/tests/collections/paper_test.py
+++ b/python/tests/collections/paper_test.py
@@ -33,10 +33,15 @@ from acl_anthology.collections.paper import (
 )
 
 
+class CollectionStub:
+    is_modified = False
+
+
 class VolumeStub:
     title = MarkupText.from_string("Generic volume")
     editors = []
     full_id_tuple = ("2099", "stub", None)
+    parent = CollectionStub()
 
 
 @pytest.fixture
@@ -129,6 +134,28 @@ def test_paper_change_id(anthology):
 
     # BUT: currently no automatic check if ID already exists, so this works
     paper.id = "1"
+
+
+@pytest.mark.parametrize(
+    "attr_name",
+    (
+        "id",
+        "bibkey",
+        "title",
+        "attachments",
+        "authors",
+        "awards",
+        "abstract",
+        "doi",
+        "ingest_date",
+        "type",
+    ),
+)
+def test_paper_setattr_sets_collection_is_modified(anthology, attr_name):
+    paper = anthology.get_paper("2022.acl-long.48")
+    assert not paper.collection.is_modified
+    setattr(paper, attr_name, getattr(paper, attr_name))
+    assert paper.collection.is_modified
 
 
 test_cases_language = (

--- a/python/tests/collections/paper_test.py
+++ b/python/tests/collections/paper_test.py
@@ -45,11 +45,10 @@ def index(anthology_stub):
 
 
 def test_paper_minimum_attribs():
-    paper_title = MarkupText.from_string("A minimal example")
     parent = None
-    paper = Paper("42", parent, bibkey="nn-1900-minimal", title=paper_title)
+    paper = Paper("42", parent, bibkey="nn-1900-minimal", title="A minimal example")
     assert not paper.is_deleted
-    assert paper.title == paper_title
+    assert paper.title == "A minimal example"
 
 
 def test_paper_web_url(anthology):
@@ -156,7 +155,7 @@ def test_paper_language(anthology, paper_id, language, language_name):
 def test_paper_bibtype():
     volume = VolumeStub()
     volume.type = VolumeType.JOURNAL
-    paper = Paper("1", volume, bibkey="", title=MarkupText.from_string(""))
+    paper = Paper("1", volume, bibkey="", title="")
     assert paper.bibtype == "article"
     volume.type = VolumeType.PROCEEDINGS
     assert paper.bibtype == "inproceedings"

--- a/python/tests/collections/volume_test.py
+++ b/python/tests/collections/volume_test.py
@@ -118,31 +118,28 @@ test_cases_volume_xml = (
 
 
 def test_volume_minimum_attribs():
-    volume_title = MarkupText.from_string("Lorem ipsum")
     parent = Collection("L05", None, Path("."))
     volume = Volume(
         "6",
         parent,
         type=VolumeType.JOURNAL,
-        booktitle=volume_title,
+        booktitle="Lorem ipsum",
         venue_ids=["li"],
         year="2005",
     )
     assert volume.full_id == "L05-6"
-    assert volume.title == volume_title
+    assert volume.title == "Lorem ipsum"
     assert volume.get_ingest_date().year == 1900
     assert not volume.is_workshop
 
 
 def test_volume_all_attribs():
-    volume_title = MarkupText.from_string("Lorem ipsum")
-    volume_shorttitle = MarkupText.from_string("L.I.")
     parent = Collection("2023.acl", None, Path("."))
     volume = Volume(
         id="long",
         parent=parent,
         type="proceedings",
-        booktitle=volume_title,
+        booktitle="Lorem ipsum",
         year="2023",
         address="Online",
         doi="10.100/0000",
@@ -152,7 +149,7 @@ def test_volume_all_attribs():
         month="jan",
         pdf=None,
         publisher="Myself",
-        shortbooktitle=volume_shorttitle,
+        shortbooktitle="L.I.",
         venue_ids=["li", "acl"],
     )
     assert volume.ingest_date == "2023-01-12"
@@ -256,13 +253,12 @@ def test_volume_venues_naloma(anthology):
 
 
 def test_volume_with_nonexistent_venue(anthology):
-    volume_title = MarkupText.from_string("Lorem ipsum")
     parent = Collection("L05", CollectionIndexStub(anthology), Path("."))
     volume = Volume(
         "42",
         parent,
         type=VolumeType.JOURNAL,
-        booktitle=volume_title,
+        booktitle="Lorem ipsum",
         venue_ids=["doesntexist"],
         year="2005",
     )
@@ -339,7 +335,7 @@ def test_volume_generate_paper_id(anthology):
     volume.create_paper(
         id="604",
         bibkey="my-awesome-paper",
-        title=MarkupText.from_string("The awesome paper I have never written"),
+        title="The awesome paper I have never written",
     )
     assert volume.generate_paper_id() == "605"
 
@@ -348,7 +344,7 @@ def test_volume_create_paper_implicit(anthology):
     volume = anthology.get_volume("2022.acl-long")
     authors = [NameSpec("Bollmann, Marcel")]
     paper = volume.create_paper(
-        title=MarkupText.from_string("The awesome paper I have never written"),
+        title="The awesome paper I have never written",
         authors=authors,
         ingest_date="2025-01-07",
     )
@@ -368,7 +364,7 @@ def test_volume_create_paper_explicit(anthology):
     volume = anthology.get_volume("2022.acl-long")
     authors = [NameSpec("Bollmann, Marcel")]
     paper = volume.create_paper(
-        title=MarkupText.from_string("The awesome paper I have never written"),
+        title="The awesome paper I have never written",
         authors=authors,
         ingest_date="2025-01-07",
         id="701",
@@ -389,11 +385,20 @@ def test_volume_create_paper_with_duplicate_id_should_fail(anthology):
     authors = [NameSpec("Bollmann, Marcel")]
     with pytest.raises(ValueError):
         _ = volume.create_paper(
-            title=MarkupText.from_string("The awesome paper I have never written"),
+            title="The awesome paper I have never written",
             authors=authors,
-            ingest_date="2025-01-07",
             id="42",
         )
+
+
+def test_volume_create_paper_should_parse_markup(anthology):
+    volume = anthology.get_volume("2022.acl-long")
+    authors = [NameSpec("Bollmann, Marcel")]
+    paper = volume.create_paper(
+        title="Towards $\\infty$",
+        authors=authors,
+    )
+    assert paper.title.as_text() == "Towards ∞"
 
 
 def test_volume_create_paper_with_editors(anthology):
@@ -402,9 +407,8 @@ def test_volume_create_paper_with_editors(anthology):
     # For most papers, the editors are the volume's editors
     authors = [NameSpec("Bollmann, Marcel")]
     paper = volume.create_paper(
-        title=MarkupText.from_string("The awesome paper I have never written"),
+        title="The awesome paper I have never written",
         authors=authors,
-        ingest_date="2025-01-07",
     )
     assert not paper.editors
     assert paper.get_editors() == volume.editors
@@ -412,7 +416,7 @@ def test_volume_create_paper_with_editors(anthology):
     # But the schema allows paper-level editors too
     editors = [NameSpec("Calzolari, Nicoletta")]
     paper = volume.create_paper(
-        title=MarkupText.from_string("The awesome paper I have never written"),
+        title="The awesome paper I have never written",
         authors=authors,
         editors=editors,
         ingest_date="2025-01-07",
@@ -429,7 +433,7 @@ def test_volume_create_paper_should_update_person(anthology, pre_load):
     volume = anthology.get_volume("2022.acl-long")
     authors = [NameSpec("Berg-Kirkpatrick, Taylor")]
     paper = volume.create_paper(
-        title=MarkupText.from_string("The awesome paper I have never written"),
+        title="The awesome paper I have never written",
         authors=authors,
         ingest_date="2025-01-07",
     )
@@ -448,7 +452,7 @@ def test_volume_create_paper_should_update_personindex(anthology, pre_load):
     volume = anthology.get_volume("2022.acl-long")
     authors = [NameSpec("Nonexistant, Guy Absolutely")]
     paper = volume.create_paper(
-        title=MarkupText.from_string("An entirely imaginary paper"),
+        title="An entirely imaginary paper",
         authors=authors,
         ingest_date="2025-01-07",
     )
@@ -496,7 +500,7 @@ def test_volume_type_conversion():
         6,
         parent,
         type="journal",
-        booktitle=MarkupText.from_string("Lorem ipsum"),  # "Lorem ipsum",
+        booktitle="Lorem ipsum",
         year=2005,
     )
     assert volume.id == "6"  # str

--- a/python/tests/collections/volume_test.py
+++ b/python/tests/collections/volume_test.py
@@ -235,6 +235,27 @@ def test_volume_set_ingest_date(anthology):
     assert volume.ingest_date == "2026-03-01"
 
 
+@pytest.mark.parametrize(
+    "attr_name",
+    (
+        "id",
+        "title",
+        "year",
+        "editors",
+        "venue_ids",
+        "address",
+        "ingest_date",
+        "pdf",
+        "shorttitle",
+    ),
+)
+def test_volume_setattr_sets_collection_is_modified(anthology, attr_name):
+    volume = anthology.get_volume("2022.acl-long")
+    assert not volume.parent.is_modified
+    setattr(volume, attr_name, getattr(volume, attr_name))
+    assert volume.parent.is_modified
+
+
 def test_volume_venues_j89(anthology):
     volume = anthology.get_volume("J89-1")
     assert volume.venue_ids == ["cl"]
@@ -342,12 +363,14 @@ def test_volume_generate_paper_id(anthology):
 
 def test_volume_create_paper_implicit(anthology):
     volume = anthology.get_volume("2022.acl-long")
+    assert not volume.collection.is_modified
     authors = [NameSpec("Bollmann, Marcel")]
     paper = volume.create_paper(
         title="The awesome paper I have never written",
         authors=authors,
         ingest_date="2025-01-07",
     )
+    assert volume.collection.is_modified
     assert paper.authors == authors
     assert paper.title.as_text() == "The awesome paper I have never written"
     assert paper.ingest_date == "2025-01-07"
@@ -362,6 +385,7 @@ def test_volume_create_paper_implicit(anthology):
 
 def test_volume_create_paper_explicit(anthology):
     volume = anthology.get_volume("2022.acl-long")
+    assert not volume.collection.is_modified
     authors = [NameSpec("Bollmann, Marcel")]
     paper = volume.create_paper(
         title="The awesome paper I have never written",
@@ -370,6 +394,7 @@ def test_volume_create_paper_explicit(anthology):
         id="701",
         bibkey="bollmann-2022-the-awesome",
     )
+    assert volume.collection.is_modified
     assert paper.authors == authors
     assert paper.title.as_text() == "The awesome paper I have never written"
     assert paper.ingest_date == "2025-01-07"

--- a/python/tests/people/person_test.py
+++ b/python/tests/people/person_test.py
@@ -158,6 +158,7 @@ def test_person_update_id_should_update_connected_papers(anthology):
     namespec = anthology.get(person.item_ids[0]).authors[-1]
     assert namespec.name == Name("Yang", "Liu")
     assert namespec.id == "yang-liu-new"
+    assert anthology.collections["2022.acl"].is_modified
 
 
 def test_person_cannot_update_id_when_inferred(anthology):
@@ -197,6 +198,11 @@ def test_person_make_explicit(anthology):
     person.make_explicit("nicoletta-calzolari")
     assert person.is_explicit
     assert person.id == "nicoletta-calzolari"
+    # IDs have been added to these collections:
+    assert anthology.collections["J89"].is_modified
+    assert anthology.collections["L06"].is_modified
+    # But not this one:
+    assert not anthology.collections["2022.acl"].is_modified
 
 
 def test_person_make_explicit_should_raise_when_explicit(anthology):

--- a/python/tests/people/personindex_test.py
+++ b/python/tests/people/personindex_test.py
@@ -189,7 +189,7 @@ def test_change_orcid(index):
 
 
 def test_create_person(index):
-    person = index.create_person(
+    person = index.create(
         id="matt-post",
         names=[Name("Matt", "Post")],
         orcid="0000-0002-1297-6794",
@@ -202,7 +202,7 @@ def test_create_person(index):
 
 def test_create_person_should_fail_on_duplicate_orcid(index):
     with pytest.raises(ValueError):
-        index.create_person(
+        index.create(
             id="marcel-bollmann-twin",
             names=[Name("Marcel", "Bollmann")],
             orcid="0000-0003-2598-8150",  # already assigned to "marcel-bollmann"
@@ -211,7 +211,7 @@ def test_create_person_should_fail_on_duplicate_orcid(index):
 
 def test_create_person_should_fail_on_duplicate_id(index):
     with pytest.raises(AnthologyInvalidIDError):
-        index.create_person(
+        index.create(
             id="marcel-bollmann",  # already exists
             names=[Name("Marcel", "Bollmann")],
         )
@@ -219,7 +219,7 @@ def test_create_person_should_fail_on_duplicate_id(index):
 
 def test_create_person_should_fail_on_unverified_id(index):
     with pytest.raises(AnthologyInvalidIDError):
-        index.create_person(
+        index.create(
             id="unverified/john-doe",  # cannot create this manually
             names=[Name("John", "Doe")],
         )
@@ -227,7 +227,7 @@ def test_create_person_should_fail_on_unverified_id(index):
 
 def test_create_person_should_fail_on_empty_names(index):
     with pytest.raises(ValueError):
-        index.create_person(
+        index.create(
             id="john-doe-new",
             names=[],  # cannot be empty
         )
@@ -644,7 +644,7 @@ def test_add_person_to_people_yaml_via_create_person(index, tmp_path):
     yaml_out = tmp_path / "people.create_person.yaml"
 
     # Modifications
-    index.create_person(
+    index.create(
         id="preslav-nakov",
         names=[Name("Preslav", "Nakov")],
         orcid="0000-0002-3600-1510",

--- a/python/tests/text/markuptext_test.py
+++ b/python/tests/text/markuptext_test.py
@@ -205,11 +205,12 @@ def test_markup_from_xml(inp, out):
     assert markup.as_html() == out["html"]
     assert markup.as_latex() == out["latex"]
     assert markup.as_xml() == inp
+    assert MarkupText.from_(element) == markup
     assert etree.tostring(markup.to_xml("title"), encoding="unicode") == xml
     assert markup.contains_markup == ("<" in out["html"])
 
 
-def test_simple_string():
+def test_markup_from_simple_string():
     text = "Some ASCII text without markup"
     markup = MarkupText.from_string(text)
     assert not markup.contains_markup
@@ -217,10 +218,12 @@ def test_simple_string():
     assert markup.as_html() == text
     assert markup.as_latex() == text
     assert markup.as_xml() == text
+    assert markup == text
     assert (
         etree.tostring(markup.to_xml("span"), encoding="unicode")
         == f"<span>{text}</span>"
     )
+    assert MarkupText.from_(text) == markup
 
 
 test_cases_markup_from_latex = (
@@ -424,3 +427,20 @@ def test_markup_from_latex_maybe(inp, out1, out2):
     assert markup.as_xml() == out1
     markup = MarkupText.from_latex_maybe(inp)
     assert markup.as_xml() == out2
+
+
+def test_markup_behaves_like_string():
+    markup = MarkupText.from_latex(
+        "TTCS$^{\mathcal{E}}$: a Vectorial Resource for Computing Conceptual Similarity"
+    )
+    plain_text = "TTCSℰ: a Vectorial Resource for Computing Conceptual Similarity"
+    assert markup == plain_text  # disregards markup
+    assert markup != MarkupText.from_string(plain_text)  # does not disregard markup
+    assert markup == MarkupText.from_latex(
+        "TTCS$^{\mathcal{E}}$: a Vectorial Resource for Computing Conceptual Similarity"
+    )
+    assert "Vectorial" in markup
+    assert markup.startswith("TTCS")
+    assert markup.endswith("Similarity")
+    assert markup < "XTCS"
+    assert markup < MarkupText.from_string("XTCS")

--- a/python/tests/text/markuptext_test.py
+++ b/python/tests/text/markuptext_test.py
@@ -433,9 +433,10 @@ def test_markup_behaves_like_string():
     markup = MarkupText.from_latex(
         "TTCS$^{\mathcal{E}}$: a Vectorial Resource for Computing Conceptual Similarity"
     )
-    plain_text = "TTCSℰ: a Vectorial Resource for Computing Conceptual Similarity"
-    assert markup == plain_text  # disregards markup
-    assert markup != MarkupText.from_string(plain_text)  # does not disregard markup
+    assert (
+        markup
+        == "TTCS<tex-math>^{\mathcal{E}}</tex-math>: a Vectorial Resource for Computing Conceptual Similarity"
+    )
     assert markup == MarkupText.from_latex(
         "TTCS$^{\mathcal{E}}$: a Vectorial Resource for Computing Conceptual Similarity"
     )
@@ -444,3 +445,12 @@ def test_markup_behaves_like_string():
     assert markup.endswith("Similarity")
     assert markup < "XTCS"
     assert markup < MarkupText.from_string("XTCS")
+
+
+def test_markup_cannot_be_instantiated_from_unsupported_types():
+    with pytest.raises(TypeError):
+        MarkupText(42)
+    with pytest.raises(TypeError):
+        MarkupText(["foo", "bar"])
+    with pytest.raises(TypeError):
+        MarkupText(MarkupText("foo"))

--- a/python/tests/venues_test.py
+++ b/python/tests/venues_test.py
@@ -74,8 +74,26 @@ def test_venue_roundtrip_yaml(anthology_stub, tmp_path, venue_id):
     assert out == expected
 
 
+def test_venueindex_create(anthology):
+    index = anthology.venues
+    venue = index.create(
+        id="acla", acronym="ACLA", name="ACL Anthology Workshop", is_acl=True
+    )
+    assert "acla" in index
+    assert index["acla"] is venue
+    assert venue.acronym == "ACLA"
+    assert venue.name == "ACL Anthology Workshop"
+    assert venue.is_acl
+    assert venue.path.name == "acla.yaml"
+
+
+def test_venueindex_create_with_invalid_id(anthology):
+    with pytest.raises(ValueError):
+        anthology.venues.create(id="acl-a", acronym="ACLA", name="ACL Anthology Workshop")
+
+
 def test_venueindex_cl(anthology):
-    index = VenueIndex(anthology)
+    index = anthology.venues
     venue = index.get("cl")
     assert venue.id == "cl"
     assert venue.acronym == "CL"


### PR DESCRIPTION
This commit adds two main features:

### 1. Simplified usage of MarkupText

Before:
```python
paper.title = MarkupText.from_latex_maybe("Towards GPT-$^{\\infty}$")
```

After:
```python
paper.title = "Towards GPT-$^{\\infty}$"
```

Instead of requiring that markup text is always instantiated explicitly via a builder function like `MarkupText.from_string(...)`, it can now simply be set as a string, in which case it will be parsed via `MarkupText.from_latex_maybe(...)` automatically. This should greatly simplify the API for the most common use case.

### 2. Added `Anthology.save_all()`

This didn't exist before because writing _all_ XML files takes quite some time. This PR adds a hook to classes that automatically sets `Collection.is_modified = True` whenever an attribute on a collection/volume/paper/event is changed. Consequently, there's now an `Anthology.save_all()` that only saves those XML files that have actually been modified.

### Minor changes/additions

- New venues can now be created via `Anthology.venues.create()`.
- Renamed EventLinkingType to EventLink, in analogy to NameLink.
- Added a few basic string methods to MarkupText, e.g. you can now do `if "ACL Anthology" in paper.title` without having to explicitly convert it to a string first.