### PR TITLE
[SIGWrit] Fixed a typo and added the original 2023 volume.

### DIFF
--- a/data/yaml/sigs/sigwrit.yaml
+++ b/data/yaml/sigs/sigwrit.yaml
@@ -1,6 +1,8 @@
-Name: Special Interest Group on Writing systems and Written Language (SIGMWrit)
+Name: Special Interest Group on Writing systems and Written Language (SIGWrit)
 ShortName: SIGWrit
 URL: https://sigwrit.org/
 Meetings:
   - 2024:
     - 2024.cawl-1
+  - 2023:
+    - 2023.cawl-1

--- a/data/yaml/sigs/sigwrit.yaml
+++ b/data/yaml/sigs/sigwrit.yaml
@@ -1,4 +1,4 @@
-Name: Special Interest Group on Writing systems and Written Language (SIGWrit)
+Name: Special Interest Group on Writing Systems and Written Language (SIGWrit)
 ShortName: SIGWrit
 URL: https://sigwrit.org/
 Meetings:


### PR DESCRIPTION
The landing page for [Special Interest Group on Writing systems and Written Language (SIGWrit)](https://aclanthology.org/sigs/sigwrit/) has two issues:

1.  There's a typo in the title.
2.  The original 2023 volume is missing.

