### PR TITLE
Update booktitle to use ordinal format

### DIFF
--- a/data/xml/2024.luhme.xml
+++ b/data/xml/2024.luhme.xml
@@ -2,7 +2,7 @@
 <collection id="2024.luhme">
   <volume id="1" ingest-date="2025-01-09" type="proceedings">
     <meta>
-      <booktitle>Proceedings of the First LUHME Workshop</booktitle>
+      <booktitle>Proceedings of the 1st LUHME Workshop</booktitle>
       <editor><first>Rui</first><last>Sousa-Silva</last></editor>
       <editor><first>Henrique</first><last>Lopes Cardoso</last></editor>
       <editor><first>Maarit</first><last>Koponen</last></editor>


### PR DESCRIPTION
Minor patches to update the 1st (2024) `booktitle` to use ordinal format and fixed the publishers for the 2nd (2025) book of proceedings.