### PR TITLE
[North Caucasus] Adding variants for names of languages and families.

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -4162,6 +4162,7 @@ Hindustani
 Hinglish
 Hinton
 Hinukh
+Hinuq
 Hiri Motu
 Hiroshima
 Hispanic
@@ -4900,6 +4901,7 @@ Kaiy
 Kajakse
 Kajali
 Kajaman
+Kajtak
 Kakabai
 Kakabe
 Kakanda
@@ -5115,6 +5117,8 @@ Karpoš
 Karranga
 Kars
 Karttunen
+Kartvelian
+Kartvelic
 Karuwali
 Karuzi
 Karviná
@@ -5355,6 +5359,7 @@ Khumi Chin
 Khün
 Khunsari
 Khvarshi
+Khwarshi
 Khyber Pakhtunkhwa
 Khōst
 Khūzestān
@@ -5723,6 +5728,7 @@ Kuan
 Kuanhua
 Kuanua
 Kuanyama
+Kubachi
 Kube
 Kubi
 Kubo
@@ -8205,9 +8211,12 @@ Norte
 Norte de Santander
 North and Latin America
 North Caucasian
+North Caucasus
 Northamptonshire
+Northeast Caucasian
 Northern Thai
 Northumberland
+Northwest Caucasian
 Norway
 Norwegian
 Norwegian Nynorsk
@@ -10612,6 +10621,7 @@ Souk Ahras
 Soum
 Sourou
 Sousse
+South Caucasian
 South East England
 Southampton
 Southern Min
@@ -10850,6 +10860,7 @@ Taakaev
 Tabaa Zapotec
 Tabari
 Tabaru
+Tabasaran
 Tabasco Chontal
 Tabasco Nahuatl
 Tabasco Zoque


### PR DESCRIPTION
- Four alternative terms for language families: Kartvelic, South/Northeast/Northwest Caucasian.
- More variants for individual language names + missing Tabasaran language.
