### PR TITLE
Adding frontmatter to 2024.argmining so zhexiong-liu has author status on it (closing #5090)

### DIFF
--- a/data/xml/2024.argmining.xml
+++ b/data/xml/2024.argmining.xml
@@ -17,6 +17,7 @@
     </meta>
     <frontmatter>
       <url hash="afec1ab1">2024.argmining-1.0</url>
+      <bibkey>argmining-2024-1</bibkey>
     </frontmatter>
     <paper id="1">
       <title><fixed-case>ARIES</fixed-case>: A General Benchmark for Argument Relation Identification</title>


### PR DESCRIPTION
> (Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)

Issue #5090 (Author page: zhexiong-liu): one of the editors would like the proceedings to appear on their author page. To do so, we need a front matter.

I superficially checked that the new 12-page frontmatter ( https://aclanthology.org/2024.argmining-1.0.pdf )  looks like the start of the full proceedings ( https://aclanthology.org/2024.argmining-1.pdf ).

> We need to add the `<url>` tag with checksum `afec1ab1` to the `frontmatter` block in that PR).

Done. Also added bibkey (but please check)

The old author page, year 2024 contains only one paper but not the front matter:
- https://aclanthology.org/people/zhexiong-liu/

The preview author page now lists 2 papers for 2024, one being the front matter of the ArgMining Workshop:
- https://preview.aclanthology.org/zhexiong-liu-5090/people/zhexiong-liu/
