### PR TITLE
Fix tag on author page issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-name-correction.yml
+++ b/.github/ISSUE_TEMPLATE/02-name-correction.yml
@@ -1,7 +1,7 @@
 name: Correction to Author Page
 description: Fix issues with author pages.
 title: "Author Page: {replace with author name}"
-labels: ["correction", "metadata"]
+labels: ["correction", "author-page"]
 assignees:
   - anthology-assist
 body:


### PR DESCRIPTION
I find it annoying that both metadata corrections and author pages use the same "metadata" label, which makes it impossible to filter issues. This fixes that.