### PR TITLE
2025.udw.xml: typo in editor name

### DIFF
--- a/data/xml/2025.udw.xml
+++ b/data/xml/2025.udw.xml
@@ -3,7 +3,7 @@
   <volume id="1" ingest-date="2025-07-27" type="proceedings">
     <meta>
       <booktitle>Proceedings of the Eighth Workshop on Universal Dependencies (UDW, SyntaxFest 2025)</booktitle>
-      <editor><first>Gosse</first><last>Bomma</last></editor>
+      <editor><first>Gosse</first><last>Bouma</last></editor>
       <editor><first>Çağrı</first><last>Çöltekin</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Ljubljana, Slovenia</address>


### PR DESCRIPTION
As reported in #5915 (leaving that open until the PDF is updated).