### PR TITLE
Closing #5153 and #4721 : orcid-verified yifan-peng (UDel)

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -7851,7 +7851,9 @@
   institution: Carnegie Mellon University
 - canonical: {first: Yifan, last: Peng}
   id: yifan-peng
-  comment: May refer to several people
+  orcid: 0000-0001-9309-8331
+  institution: University of Delaware
+  comment: UDel
 - canonical: {first: Christopher, last: Pennington}
   variants:
   - {first: Chris, last: Pennington}


### PR DESCRIPTION
TL;DR:
- checked all 11 papers under `yifan-peng` id belong to this orcid-identified person
- change comment from 'may refer to several' to 'UDel', added orcid and degree institution (PhD from UDel)

> (Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)

See above TL;DR.
Changes as promised in discussion in #5153 .
Checked all 11 papers under this id `yifan-peng`, confident they all belong to orcid-verified person: two most recent papers have orcid-attribute in XML, some further mentioned on orcid.org page, others share affiliation/email address/research topic with the others, plus confirmation in issue discussions from author that these are his papers.
Effect: all Yifan Peng (co-)authored papers are now associated with one of two orcid-verified persons: `yifan-peng` (UDel, now at Weill Cornell Medicine) or `yifan-peng-cmu`

Should close #5153 and #4721
