### PR TITLE
Fixed casing for Nko, Zeno in paper titles; fix ELRA abbreviation in OSACT 2020

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -8162,6 +8162,7 @@ Nkari
 Nkhata
 Nkhotakota
 Nkhumbi
+Nko
 Nkongho
 Nkonya
 Nkoroo

--- a/data/xml/2020.osact.xml
+++ b/data/xml/2020.osact.xml
@@ -8,7 +8,7 @@
       <editor><first>Kareem</first><last>Darwish</last></editor>
       <editor><first>Tamer</first><last>Elsayed</last></editor>
       <editor><first>Hamdy</first><last>Mubarak</last></editor>
-      <publisher>European Language Resource Association</publisher>
+      <publisher>European Language Resources Association</publisher>
       <address>Marseille, France</address>
       <month>May</month>
       <year>2020</year>

--- a/data/xml/2023.wmt.xml
+++ b/data/xml/2023.wmt.xml
@@ -493,7 +493,7 @@
       <doi>10.18653/v1/2023.wmt-1.33</doi>
     </paper>
     <paper id="34">
-      <title>Machine Translation for Nko: Tools, Corpora, and Baseline Results</title>
+      <title>Machine Translation for <fixed-case>N</fixed-case>ko: Tools, Corpora, and Baseline Results</title>
       <author><first>Moussa</first><last>Doumbouya</last></author>
       <author><first>Baba Mamadi</first><last>Diané</last></author>
       <author><first>Solo Farabado</first><last>Cissé</last></author>

--- a/data/xml/2024.emnlp.xml
+++ b/data/xml/2024.emnlp.xml
@@ -13645,7 +13645,7 @@
       <doi>10.18653/v1/2024.emnlp-main.982</doi>
     </paper>
     <paper id="983">
-      <title>The Zeno’s Paradox of ‘Low-Resource’ Languages</title>
+      <title>The <fixed-case>Z</fixed-case>eno’s Paradox of ‘Low-Resource’ Languages</title>
       <author><first>Hellina Hailu</first><last>Nigatu</last><affiliation>Mohamed bin Zayed University of Artificial Intelligence and Electrical Engineering &amp; Computer Science Department, University of California, Berkeley</affiliation></author>
       <author orcid="0000-0002-3501-5136"><first>Atnafu Lambebo</first><last>Tonja</last><affiliation>Mohamed bin Zayed University of Artificial Intelligence and Instituto Politécnico Nacional</affiliation></author>
       <author><first>Benjamin</first><last>Rosman</last><affiliation>University of the Witwatersrand</affiliation></author>


### PR DESCRIPTION
Hi! I made some small metadata fixes:

- I added Nko to the fixed-casing truelist and edited the paper title metadata of https://aclanthology.org/2023.wmt-1.34/ accordingly.
- I edited the paper title metadata of https://aclanthology.org/2024.emnlp-main.983/ so "Zeno" is fixed-cased.
- I edited the proceedings metadata of https://aclanthology.org/volumes/2020.osact-1/ to fix a typo in the publisher's name (an 's' was missing): European Language Resource Association -> European Language Resource**s** Association. The edited version reflects ELRA's (old) acronym and matches the metadata in the proceedings PDF (bottom of page 2: https://aclanthology.org/2020.osact-1.0.pdf) and the watermark in the paper PDFs (e.g., https://aclanthology.org/2020.osact-1.1.pdf)
