### PR TITLE
WMT2025 - Fixed author name

### DIFF
--- a/data/xml/2025.wmt.xml
+++ b/data/xml/2025.wmt.xml
@@ -198,7 +198,7 @@
       <title><fixed-case>D</fixed-case>oc<fixed-case>HPLT</fixed-case>: A Massively Multilingual Document-Level Translation Dataset</title>
       <author><first>Dayyán</first><last>O’Brien</last><affiliation>University of Edinburgh</affiliation></author>
       <author><first>Bhavitvya</first><last>Malik</last><affiliation>University of Edinburgh</affiliation></author>
-      <author><first>Ona</first><last>De Gibert</last><affiliation>University of Helsinki</affiliation></author>
+      <author><first>Ona</first><last>de Gibert</last><affiliation>University of Helsinki</affiliation></author>
       <author><first>Pinzhen</first><last>Chen</last><affiliation>University of Edinburgh and Aveni</affiliation></author>
       <author><first>Barry</first><last>Haddow</last><affiliation>University of Edinburgh and Aveni</affiliation></author>
       <author><first>Jörg</first><last>Tiedemann</last><affiliation>University of Helsinki</affiliation></author>


### PR DESCRIPTION
Hi, I fixed an author name to reflect the PDF. The surname (O'brien) was in lowercase while the PDF had the surname as O'Brien.

