### PR TITLE
Streamline instructions for maintaining author pages

### DIFF
--- a/hugo/content/info/author-pages.md
+++ b/hugo/content/info/author-pages.md
@@ -4,7 +4,6 @@ linktitle: Author pages
 subtitle: How to keep your author page up-to-date
 date: "2026-01-28"
 ---
-
 Every author appearing on a paper in the Anthology is given an author page. The ACL Anthology distinguishes between _verified_ and _unverified_ authors.
 
 A verified author has an ORCID icon <i class="fab fa-orcid text-verified"></i> next to the author's name. If your author page is verified:

--- a/hugo/content/info/author-pages.md
+++ b/hugo/content/info/author-pages.md
@@ -58,5 +58,5 @@ After your author page is verified, any papers published under different spellin
 
 - Find your ACL Anthology author page (by using the search bar, or by finding one of your papers and clicking on your name).
 - Click on the "Fix author" button at the bottom of the links on the right-hand side of the page.
-- Fill out at least the required fields, check the "Merge profiles" checkbox, and list your papers in the "Supporting Information" field.
+- Fill out at least the required fields, check the "Merge profiles" checkbox, and list the pages to be merged in the "Supporting Information" field.
 - Click on the "Create" button, and wait for the issue to be reviewed by Anthology staff.

--- a/hugo/content/info/author-pages.md
+++ b/hugo/content/info/author-pages.md
@@ -1,0 +1,62 @@
+---
+Title: Author pages
+linktitle: Author pages
+subtitle: How to keep your author page up-to-date
+date: "2026-01-28"
+---
+Every author appearing on a paper in the Anthology is given an author page. The ACL Anthology distinguishes between _verified_ and _unverified_ authors.
+
+A verified author has an ORCID icon <i class="fab fa-orcid text-verified"></i> next to the author's name. If your author page is verified:
+- Papers linked to your ORCID iD will appear on your page.
+- Papers by someone with the same name as you, but linked to a different ORCID iD, will not appear on your page.
+- However, papers by someone with the same name as you, but not linked to an ORCID iD, may still appear on your page. For more information, please see [How to split an author page](#how-to-split-an-author-page).
+
+An unverified author page has `/unverified/` appended to its URL, and a question mark <i class="fas fa-question-circle text-secondary"></i> next to the author's name. If your author page is unverified:
+- Papers that list you as an author with a different spelling will appear on a different author page. For more information, please see [How to merge two author pages](#how-to-merge-two-author-pages).
+- Papers by someone with the same name as you will appear on your author page. For more information, please see [How to split an author page](#how-to-split-an-author-page).
+
+For more details on how verification works, please see [How the ACL Anthology verifies authors]({{< ref "/info/verification">}}). To learn how to get your author page verified, please continue to [How to get an author page verified](#how-to-get-an-author-page-verified).
+
+### How to get an author page verified
+
+1. Obtain an ORCID iD:
+
+- Visit [the ORCID registration form](https://orcid.org/register).
+- Add name variants: Set your given and family names, your published name, and any name variants you have published under (e.g., with or without middle initials, former names, etc.). It is especially important to make sure you have at least one Latin-script variant of your name. ([This profile](https://orcid.org/0000-0002-1831-3457) is a good example.)
+- Make sure your name is visible to everyone.
+- Add educational history and affiliations: When we manually disambiguate an author, we may need to know the institution from which you received (or expect to receive) your highest degree, as part of our [human-focused person ID system]({{< ref "/info/names" >}}).
+- Less importantly, it can be helpful to the disambiguation process if you make the effort to add a few representative publications.
+
+For more information about ORCID iDs and how the Anthology uses them, please [ORCID iDs in the ACL Anthology]({{< ref "/info/orcid">}}).
+
+2. Link your profiles on conference management systems to your ORCID iD:
+
+- OpenReview: Visit the ["Edit Profile" page](https://openreview.net/profile/edit). (If necessary, enter your username and password and click on "Login to OpenReview.") Click on the "Personal Links" section. Enter your ORCID in the "ORCID URL" field, and click on the "Save Profile Changes" button.
+- Softconf/START: Visit the ["Update Profile" page](https://www.softconf.com/naacl2021/super/scmd.cgi?ucmd=updateProfile). (If necessary, click on "To Login Page", enter your username and password, click on the "ENTER" button, and click on ["Update Profile"](https://www.softconf.com/naacl2021/super/scmd.cgi?ucmd=updateProfile) again.) Scroll down to the "Additional Information for Authors and Reviewers" section. Enter your ORCID in the "ORCID" field, and click on the "SUBMIT DATA" button.
+
+In each of these systems, the name that you enter is the one that gets used in the paper's metadata. Please make sure that this name matches the name on the PDF file, and that this name matches one of the ORCID variants, ideally your published name.
+
+3. File an issue on GitHub.
+
+- Find your ACL Anthology author page (by using the search bar, or by finding one of your papers and clicking on your name).
+- Click on the "Fix author" button at the bottom of the links on the right-hand side of the page.
+- Fill out at least the required fields, and check the "Verification" checkbox.
+- Click on the "Create" button, and wait for the issue to be reviewed by Anthology staff.
+
+### How to split an author page
+
+When your author page is first verified, any papers published under your name will appear on your page. However, if another author has the same name as you, their papers may also appear on your page. To fix this, please file a split request.
+
+- Find your ACL Anthology author page (by using the search bar, or by finding one of your papers and clicking on your name).
+- Click on the "Fix author" button at the bottom of the links on the right-hand side of the page.
+- Fill out at least the required fields, check the "Split/disambiguate" checkbox, and list your papers in the "Supporting Information" field.
+- Click on the "Create" button, and wait for the issue to be reviewed by Anthology staff.
+
+### How to merge two author pages
+
+After your author page is verified, any papers published under different spellings of your name, if they are not linked to an ORCID iD, may appear on a different author page. To fix this, please file a merge request.
+
+- Find your ACL Anthology author page (by using the search bar, or by finding one of your papers and clicking on your name).
+- Click on the "Fix author" button at the bottom of the links on the right-hand side of the page.
+- Fill out at least the required fields, check the "Merge profiles" checkbox, and list your papers in the "Supporting Information" field.
+- Click on the "Create" button, and wait for the issue to be reviewed by Anthology staff.

--- a/hugo/content/info/author-pages.md
+++ b/hugo/content/info/author-pages.md
@@ -4,6 +4,7 @@ linktitle: Author pages
 subtitle: How to keep your author page up-to-date
 date: "2026-01-28"
 ---
+
 Every author appearing on a paper in the Anthology is given an author page. The ACL Anthology distinguishes between _verified_ and _unverified_ authors.
 
 A verified author has an ORCID icon <i class="fab fa-orcid text-verified"></i> next to the author's name. If your author page is verified:

--- a/hugo/content/info/orcid.md
+++ b/hugo/content/info/orcid.md
@@ -20,4 +20,4 @@ We urge every author who is actively publishing papers to create an ORCID iD and
 
 Less importantly, it can be helpful to the disambiguation process if you make the effort to add a few representative publications.
 
-Finally, make sure that the name you enter into submission mangagement systems (such as Softconf or OpenReview) matches one of the ORCID variants, ideally the published name. The name variant entered into these systems is the one that gets used as the paper's metadata, and should also match the PDF.
+Finally, make sure that the name you enter into submission management systems (such as Softconf or OpenReview) matches one of the ORCID variants, ideally the published name. The name variant entered into these systems is the one that gets used as the paper's metadata, and should also match the PDF.


### PR DESCRIPTION
This is meant to help with #7230. It creates a new page, `info/author-pages`, that collects together all the instructions I could find about maintaining one's author page. I propose for it to be the destination of the question mark link on unverified author pages, but I don't necessarily propose for it to be a separate page -- I would be fine with merging it with `info/verification`.

