### PR TITLE
Another attempt to clarify the wording on author correction form

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-name-correction.yml
+++ b/.github/ISSUE_TEMPLATE/02-name-correction.yml
@@ -17,12 +17,10 @@ body:
     attributes:
       label: Confirming that Paper Metadata is Correct
       description: |
-        Anthology policy is that the recorded metadata should match what is displayed on the PDF.
-        Prior to submitting an author correction, you must ensure that all affected papers have the correct
-        author metadata. This can be done using the "Fix data" button on each paper page (e.g., https://aclanthology.org/1962.earlymt-1.6/).
-        This button will lead you through creation of Github issues, using a separate template.
+        Anthology policy is that the metadata (i.e., what appears on the web pages) should match what is displayed on the PDF exactly, including any middle names and/or initials of authors.
+        If this is not the case, **you must first use the "Fix data" button on each affected paper's page to correct this** (e.g., https://aclanthology.org/1962.earlymt-1.6/) before submitting an author correction.  This form should _only_ be used if there are issues that remain after fixing all the author metadata.
       options:
-        - label: I confirm that all affected papers have correct author metadata.
+        - label: I confirm that all affected papers show the exact same names on the website as on the PDF.
           required: True
   - type: textarea
     id: name_pages_affected


### PR DESCRIPTION
As the title says, here’s another suggestion for maybe making the intention behind the "author metadata check" clearer.