### PR TITLE
Added Author Page for Alexander Miserlis Hoyle (merge variants, ORCID, degree)

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -4366,6 +4366,12 @@
 - canonical: {first: David M., last: Howcroft}
   variants:
   - {first: David, last: Howcroft}
+- canonical: {first: Alexander Miserlis, last: Hoyle}
+  id: alexander-miserlis-hoyle
+  orcid: 0009-0004-3375-0470
+  degree: University of Maryland
+  variants:
+  - {first: Alexander, last: Hoyle}
 - canonical: {first: Frederick M., last: Hoyt}
   variants:
   - {first: Frederick, last: Hoyt}


### PR DESCRIPTION
> (Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)

Closes #5204

Added Alexander Miserlis Hoyle to name variants.
Including [ORCID iD](https://orcid.org/0009-0004-3375-0470), degree and variant without "Miserlis".
Author asked full name including Miserlis to be canonical one. 
In XML Miserlis is associated to the first name.
No ORCID found in XML.

Status quo: 19 papers total on two pages
- https://aclanthology.org/people/alexander-hoyle/
- https://aclanthology.org/people/alexander-miserlis-hoyle/

Changes
- https://preview.aclanthology.org/author-page-alexander-miserlis-hoyle/people/alexander-miserlis-hoyle/  19 papers
- https://preview.aclanthology.org/author-page-alexander-miserlis-hoyle/people/alexander-hoyle/  doesn't exist

