### PR TITLE
Make AIME-Con a top-level venue

### DIFF
--- a/data/yaml/venues/aimecon.yaml
+++ b/data/yaml/venues/aimecon.yaml
@@ -1,2 +1,3 @@
 acronym: AIME-Con
 name: Artificial Intelligence in Measurement and Education Conference (AIME-Con)
+is_toplevel: true


### PR DESCRIPTION
This pull request makes a minor update to the `data/yaml/venues/aimecon.yaml` file to mark AIME-Con as a top-level conference.

* Set the `is_toplevel` property to `true` for AIME-Con in `data/yaml/venues/aimecon.yaml`.