### PR TITLE
Add more volumes to SIGARAB (1st to 4th WANLP, ArabicNLP 2025)

### DIFF
--- a/data/yaml/sigs/sigarab.yaml
+++ b/data/yaml/sigs/sigarab.yaml
@@ -18,3 +18,11 @@ Meetings:
   - 2020:
     - 2020.wanlp-1
     - 2020.osact-1
+  - 2019:
+    - W19-46  # Fourth Arabic Natural Language Processing Workshop
+  - 2017:
+    - W17-13  # Third Arabic Natural Language Processing Workshop
+  - 2015:
+    - W15-32  # Second Workshop on Arabic Natural Language Processing
+  - 2014:
+    - W14-36  # EMNLP 2014 Workshop on Arabic Natural Language Processing (ANLP)


### PR DESCRIPTION
> (Please replace this text with a description of the changes effected by this pull request.
Include a link to the corresponding Github Issue, if there is one.
Details on how to do this ([can be found here](https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)).)

Closes #6621

Extend list of volumes appearing under https://aclanthology.org/sigs/sigarab/

## Quoting issue submitter

> Under the SIGARAB page, we want to add the newest ArabicNLP volumes found here: https://aclanthology.org/events/arabicnlp-2025/

> Additionally, we want to add all the previous events in WANLP under it as well. Those volumes can be found here: https://aclanthology.org/venues/wanlp/

## Nothing missed?

- OSACT: 3 items so far, all in sigarab.yaml: https://aclanthology.org/venues/osact/
- WANLP: 7 items, all in sigarab.yaml now: https://aclanthology.org/venues/wanlp/
- ArabicNLP: 4 items from 3 years, all in sigarab now: https://aclanthology.org/venues/arabicnlp/

The issue submitter didn't mention it, but the [sigarab website](https://aclanthology.org/sigs/sigarab/) additionally mentions next to OSACT under "Schedule Coordination with other Arabic NLP events":
- The Workshop on NLP for Languages Using Arabic Script (AbjadNLP)
  - ACL Anthology: https://aclanthology.org/venues/abjadnlp/  (1 item: `2025.abjadnlp-1`)
- The Workshop on Nakba Narratives as Language Resources (NakbaNLP)
  - ACL Anthology: https://aclanthology.org/venues/nakbanlp/ (1 item: `2025.nakbanlp-1`)
- International Workshop on Arabic Big Data & AI (IWABigDAI)
  - not found in ACL Anthology?

## More information

- https://www.sigarab.org/ 
  - lists ArabicNLP Conference with last subitem saying "Previously The Workshop on Arabic Natural Language Processing (WANLP)"
  - lists under "Schedule Coordination with other Arabic NLP events"
    - OSACT: https://aclanthology.org/venues/osact/
    - AbjadNLP: https://aclanthology.org/venues/abjadnlp/
    - NakbaNLP: https://aclanthology.org/venues/nakbanlp/
    - IWABigDAI
- https://www.aclweb.org/adminwiki/index.php?title=SIG_Compliance#SIGARAB:_SIG_on_Arabic_Natural_Language_Processing
- With issue #4127 (PR closed it) the same issue submitter has asked to add SIGARAB as a SIG
  - "All the WANLP and ArabicNLP proceedings needs to go under it. As well as those for OSACT."
- Sigarab has been established 2022, but the yaml already contained volumes dating back til 2020.

