### PR TITLE
Name variants: Lucía Ormaechea Grijalba

### DIFF
--- a/data/xml/2022.amta.xml
+++ b/data/xml/2022.amta.xml
@@ -225,7 +225,7 @@
       <author><first>Pierrette</first><last>Bouillon</last></author>
       <author><first>Magali</first><last>Norré</last></author>
       <author><first>Johanna</first><last>Gerlach</last></author>
-      <author><first>Lucia Ormaechea</first><last>Grijalba</last></author>
+      <author><first>Lucía</first><last>Ormaechea Grijalba</last></author>
       <pages>252-263</pages>
       <url hash="1aa99cc7">2022.amta-research.19</url>
       <abstract>The use of images has been shown to positively affect patient comprehension in medical settings, in particular to deliver specific medical instructions. However, tools that automatically translate sentences into pictographs are still scarce due to the lack of resources. Previous studies have focused on the translation of sentences into pictographs by using WordNet combined with rule-based approaches and deep learning methods. In this work, we showed how we leveraged the BabelDr system, a speech to speech translator for medical triage, to build a speech to pictograph translator using UMLS and neural machine translation approaches. We showed that the translation from French sentences to a UMLS gloss can be viewed as a machine translation task and that a Multilingual Neural Machine Translation system achieved the best results.</abstract>

--- a/data/xml/2022.jeptalnrecital.xml
+++ b/data/xml/2022.jeptalnrecital.xml
@@ -669,7 +669,7 @@
     <paper id="9">
       <title>Une chaîne de traitements pour la simplification automatique de la parole et sa traduction automatique vers des pictogrammes (Simplification and automatic translation of speech into pictograms )</title>
       <author><first>Cécile</first><last>Macaire</last></author>
-      <author><first>Lucia</first><last>Ormaechea-Grijalba</last></author>
+      <author><first>Lucía</first><last>Ormaechea Grijalba</last></author>
       <author><first>Adrien</first><last>Pupier</last></author>
       <pages>111–123</pages>
       <abstract>La Communication Alternative et Augmentée (CAA) prend une place importante chez les personnes en situation de handicap ainsi que leurs proches à cause de la difficulté de son utilisation. Pour réduire ce poids, l’utilisation d’outils de traduction de la parole en pictogrammes est pertinente. De plus, ils peuvent être d’une grande aide pour l’accessibilité communicative dans le milieu hospitalier. Dans cet article, nous présentons un projet de recherche visant à développer un système de traduction de la parole vers des pictogrammes. Il met en jeu une chaîne de traitement comportant plusieurs axes relevant du traitement automatique des langues et de la parole, tels que la reconnaissance automatique de la parole, l’analyse syntaxique, la simplification de texte et la traduction automatique vers les pictogrammes. Nous présentons les difficultés liées à chacun de ces axes ainsi que, pour certains, les pistes de résolution.</abstract>

--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -7639,6 +7639,9 @@
 - canonical: {first: Zeynep, last: Orhan}
   variants:
   - {first: Orhan, last: Zeynep}
+- canonical: {first: Lucía, last: Ormaechea}
+  variants:
+  - {first: Lucía, last: Ormaechea Grijalba}
 - canonical: {first: Maite, last: Oronoz}
   id: maite-oronoz
 - canonical: {first: J. Walker, last: Orr}


### PR DESCRIPTION
> (Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)

Closes #4387

Lucía Ormaechea Grijalba

Checked paper metadata matches PDF, changed it where necessary.
Listed name variants explicitly, making the preferred one the canonical:
> with my canonical name being: **Lucía Ormaechea**.

Issue submitter didn't provide ORCID or institution, therefore not adding `orcid`, `degree` or `id`.

Instead of two pages ( https://aclanthology.org/people/lucia-ormaechea/ , https://aclanthology.org/people/lucia-ormaechea-grijalba/ ) with 5+2 papers there should be only one page with 7 papers.

Preview: 
- 404: https://preview.aclanthology.org/name-variant-lucia-ormaechea/people/lucia-ormaechea-grijalba/
- 7 papers: https://preview.aclanthology.org/name-variant-lucia-ormaechea/people/lucia-ormaechea/

