### PR TITLE
bulk_verify_all.py for simple verification requests

### DIFF
--- a/bin/correct/bulk_process_simple_verifications.py
+++ b/bin/correct/bulk_process_simple_verifications.py
@@ -206,6 +206,7 @@ class AnthologyMetadataUpdater:
                     log.error(
                         f'Failed to apply changes to #{issue.number}: {e}',
                     )
+                    log.exception(e)
                     self.stats["error_issues"] += 1
                     self.load_anthology()
                     continue
@@ -222,7 +223,7 @@ class AnthologyMetadataUpdater:
 
             except Exception as e:
                 log.error(f'Error processing issue {issue.number}: {type(e)}: {e}')
-                e.print_stack_trace()
+                log.exception(e)
                 self.stats["error_issues"] += 1
                 self.load_anthology()
                 continue


### PR DESCRIPTION
As discussed in #7274, a script to handle approved issues requesting to convert an /unverified author page into a verified one. Will fail if a verified author with that ID already exists (that should be a merge). Will not apply to requests that indicate a split, merge, or name change is requested.