### PR TITLE
Create redirects for name slugs to verified IDs

### DIFF
--- a/hugo/content/people/_content.gotmpl
+++ b/hugo/content/people/_content.gotmpl
@@ -3,6 +3,7 @@
       "kind" "page"
       "path" $person_id
       "slug" (index (split $person_id "/") -1)
+      "aliases" $person.aliases
       "params" (dict "name" $person_id "lastname" $person.last)
       "title" $person.full
    }}


### PR DESCRIPTION
Based on the suggestion in https://github.com/acl-org/acl-anthology/pull/6807#issuecomment-3765955585 ff.

Probably depends on #7253 to build correctly, but I verified that it works locally.