### PR TITLE
Verify Marcel Bollmann

### DIFF
--- a/data/xml/2020.acl.xml
+++ b/data/xml/2020.acl.xml
@@ -9388,14 +9388,14 @@
     </paper>
     <paper id="699">
       <title>On Forgetting to Cite Older Papers: An Analysis of the <fixed-case>ACL</fixed-case> <fixed-case>A</fixed-case>nthology</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Desmond</first><last>Elliott</last></author>
       <pages>7819–7827</pages>
       <abstract>The field of natural language processing is experiencing a period of unprecedented growth, and with it a surge of published papers. This represents an opportunity for us to take stock of how we cite the work of other researchers, and whether this growth comes at the expense of “forgetting” about older literature. In this paper, we address this question through bibliographic analysis. By looking at the age of outgoing citations in papers published at selected ACL venues between 2010 and 2019, we find that there is indeed a tendency for recent papers to cite more recent work, but the rate at which papers older than 15 years are cited has remained relatively stable.</abstract>
       <url hash="2ac03cc9">2020.acl-main.699</url>
       <attachment type="Software" hash="68b7c6c1">2020.acl-main.699.Software.zip</attachment>
-      <doi>10.18653/v1/2020.acl-main.699</doi>
       <attachment type="Dataset" hash="631de170">2020.acl-main.699.Dataset.zip</attachment>
+      <doi>10.18653/v1/2020.acl-main.699</doi>
       <video href="http://slideslive.com/38929066"/>
       <bibkey>bollmann-elliott-2020-forgetting</bibkey>
     </paper>

--- a/data/xml/2021.americasnlp.xml
+++ b/data/xml/2021.americasnlp.xml
@@ -336,7 +336,7 @@
     </paper>
     <paper id="28">
       <title><fixed-case>M</fixed-case>oses and the Character-Based Random Babbling Baseline: <fixed-case>C</fixed-case>o<fixed-case>AS</fixed-case>ta<fixed-case>L</fixed-case> at <fixed-case>A</fixed-case>mericas<fixed-case>NLP</fixed-case> 2021 Shared Task</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Rahul</first><last>Aralikatte</last></author>
       <author><first>Héctor</first><last>Murrieta Bello</last></author>
       <author><first>Daniel</first><last>Hershcovich</last></author>

--- a/data/xml/2021.eacl.xml
+++ b/data/xml/2021.eacl.xml
@@ -1955,7 +1955,7 @@
     </paper>
     <paper id="162">
       <title>Error Analysis and the Role of Morphology</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <pages>1887–1900</pages>
       <abstract>We evaluate two common conjectures in error analysis of NLP models: (i) Morphology is predictive of errors; and (ii) the importance of morphology increases with the morphological complexity of a language. We show across four different tasks and up to 57 languages that of these conjectures, somewhat surprisingly, only (i) is true. Using morphological features does improve error prediction across tasks; however, this effect is less pronounced with morphologically complex languages. We speculate this is because morphology is more discriminative in morphologically simple languages. Across all four tasks, case and gender are the morphological features most predictive of error.</abstract>

--- a/data/xml/2021.wat.xml
+++ b/data/xml/2021.wat.xml
@@ -335,7 +335,7 @@
       <author><first>Héctor Ricardo</first><last>Murrieta Bello</last></author>
       <author><first>Miryam</first><last>de Lhoneux</last></author>
       <author><first>Daniel</first><last>Hershcovich</last></author>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <pages>205–211</pages>
       <abstract>This work shows that competitive translation results can be obtained in a constrained setting by incorporating the latest advances in memory and compute optimization. We train and evaluate large multilingual translation models using a single GPU for a maximum of 100 hours and get within 4-5 BLEU points of the top submission on the leaderboard. We also benchmark standard baselines on the PMI corpus and re-discover well-known shortcomings of translation systems and metrics.</abstract>

--- a/data/xml/2023.nlposs.xml
+++ b/data/xml/2023.nlposs.xml
@@ -138,7 +138,7 @@
     </paper>
     <paper id="10">
       <title>Two Decades of the <fixed-case>ACL</fixed-case> <fixed-case>A</fixed-case>nthology: Development, Impact, and Open Challenges</title>
-      <author><first>Marcel</first><last>Bollmann</last><affiliation>Linköping University</affiliation></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last><affiliation>Linköping University</affiliation></author>
       <author><first>Nathan</first><last>Schneider</last><affiliation>Georgetown University</affiliation></author>
       <author><first>Arne</first><last>Köhn</last></author>
       <author><first>Matt</first><last>Post</last><affiliation>Microsoft and Johns Hopkins University</affiliation></author>

--- a/data/xml/2024.nejlt.xml
+++ b/data/xml/2024.nejlt.xml
@@ -3,7 +3,7 @@
   <volume id="1" ingest-date="2025-01-08" type="journal">
     <meta>
       <booktitle>Northern European Journal of Language Technology, Volume 10</booktitle>
-      <editor><first>Marcel</first><last>Bollmann</last></editor>
+      <editor id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></editor>
       <publisher>Linköping University Electronic Press</publisher>
       <address>Linköping, Sweden</address>
       <month>December</month>

--- a/data/xml/2024.tacl.xml
+++ b/data/xml/2024.tacl.xml
@@ -683,7 +683,7 @@
       <author><first>Ernests</first><last>Lavrinovics</last></author>
       <author><first>Diptesh</first><last>Kanojia</last></author>
       <author><first>Paul</first><last>Belony</last></author>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Loïc</first><last>Grobol</last></author>
       <author><first>Miryam de</first><last>Lhoneux</last></author>
       <author><first>Daniel</first><last>Hershcovich</last></author>

--- a/data/xml/C16.xml
+++ b/data/xml/C16.xml
@@ -146,7 +146,7 @@
     </paper>
     <paper id="13">
       <title>Improving historical spelling normalization with bi-directional <fixed-case>LSTM</fixed-case>s and multi-task learning</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <pages>131–139</pages>
       <url hash="2c4b69d0">C16-1013</url>

--- a/data/xml/D19.xml
+++ b/data/xml/D19.xml
@@ -12963,7 +12963,7 @@ Typo in Table 4 fixed to reflect correct recall of presented system.</revision>
     </paper>
     <paper id="12">
       <title>Few-Shot and Zero-Shot Learning for Historical Text Normalization</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Natalia</first><last>Korchagina</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <pages>104–114</pages>

--- a/data/xml/N19.xml
+++ b/data/xml/N19.xml
@@ -4779,7 +4779,7 @@
     </paper>
     <paper id="389">
       <title>A Large-Scale Comparison of Historical Text Normalization Systems</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <pages>3885–3898</pages>
       <abstract>There is no consensus on the state-of-the-art approach to historical text normalization. Many techniques have been proposed, including rule-based methods, distance metrics, character-based statistical machine translation, and neural encoder–decoder models, but studies have used different datasets, different evaluation methods, and have come to different conclusions. This paper presents the largest study of historical text normalization done so far. We critically survey the existing literature and report experiments on eight languages, comparing systems spanning all categories of proposed normalization techniques, analysing the effect of training data quantity, and using different evaluation methods. The datasets and scripts are made publicly available.</abstract>
       <url hash="12ade017">N19-1389</url>

--- a/data/xml/P17.xml
+++ b/data/xml/P17.xml
@@ -414,7 +414,7 @@ two word-vectors results in a vector that is only a small angle away from the ve
     </paper>
     <paper id="31">
       <title>Learning attention for historical text normalization by learning to pronounce</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Joachim</first><last>Bingel</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <pages>332–344</pages>

--- a/data/xml/P19.xml
+++ b/data/xml/P19.xml
@@ -2014,7 +2014,7 @@
     <paper id="157">
       <title>Historical Text Normalization with Delayed Rewards</title>
       <author><first>Simon</first><last>Flachs</last></author>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <pages>1614–1619</pages>
       <abstract>Training neural sequence-to-sequence models with simple token-level log-likelihood is now a standard approach to historical text normalization, albeit often outperformed by phrase-based models. Policy gradient training enables direct optimization for exact matches, and while the small datasets in historical text normalization are prohibitive of from-scratch reinforcement learning, we show that policy gradient fine-tuning leads to significant improvements across the board. Policy gradient training, in particular, leads to more accurate normalizations for long or unseen words.</abstract>

--- a/data/xml/R19.xml
+++ b/data/xml/R19.xml
@@ -152,7 +152,7 @@
       <title>Naive Regularizers for Low-Resource Neural Machine Translation</title>
       <author><first>Meriem</first><last>Beloucif</last></author>
       <author><first>Ana Valeria</first><last>Gonzalez</last></author>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <pages>102–111</pages>
       <abstract>Neural machine translation models have little inductive bias, which can be a disadvantage in low-resource scenarios. Neural models have to be trained on large amounts of data and have been shown to perform poorly when only limited data is available. We show that using naive regularization methods, based on sentence length, punctuation and word frequencies, to penalize translations that are very different from the input sentences, consistently improves the translation quality across multiple low-resource languages. We experiment with 12 language pairs, varying the training data size between 17k to 230k sentence pairs. Our best regularizer achieves an average increase of 1.5 BLEU score and 1.0 TER score across all the language pairs. For example, we achieve a BLEU score of 26.70 on the IWSLT15 English–Vietnamese translation task simply by using relative differences in punctuation as a regularizer.</abstract>

--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -5472,7 +5472,7 @@
     </paper>
     <paper id="17">
       <title>Adapting <fixed-case>S</fixed-case>imple<fixed-case>NLG</fixed-case> to <fixed-case>G</fixed-case>erman</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <pages>133–138</pages>
       <url hash="eb0f3bc8">W11-2817</url>
       <attachment type="software" hash="b2e0f7bd">W11-2817.Software.zip</attachment>
@@ -7311,7 +7311,7 @@
     </paper>
     <paper id="6">
       <title>Rule-Based Normalization of Historical Texts</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Florian</first><last>Petran</last></author>
       <author><first>Stefanie</first><last>Dipper</last></author>
       <pages>34–42</pages>

--- a/data/xml/W13.xml
+++ b/data/xml/W13.xml
@@ -3752,7 +3752,7 @@
     </paper>
     <paper id="2">
       <title><fixed-case>POS</fixed-case> Tagging for Historical Texts with Sparse Training Data</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <pages>11–18</pages>
       <url hash="2f495553">W13-2302</url>
       <bibkey>bollmann-2013-pos</bibkey>

--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -1230,7 +1230,7 @@
     </paper>
     <paper id="12">
       <title><fixed-case>C</fixed-case>or<fixed-case>A</fixed-case>: A web-based annotation tool for historical and other non-standard language data</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Florian</first><last>Petran</last></author>
       <author><first>Stefanie</first><last>Dipper</last></author>
       <author><first>Julia</first><last>Krasselt</last></author>

--- a/data/xml/W16.xml
+++ b/data/xml/W16.xml
@@ -2762,7 +2762,7 @@
     </paper>
     <paper id="11">
       <title>Evaluating Inter-Annotator Agreement on Historical Spelling Normalization</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author><first>Stefanie</first><last>Dipper</last></author>
       <author><first>Florian</first><last>Petran</last></author>
       <pages>89–98</pages>

--- a/data/xml/W18.xml
+++ b/data/xml/W18.xml
@@ -5353,7 +5353,7 @@
     </paper>
     <paper id="3">
       <title>Multi-task learning for historical text normalization: Size matters</title>
-      <author><first>Marcel</first><last>Bollmann</last></author>
+      <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last></author>
       <author id="anders-sogaard"><first>Anders</first><last>Søgaard</last></author>
       <author><first>Joachim</first><last>Bingel</last></author>
       <pages>19–24</pages>

--- a/data/yaml/people.yaml
+++ b/data/yaml/people.yaml
@@ -35618,6 +35618,10 @@ marcel-adam-just:
   names:
   - {first: Marcel Adam, last: Just}
   - {first: Marcel, last: Just}
+marcel-bollmann:
+  names:
+  - {first: Marcel, last: Bollmann}
+  orcid: 0000-0003-2598-8150
 marcel-p-van-lohuizen:
   names:
   - {first: Marcel P., last: van Lohuizen}


### PR DESCRIPTION
Opening this PR to verify myself, but also to demonstrate a feature of the library that we may or may not want to use. @mjpost @weissenh 

Since I confirm that all papers on https://aclanthology.org/people/marcel-bollmann/unverified/ are mine, the correct thing to do upon verification (IMO) is to not just add my ORCID and names to `people.yaml`, but also to add my ID to all of these papers. I did this by running:

```python
person = anthology.get_person("marcel-bollmann/unverified")
person.orcid = "0000-0003-2598-8150"
person.make_explicit("marcel-bollmann")
anthology.save_all()
```

I understand it may not always be correct to associate _all_ papers on the unverified page with a new verified person, but in case it is, this is a shortcut for doing so.