### PR TITLE
Added author page for Rifki Afina Putri

### DIFF
--- a/data/yaml/name_variants.yaml
+++ b/data/yaml/name_variants.yaml
@@ -8297,6 +8297,9 @@
   id: james-pustejovsky
   variants:
   - {first: James D., last: Pustejovsky}
+- canonical: {first: Rifki Afina, last: Putri}
+  orcid: 0000-0002-6118-4566
+  degree: Korea Advanced Institute of Science and Technology (KAIST)
 - canonical: {first: Guy, last: Pérennou}
   id: guy-perennou
 - canonical: {first: Chantal, last: Pérez-Hernández}


### PR DESCRIPTION
Recording ORCID for this author in `name_variants.yaml` together with degree institution.

- merge has already been done by metadata corrections: no need to record "Rifki Putri" as name variant?
- [ORCID](https://orcid.org/0000-0002-6118-4566) found in XML and mentioned by issue submitter
- degree found on orcid.org, [homepage](https://rifkiaputri.github.io/) linked via issue submitter and supporting evidence from matching affiliation in XML
- "Afina" put to first name as this is how it is done in the XML data 

> (Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)

Closes #4082

Evidence that all 9 papers belong to same author (no namesake)
- 5 papers come with `orcid attribute in XML
- 6 papers mention KAIST as affiliation in XML
- remaining ones have consistent affiliation in PDF with homepage/orcid.org (recently changed to Universitas Gadjah Mada)
