### PR TITLE
Update credits

### DIFF
--- a/hugo/content/info/credits.md
+++ b/hugo/content/info/credits.md
@@ -14,6 +14,7 @@ We are grateful to all our contributors whose work makes this collection of scho
 + [Arne Köhn](https://arne.chark.eu) (New Work SE)
 + [Daniel Gildea](https://www.cs.rochester.edu/u/gildea/) (University of Rochester)
 + [Nathan Schneider](http://people.cs.georgetown.edu/nschneid/) (Georgetown University)
++ [Pia Weißenhorn](https://github.com/weissenh)
 
 ### Past Volunteers
 


### PR DESCRIPTION
I noticed that my affiliation on our [credits page](https://aclanthology.org/info/credits/) was almost three years out-of-date. I suppose there is other information that could be updated there as well (there have been changes among the paid assistants AFAIK), so let’s maybe use this PR to do this. @mjpost 