### PR TITLE
Update publisher information in XML file

### DIFF
--- a/data/xml/2025.luhme.xml
+++ b/data/xml/2025.luhme.xml
@@ -7,7 +7,7 @@
       <editor><first>Rui</first><last>Sousa-Silva</last></editor>
       <editor><first>Maarit</first><last>Koponen</last></editor>
       <editor><first>Antonio</first><last>Pareja-Lora</last></editor>
-      <publisher>LUHME</publisher>
+      <publisher>UP - Universidade do Porto (https://doi.org/10.21747/978-989-9193-73-4/lan2), LIACC - Laboratório de Inteligência Artificial e Ciência de Computadores da Universidade do Porto, CLUP - Centro de Linguística da Universidade do Porto, UEF - The University of Eastern Finland and UAH - Universidad de Alcalá.</publisher>
       <address>Bologna, Italy</address>
       <month>October</month>
       <year>2025</year>


### PR DESCRIPTION
Minor patches to update the 1st (2024) `booktitle` to use ordinal format and fixed the publishers for the 2nd (2025) book of proceedings.