### PR TITLE
author page template: add checkbox to confirm author is already published in the Anthology

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-name-correction.yml
+++ b/.github/ISSUE_TEMPLATE/02-name-correction.yml
@@ -13,6 +13,16 @@ body:
         of the author's name, while splitting allows the separation of papers published under the same
         name but belonging to different people.
   - type: checkboxes
+    id: in_anth_check
+    attributes:
+      label: Confirming that Author is Published in the Anthology
+      description: |
+        The Anthology only hosts publications submitted by certain venues (conferences/journals), and only has pages
+        for authors of these publications (not individually created user profiles).
+      options:
+        - label: I confirm that this concerns an author who already has at least one publication in the Anthology.
+          required: True
+  - type: checkboxes
     id: name_correction_check
     attributes:
       label: Confirming that Paper Metadata is Correct


### PR DESCRIPTION
There has been confusion on this point, with some author page requests expecting us to have user-created profiles like ResearchGate.