### PR TITLE
Ingest TACL 2025 papers (Volume 13 update)

### DIFF
--- a/data/xml/2025.tacl.xml
+++ b/data/xml/2025.tacl.xml
@@ -11,16 +11,46 @@
     </meta>
     <paper id="1">
       <title>Dolomites: Domain-Specific Long-Form Methodical Tasks</title>
-      <author><first>Chaitanya</first><last>Malaviya</last></author>
-      <author><first>Priyanka</first><last>Agrawal</last></author>
-      <author><first>Kuzman</first><last>Ganchev</last></author>
-      <author><first>Pranesh</first><last>Srinivasan</last></author>
-      <author><first>Fantine</first><last>Huot</last></author>
-      <author><first>Jonathan</first><last>Berant</last></author>
-      <author><first>Mark</first><last>Yatskar</last></author>
-      <author><first>Dipanjan</first><last>Das</last></author>
-      <author><first>Mirella</first><last>Lapata</last></author>
-      <author><first>Chris</first><last>Alberti</last></author>
+      <author>
+        <first>Chaitanya</first>
+        <last>Malaviya</last>
+      </author>
+      <author>
+        <first>Priyanka</first>
+        <last>Agrawal</last>
+      </author>
+      <author>
+        <first>Kuzman</first>
+        <last>Ganchev</last>
+      </author>
+      <author>
+        <first>Pranesh</first>
+        <last>Srinivasan</last>
+      </author>
+      <author>
+        <first>Fantine</first>
+        <last>Huot</last>
+      </author>
+      <author>
+        <first>Jonathan</first>
+        <last>Berant</last>
+      </author>
+      <author>
+        <first>Mark</first>
+        <last>Yatskar</last>
+      </author>
+      <author>
+        <first>Dipanjan</first>
+        <last>Das</last>
+      </author>
+      <author>
+        <first>Mirella</first>
+        <last>Lapata</last>
+      </author>
+      <author>
+        <first>Chris</first>
+        <last>Alberti</last>
+      </author>
       <doi>10.1162/tacl_a_00727</doi>
       <abstract>Experts in various fields routinely perform methodical writing tasks to plan, organize, and report their work. From a clinician writing a differential diagnosis for a patient, to a teacher writing a lesson plan for students, these tasks are pervasive, requiring to methodically generate structured long-form output for a given input. We develop a typology of methodical tasks structured in the form of a task objective, procedure, input, and output, and introduce DoLoMiTes, a novel benchmark with specifications for 519 such tasks elicited from hundreds of experts from across 25 fields. Our benchmark further contains specific instantiations of methodical tasks with concrete input and output examples (1,857 in total) which we obtain by collecting expert revisions of up to 10 model-generated examples of each task. We use these examples to evaluate contemporary language models, highlighting that automating methodical tasks is a challenging long-form generation problem, as it requires performing complex inferences, while drawing upon the given context as well as domain knowledge. Our dataset is available at https://dolomites-benchmark.github.io/.</abstract>
       <pages>1–29</pages>
@@ -28,23 +58,72 @@
       <bibkey>malaviya-etal-2025-dolomites</bibkey>
     </paper>
     <paper id="2">
-      <title><fixed-case>S</fixed-case>pi<fixed-case>R</fixed-case>it-<fixed-case>LM</fixed-case>: Interleaved Spoken and Written Language Model</title>
-      <author><first>Tu Anh</first><last>Nguyen</last></author>
-      <author><first>Benjamin</first><last>Muller</last></author>
-      <author><first>Bokai</first><last>Yu</last></author>
-      <author><first>Marta R.</first><last>Costa-jussa</last></author>
-      <author><first>Maha</first><last>Elbayad</last></author>
-      <author><first>Sravya</first><last>Popuri</last></author>
-      <author><first>Christophe</first><last>Ropers</last></author>
-      <author><first>Paul-Ambroise</first><last>Duquenne</last></author>
-      <author><first>Robin</first><last>Algayres</last></author>
-      <author><first>Ruslan</first><last>Mavlyutov</last></author>
-      <author><first>Itai</first><last>Gat</last></author>
-      <author><first>Mary</first><last>Williamson</last></author>
-      <author><first>Gabriel</first><last>Synnaeve</last></author>
-      <author><first>Juan</first><last>Pino</last></author>
-      <author id="benoit-sagot"><first>Benoît</first><last>Sagot</last></author>
-      <author><first>Emmanuel</first><last>Dupoux</last></author>
+      <title>
+        <fixed-case>S</fixed-case>pi<fixed-case>R</fixed-case>it-<fixed-case>LM</fixed-case>: Interleaved Spoken and Written Language Model</title>
+      <author>
+        <first>Tu Anh</first>
+        <last>Nguyen</last>
+      </author>
+      <author>
+        <first>Benjamin</first>
+        <last>Muller</last>
+      </author>
+      <author>
+        <first>Bokai</first>
+        <last>Yu</last>
+      </author>
+      <author>
+        <first>Marta R.</first>
+        <last>Costa-jussa</last>
+      </author>
+      <author>
+        <first>Maha</first>
+        <last>Elbayad</last>
+      </author>
+      <author>
+        <first>Sravya</first>
+        <last>Popuri</last>
+      </author>
+      <author>
+        <first>Christophe</first>
+        <last>Ropers</last>
+      </author>
+      <author>
+        <first>Paul-Ambroise</first>
+        <last>Duquenne</last>
+      </author>
+      <author>
+        <first>Robin</first>
+        <last>Algayres</last>
+      </author>
+      <author>
+        <first>Ruslan</first>
+        <last>Mavlyutov</last>
+      </author>
+      <author>
+        <first>Itai</first>
+        <last>Gat</last>
+      </author>
+      <author>
+        <first>Mary</first>
+        <last>Williamson</last>
+      </author>
+      <author>
+        <first>Gabriel</first>
+        <last>Synnaeve</last>
+      </author>
+      <author>
+        <first>Juan</first>
+        <last>Pino</last>
+      </author>
+      <author id="benoit-sagot">
+        <first>Benoît</first>
+        <last>Sagot</last>
+      </author>
+      <author>
+        <first>Emmanuel</first>
+        <last>Dupoux</last>
+      </author>
       <doi>10.1162/tacl_a_00728</doi>
       <abstract>We introduce SpiRit-LM, a foundation multimodal language model that freely mixes text and speech. Our model is based on a 7B pretrained text language model that we extend to the speech modality by continuously training it on text and speech units. Speech and text sequences are concatenated as a single stream of tokens, and trained with a word-level interleaving method using a small automatically curated speech-text parallel corpus. SpiRit-LM comes in two versions: a Base version that uses speech phonetic units (HuBERT) and an Expressive version that models expressivity using pitch and style units in addition to the phonetic units. For both versions, the text is encoded with subword BPE tokens. The resulting model displays both the semantic abilities of text models and the expressive abilities of speech models. Additionally, we demonstrate that SpiRit-LM can learn new tasks in a few-shot fashion across modalities (i.e., ASR, TTS, Speech Classification). We make available model weights and inference code.1,2</abstract>
       <pages>30–52</pages>
@@ -52,11 +131,24 @@
       <bibkey>nguyen-etal-2025-spirit</bibkey>
     </paper>
     <paper id="3">
-      <title><fixed-case>CLAP</fixed-case>nq: Cohesive Long-form Answers from Passages in Natural Questions for <fixed-case>RAG</fixed-case> systems</title>
-      <author><first>Sara</first><last>Rosenthal</last></author>
-      <author id="avirup-sil"><first>Avirup</first><last>Sil</last></author>
-      <author id="radu-florian"><first>Radu</first><last>Florian</last></author>
-      <author id="salim-roukos"><first>Salim</first><last>Roukos</last></author>
+      <title>
+        <fixed-case>CLAP</fixed-case>nq: Cohesive Long-form Answers from Passages in Natural Questions for <fixed-case>RAG</fixed-case> systems</title>
+      <author>
+        <first>Sara</first>
+        <last>Rosenthal</last>
+      </author>
+      <author id="avirup-sil">
+        <first>Avirup</first>
+        <last>Sil</last>
+      </author>
+      <author id="radu-florian">
+        <first>Radu</first>
+        <last>Florian</last>
+      </author>
+      <author id="salim-roukos">
+        <first>Salim</first>
+        <last>Roukos</last>
+      </author>
       <doi>10.1162/tacl_a_00729</doi>
       <abstract>Retrieval Augmented Generation (RAG) has become a popular application for large language models. It is preferable that successful RAG systems provide accurate answers that are supported by being grounded in a passage without any hallucinations. While considerable work is required for building a full RAG pipeline, being able to benchmark performance is also necessary. We present CLAPnq, a benchmark Long-form Question Answering dataset for the full RAG pipeline. CLAPnq includes long answers with grounded gold passages from Natural Questions (NQ) and a corpus to perform either retrieval, generation, or the full RAG pipeline. The CLAPnq answers are concise, 3x smaller than the full passage, and cohesive, meaning that the answer is composed fluently, often by integrating multiple pieces of the passage that are not contiguous. RAG models must adapt to these properties to be successful at CLAPnq. We present baseline experiments and analysis for CLAPnq that highlight areas where there is still significant room for improvement in grounded RAG. CLAPnq is publicly available at https://github.com/primeqa/clapnq.</abstract>
       <pages>53–72</pages>
@@ -65,13 +157,34 @@
     </paper>
     <paper id="4">
       <title>Salute the Classic: Revisiting Challenges of Machine Translation in the Age of Large Language Models</title>
-      <author><first>Jianhui</first><last>Pang</last></author>
-      <author><first>Fanghua</first><last>Ye</last></author>
-      <author><first>Derek Fai</first><last>Wong</last></author>
-      <author><first>Dian</first><last>Yu</last></author>
-      <author><first>Shuming</first><last>Shi</last></author>
-      <author><first>Zhaopeng</first><last>Tu</last></author>
-      <author><first>Longyue</first><last>Wang</last></author>
+      <author>
+        <first>Jianhui</first>
+        <last>Pang</last>
+      </author>
+      <author>
+        <first>Fanghua</first>
+        <last>Ye</last>
+      </author>
+      <author>
+        <first>Derek Fai</first>
+        <last>Wong</last>
+      </author>
+      <author>
+        <first>Dian</first>
+        <last>Yu</last>
+      </author>
+      <author>
+        <first>Shuming</first>
+        <last>Shi</last>
+      </author>
+      <author>
+        <first>Zhaopeng</first>
+        <last>Tu</last>
+      </author>
+      <author>
+        <first>Longyue</first>
+        <last>Wang</last>
+      </author>
       <doi>10.1162/tacl_a_00730</doi>
       <abstract>The evolution of Neural Machine Translation (NMT) has been significantly influenced by six core challenges (Koehn and Knowles, 2017) that have acted as benchmarks for progress in this field. This study revisits these challenges, offering insights into their ongoing relevance in the context of advanced Large Language Models (LLMs): domain mismatch, amount of parallel data, rare word prediction, translation of long sentences, attention model as word alignment, and sub-optimal beam search. Our empirical findings show that LLMs effectively reduce reliance on parallel data for major languages during pretraining and significantly improve translation of long sentences containing approximately 80 words, even translating documents up to 512 words. Despite these improvements, challenges in domain mismatch and rare word prediction persist. While NMT-specific challenges like word alignment and beam search may not apply to LLMs, we identify three new challenges in LLM-based translation: inference efficiency, translation of low-resource languages during pretraining, and human-aligned evaluation.</abstract>
       <pages>73–95</pages>
@@ -80,10 +193,22 @@
     </paper>
     <paper id="5">
       <title>Investigating Critical Period Effects in Language Acquisition through Neural Language Models</title>
-      <author><first>Ionut</first><last>Constantinescu</last></author>
-      <author><first>Tiago</first><last>Pimentel</last></author>
-      <author><first>Ryan</first><last>Cotterell</last></author>
-      <author><first>Alex</first><last>Warstadt</last></author>
+      <author>
+        <first>Ionut</first>
+        <last>Constantinescu</last>
+      </author>
+      <author>
+        <first>Tiago</first>
+        <last>Pimentel</last>
+      </author>
+      <author>
+        <first>Ryan</first>
+        <last>Cotterell</last>
+      </author>
+      <author>
+        <first>Alex</first>
+        <last>Warstadt</last>
+      </author>
       <doi>10.1162/tacl_a_00725</doi>
       <abstract>Humans appear to have a critical period (CP) for language acquisition: Second language (L2) acquisition becomes harder after early childhood, and ceasing exposure to a first language (L1) after this period (but not before) typically does not lead to substantial loss of L1 proficiency. It is unknown whether these CP effects result from innately determined brain maturation or as a stabilization of neural connections naturally induced by experience. In this study, we use language models (LMs) to test the extent to which these phenomena are peculiar to humans, or shared by a broader class of language learners. We vary the age of exposure by training LMs on language pairs in various experimental conditions, and find that LMs, which lack any direct analog to innate maturational stages, do not show CP effects when the age of exposure of L2 is delayed. Our results contradict the claim that CP effects are an inevitable result of statistical learning, and they are consistent with an innate mechanism for CP effects. We show that we can reverse-engineer the CP by introducing a regularizer partway through training to simulate a maturational decrease in plasticity. All in all, our results suggest that L1 learning on its own may not be enough to induce a CP, and additional engineering is necessary to make language models more cognitively plausible.</abstract>
       <pages>96–120</pages>
@@ -92,13 +217,34 @@
     </paper>
     <paper id="6">
       <title>Learning Syntax Without Planting Trees: Understanding Hierarchical Generalization in Transformers</title>
-      <author><first>Kabir</first><last>Ahuja</last></author>
-      <author><first>Vidhisha</first><last>Balachandran</last></author>
-      <author><first>Madhur</first><last>Panwar</last></author>
-      <author><first>Tianxing</first><last>He</last></author>
-      <author id="noah-a-smith"><first>Noah A.</first><last>Smith</last></author>
-      <author><first>Navin</first><last>Goyal</last></author>
-      <author><first>Yulia</first><last>Tsvetkov</last></author>
+      <author>
+        <first>Kabir</first>
+        <last>Ahuja</last>
+      </author>
+      <author>
+        <first>Vidhisha</first>
+        <last>Balachandran</last>
+      </author>
+      <author>
+        <first>Madhur</first>
+        <last>Panwar</last>
+      </author>
+      <author>
+        <first>Tianxing</first>
+        <last>He</last>
+      </author>
+      <author id="noah-a-smith">
+        <first>Noah A.</first>
+        <last>Smith</last>
+      </author>
+      <author>
+        <first>Navin</first>
+        <last>Goyal</last>
+      </author>
+      <author>
+        <first>Yulia</first>
+        <last>Tsvetkov</last>
+      </author>
       <doi>10.1162/tacl_a_00733</doi>
       <abstract>Transformers trained on natural language data have been shown to exhibit hierarchical generalization without explicitly encoding any structural bias. In this work, we investigate sources of inductive bias in transformer models and their training that could cause such preference for hierarchical generalization. We extensively experiment with transformers trained on five synthetic, controlled datasets using several training objectives and show that, while objectives such as sequence-to-sequence modeling, classification, etc., often fail to lead to hierarchical generalization, the language modeling objective consistently leads to transformers generalizing hierarchically. We then study how different generalization behaviors emerge during the training by conducting pruning experiments that reveal the joint existence of subnetworks within the model implementing different generalizations. Finally, we take a Bayesian perspective to understand transformers’ preference for hierarchical generalization: We establish a correlation between whether transformers generalize hierarchically on a dataset and if the simplest explanation of that dataset is provided by a hierarchical grammar compared to regular grammars exhibiting linear generalization. Overall, our work presents new insights on the origins of hierarchical generalization in transformers and provides a theoretical framework for studying generalization in language models.</abstract>
       <pages>121–141</pages>
@@ -107,10 +253,22 @@
     </paper>
     <paper id="10">
       <title>Navigating Cultural Chasms: Exploring and Unlocking the Cultural <fixed-case>POV</fixed-case> of Text-To-Image Models</title>
-      <author><first>Mor</first><last>Ventura</last></author>
-      <author><first>Eyal</first><last>Ben-David</last></author>
-      <author><first>Anna</first><last>Korhonen</last></author>
-      <author><first>Roi</first><last>Reichart</last></author>
+      <author>
+        <first>Mor</first>
+        <last>Ventura</last>
+      </author>
+      <author>
+        <first>Eyal</first>
+        <last>Ben-David</last>
+      </author>
+      <author>
+        <first>Anna</first>
+        <last>Korhonen</last>
+      </author>
+      <author>
+        <first>Roi</first>
+        <last>Reichart</last>
+      </author>
       <doi>10.1162/tacl_a_00732</doi>
       <abstract>Text-To-Image (TTI) models, such as DALL-E and StableDiffusion, have demonstrated remarkable prompt-based image generation capabilities. Multilingual encoders may have a substantial impact on the cultural agency of these models, as language is a conduit of culture. In this study, we explore the cultural perception embedded in TTI models by characterizing culture across three tiers: cultural dimensions, cultural domains, and cultural concepts. Based on this ontology, we derive prompt templates to unlock the cultural knowledge in TTI models, and propose a comprehensive suite of evaluation techniques, including intrinsic evaluations using the CLIP space, extrinsic evaluations with a Visual-Question-Answer models and human assessments, to evaluate the cultural content of TTI-generated images. To bolster our research, we introduce the CulText2I dataset, based on six diverse TTI models and spanning ten languages. Our experiments provide insights regarding Do, What, Which, and How research questions about the nature of cultural encoding in TTI models, paving the way for cross-cultural applications of these models.1</abstract>
       <pages>142–166</pages>
@@ -119,15 +277,42 @@
     </paper>
     <paper id="7">
       <title>A Confidence-based Acquisition Model for Self-supervised Active Learning and Label Correction</title>
-      <author><first>Carel van</first><last>Niekerk</last></author>
-      <author><first>Christian</first><last>Geishauser</last></author>
-      <author><first>Michael</first><last>Heck</last></author>
-      <author><first>Shutong</first><last>Feng</last></author>
-      <author><first>Hsien-chin</first><last>Lin</last></author>
-      <author><first>Nurul</first><last>Lubis</last></author>
-      <author id="benjamin-matthias-ruppik"><first>Benjamin</first><last>Ruppik</last></author>
-      <author><first>Renato</first><last>Vukovic</last></author>
-      <author id="milica-gasic"><first>Milica</first><last>Gašić</last></author>
+      <author>
+        <first>Carel van</first>
+        <last>Niekerk</last>
+      </author>
+      <author>
+        <first>Christian</first>
+        <last>Geishauser</last>
+      </author>
+      <author>
+        <first>Michael</first>
+        <last>Heck</last>
+      </author>
+      <author>
+        <first>Shutong</first>
+        <last>Feng</last>
+      </author>
+      <author>
+        <first>Hsien-chin</first>
+        <last>Lin</last>
+      </author>
+      <author>
+        <first>Nurul</first>
+        <last>Lubis</last>
+      </author>
+      <author id="benjamin-matthias-ruppik">
+        <first>Benjamin</first>
+        <last>Ruppik</last>
+      </author>
+      <author>
+        <first>Renato</first>
+        <last>Vukovic</last>
+      </author>
+      <author id="milica-gasic">
+        <first>Milica</first>
+        <last>Gašić</last>
+      </author>
       <doi>10.1162/tacl_a_00734</doi>
       <abstract>Supervised neural approaches are hindered by their dependence on large, meticulously annotated datasets, a requirement that is particularly cumbersome for sequential tasks. The quality of annotations tends to deteriorate with the transition from expert-based to crowd-sourced labeling. To address these challenges, we present CAMEL (Confidence-based Acquisition Model for Efficient self-supervised active Learning), a pool-based active learning framework tailored to sequential multi-output problems. CAMEL possesses two core features: (1) it requires expert annotators to label only a fraction of a chosen sequence, and (2) it facilitates self-supervision for the remainder of the sequence. By deploying a label correction mechanism, CAMEL can also be utilized for data cleaning. We evaluate CAMEL on two sequential tasks, with a special emphasis on dialogue belief tracking, a task plagued by the constraints of limited and noisy datasets. Our experiments demonstrate that CAMEL significantly outperforms the baselines in terms of efficiency. Furthermore, the data corrections suggested by our method contribute to an overall improvement in the quality of the resulting datasets.1</abstract>
       <pages>167–187</pages>
@@ -135,15 +320,40 @@
       <bibkey>niekerk-etal-2025-confidence</bibkey>
     </paper>
     <paper id="8">
-      <title><fixed-case>OPT</fixed-case>-Tree: Speculative Decoding with Adaptive Draft Tree Structure</title>
-      <author><first>Jikai</first><last>Wang</last></author>
-      <author><first>Yi</first><last>Su</last></author>
-      <author><first>Juntao</first><last>Li</last></author>
-      <author><first>Qingrong</first><last>Xia</last></author>
-      <author><first>Zi</first><last>Ye</last></author>
-      <author><first>Xinyu</first><last>Duan</last></author>
-      <author><first>Zhefeng</first><last>Wang</last></author>
-      <author><first>Min</first><last>Zhang</last></author>
+      <title>
+        <fixed-case>OPT</fixed-case>-Tree: Speculative Decoding with Adaptive Draft Tree Structure</title>
+      <author>
+        <first>Jikai</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Yi</first>
+        <last>Su</last>
+      </author>
+      <author>
+        <first>Juntao</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Qingrong</first>
+        <last>Xia</last>
+      </author>
+      <author>
+        <first>Zi</first>
+        <last>Ye</last>
+      </author>
+      <author>
+        <first>Xinyu</first>
+        <last>Duan</last>
+      </author>
+      <author>
+        <first>Zhefeng</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Min</first>
+        <last>Zhang</last>
+      </author>
       <doi>10.1162/tacl_a_00735</doi>
       <abstract>Autoregressive language models demonstrate excellent performance in various scenarios. However, the inference efficiency is limited by its one-step-one-word generation mode, which has become a pressing problem recently as the models become increasingly larger. Speculative decoding employs a “draft and then verify” mechanism to allow multiple tokens to be generated in one step, realizing lossless acceleration. Existing methods mainly adopt fixed heuristic draft structures, which do not adapt to different situations to maximize the acceptance length during verification. To alleviate this dilemma, we propose OPT-Tree, an algorithm to construct adaptive and scalable draft trees, which can be applied to any autoregressive draft model. It searches the optimal tree structure that maximizes the mathematical expectation of the acceptance length in each decoding step. Experimental results reveal that OPT-Tree outperforms the existing draft structures and achieves a speed-up ratio of up to 3.2 compared with autoregressive decoding. If the draft model is powerful enough and the node budget is sufficient, it can generate more than ten tokens in a single step. Our code is available at https://github.com/Jikai0Wang/OPT-Tree.</abstract>
       <pages>188–199</pages>
@@ -152,11 +362,26 @@
     </paper>
     <paper id="9">
       <title>Transformers as Transducers</title>
-      <author><first>Lena</first><last>Strobl</last></author>
-      <author><first>Dana</first><last>Angluin</last></author>
-      <author><first>David</first><last>Chiang</last></author>
-      <author><first>Jonathan</first><last>Rawski</last></author>
-      <author><first>Ashish</first><last>Sabharwal</last></author>
+      <author>
+        <first>Lena</first>
+        <last>Strobl</last>
+      </author>
+      <author>
+        <first>Dana</first>
+        <last>Angluin</last>
+      </author>
+      <author>
+        <first>David</first>
+        <last>Chiang</last>
+      </author>
+      <author>
+        <first>Jonathan</first>
+        <last>Rawski</last>
+      </author>
+      <author>
+        <first>Ashish</first>
+        <last>Sabharwal</last>
+      </author>
       <doi>10.1162/tacl_a_00736</doi>
       <abstract>We study the sequence-to-sequence mapping capacity of transformers by relating them to finite transducers, and find that they can express surprisingly large classes of (total functional) transductions. We do so using variants of RASP, a programming language designed to help people “think like transformers,” as an intermediate representation. We extend the existing Boolean variant B-RASP to sequence-to-sequence transductions and show that it computes exactly the first-order rational transductions (such as string rotation). Then, we introduce two new extensions. B-RASP[pos] enables calculations on positions (such as copying the first half of a string) and contains all first-order regular transductions. S-RASP adds prefix sum, which enables additional arithmetic operations (such as squaring a string) and contains all first-order polyregular transductions. Finally, we show that masked average-hard attention transformers can simulate S-RASP.</abstract>
       <pages>200–219</pages>
@@ -165,21 +390,66 @@
     </paper>
     <paper id="11">
       <title>Benchmarking Uncertainty Quantification Methods for Large Language Models with <fixed-case>LM</fixed-case>-Polygraph</title>
-      <author><first>Roman</first><last>Vashurin</last></author>
-      <author><first>Ekaterina</first><last>Fadeeva</last></author>
-      <author><first>Artem</first><last>Vazhentsev</last></author>
-      <author><first>Lyudmila</first><last>Rvanova</last></author>
-      <author><first>Daniil</first><last>Vasilev</last></author>
-      <author><first>Akim</first><last>Tsvigun</last></author>
-      <author><first>Sergey</first><last>Petrakov</last></author>
-      <author><first>Rui</first><last>Xing</last></author>
-      <author><first>Abdelrahman</first><last>Sadallah</last></author>
-      <author><first>Kirill</first><last>Grishchenkov</last></author>
-      <author><first>Alexander</first><last>Panchenko</last></author>
-      <author id="timothy-baldwin"><first>Timothy</first><last>Baldwin</last></author>
-      <author id="preslav-nakov"><first>Preslav</first><last>Nakov</last></author>
-      <author><first>Maxim</first><last>Panov</last></author>
-      <author><first>Artem</first><last>Shelmanov</last></author>
+      <author>
+        <first>Roman</first>
+        <last>Vashurin</last>
+      </author>
+      <author>
+        <first>Ekaterina</first>
+        <last>Fadeeva</last>
+      </author>
+      <author>
+        <first>Artem</first>
+        <last>Vazhentsev</last>
+      </author>
+      <author>
+        <first>Lyudmila</first>
+        <last>Rvanova</last>
+      </author>
+      <author>
+        <first>Daniil</first>
+        <last>Vasilev</last>
+      </author>
+      <author>
+        <first>Akim</first>
+        <last>Tsvigun</last>
+      </author>
+      <author>
+        <first>Sergey</first>
+        <last>Petrakov</last>
+      </author>
+      <author>
+        <first>Rui</first>
+        <last>Xing</last>
+      </author>
+      <author>
+        <first>Abdelrahman</first>
+        <last>Sadallah</last>
+      </author>
+      <author>
+        <first>Kirill</first>
+        <last>Grishchenkov</last>
+      </author>
+      <author>
+        <first>Alexander</first>
+        <last>Panchenko</last>
+      </author>
+      <author id="timothy-baldwin">
+        <first>Timothy</first>
+        <last>Baldwin</last>
+      </author>
+      <author id="preslav-nakov">
+        <first>Preslav</first>
+        <last>Nakov</last>
+      </author>
+      <author>
+        <first>Maxim</first>
+        <last>Panov</last>
+      </author>
+      <author>
+        <first>Artem</first>
+        <last>Shelmanov</last>
+      </author>
       <doi>10.1162/tacl_a_00737</doi>
       <abstract>The rapid proliferation of large language models (LLMs) has stimulated researchers to seek effective and efficient approaches to deal with LLM hallucinations and low-quality outputs. Uncertainty quantification (UQ) is a key element of machine learning applications in dealing with such challenges. However, research to date on UQ for LLMs has been fragmented in terms of techniques and evaluation methodologies. In this work, we address this issue by introducing a novel benchmark that implements a collection of state-of-the-art UQ baselines and offers an environment for controllable and consistent evaluation of novel UQ techniques over various text generation tasks. Our benchmark also supports the assessment of confidence normalization methods in terms of their ability to provide interpretable scores. Using our benchmark, we conduct a large-scale empirical investigation of UQ and normalization techniques across eleven tasks, identifying the most effective approaches.</abstract>
       <pages>220–248</pages>
@@ -188,11 +458,26 @@
     </paper>
     <paper id="12">
       <title>Supervised Neural Topic Modeling with Label Alignment</title>
-      <author><first>Ruihao</first><last>Chen</last></author>
-      <author><first>Hegang</first><last>Chen</last></author>
-      <author><first>Yuyin</first><last>Lu</last></author>
-      <author><first>Yanghui</first><last>Rao</last></author>
-      <author><first>Chunjiang</first><last>Zhu</last></author>
+      <author>
+        <first>Ruihao</first>
+        <last>Chen</last>
+      </author>
+      <author>
+        <first>Hegang</first>
+        <last>Chen</last>
+      </author>
+      <author>
+        <first>Yuyin</first>
+        <last>Lu</last>
+      </author>
+      <author>
+        <first>Yanghui</first>
+        <last>Rao</last>
+      </author>
+      <author>
+        <first>Chunjiang</first>
+        <last>Zhu</last>
+      </author>
       <doi>10.1162/tacl_a_00738</doi>
       <abstract>Neural topic modeling is a scalable automated technique for text data mining. In various downstream tasks of topic modeling, it is preferred that the discovered topics well align with labels. However, due to the lack of guidance from labels, unsupervised neural topic models are less powerful in this situation. Existing supervised neural topic models often adopt a label-free prior to generate the latent document-topic distributions and use them to predict the labels and thus achieve label-topic alignment indirectly. Such a mechanism faces the following issues: 1) The label-free prior leads to topics blending the latent patterns of multiple labels; and 2) One is unable to intuitively identify the explicit relationships between labels and the discovered topics. To tackle these problems, we develop a novel supervised neural topic model which utilizes a chain-structured graphical model with a label-conditioned prior. Soft indicators are introduced to explicitly construct the label-topic relationships. To obtain well-organized label-topic relationships, we formalize an entropy-regularized optimal transport problem on the embedding space and model them as the transport plan. Moreover, our proposed method can be flexibly integrated with most existing unsupervised neural topic models. Experimental results on multiple datasets demonstrate that our model can greatly enhance the alignment between labels and topics while maintaining good topic quality.</abstract>
       <pages>249–263</pages>
@@ -201,8 +486,14 @@
     </paper>
     <paper id="13">
       <title>From Robustness to Improved Generalization and Calibration in Pre-trained Language Models</title>
-      <author><first>Josip</first><last>Jukić</last></author>
-      <author><first>Jan</first><last>Šnajder</last></author>
+      <author>
+        <first>Josip</first>
+        <last>Jukić</last>
+      </author>
+      <author>
+        <first>Jan</first>
+        <last>Šnajder</last>
+      </author>
       <doi>10.1162/tacl_a_00739</doi>
       <abstract>Enforcing representation smoothness in pre-trained language models (PLMs) through Jacobian and Hessian regularization provides an effective approach for enhancing both robustness and generalization. Although such regularization methods have proven effective in computer vision, their application in natural language processing, where PLM inputs are derived from a discrete domain, poses unique challenges. We introduce JacHess, a regularization approach for PLMs that minimizes the norms of the Jacobian and Hessian matrices in intermediate representations, using embeddings as substitutes for discrete token inputs. JacHess supports dual-mode regularization, alternating between fine-tuning with labeled data and regularization with unlabeled data. We evaluate JacHess on the GLUE benchmark and demonstrate that it consistently and significantly improves in-distribution generalization and enhances performance under domain shift. Across diverse PLMs, JacHess outperforms comparable representation-based regularization methods and unregularized fine-tuning, while also improving model calibration. Our findings, coupled with a computationally efficient estimator for the Jacobian and Hessian norms, position JacHess as a robust and widely applicable solution for enhancing PLM performance.</abstract>
       <pages>264–280</pages>
@@ -211,10 +502,22 @@
     </paper>
     <paper id="14">
       <title>How “Real” is Your Real-Time Simultaneous Speech-to-Text Translation System?</title>
-      <author><first>Sara</first><last>Papi</last></author>
-      <author><first>Peter</first><last>Polák</last></author>
-      <author><first>Dominik</first><last>Macháček</last></author>
-      <author id="ondrej-bojar"><first>Ondřej</first><last>Bojar</last></author>
+      <author>
+        <first>Sara</first>
+        <last>Papi</last>
+      </author>
+      <author>
+        <first>Peter</first>
+        <last>Polák</last>
+      </author>
+      <author>
+        <first>Dominik</first>
+        <last>Macháček</last>
+      </author>
+      <author id="ondrej-bojar">
+        <first>Ondřej</first>
+        <last>Bojar</last>
+      </author>
       <doi>10.1162/tacl_a_00740</doi>
       <abstract>Simultaneous speech-to-text translation (SimulST) translates source-language speech into target-language text concurrently with the speaker’s speech, ensuring low latency for better user comprehension. Despite its intended application to unbounded speech, most research has focused on human pre-segmented speech, simplifying the task and overlooking significant challenges. This narrow focus, coupled with widespread terminological inconsistencies, is limiting the applicability of research outcomes to real-world applications, ultimately hindering progress in the field. Our extensive literature review of 110 papers not only reveals these critical issues in current research but also serves as the foundation for our key contributions. We: 1) define the steps and core components of a SimulST system, proposing a standardized terminology and taxonomy; 2) conduct a thorough analysis of community trends; and 3) offer concrete recommendations and future directions to bridge the gaps in existing literature, from evaluation frameworks to system architectures, for advancing the field towards more realistic and effective SimulST solutions.</abstract>
       <pages>281–313</pages>
@@ -223,10 +526,22 @@
     </paper>
     <paper id="15">
       <title>Self-Rationalization in the Wild: A Large-scale Out-of-Distribution Evaluation on <fixed-case>NLI</fixed-case>-related tasks</title>
-      <author id="jing-yang-campinas"><first>Jing</first><last>Yang</last></author>
-      <author><first>Max</first><last>Glockner</last></author>
-      <author><first>Anderson</first><last>Rocha</last></author>
-      <author><first>Iryna</first><last>Gurevych</last></author>
+      <author id="jing-yang-campinas">
+        <first>Jing</first>
+        <last>Yang</last>
+      </author>
+      <author>
+        <first>Max</first>
+        <last>Glockner</last>
+      </author>
+      <author>
+        <first>Anderson</first>
+        <last>Rocha</last>
+      </author>
+      <author>
+        <first>Iryna</first>
+        <last>Gurevych</last>
+      </author>
       <doi>10.1162/tacl_a_00741</doi>
       <abstract>Free-text explanations are expressive and easy to understand, but many datasets lack annotated explanation data, making it challenging to train models for explainable predictions. To address this, we investigate how to use existing explanation datasets for self-rationalization and evaluate models’ out-of-distribution (OOD) performance. We fine-tune T5-Large and OLMo-7B models and assess the impact of fine-tuning data quality, the number of fine-tuning samples, and few-shot selection methods. The models are evaluated on 19 diverse OOD datasets across three tasks: natural language inference (NLI), fact-checking, and hallucination detection in abstractive summarization. For the generated explanation evaluation, we conduct a human study on 13 selected models and study its correlation with the Acceptability score (T5-11B) and three other LLM-based reference-free metrics. Human evaluation shows that the Acceptability score correlates most strongly with human judgments, demonstrating its effectiveness in evaluating free-text explanations. Our findings reveal: 1) few annotated examples effectively adapt models for OOD explanation generation; 2) compared to sample selection strategies, fine-tuning data source has a larger impact on OOD performance; and 3) models with higher label prediction accuracy tend to produce better explanations, as reflected by higher Acceptability scores.1</abstract>
       <pages>314–342</pages>
@@ -234,12 +549,28 @@
       <bibkey>yang-etal-2025-self</bibkey>
     </paper>
     <paper id="16">
-      <title><fixed-case>DEAR</fixed-case>: Disentangled Event-Agnostic Representation Learning for Early Fake News Detection</title>
-      <author><first>Xiao</first><last>Pu</last></author>
-      <author><first>Hao</first><last>Wu</last></author>
-      <author><first>Xiuli</first><last>Bi</last></author>
-      <author><first>Yu</first><last>Wu</last></author>
-      <author><first>Xinbo</first><last>Gao</last></author>
+      <title>
+        <fixed-case>DEAR</fixed-case>: Disentangled Event-Agnostic Representation Learning for Early Fake News Detection</title>
+      <author>
+        <first>Xiao</first>
+        <last>Pu</last>
+      </author>
+      <author>
+        <first>Hao</first>
+        <last>Wu</last>
+      </author>
+      <author>
+        <first>Xiuli</first>
+        <last>Bi</last>
+      </author>
+      <author>
+        <first>Yu</first>
+        <last>Wu</last>
+      </author>
+      <author>
+        <first>Xinbo</first>
+        <last>Gao</last>
+      </author>
       <doi>10.1162/tacl_a_00743</doi>
       <abstract>Detecting fake news early is challenging due to the absence of labeled articles for emerging events in training data. To address this, we propose a Disentangled Event-Agnostic Representation (DEAR) learning approach. Our method begins with a BERT-based adaptive multi-grained semantic encoder that captures hierarchical and comprehensive textual representations of the input news content. To effectively separate latent authenticity-related and event-specific knowledge within the news content, we employ a disentanglement architecture. To further enhance the decoupling effect, we introduce a cross-perturbation mechanism that perturbs authenticity-related representation with the event-specific one, and vice versa, deriving a robust and discerning authenticity-related signal. Additionally, we implement a refinement learning scheme to minimize potential interactions between two decoupled representations, ensuring that the authenticity signal remains strong and unaffected by event-specific details. Experimental results demonstrate that our approach effectively mitigates the impact of event-specific influence, outperforming state-of-the-art methods. In particular, it achieves a 6.0% improvement in accuracy on the PHEME dataset over MDDA, a similar approach that decouples latent content and style knowledge, in scenarios involving articles from unseen events different from the topics of the training set.</abstract>
       <pages>343–356</pages>
@@ -247,12 +578,28 @@
       <bibkey>pu-etal-2025-dear</bibkey>
     </paper>
     <paper id="17">
-      <title><fixed-case>LLM</fixed-case> Reading Tea Leaves: Automatically Evaluating Topic Models with Large Language Models</title>
-      <author><first>Xiaohao</first><last>Yang</last></author>
-      <author><first>He</first><last>Zhao</last></author>
-      <author><first>Dinh</first><last>Phung</last></author>
-      <author><first>Wray</first><last>Buntine</last></author>
-      <author><first>Lan</first><last>Du</last></author>
+      <title>
+        <fixed-case>LLM</fixed-case> Reading Tea Leaves: Automatically Evaluating Topic Models with Large Language Models</title>
+      <author>
+        <first>Xiaohao</first>
+        <last>Yang</last>
+      </author>
+      <author>
+        <first>He</first>
+        <last>Zhao</last>
+      </author>
+      <author>
+        <first>Dinh</first>
+        <last>Phung</last>
+      </author>
+      <author>
+        <first>Wray</first>
+        <last>Buntine</last>
+      </author>
+      <author>
+        <first>Lan</first>
+        <last>Du</last>
+      </author>
       <doi>10.1162/tacl_a_00744</doi>
       <abstract>Topic modeling has been a widely used tool for unsupervised text analysis. However, comprehensive evaluations of a topic model remain challenging. Existing evaluation methods are either less comparable across different models (e.g., perplexity) or focus on only one specific aspect of a model (e.g., topic quality or document representation quality) at a time, which is insufficient to reflect the overall model performance. In this paper, we propose WALM (Word Agreement with Language Model), a new evaluation method for topic modeling that considers the semantic quality of document representations and topics in a joint manner, leveraging the power of Large Language Models (LLMs). With extensive experiments involving different types of topic models, WALM is shown to align with human judgment and can serve as a complementary evaluation method to the existing ones, bringing a new perspective to topic modeling. Our software package is available at https://github.com/Xiaohao-Yang/Topic_Model_Evaluation.</abstract>
       <pages>357–375</pages>
@@ -261,13 +608,34 @@
     </paper>
     <paper id="18">
       <title>The <fixed-case>T</fixed-case>hai <fixed-case>U</fixed-case>niversal <fixed-case>D</fixed-case>ependency Treebank</title>
-      <author><first>Panyut</first><last>Sriwirote</last></author>
-      <author><first>Wei Qi</first><last>Leong</last></author>
-      <author><first>Charin</first><last>Polpanumas</last></author>
-      <author><first>Santhawat</first><last>Thanyawong</last></author>
-      <author><first>William Chandra</first><last>Tjhi</last></author>
-      <author><first>Wirote</first><last>Aroonmanakun</last></author>
-      <author><first>Attapol T.</first><last>Rutherford</last></author>
+      <author>
+        <first>Panyut</first>
+        <last>Sriwirote</last>
+      </author>
+      <author>
+        <first>Wei Qi</first>
+        <last>Leong</last>
+      </author>
+      <author>
+        <first>Charin</first>
+        <last>Polpanumas</last>
+      </author>
+      <author>
+        <first>Santhawat</first>
+        <last>Thanyawong</last>
+      </author>
+      <author>
+        <first>William Chandra</first>
+        <last>Tjhi</last>
+      </author>
+      <author>
+        <first>Wirote</first>
+        <last>Aroonmanakun</last>
+      </author>
+      <author>
+        <first>Attapol T.</first>
+        <last>Rutherford</last>
+      </author>
       <doi>10.1162/tacl_a_00745</doi>
       <abstract>Automatic dependency parsing of Thai sentences has been underexplored, as evidenced by the lack of large Thai dependency treebanks with complete dependency structures and the lack of a published evaluation of state-of-the-art models, especially transformer-based parsers. In this work, we addressed these gaps by introducing the Thai Universal Dependency Treebank (TUD), a new Thai treebank consisting of 3,627 trees annotated according to the Universal Dependencies (UD) framework. We then benchmarked 92 dependency parsing models that incorporate pretrained transformers on Thai-PUD and our TUD, achieving state-of-the-art results and shedding light on the optimal model components for Thai dependency parsing. Our error analysis of the models also reveals that polyfunctional words, serial verb construction, and lack of rich morphosyntactic features present main challenges for Thai dependency parsing.</abstract>
       <pages>376–391</pages>
@@ -276,12 +644,30 @@
     </paper>
     <paper id="19">
       <title>Diverse <fixed-case>AI</fixed-case> Feedback For Large Language Model Alignment</title>
-      <author><first>Tianshu</first><last>Yu</last></author>
-      <author><first>Ting-En</first><last>Lin</last></author>
-      <author><first>Yuchuan</first><last>Wu</last></author>
-      <author><first>Min</first><last>Yang</last></author>
-      <author><first>Fei</first><last>Huang</last></author>
-      <author><first>Yongbin</first><last>Li</last></author>
+      <author>
+        <first>Tianshu</first>
+        <last>Yu</last>
+      </author>
+      <author>
+        <first>Ting-En</first>
+        <last>Lin</last>
+      </author>
+      <author>
+        <first>Yuchuan</first>
+        <last>Wu</last>
+      </author>
+      <author>
+        <first>Min</first>
+        <last>Yang</last>
+      </author>
+      <author>
+        <first>Fei</first>
+        <last>Huang</last>
+      </author>
+      <author>
+        <first>Yongbin</first>
+        <last>Li</last>
+      </author>
       <doi>10.1162/tacl_a_00746</doi>
       <abstract>Recent advances in large language models (LLMs) focus on aligning models with human values to minimize harmful content. However, existing methods often rely on a single type of feedback, such as preferences, annotated labels, or critiques, which can lead to overfitting and suboptimal performance. In this paper, we propose Diverse AIFeedback (DAIF), a novel approach that integrates three types of feedback—critique, refinement, and preference—tailored to tasks of varying uncertainty levels. Through an analysis of information gain, we show that critique feedback is most effective for low-uncertainty tasks, refinement feedback for medium-uncertainty tasks, and preference feedback for high-uncertainty tasks. Training with this diversified feedback reduces overfitting and improves alignment. Experimental results across three tasks—question answering, dialog generation, and text summarization–demonstrate that DAIF outperforms traditional methods relying on a single feedback type.1</abstract>
       <pages>392–407</pages>
@@ -290,8 +676,14 @@
     </paper>
     <paper id="20">
       <title>How Much Semantic Information is Available in Large Language Model Tokens?</title>
-      <author><first>David A.</first><last>Haslett</last></author>
-      <author><first>Zhenguang G.</first><last>Cai</last></author>
+      <author>
+        <first>David A.</first>
+        <last>Haslett</last>
+      </author>
+      <author>
+        <first>Zhenguang G.</first>
+        <last>Cai</last>
+      </author>
       <doi>10.1162/tacl_a_00747</doi>
       <abstract>Large language models segment many words into multiple tokens, and companies that make those models claim that meaningful subword tokens are essential. To investigate whether subword tokens bear meaning, we segmented tens of thousands of words from each of 41 languages according to three generations of GPT tokenizers. We found that words sharing tokens are more semantically similar than expected by chance or expected from length alone, that tokens capture morphological information even when they don’t look like morphemes, and that tokens capture more information than is explained by morphology. In languages that use a script other than the Latin alphabet, GPT-4 tokens are uninformative, but GPT-4o has improved this situation. These results suggest that comparing tokens to morphemes overlooks the wider variety of semantic information available in word form and that standard tokenization methods successfully capture much of that information.</abstract>
       <pages>408–423</pages>
@@ -300,8 +692,14 @@
     </paper>
     <paper id="21">
       <title>Phonetic Reconstruction of the Consonant System of Middle <fixed-case>C</fixed-case>hinese via Mixed Integer Optimization</title>
-      <author><first>Xiaoxi</first><last>Luo</last></author>
-      <author><first>Weiwei</first><last>Sun</last></author>
+      <author>
+        <first>Xiaoxi</first>
+        <last>Luo</last>
+      </author>
+      <author>
+        <first>Weiwei</first>
+        <last>Sun</last>
+      </author>
       <doi>10.1162/tacl_a_00742</doi>
       <abstract>This paper is concerned with phonetic reconstruction of the consonant system of Middle Chinese. We propose to cast the problem as a Mixed Integer Programming problem, which is able to automatically explore homophonic information from ancient rhyme dictionaries and phonetic information from modern Chinese dialects, the descendants of Middle Chinese. Numerical evaluation on a wide range of synthetic and real data demonstrates the effectiveness and robustness of the new method. We apply the method to information from Guǎngyùn and 20 modern Chinese dialects to obtain a new phonetic reconstruction result. A linguistically motivated discussion of this result is also provided.1</abstract>
       <pages>424–441</pages>
@@ -310,14 +708,38 @@
     </paper>
     <paper id="22">
       <title>Anchored Preference Optimization and Contrastive Revisions: Addressing Underspecification in Alignment</title>
-      <author><first>Karel</first><last>D’Oosterlinck</last></author>
-      <author><first>Winnie</first><last>Xu</last></author>
-      <author><first>Chris</first><last>Develder</last></author>
-      <author><first>Thomas</first><last>Demeester</last></author>
-      <author><first>Amanpreet</first><last>Singh</last></author>
-      <author><first>Christopher</first><last>Potts</last></author>
-      <author><first>Douwe</first><last>Kiela</last></author>
-      <author><first>Shikib</first><last>Mehri</last></author>
+      <author>
+        <first>Karel</first>
+        <last>D’Oosterlinck</last>
+      </author>
+      <author>
+        <first>Winnie</first>
+        <last>Xu</last>
+      </author>
+      <author>
+        <first>Chris</first>
+        <last>Develder</last>
+      </author>
+      <author>
+        <first>Thomas</first>
+        <last>Demeester</last>
+      </author>
+      <author>
+        <first>Amanpreet</first>
+        <last>Singh</last>
+      </author>
+      <author>
+        <first>Christopher</first>
+        <last>Potts</last>
+      </author>
+      <author>
+        <first>Douwe</first>
+        <last>Kiela</last>
+      </author>
+      <author>
+        <first>Shikib</first>
+        <last>Mehri</last>
+      </author>
       <doi>10.1162/tacl_a_00748</doi>
       <abstract>Large Language Models (LLMs) are often aligned using contrastive alignment objectives and preference pair datasets. The interaction between model, paired data, and objective makes alignment a complicated procedure, sometimes producing subpar results. We study this and find that (i) preference data gives a better learning signal when the underlying responses are contrastive, and (ii) alignment objectives lead to better performance when they specify more control over the model during training. Based on these insights, we introduce Contrastive Learning from AI Revisions (CLAIR), a data-creation method which leads to more contrastive preference pairs, and Anchored Preference Optimization (APO), a controllable and more stable alignment objective. We align Llama-3-8B-Instruct using various comparable datasets and alignment objectives and measure MixEval-Hard scores, which correlate highly with human judgments. The CLAIR preferences lead to the strongest performance out of all datasets, and APO consistently outperforms less controllable objectives. Our best model, trained on 32K CLAIR preferences with APO, improves Llama-3-8B-Instruct by 7.65%, closing the gap with GPT4-turbo by 45%. Our code and datasets are available.</abstract>
       <pages>442–460</pages>
@@ -325,12 +747,28 @@
       <bibkey>d-oosterlinck-etal-2025-anchored</bibkey>
     </paper>
     <paper id="23">
-      <title><fixed-case>TANQ</fixed-case>: An Open Domain Dataset of Table Answered Questions</title>
-      <author><first>Mubashara</first><last>Akhtar</last></author>
-      <author><first>Chenxi</first><last>Pang</last></author>
-      <author><first>Andreea</first><last>Marzoca</last></author>
-      <author><first>Yasemin</first><last>Altun</last></author>
-      <author><first>Julian Martin</first><last>Eisenschlos</last></author>
+      <title>
+        <fixed-case>TANQ</fixed-case>: An Open Domain Dataset of Table Answered Questions</title>
+      <author>
+        <first>Mubashara</first>
+        <last>Akhtar</last>
+      </author>
+      <author>
+        <first>Chenxi</first>
+        <last>Pang</last>
+      </author>
+      <author>
+        <first>Andreea</first>
+        <last>Marzoca</last>
+      </author>
+      <author>
+        <first>Yasemin</first>
+        <last>Altun</last>
+      </author>
+      <author>
+        <first>Julian Martin</first>
+        <last>Eisenschlos</last>
+      </author>
       <doi>10.1162/tacl_a_00749</doi>
       <abstract>Language models, potentially augmented with tool usage such as retrieval, are becoming the go-to means of answering questions. Understanding and answering questions in real-world settings often requires retrieving information from different sources, processing and aggregating data to extract insights, and presenting complex findings in form of structured artifacts such as novel tables, charts, or infographics. In this paper, we introduce TANQ,1 the first open-domain question answering dataset where the answers require building tables from information across multiple sources. We release the full source attribution for every cell in the resulting table and benchmark state-of-the-art language models in open, oracle, and closed book setups. Our best-performing baseline, Gemini Flash, reaches an overall F1 score of 60.7, lagging behind human performance by 12.3 points. We analyze baselines’ performance across different dataset attributes such as different skills required for this task, including multi-hop reasoning, math operations, and unit conversions. We further discuss common failures in model-generated answers, suggesting that TANQ is a complex task with many challenges ahead.</abstract>
       <pages>461–480</pages>
@@ -339,9 +777,18 @@
     </paper>
     <paper id="24">
       <title>Few-Shot Multilingual Open-Domain <fixed-case>QA</fixed-case> from Five Examples</title>
-      <author><first>Fan</first><last>Jiang</last></author>
-      <author><first>Tom</first><last>Drummond</last></author>
-      <author id="trevor-cohn"><first>Trevor</first><last>Cohn</last></author>
+      <author>
+        <first>Fan</first>
+        <last>Jiang</last>
+      </author>
+      <author>
+        <first>Tom</first>
+        <last>Drummond</last>
+      </author>
+      <author id="trevor-cohn">
+        <first>Trevor</first>
+        <last>Cohn</last>
+      </author>
       <doi>10.1162/tacl_a_00750</doi>
       <abstract>Recent approaches to multilingual open- domain question answering (MLODQA) have achieved promising results given abundant language-specific training data. However, the considerable annotation cost limits the application of these methods for underrepresented languages. We introduce a few-shot learning approach to synthesize large-scale multilingual data from large language models (LLMs). Our method begins with large-scale self-supervised pre-training using WikiData, followed by training on high-quality synthetic multilingual data generated by prompting LLMs with few-shot supervision. The final model, FsModQA, significantly outperforms existing few-shot and supervised baselines in MLODQA and cross-lingual and monolingual retrieval. We further show our method can be extended for effective zero-shot adaptation to new languages through a cross-lingual prompting strategy with only English-supervised data, making it a general and applicable solution for MLODQA tasks without costly large-scale annotation.</abstract>
       <pages>481–504</pages>
@@ -350,10 +797,22 @@
     </paper>
     <paper id="25">
       <title>Navigating the Landscape of Hint Generation Research: From the Past to the Future</title>
-      <author><first>Anubhav</first><last>Jangra</last></author>
-      <author><first>Jamshid</first><last>Mozafari</last></author>
-      <author><first>Adam</first><last>Jatowt</last></author>
-      <author><first>Smaranda</first><last>Muresan</last></author>
+      <author>
+        <first>Anubhav</first>
+        <last>Jangra</last>
+      </author>
+      <author>
+        <first>Jamshid</first>
+        <last>Mozafari</last>
+      </author>
+      <author>
+        <first>Adam</first>
+        <last>Jatowt</last>
+      </author>
+      <author>
+        <first>Smaranda</first>
+        <last>Muresan</last>
+      </author>
       <doi>10.1162/tacl_a_00751</doi>
       <abstract>Digital education has gained popularity in the last decade, especially after the COVID-19 pandemic. With the improving capabilities of large language models to reason and communicate with users, envisioning intelligent tutoring systems that can facilitate self-learning is not very far-fetched. One integral component to fulfill this vision is the ability to give accurate and effective feedback via hints to scaffold the learning process. In this survey article, we present a comprehensive review of prior research on hint generation, aiming to bridge the gap between research in education and cognitive science, and research in AI and Natural Language Processing. Informed by our findings, we propose a formal definition of the hint generation task, and discuss the roadmap of building an effective hint generation system aligned with the formal definition, including open challenges, future directions and ethical considerations.</abstract>
       <pages>505–528</pages>
@@ -362,13 +821,34 @@
     </paper>
     <paper id="26">
       <title>Know Your Limits: A Survey of Abstention in Large Language Models</title>
-      <author><first>Bingbing</first><last>Wen</last></author>
-      <author><first>Jihan</first><last>Yao</last></author>
-      <author><first>Shangbin</first><last>Feng</last></author>
-      <author><first>Chenjun</first><last>Xu</last></author>
-      <author><first>Yulia</first><last>Tsvetkov</last></author>
-      <author><first>Bill</first><last>Howe</last></author>
-      <author id="lucy-lu-wang"><first>Lucy Lu</first><last>Wang</last></author>
+      <author>
+        <first>Bingbing</first>
+        <last>Wen</last>
+      </author>
+      <author>
+        <first>Jihan</first>
+        <last>Yao</last>
+      </author>
+      <author>
+        <first>Shangbin</first>
+        <last>Feng</last>
+      </author>
+      <author>
+        <first>Chenjun</first>
+        <last>Xu</last>
+      </author>
+      <author>
+        <first>Yulia</first>
+        <last>Tsvetkov</last>
+      </author>
+      <author>
+        <first>Bill</first>
+        <last>Howe</last>
+      </author>
+      <author id="lucy-lu-wang">
+        <first>Lucy Lu</first>
+        <last>Wang</last>
+      </author>
       <doi>10.1162/tacl_a_00754</doi>
       <abstract>Abstention, the refusal of large language models (LLMs) to provide an answer, is increasingly recognized for its potential to mitigate hallucinations and enhance safety in LLM systems. In this survey, we introduce a framework to examine abstention from three perspectives: the query, the model, and human values. We organize the literature on abstention methods, benchmarks, and evaluation metrics using this framework, and discuss merits and limitations of prior work. We further identify and motivate areas for future research, such as whether abstention can be achieved as a meta-capability that transcends specific tasks or domains, and opportunities to optimize abstention abilities in specific contexts. In doing so, we aim to broaden the scope and impact of abstention methodologies in AI systems.1</abstract>
       <pages>529–556</pages>
@@ -376,12 +856,28 @@
       <bibkey>wen-etal-2025-know</bibkey>
     </paper>
     <paper id="27">
-      <title><fixed-case>T</fixed-case>axo<fixed-case>P</fixed-case>ro: A Plug-In <fixed-case>L</fixed-case>o<fixed-case>RA</fixed-case>-based Cross-Domain Method for Low-Resource Taxonomy Completion</title>
-      <author><first>Hongyuan</first><last>Xu</last></author>
-      <author><first>Yuhang</first><last>Niu</last></author>
-      <author><first>Ciyi</first><last>Liu</last></author>
-      <author><first>Yanlong</first><last>Wen</last></author>
-      <author><first>Xiaojie</first><last>Yuan</last></author>
+      <title>
+        <fixed-case>T</fixed-case>axo<fixed-case>P</fixed-case>ro: A Plug-In <fixed-case>L</fixed-case>o<fixed-case>RA</fixed-case>-based Cross-Domain Method for Low-Resource Taxonomy Completion</title>
+      <author>
+        <first>Hongyuan</first>
+        <last>Xu</last>
+      </author>
+      <author>
+        <first>Yuhang</first>
+        <last>Niu</last>
+      </author>
+      <author>
+        <first>Ciyi</first>
+        <last>Liu</last>
+      </author>
+      <author>
+        <first>Yanlong</first>
+        <last>Wen</last>
+      </author>
+      <author>
+        <first>Xiaojie</first>
+        <last>Yuan</last>
+      </author>
       <doi>10.1162/tacl_a_00755</doi>
       <abstract>Low-resource taxonomy completion aims to automatically insert new concepts into the existing taxonomy, in which only a few in-domain training samples are available. Recent studies have achieved considerable progress by incorporating prior knowledge from pre-trained language models (PLMs). However, these studies tend to overly rely on such knowledge and neglect the shareable knowledge across different taxonomies. In this paper, we propose TaxoPro, a plug-in LoRA-based cross-domain method, that captures shareable knowledge from the high- resource taxonomy to improve PLM-based low-resource taxonomy completion techniques. To prevent negative interference between domain-specific and domain-shared knowledge, TaxoPro decomposes cross- domain knowledge into domain-shared and domain-specific components, storing them using low-rank matrices (LoRA). Additionally, TaxoPro employs two auxiliary losses to regulate the flow of shareable knowledge. Experimental results demonstrate that TaxoPro improves PLM-based techniques, achieving state-of-the-art performance in completing low-resource taxonomies. Code is available at https://github.com/cyclexu/TaxoPro.</abstract>
       <pages>557–576</pages>
@@ -390,12 +886,30 @@
     </paper>
     <paper id="28">
       <title>Exploring Practical Gaps in Using Cross Entropy to Implement Maximum Mutual Information Criterion for Rationalization</title>
-      <author><first>Wei</first><last>Liu</last></author>
-      <author><first>Zhiying</first><last>Deng</last></author>
-      <author><first>Zhongyu</first><last>Niu</last></author>
-      <author><first>Jun</first><last>Wang</last></author>
-      <author><first>Haozhao</first><last>Wang</last></author>
-      <author><first>Ruixuan</first><last>Li</last></author>
+      <author>
+        <first>Wei</first>
+        <last>Liu</last>
+      </author>
+      <author>
+        <first>Zhiying</first>
+        <last>Deng</last>
+      </author>
+      <author>
+        <first>Zhongyu</first>
+        <last>Niu</last>
+      </author>
+      <author>
+        <first>Jun</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Haozhao</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Ruixuan</first>
+        <last>Li</last>
+      </author>
       <doi>10.1162/tacl_a_00758</doi>
       <abstract>Rationalization is a framework that aims to build self-explanatory NLP models by extracting a subset of human-intelligible pieces of their inputting texts. It involves a cooperative game where a selector selects the most human-intelligible parts of the input as the rationale, followed by a predictor that makes predictions based on these selected rationales. Existing literature uses the cross-entropy between the model’s predictions and the ground-truth labels to measure the informativeness of the selected rationales, guiding the selector to choose better ones. In this study, we first theoretically analyze the objective of rationalization by decomposing it into two parts: the model-agnostic informativeness of the rationale candidates and the predictor’s degree of fit. We then provide various empirical evidence to support that, under this framework, the selector tends to sample from a limited small region, causing the predictor to overfit these localized areas. This results in a significant mismatch between the cross-entropy objective and the informativeness of the rationale candidates, leading to suboptimal solutions. To address this issue, we propose a simple yet effective method that introduces random vicinal1 perturbations to the selected rationale candidates. This approach broadens the predictor’s assessment to a vicinity around the selected rationale candidate. Compared to recent competitive methods, our method significantly improves rationale quality (by up to 6.6%) across six widely used classification datasets. The term “vicinal” is borrowed from vicinal risk minimization (Chapelle et al., 2000); “vicinal” means neighboring or adjacent.</abstract>
       <pages>577–594</pages>
@@ -404,12 +918,30 @@
     </paper>
     <paper id="29">
       <title>A Comparative Approach for Auditing Multilingual Phonetic Transcript Archives</title>
-      <author><first>Farhan</first><last>Samir</last></author>
-      <author><first>Emily P.</first><last>Ahn</last></author>
-      <author><first>Shreya</first><last>Prakash</last></author>
-      <author><first>Márton</first><last>Soskuthy</last></author>
-      <author><first>Vered</first><last>Shwartz</last></author>
-      <author><first>Jian</first><last>Zhu</last></author>
+      <author>
+        <first>Farhan</first>
+        <last>Samir</last>
+      </author>
+      <author>
+        <first>Emily P.</first>
+        <last>Ahn</last>
+      </author>
+      <author>
+        <first>Shreya</first>
+        <last>Prakash</last>
+      </author>
+      <author>
+        <first>Márton</first>
+        <last>Soskuthy</last>
+      </author>
+      <author>
+        <first>Vered</first>
+        <last>Shwartz</last>
+      </author>
+      <author>
+        <first>Jian</first>
+        <last>Zhu</last>
+      </author>
       <doi>10.1162/tacl_a_00759</doi>
       <abstract>Curating datasets that span multiple languages is challenging. To make the collection more scalable, researchers often incorporate one or more imperfect classifiers in the process, like language identification models. These models, however, are prone to failure, resulting in some language partitions being unreliable for downstream tasks. We introduce a statistical test, the Preference Proportion Test, for identifying such unreliable partitions. By annotating only 20 samples for a language partition, we are able to identify systematic transcription errors for 10 language partitions in a recent large multilingual transcribed audio archive, X-IPAPack (Zhu et al., 2024). We find that filtering these low-quality partitions out when training models for the downstream task of phonetic transcription brings substantial benefits, most notably a 25.7% relative improvement on transcribing recordings in out-of-distribution languages. Our work contributes an effective method for auditing multilingual audio archives.1</abstract>
       <pages>595–612</pages>
@@ -418,11 +950,26 @@
     </paper>
     <paper id="30">
       <title>Understanding Epistemic Language with a Language-augmented <fixed-case>B</fixed-case>ayesian Theory of Mind</title>
-      <author><first>Lance</first><last>Ying</last></author>
-      <author><first>Tan</first><last>Zhi-Xuan</last></author>
-      <author><first>Lionel</first><last>Wong</last></author>
-      <author><first>Vikash</first><last>Mansinghka</last></author>
-      <author><first>Joshua B.</first><last>Tenenbaum</last></author>
+      <author>
+        <first>Lance</first>
+        <last>Ying</last>
+      </author>
+      <author>
+        <first>Tan</first>
+        <last>Zhi-Xuan</last>
+      </author>
+      <author>
+        <first>Lionel</first>
+        <last>Wong</last>
+      </author>
+      <author>
+        <first>Vikash</first>
+        <last>Mansinghka</last>
+      </author>
+      <author>
+        <first>Joshua B.</first>
+        <last>Tenenbaum</last>
+      </author>
       <doi>10.1162/tacl_a_00752</doi>
       <abstract>How do people understand and evaluate claims about others’ beliefs, even though these beliefs cannot be directly observed? In this paper, we introduce a cognitive model of epistemic language interpretation, grounded in Bayesian inferences about other agents’ goals, beliefs, and intentions: a language-augmented Bayesian theory-of-mind (LaBToM). By translating natural language into an epistemic “language-of-thought” with grammar-constrained LLM decoding, then evaluating these translations against the inferences produced by inverting a generative model of rational action and perception, LaBToM captures graded plausibility judgments of epistemic claims. We validate our model in an experiment where participants watch an agent navigate a maze to find keys hidden in boxes needed to reach their goal, then rate sentences about the agent’s beliefs. In contrast with multimodal LLMs (GPT-4o, Gemini Pro) and ablated models, our model correlates highly with human judgments for a wide range of expressions, including modal language, uncertainty expressions, knowledge claims, likelihood comparisons, and attributions of false belief.</abstract>
       <pages>613–637</pages>
@@ -431,9 +978,18 @@
     </paper>
     <paper id="31">
       <title>Culturally Aware and Adapted <fixed-case>NLP</fixed-case>: A Taxonomy and a Survey of the State of the Art</title>
-      <author><first>Chen Cecilia</first><last>Liu</last></author>
-      <author><first>Iryna</first><last>Gurevych</last></author>
-      <author><first>Anna</first><last>Korhonen</last></author>
+      <author>
+        <first>Chen Cecilia</first>
+        <last>Liu</last>
+      </author>
+      <author>
+        <first>Iryna</first>
+        <last>Gurevych</last>
+      </author>
+      <author>
+        <first>Anna</first>
+        <last>Korhonen</last>
+      </author>
       <doi>10.1162/tacl_a_00760</doi>
       <abstract>The surge of interest in culture in NLP has inspired much recent research, but a shared understanding of “culture” remains unclear, making it difficult to evaluate progress in this emerging area. Drawing on prior research in NLP and related fields, we propose a fine-grained taxonomy of elements in culture that can provide a systematic framework for analyzing and understanding research progress. Using the taxonomy, we survey existing resources and methods for culturally aware and adapted NLP, providing an overview of the state of the art and the research gaps that still need to be filled.</abstract>
       <pages>652–689</pages>
@@ -442,8 +998,14 @@
     </paper>
     <paper id="32">
       <title>Sense-specific Historical Word Usage Generation</title>
-      <author><first>Pierluigi</first><last>Cassotti</last></author>
-      <author><first>Nina</first><last>Tahmasebi</last></author>
+      <author>
+        <first>Pierluigi</first>
+        <last>Cassotti</last>
+      </author>
+      <author>
+        <first>Nina</first>
+        <last>Tahmasebi</last>
+      </author>
       <doi>10.1162/tacl_a_00761</doi>
       <abstract>Large-scale sense-annotated corpora are important for a range of tasks but are hard to come by. Dictionaries that record and describe the vocabulary of a language often offer a small set of real-world example sentences for each sense of a word. However, on their own, these sentences are too few to be used as diachronic sense-annotated corpora. We propose a targeted strategy for training and evaluating generative models producing historically and semantically accurate word usages given any word, sense definition, and year triple. Our results demonstrate that fine-tuned models can generate usages with the same properties as real-world example sentences from a reference dictionary. Thus the generated usages will be suitable for training and testing computational models where large-scale sense-annotated corpora are needed but currently unavailable.</abstract>
       <pages>690–708</pages>
@@ -451,18 +1013,1465 @@
       <bibkey>cassotti-tahmasebi-2025-sense</bibkey>
     </paper>
     <paper id="33">
-      <title><fixed-case>NLP</fixed-case> Security and Ethics, in the Wild</title>
-      <author><first>Heather</first><last>Lent</last></author>
-      <author><first>Erick</first><last>Galinkin</last></author>
-      <author><first>Yiyi</first><last>Chen</last></author>
-      <author><first>Jens Myrup</first><last>Pedersen</last></author>
-      <author id="leon-derczynski"><first>Leon</first><last>Derczynski</last></author>
-      <author><first>Johannes</first><last>Bjerva</last></author>
+      <title>
+        <fixed-case>NLP</fixed-case> Security and Ethics, in the Wild</title>
+      <author>
+        <first>Heather</first>
+        <last>Lent</last>
+      </author>
+      <author>
+        <first>Erick</first>
+        <last>Galinkin</last>
+      </author>
+      <author>
+        <first>Yiyi</first>
+        <last>Chen</last>
+      </author>
+      <author>
+        <first>Jens Myrup</first>
+        <last>Pedersen</last>
+      </author>
+      <author id="leon-derczynski">
+        <first>Leon</first>
+        <last>Derczynski</last>
+      </author>
+      <author>
+        <first>Johannes</first>
+        <last>Bjerva</last>
+      </author>
       <doi>10.1162/tacl_a_00762</doi>
       <abstract>As NLP models are used by a growing number of end-users, an area of increasing importance is NLP Security (NLPSec): assessing the vulnerability of models to malicious attacks and developing comprehensive countermeasures against them. While work at the intersection of NLP and cybersecurity has the potential to create safer NLP for all, accidental oversights can result in tangible harm (e.g., breaches of privacy or proliferation of malicious models). In this emerging field, however, the research ethics of NLP have not yet faced many of the long-standing conundrums pertinent to cybersecurity, until now. We thus examine contemporary works across NLPSec, and explore their engagement with cybersecurity’s ethical norms. We identify trends across the literature, ultimately finding alarming gaps on topics like harm minimization and responsible disclosure. To alleviate these concerns, we provide concrete recommendations to help NLP researchers navigate this space more ethically, bridging the gap between traditional cybersecurity and NLP ethics, which we frame as “white hat NLP”. The goal of this work is to help cultivate an intentional culture of ethical research for those working in NLP Security.</abstract>
       <pages>709–743</pages>
       <url hash="4f1bf968">2025.tacl-1.33</url>
       <bibkey>lent-etal-2025-nlp</bibkey>
+    </paper>
+    <paper id="34">
+      <title>Patchwise Cooperative Game-based Interpretability Method for Large Vision-language Models</title>
+      <author>
+        <first>Yao</first>
+        <last>Zhu</last>
+      </author>
+      <author>
+        <first>Yunjian</first>
+        <last>Zhang</last>
+      </author>
+      <author>
+        <first>Zizhe</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Xiu</first>
+        <last>Yan</last>
+      </author>
+      <author>
+        <first>Peng</first>
+        <last>Sun</last>
+      </author>
+      <author>
+        <first>Xiangyang</first>
+        <last>Ji</last>
+      </author>
+      <doi>10.1162/tacl_a_00756</doi>
+      <abstract>Amidst the rapid advancement of artificial intelligence, research on large vision-language models (LVLMs) has emerged as a pivotal area. However, understanding their internal mechanisms remains challenging due to the limitations of existing interpretability methods, especially regarding faithfulness and plausibility. To address this, we first construct a human response interpretability dataset that evaluates the plausibility of model explanations by comparing the attention regions between the model and humans when answering the same questions. We then propose a patchwise cooperative game-based interpretability method for LVLMs, which employs Shapley values to quantify the impact of individual image patches on generation likelihood and enhances computational efficiency through a single input approximation approach. Experimental results demonstrate our method’s faithfulness, plausibility, and robustness. Our method provides researchers with deeper insights into model behavior, allowing for an examination of the specific image regions each layer relies on during response generation, ultimately enhancing model reliability. Our code is available at https://github.com/ZY123-GOOD/Patchwise_Cooperative.</abstract>
+      <pages>744–759</pages>
+      <url>https://doi.org/10.1162/tacl_a_00756</url>
+      <bibkey>zhu-etal-2025-patchwise</bibkey>
+    </paper>
+    <paper id="35">
+      <title>REAL Sampling: Boosting Factuality and Diversity of Open-ended Generation by Extrapolating the Entropy of an Infinitely Large LM</title>
+      <author>
+        <first>Haw-Shiuan</first>
+        <last>Chang</last>
+      </author>
+      <author>
+        <first>Nanyun</first>
+        <last>Peng</last>
+      </author>
+      <author>
+        <first>Mohit</first>
+        <last>Bansal</last>
+      </author>
+      <author>
+        <first>Anil</first>
+        <last>Ramakrishna</last>
+      </author>
+      <author>
+        <first>Tagyoung</first>
+        <last>Chung</last>
+      </author>
+      <doi>10.1162/tacl_a_00757</doi>
+      <abstract>Decoding methods for large language models (LLMs) usually struggle with the tradeoff between ensuring factuality and maintaining diversity. In this paper, we propose REAL (Residual Entropy from Asymptotic Line) sampling,1 which predicts the step-wise hallucination likelihood of an LLM. When an LLM is likely to hallucinate, REAL lowers the p threshold in nucleus sampling. Otherwise, REAL sampling increases the p threshold to boost the diversity. To predict the step-wise hallucination likelihood without supervision, we construct a THF (Token-level Hallucination Forecasting) model, which predicts the asymptotic entropy (i.e., inherent uncertainty) of the next token by extrapolating the next-token entropies of an infinitely large language model from a series of LLMs with different sizes. If an LLM’s entropy is higher than the asymptotic entropy (i.e., the LLM is more uncertain than it should be), the THF model predicts a high hallucination hazard, which leads to a lower p threshold in REAL sampling. In the FactualityPrompts benchmark (Lee et al., 2022), we demonstrate that REAL sampling based on a 70M THF model can substantially improve the factuality and diversity of 7B LLMs simultaneously. After combined with contrastive decoding, REAL sampling outperforms 13 sampling methods, and generates texts that are more factual than the greedy sampling and more diverse than the nucleus sampling with p = 0.5.</abstract>
+      <pages>760–783</pages>
+      <url>https://doi.org/10.1162/tacl_a_00757</url>
+      <bibkey>chang-etal-2025-real</bibkey>
+    </paper>
+    <paper id="36">
+      <title>mtRAG: A Multi-Turn Conversational Benchmark for Evaluating Retrieval-Augmented Generation Systems</title>
+      <author>
+        <first>Yannis</first>
+        <last>Katsis</last>
+      </author>
+      <author>
+        <first>Sara</first>
+        <last>Rosenthal</last>
+      </author>
+      <author>
+        <first>Kshitij</first>
+        <last>Fadnis</last>
+      </author>
+      <author>
+        <first>Chulaka</first>
+        <last>Gunasekara</last>
+      </author>
+      <author>
+        <first>Young-Suk</first>
+        <last>Lee</last>
+      </author>
+      <author>
+        <first>Lucian</first>
+        <last>Popa</last>
+      </author>
+      <author>
+        <first>Vraj</first>
+        <last>Shah</last>
+      </author>
+      <author>
+        <first>Huaiyu</first>
+        <last>Zhu</last>
+      </author>
+      <author>
+        <first>Danish</first>
+        <last>Contractor</last>
+      </author>
+      <author>
+        <first>Marina</first>
+        <last>Danilevsky</last>
+      </author>
+      <doi>10.1162/tacl.a.19</doi>
+      <abstract>Retrieval-augmented generation (RAG) has recently become a very popular task for Large Language Models (LLMs). Evaluating them on multi-turn RAG conversations, where the system is asked to generate a response to a question in the context of a preceding conversation, is an important and often overlooked task with several additional challenges. We present mtRAG, an end-to-end human-generated multi-turn RAG benchmark that reflects several real-world properties across diverse dimensions for evaluating the full RAG pipeline. mtRAG contains 110 conversations averaging 7.7 turns each across four domains for a total of 842 tasks. We also explore automation paths via synthetic data and LLM-as-a-Judge evaluation. Our human and automatic evaluations show that even state-of-the-art LLM RAG systems struggle on mtRAG. We demonstrate the need for strong retrieval and generation systems that can handle later turns, unanswerable questions, non-standalone questions, and multiple domains. mtRAG is available at https://github.com/ibm/mt-rag-benchmark.</abstract>
+      <pages>784–808</pages>
+      <url>https://doi.org/10.1162/tacl.a.19</url>
+      <bibkey>katsis-etal-2025-mtrag</bibkey>
+    </paper>
+    <paper id="37">
+      <title>Data Contamination Quiz: A Tool to Detect and Estimate Contamination in Large Language Models</title>
+      <author>
+        <first>Shahriar</first>
+        <last>Golchin</last>
+      </author>
+      <author>
+        <first>Mihai</first>
+        <last>Surdeanu</last>
+      </author>
+      <doi>10.1162/tacl.a.20</doi>
+      <abstract>We propose the Data Contamination Quiz (DCQ), a simple and effective approach to detect data contamination in large language models (LLMs) and estimate the amount of it. Specifically, we frame data contamination detection as a series of multiple-choice questions, devising a quiz format wherein three perturbed versions of each instance, subsampled from a specific dataset partition, are created. These changes only include word-level perturbations. The generated perturbations, along with the original dataset instance, form the options in the DCQ, with an extra option accommodating the selection of none of the provided options. Given that the only distinguishing signal among the options is the exact wording with respect to the original dataset instance, an LLM, when tasked with identifying the original dataset instance, gravitates towards selecting the original one if it has been exposed to it. While accounting for positional biases in LLMs, the quiz performance reveals the contamination level for the tested model with the dataset partition to which the quiz pertains. Applied to various datasets and LLMs, under controlled and uncontrolled contamination, our findings—while fully lacking access to training data and model parameters—suggest that DCQ achieves state-of-the-art results and uncovers greater contamination levels through memorization compared to existing methods. Also, it proficiently bypasses more safety filters, especially those set to avoid generating copyrighted content.1</abstract>
+      <pages>809–830</pages>
+      <url>https://doi.org/10.1162/tacl.a.20</url>
+      <bibkey>golchin-etal-2025-data</bibkey>
+    </paper>
+    <paper id="38">
+      <title>Continual Pre-training on Character-level Noisy Texts Makes Decoder-based Language Models Robust Few-shot Learners</title>
+      <author>
+        <first>Takeshi</first>
+        <last>Kojima</last>
+      </author>
+      <author>
+        <first>Yutaka</first>
+        <last>Matsuo</last>
+      </author>
+      <author>
+        <first>Yusuke</first>
+        <last>Iwasawa</last>
+      </author>
+      <doi>10.1162/tacl.a.21</doi>
+      <abstract>Recent decoder-based pre-trained language models (PLMs) generally use subword tokenizers. However, adding character-level perturbations drastically changes the delimitation of texts by the tokenizers, leading to the vulnerability of PLMs. This study proposes a method of continual pre-training to convert decoder-based PLMs with subword tokenizers into perturbation-robust few-shot in-context learners. Our method continually trains decoder-based PLMs to predict the next tokens conditioning on artificially created character-level noisy texts. Since decoder-based language models are auto-regressive, we skip noised words from the target optimization. In addition, to maintain the same word prediction performance under noisy text as clean text, our method employs word distribution matching between the original PLMs and training models. We conducted experiments on various subword-based PLMs, including GPT2, Pythia, Mistral, Gemma2, and Llama3, ranging from 1B to 8B parameters. The results demonstrate that our method consistently improves the performance of few-shot in-context learning on downstream tasks which contain actual typos or misspellings as well as artificial noise.1</abstract>
+      <pages>831–847</pages>
+      <url>https://doi.org/10.1162/tacl.a.21</url>
+      <bibkey>kojima-etal-2025-continual</bibkey>
+    </paper>
+    <paper id="39">
+      <title>Prompt Contrastive Transformation: An Enhanced Strategy for Efficient Prompt Transfer in Natural Language Processing</title>
+      <author>
+        <first>Shu</first>
+        <last>Zhao</last>
+      </author>
+      <author>
+        <first>Shiji</first>
+        <last>Yang</last>
+      </author>
+      <author>
+        <first>Shicheng</first>
+        <last>Tan</last>
+      </author>
+      <author>
+        <first>Zhen</first>
+        <last>Yang</last>
+      </author>
+      <author>
+        <first>Congyao</first>
+        <last>Mei</last>
+      </author>
+      <author>
+        <first>Zhen</first>
+        <last>Duan</last>
+      </author>
+      <author>
+        <first>Yanping</first>
+        <last>Zhang</last>
+      </author>
+      <author>
+        <first>Jie</first>
+        <last>Chen</last>
+      </author>
+      <doi>10.1162/tacl.a.22</doi>
+      <abstract>Prompt transfer is a transfer learning method based on prompt tuning, which enhances the parameter performance of prompts in target tasks by transferring source prompt embeddings. Among existing methods, weighted aggregation is effective and possesses the advantages of being lightweight and modular. However, these methods may transfer redundant or irrelevant information from the source prompts to the target prompt, leading to negative impacts. To alleviate this problem, we propose Prompt Contrastive Transformation (PCT), which achieves efficient prompt transfer through prompt contrastive transformation and attentional fusion. PCT transforms the source prompt into task-agnostic embedding and task-specific embeddings through singular value decomposition and contrastive learning, reducing information redundancy among source prompts. The attention module in PCT selects more effective task-specific embeddings and fuses them with task-agnostic embedding into the target prompt. Experimental results show that, despite tuning only 0.035% of task-specific parameters, PCT achieves improvements in prompt transfer for single target task adaptation across various NLP tasks.</abstract>
+      <pages>848–860</pages>
+      <url>https://doi.org/10.1162/tacl.a.22</url>
+      <bibkey>zhao-etal-2025-prompt</bibkey>
+    </paper>
+    <paper id="40">
+      <title>Accurate and Efficient Fine-Tuning of Quantized Large Language Models Through Optimal Balance in Adaptation</title>
+      <author>
+        <first>Ao</first>
+        <last>Shen</last>
+      </author>
+      <author>
+        <first>Zhiquan</first>
+        <last>Lai</last>
+      </author>
+      <author>
+        <first>Qiang</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Xionglve</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Lizhi</first>
+        <last>Zhang</last>
+      </author>
+      <author>
+        <first>Dongsheng</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Jiaxin</first>
+        <last>Li</last>
+      </author>
+      <doi>10.1162/tacl.a.23</doi>
+      <abstract>Large Language Models (LLMs) have demonstrated impressive performance across various domains. However, the enormous number of model parameters makes fine-tuning challenging, significantly limiting their application and deployment. Existing solutions combine parameter quantization with Low-Rank Adaptation (LoRA), reducing memory usage but causing performance degradation. Additionally, converting fine-tuned models to low-precision representations further degrades performance. In this paper, we identify an imbalance in fine-tuning quantized LLMs with LoRA: overly complex adapter inputs and outputs versus low effective trainability of the adapter, leading to underfitting during fine-tuning. Thus, we propose Quantized LLMs fine-tuning with Balanced Low-Rank Adaptation (Q-BLoRA), which simplifies the adapter’s inputs and outputs while increasing the adapter’s rank to alleviate underfitting during fine-tuning. For low-precision deployment, we propose Quantization-Aware fine-tuning with Balanced Low-Rank Adaptation (QA-BLoRA), which aligns with the block-wise quantization and facilitates quantization-aware fine-tuning of low-rank adaptation based on the parameter merging of Q-BLoRA. Both Q-BLoRA and QA-BLoRA are easily implemented and offer the following optimizations: (i) Q-BLoRA consistently achieves state-of-the-art accuracy compared to baselines and other variants; (ii) QA-BLoRA enables the direct generation of low-precision inference models, which exhibit significant performance improvements over other low-precision models. We validate the effectiveness of Q-BLoRA and QA-BLoRA across various models and scenarios. Code has been made available at https://github.com/xiaocaigou/qbaraqahira.</abstract>
+      <pages>861–877</pages>
+      <url>https://doi.org/10.1162/tacl.a.23</url>
+      <bibkey>shen-etal-2025-accurate</bibkey>
+    </paper>
+    <paper id="41">
+      <title>Contextualized Evaluations: Judging Language Model Responses to Underspecified Queries</title>
+      <author>
+        <first>Chaitanya</first>
+        <last>Malaviya</last>
+      </author>
+      <author>
+        <first>Joseph Chee</first>
+        <last>Chang</last>
+      </author>
+      <author>
+        <first>Dan</first>
+        <last>Roth</last>
+      </author>
+      <author>
+        <first>Mohit</first>
+        <last>Iyyer</last>
+      </author>
+      <author>
+        <first>Mark</first>
+        <last>Yatskar</last>
+      </author>
+      <author>
+        <first>Kyle</first>
+        <last>Lo</last>
+      </author>
+      <doi>10.1162/tacl.a.24</doi>
+      <abstract>Language model users often issue queries that lack specification, where the context under which a query was issued—such as the user’s identity, the query’s intent, and the criteria for a response to be useful—is not explicit. For instance, a good response to a subjective query like “What book should I read next?” would depend on the user’s preferences, and a good response to an open-ended query like “How do antibiotics work against bacteria?” would depend on the user’s expertise. This makes evaluation of responses to such queries an ill-posed task, as evaluators may make arbitrary judgments about the response quality. To remedy this, we present contextualized evaluations, a protocol that synthetically constructs context surrounding an underspecified query and provides it during evaluation. We find that the presence of context can 1) alter conclusions drawn from evaluation, even flipping benchmark rankings between model pairs, 2) nudge evaluators to make fewer judgments based on surface-level criteria, like style, and 3) provide new insights about model behavior across diverse contexts. Specifically, our procedure suggests a potential bias towards WEIRD (Western, Educated, Industrialized, Rich and Democratic) contexts in models’ “default” responses and we find that models are not equally sensitive to following different contexts, even when they are provided in prompts.1</abstract>
+      <pages>878–900</pages>
+      <url>https://doi.org/10.1162/tacl.a.24</url>
+      <bibkey>malaviya-etal-2025-contextualized</bibkey>
+    </paper>
+    <paper id="42">
+      <title>(Perhaps) Beyond Human Translation: Harnessing Multi-Agent Collaboration for Translating Ultra-Long Literary Texts</title>
+      <author>
+        <first>Minghao</first>
+        <last>Wu</last>
+      </author>
+      <author>
+        <first>Jiahao</first>
+        <last>Xu</last>
+      </author>
+      <author>
+        <first>Yulin</first>
+        <last>Yuan</last>
+      </author>
+      <author>
+        <first>Gholamreza</first>
+        <last>Haffari</last>
+      </author>
+      <author>
+        <first>Longyue</first>
+        <last>Wan</last>
+      </author>
+      <author>
+        <first>Weihua</first>
+        <last>Luo</last>
+      </author>
+      <author>
+        <first>Kaifu</first>
+        <last>Zhang</last>
+      </author>
+      <doi>10.1162/tacl.a.25</doi>
+      <abstract>Literary translations remains one of the most challenging frontiers in machine translation due to the complexity of capturing figurative language, cultural nuances, and unique stylistic elements. In this work, we introduce TransAgents, a novel multi-agent framework that simulates the roles and collaborative practices of a human translation company, including a CEO, Senior Editor, Junior Editor, Translator, Localization Specialist, and Proofreader. The translation process is divided into two stages: a preparation stage where the team is assembled and comprehensive translation guidelines are drafted, and an execution stage that involves sequential translation, localization, proofreading, and a final quality check. Furthermore, we propose two innovative evaluation strategies: Monolingual Human Preference (MHP), which evaluates translations based solely on target language quality and cultural appropriateness, and BLP, which leverages large language models like gpt-4 for direct text comparison. Although TransAgents achieves lower d-BLEU scores, due to the limited diversity of references, its translations are significantly better than those of other baselines and are preferred by both human evaluators and LLMs over traditional human references and gpt-4 translations. Our findings highlight the potential of multi-agent collaboration in enhancing translation quality, particularly for longer texts.1</abstract>
+      <pages>901–922</pages>
+      <url>https://doi.org/10.1162/tacl.a.25</url>
+      <bibkey>wu-etal-2025-perhaps</bibkey>
+    </paper>
+    <paper id="43">
+      <title>STPar: A Structure-Aware Triaffine Parser for Screenplay Character Coreference Resolution</title>
+      <author>
+        <first>Li</first>
+        <last>Zheng</last>
+      </author>
+      <author>
+        <first>Hao</first>
+        <last>Fei</last>
+      </author>
+      <author>
+        <first>Lei</first>
+        <last>Chen</last>
+      </author>
+      <author>
+        <first>Bobo</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Fei</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Chong</first>
+        <last>Teng</last>
+      </author>
+      <author>
+        <first>Liang</first>
+        <last>Zhao</last>
+      </author>
+      <author>
+        <first>Donghong</first>
+        <last>Ji</last>
+      </author>
+      <doi>10.1162/tacl.a.28</doi>
+      <abstract>Character Coreference Resolution in Movie Screenplays (MovieCoref) is a newly emerging task for understanding complex movie plots and character relationships. This task poses greater challenges than traditional coreference resolution, due to the intricate narrative structures and character interactions unique to screenplays. In light of these challenges, we introduce a novel approach: a Structure-aware Triaffine Parser (STPar) for the MovieCoref task. STPar combines discourse and syntactic structures in the feature encoding process, enabling comprehensive analysis of ternary relationships and complex interactions. During the pairing process, STPar utilizes a triaffine scorer to consider high-order relations between candidate mention pairs, thus enhancing its ability to capture detailed narrative structures. In addition, STPar incorporates multi-task learning, encompassing singleton and span detection tasks, to further improve coreference resolution performance. Our evaluations on the MovieCoref dataset demonstrate that STPar significantly outperforms the best baseline by 7.4%, 21.5%, 7.1%, and 10.2% in F1 scores of B3, CEAFe, LEA, and CoNLL. Further analysis highlights the benefits of integrating structural discourse and syntactic information as well as the combined approaches of triaffine and multi-task learning.1</abstract>
+      <pages>923–937</pages>
+      <url>https://doi.org/10.1162/tacl.a.28</url>
+      <bibkey>zheng-etal-2025-stpar</bibkey>
+    </paper>
+    <paper id="44">
+      <title>MAKE: Memory-Associated Knowledge Editing</title>
+      <author>
+        <first>Seongsik</first>
+        <last>Park</last>
+      </author>
+      <author>
+        <first>Sangmin</first>
+        <last>Park</last>
+      </author>
+      <author>
+        <first>Jaieun</first>
+        <last>Kim</last>
+      </author>
+      <author>
+        <first>Harksoo</first>
+        <last>Kim</last>
+      </author>
+      <doi>10.1162/tacl.a.26</doi>
+      <abstract>Knowledge editing aims to efficiently modify large language models (LLMs) to rectify erroneous or outdated information without retraining the model. However, prior methods frequently struggle to preserve the original capabilities of LLMs after editing. To address this challenge, we propose Memory-Associated Knowledge Editing (MAKE), a novel framework that treats memory-based knowledge editing as retrieval-augmented generation. MAKE stores edits in an external memory and retrieves them when handling inputs similar to the edits. Our method decouples edited information from LLMs, thereby maintaining their original abilities while enabling accurate knowledge updates. Experimental results across multiple knowledge editing benchmarks demonstrate that MAKE achieves state-of-the-art editing performance while substantially preserving the general capabilities of the base model.</abstract>
+      <pages>938–952</pages>
+      <url>https://doi.org/10.1162/tacl.a.26</url>
+      <bibkey>park-etal-2025-make</bibkey>
+    </paper>
+    <paper id="45">
+      <title>Investigating Adversarial Trigger Transfer in Large Language Models</title>
+      <author>
+        <first>Nicholas</first>
+        <last>Meade</last>
+      </author>
+      <author>
+        <first>Arkil</first>
+        <last>Patel</last>
+      </author>
+      <author>
+        <first>Siva</first>
+        <last>Reddy</last>
+      </author>
+      <doi>10.1162/tacl.a.27</doi>
+      <abstract>Adversarial attacks on language models have raised significant safety concerns. One particularly concerning class of attacks involves adversarial triggers: short sequences of tokens that, when appended to a prompt, cause a model to generate harmful content. While prior work has demonstrated the effectiveness of such triggers, there has been limited systematic study of their transferability across different models. In this work, we present a comprehensive analysis of adversarial trigger transfer across large language models (LLMs). We investigate how triggers trained on one model transfer to other models, examining the effects of model family, model size, and training objective on transferability. Our findings reveal that triggers often exhibit strong transfer within model families and that larger models tend to be more robust to transferred triggers.</abstract>
+      <pages>953–979</pages>
+      <url>https://doi.org/10.1162/tacl.a.27</url>
+      <bibkey>meade-etal-2025-investigating</bibkey>
+    </paper>
+    <paper id="46">
+      <title>Human Choice Prediction in Language-based Persuasion Games: Simulation-based Off-Policy Evaluation</title>
+      <author>
+        <first>Eilam</first>
+        <last>Shapira</last>
+      </author>
+      <author>
+        <first>Omer</first>
+        <last>Madmon</last>
+      </author>
+      <author>
+        <first>Reut</first>
+        <last>Apel</last>
+      </author>
+      <author>
+        <first>Moshe</first>
+        <last>Tennenholtz</last>
+      </author>
+      <author>
+        <first>Roi</first>
+        <last>Reichart</last>
+      </author>
+      <doi>10.1162/tacl.a.16</doi>
+      <abstract>Recent advances in Large Language Models (LLMs) have spurred interest in designing LLM-based agents for tasks that involve interaction with human and artificial agents. This paper addresses a key aspect in the design of such agents: predicting human decisions in off-policy evaluation (OPE). We focus on language-based persuasion games, where an expert aims to influence the decision-maker through verbal messages. In our OPE framework, the prediction model is trained on human interaction data collected from encounters with one set of expert agents, and its performance is evaluated on interactions with a different set of experts. Using a dedicated application, we collected a dataset of 87K decisions from humans playing a repeated decision-making game with artificial agents. To enhance off-policy performance, we propose a simulation technique involving interactions across the entire agent space and simulated decision-makers. Our learning strategy yields significant OPE gains, e.g., improving prediction accuracy in the top 15% challenging cases by 7.1%.1</abstract>
+      <pages>980–1006</pages>
+      <url>https://doi.org/10.1162/tacl.a.16</url>
+      <bibkey>shapira-etal-2025-human</bibkey>
+    </paper>
+    <paper id="47">
+      <title>Efficient Tuning of Large Language Models for Knowledge-Grounded Dialogue Generation</title>
+      <author>
+        <first>Bo</first>
+        <last>Zhang</last>
+      </author>
+      <author>
+        <first>Hui</first>
+        <last>Ma</last>
+      </author>
+      <author>
+        <first>Dailin</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Jian</first>
+        <last>Ding</last>
+      </author>
+      <author>
+        <first>Jian</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Bo</first>
+        <last>Xu</last>
+      </author>
+      <author>
+        <first>HongFei</first>
+        <last>Lin</last>
+      </author>
+      <doi>10.1162/tacl.a.17</doi>
+      <abstract>Large language models (LLMs) demonstrate remarkable text comprehension and generation capabilities but often lack the ability to utilize up-to-date or domain-specific knowledge not included in their training data. To address this gap, we introduce KEDiT, an efficient method for fine-tuning LLMs for knowledge-grounded dialogue generation. KEDiT operates in two main phases. First, it employs an information bottleneck to compress retrieved knowledge into learnable parameters, retaining essential information while minimizing computational overhead. Second, a lightweight knowledge-aware adapter integrates these compressed knowledge vectors into the LLM during fine-tuning, updating less than 2% of the model parameters. The experimental results on the Wizard of Wikipedia and a newly constructed PubMed-Dialog dataset demonstrate that KEDiT excels in generating contextually relevant and informative responses, outperforming competitive baselines in automatic, LLM-based, and human evaluations. This approach effectively combines the strengths of pretrained LLMs with the adaptability needed for incorporating dynamic knowledge, presenting a scalable solution for fields such as medicine.1</abstract>
+      <pages>1007–1031</pages>
+      <url>https://doi.org/10.1162/tacl.a.17</url>
+      <bibkey>zhang-etal-2025-efficient</bibkey>
+    </paper>
+    <paper id="48">
+      <title>MURI: High-Quality Instruction Tuning Datasets for Low-Resource Languages via Reverse Instructions</title>
+      <author>
+        <first>Abdullatif</first>
+        <last>Köksal</last>
+      </author>
+      <author>
+        <first>Marion</first>
+        <last>Thaler</last>
+      </author>
+      <author>
+        <first>Ayyoob</first>
+        <last>Imani</last>
+      </author>
+      <author>
+        <first>Ahmet</first>
+        <last>Üstün</last>
+      </author>
+      <author>
+        <first>Anna</first>
+        <last>Korhonen</last>
+      </author>
+      <author>
+        <first>Hinrich</first>
+        <last>Schütze</last>
+      </author>
+      <doi>10.1162/tacl.a.18</doi>
+      <abstract>Instruction tuning enhances large language models (LLMs) by aligning them with human preferences across diverse tasks. Traditional approaches to create instruction tuning datasets face serious challenges for low-resource languages due to their dependence on data annotation. This work introduces a novel method, Multilingual Reverse Instructions (MURI), which generates high-quality instruction tuning datasets for low-resource languages without requiring human annotators or pre-existing multilingual models. Utilizing reverse instructions and a translation pipeline, MURI produces instruction-output pairs from existing human-written texts in low-resource languages. This method ensures cultural relevance and diversity by sourcing texts from different native domains and applying filters to eliminate inappropriate content. Our dataset, MURI-IT, includes more than 2 million instruction-output pairs across 200 languages. Evaluation by native speakers and fine-tuning experiments with mT5 models demonstrate the approach’s effectiveness for both NLU and open-ended generation. We publicly release datasets and models at https://github.com/akoksal/muri.</abstract>
+      <pages>1032–1055</pages>
+      <url>https://doi.org/10.1162/tacl.a.18</url>
+      <bibkey>kksal-etal-2025-muri</bibkey>
+    </paper>
+    <paper id="49">
+      <title>KEFT: Knowledge-Enhanced Fine-Tuning for Large Language Models in Domain-Specific Question Answering</title>
+      <author>
+        <first>Haiyun</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Jixin</first>
+        <last>Zhang</last>
+      </author>
+      <author>
+        <first>Hua</first>
+        <last>Shen</last>
+      </author>
+      <author>
+        <first>Ke</first>
+        <last>Cheng</last>
+      </author>
+      <author>
+        <first>Xiaofeng</first>
+        <last>Huang</last>
+      </author>
+      <doi>10.1162/tacl.a.31</doi>
+      <abstract>The rapid advancement of large language models (LLMs) has opened up promising opportunities for their downstream applications in question-answering (QA), such as ChatGPT, ChatGLM, etc. However, such LLMs do not perform very well in domain-specific QA tasks without fine-tuning. But directly fine-tuning LLMs on domain-specific corpus data may lead to catastrophic forgetting, causing the LLMs to lose their general language capability. To address this problem, we propose the Knowledge-Enhanced Fine-Tuning (KEFT) method, an unsupervised fine-tuning approach to enhance the knowledge capability of LLMs in domain-specific QA tasks while preserving their general language capability. KEFT leverages the inherent language comprehension of pre-trained LLMs to generate synthetic-QA datasets from domain-specific corpus data autonomously for fine-tuning, and adopts a Low-Rank Adaptation (LoRA) method to further alleviate over-fitting. Furthermore, to enhance the representation of domain-specific knowledge, we introduce a knowledge-enhanced fine-tuning loss function, which encourages the model to learn the knowledge-question connection, thereby generating natural and knowledgeable answers. Our evaluations across multiple domain-specific datasets demonstrate that KEFT surpasses state-of-the-art fine-tuning approaches, enhancing the performance of various LLMs in QA tasks in both English and Chinese languages.</abstract>
+      <pages>1056–1067</pages>
+      <url>https://doi.org/10.1162/tacl.a.31</url>
+      <bibkey>li-etal-2025-keft</bibkey>
+    </paper>
+    <paper id="50">
+      <title>BenCzechMark : A Czech-Centric Multitask and Multimetric Benchmark for Large Language Models with Duel Scoring Mechanism</title>
+      <author>
+        <first>Martin</first>
+        <last>Fajcik</last>
+      </author>
+      <author>
+        <first>Martin</first>
+        <last>Docekal</last>
+      </author>
+      <author>
+        <first>Jan</first>
+        <last>Dolezal</last>
+      </author>
+      <author>
+        <first>Karel</first>
+        <last>Ondrej</last>
+      </author>
+      <author>
+        <first>Karel</first>
+        <last>Beneš</last>
+      </author>
+      <author>
+        <first>Jan</first>
+        <last>Kapsa</last>
+      </author>
+      <author>
+        <first>Pavel</first>
+        <last>Smrz</last>
+      </author>
+      <author>
+        <first>Alexander</first>
+        <last>Polok</last>
+      </author>
+      <author>
+        <first>Michal</first>
+        <last>Hradis</last>
+      </author>
+      <author>
+        <first>Zuzana</first>
+        <last>Neverilova</last>
+      </author>
+      <author>
+        <first>Ales</first>
+        <last>Horak</last>
+      </author>
+      <author>
+        <first>Radoslav</first>
+        <last>Sabol</last>
+      </author>
+      <author>
+        <first>Michal</first>
+        <last>Stefanik</last>
+      </author>
+      <author>
+        <first>Adam</first>
+        <last>Jirkovsky</last>
+      </author>
+      <author>
+        <first>David</first>
+        <last>Adamczyk</last>
+      </author>
+      <author>
+        <first>Petr</first>
+        <last>Hyner</last>
+      </author>
+      <author>
+        <first>Jan</first>
+        <last>Hula</last>
+      </author>
+      <author>
+        <first>Hynek</first>
+        <last>Kydlicek</last>
+      </author>
+      <doi>10.1162/tacl.a.32</doi>
+      <abstract>We present BenCzechMark (BCM), the first comprehensive Czech language benchmark designed for large language models, offering diverse tasks, multiple task formats, and multiple evaluation metrics. Its duel scoring system is grounded in statistical significance theory and uses aggregation across tasks inspired by social preference theory. Our benchmark encompasses 50 challenging tasks, with corresponding test datasets, primarily in native Czech, with 14 newly collected ones. These tasks span 8 categories and cover diverse domains, including historical Czech news, essays from pupils or language learners, and spoken word. Furthermore, we collect and clean BUT-Large Czech Collection, the largest publicly available clean Czech language corpus, and use it for (i) contamination analysis and (ii) continuous pretraining of the first Czech-centric 7B language model with Czech-specific tokenization. We use our model as a baseline for comparison with publicly available multilingual models. Lastly, we release and maintain a leaderboard with existing 50 model submissions, where new model submissions can be made at https://huggingface.co/spaces/CZLC/BenCzechMark.</abstract>
+      <pages>1068–1095</pages>
+      <url>https://doi.org/10.1162/tacl.a.32</url>
+      <bibkey>fajcik-etal-2025-benczechmark</bibkey>
+    </paper>
+    <paper id="51">
+      <title>Analyzing and Adapting Large Language Models for Few-Shot Multilingual NLU: Are We There Yet?</title>
+      <author>
+        <first>Evgeniia</first>
+        <last>Razumovskaia</last>
+      </author>
+      <author>
+        <first>Ivan</first>
+        <last>Vulić</last>
+      </author>
+      <author>
+        <first>Anna</first>
+        <last>Korhonen</last>
+      </author>
+      <doi>10.1162/tacl.a.33</doi>
+      <abstract>Supervised fine-tuning (SFT), supervised instruction tuning (SIT), and in-context learning (ICL) are three alternative, de facto standard approaches to few-shot learning. ICL has gained popularity recently with the advent of LLMs due to its versatile simplicity and sample efficiency. Prior research has conducted only limited investigation into how these approaches work for multilingual few-shot learning, and the focus so far has been mostly on their performance. In this work, we present an extensive and systematic comparison of the three approaches, testing them on a variety of high- and low-resource languages over five different NLU tasks, and a myriad of language and domain setups. Importantly, performance is only one aspect of the comparison, where we also analyze and discuss the approaches through the optics of their computational, inference and financial costs. Some of the highlighted findings concern an excellent trade-off between performance and resource requirements/cost for SIT. We further analyze the impact of target language adaptation of pretrained LLMs and find that the standard adaptation approaches can (superficially) improve target language generation capabilities, but language understanding elicited through ICL does not improve accordingly and remains limited, especially for low-resource languages.</abstract>
+      <pages>1096–1120</pages>
+      <url>https://doi.org/10.1162/tacl.a.33</url>
+      <bibkey>razumovskaia-etal-2025-analyzing</bibkey>
+    </paper>
+    <paper id="52">
+      <title>DARE: Diverse Visual Question Answering with Robustness Evaluation</title>
+      <author>
+        <first>Hannah</first>
+        <last>Sterz</last>
+      </author>
+      <author>
+        <first>Jonas</first>
+        <last>Pfeiffer</last>
+      </author>
+      <author>
+        <first>Ivan</first>
+        <last>Vulić</last>
+      </author>
+      <doi>10.1162/tacl.a.29</doi>
+      <abstract>Vision Language Models (VLMs) extend remarkable capabilities of text-only large language models and vision-only models, being able to learn from and process multi-modal vision-text input. While modern VLMs perform well on a number of standard image classification and image-text matching tasks, they still struggle with a number of crucial vision-language (VL) reasoning abilities such as counting and spatial reasoning. Moreover, while they might be very brittle to small variations in instructions and/or evaluation protocols, existing benchmarks fail to evaluate their robustness (or rather the lack of it). In order to couple challenging VL scenarios with comprehensive robustness evaluation, we introduce DARE, Diverse Visual Question Answering with Robustness Evaluation, a carefully created and curated multiple-choice VQA benchmark. DARE evaluates VLM performance on five diverse categories and includes four robustness-oriented evaluations based on the variations of prompts, the subsets of answer options, the output format, and the number of correct answers. Among a spectrum of other findings, we report that state-of-the-art VLMs still struggle with questions in most categories and are unable to consistently deliver their peak performance across the tested robustness evaluations. Consequently, our work calls for the systematic addition of robustness evaluations in future VLM research.</abstract>
+      <pages>1121–1145</pages>
+      <url>https://doi.org/10.1162/tacl.a.29</url>
+      <bibkey>sterz-etal-2025-dare</bibkey>
+    </paper>
+    <paper id="53">
+      <title>Explanatory Summarization with Discourse-Driven Planning</title>
+      <author>
+        <first>Dongqi</first>
+        <last>Liu</last>
+      </author>
+      <author>
+        <first>Xi</first>
+        <last>Yu</last>
+      </author>
+      <author>
+        <first>Vera</first>
+        <last>Demberg</last>
+      </author>
+      <author>
+        <first>Mirella</first>
+        <last>Lapata</last>
+      </author>
+      <doi>10.1162/tacl.a.30</doi>
+      <abstract>Lay summaries for scientific documents typically include explanations to help readers grasp sophisticated concepts or arguments. However, current automatic summarization methods do not explicitly model explanations, which makes it difficult to align the proportion of explanatory content with human-written summaries. In this paper, we present a plan-based approach that leverages discourse frameworks to organize summary generation and guide explanatory sentences by prompting responses to the plan. Specifically, we propose two discourse-driven planning strategies, where the plan is conditioned as part of the input or part of the output prefix, respectively. Empirical experiments on three lay summarization datasets show that our approach outperforms existing state-of-the-art methods in terms of summary quality, and it enhances model robustness, controllability, and mitigates hallucination. The project information is available at https://dongqi.me/projects/ExpSum.</abstract>
+      <pages>1146–1170</pages>
+      <url>https://doi.org/10.1162/tacl.a.30</url>
+      <bibkey>liu-etal-2025-explanatory</bibkey>
+    </paper>
+    <paper id="54">
+      <title>Overcoming Source Object Grounding for Semantic Image Editing</title>
+      <author>
+        <first>Yeonjoon</first>
+        <last>Jung</last>
+      </author>
+      <author>
+        <first>Seungtaek</first>
+        <last>Choi</last>
+      </author>
+      <author>
+        <first>Seung-won</first>
+        <last>Hwang</last>
+      </author>
+      <doi>10.1162/tacl.a.34</doi>
+      <abstract>Recent diffusion models have demonstrated remarkable capabilities in text-to-image generation. However, their stochastic denoising process often causes semantic image editing (SIE) models to misapply textual instructions. That is, models often leave the source object unchanged or erroneously alter the background. We refer to this challenge as source object grounding. To address this challenge, we introduce R-SIE, a region-wise SIE framework. During the inference, R-SIE models noise separately for distinct image regions, enabling precise control over the transformed areas. To reinforce the inference, we devise an automatic pipeline leveraging bounding boxes to generate unambiguous training data. Additionally, we propose two region-focused metrics, CLIP-Region Class (CLIP-RC) and CLIP-Global Context (CLIP-GC), to independently assess how well the source object is edited and the background is preserved, respectively. Experimental results demonstrate that region-wise diffusion improves existing baselines, and our data generation pipeline further enhances these improvements.1</abstract>
+      <pages>1171–1185</pages>
+      <url>https://doi.org/10.1162/tacl.a.34</url>
+      <bibkey>jung-etal-2025-overcoming</bibkey>
+    </paper>
+    <paper id="55">
+      <title>Active Knowledge Structuring for Large Language Models in Materials Science Text Mining</title>
+      <author>
+        <first>Xin</first>
+        <last>Zhang</last>
+      </author>
+      <author>
+        <first>Jingling</first>
+        <last>Yuan</last>
+      </author>
+      <author>
+        <first>Peiliang</first>
+        <last>Zhang</last>
+      </author>
+      <author>
+        <first>Jia</first>
+        <last>Liu</last>
+      </author>
+      <author>
+        <first>Lin</first>
+        <last>Li</last>
+      </author>
+      <doi>10.1162/tacl.a.36</doi>
+      <abstract>Large Language Models (LLMs) offer a promising alternative to traditional Materials Science Text Mining (MSTM) by reducing the need for extensive data labeling and fine-tuning. However, existing zero-/few-shot methods still face limitations in aligning with personalized needs in scientific discovery. To address this, we propose ClassMATe, an active knowledge structuring approach for MSTM. Specifically, we first propose a class definition stylization method to structure knowledge, enabling explicit clustering of latent material knowledge in LLMs for enhanced inference. To align with the scientists’ needs, we propose an active needs refining strategy that iteratively clarifies needs by learning from uncertainty-aware hard samples of LLMs, further refining the knowledge structuring. Extensive experiments on seven tasks and eight datasets show that ClassMATe, as a plug-and-play method, achieves performance comparable to supervised learning without requiring fine-tuning or extra knowledge base, highlighting the potential to bridge the gap between LLMs’ latent knowledge and real-world scientific applications.1</abstract>
+      <pages>1186–1203</pages>
+      <url>https://doi.org/10.1162/tacl.a.36</url>
+      <bibkey>zhang-etal-2025-active</bibkey>
+    </paper>
+    <paper id="56">
+      <title>A Systematic Review of NLP for Dementia: Tasks, Datasets, and Opportunities</title>
+      <author>
+        <first>Lotem</first>
+        <last>Peled-Cohen</last>
+      </author>
+      <author>
+        <first>Roi</first>
+        <last>Reichart</last>
+      </author>
+      <doi>10.1162/tacl.a.35</doi>
+      <abstract>The close link between cognitive decline and language has fostered long-standing collaboration between the NLP and medical communities in dementia research. To examine this, we reviewed over 240 papers applying NLP to dementia-related efforts, drawing from medical, technological, and NLP-focused literature. We identify key research areas, including dementia detection, linguistic biomarker extraction, caregiver support, and patient assistance, showing that half of all papers focus solely on dementia detection using clinical data. Yet, many directions remain unexplored, such as artificially degraded language models, synthetic data, digital twins, and more. We highlight gaps and opportunities around trust, scientific rigor, applicability, and cross-community collaboration. We raise ethical dilemmas in the field, and highlight the diverse datasets encountered throughout our review including recorded, written, structured, spontaneous, synthetic, clinical, social media–based, and more. This review aims to inspire more creative, impactful, and rigorous research on NLP for dementia.</abstract>
+      <pages>1204–1244</pages>
+      <url>https://doi.org/10.1162/tacl.a.35</url>
+      <bibkey>peledcohen-etal-2025-systematic</bibkey>
+    </paper>
+    <paper id="57">
+      <title>Elements of World Knowledge (EWoK): A Cognition-Inspired Framework for Evaluating Basic World Knowledge in Language Models</title>
+      <author>
+        <first>Anna A.</first>
+        <last>Ivanova</last>
+      </author>
+      <author>
+        <first>Aalok</first>
+        <last>Sathe</last>
+      </author>
+      <author>
+        <first>Benjamin</first>
+        <last>Lipkin</last>
+      </author>
+      <author>
+        <first>Unnathi U.</first>
+        <last>Kumar</last>
+      </author>
+      <author>
+        <first>Setayesh</first>
+        <last>Radkani</last>
+      </author>
+      <author>
+        <first>Thomas H.</first>
+        <last>Clark</last>
+      </author>
+      <author>
+        <first>Carina</first>
+        <last>Kauf</last>
+      </author>
+      <author>
+        <first>Jennifer</first>
+        <last>Hu</last>
+      </author>
+      <author>
+        <first>R. T.</first>
+        <last>Pramod</last>
+      </author>
+      <author>
+        <first>Gabriel</first>
+        <last>Grand</last>
+      </author>
+      <author>
+        <first>Vivian C.</first>
+        <last>Paulun</last>
+      </author>
+      <author>
+        <first>Maria</first>
+        <last>Ryskina</last>
+      </author>
+      <author>
+        <first>Ekin</first>
+        <last>Akyürek</last>
+      </author>
+      <author>
+        <first>Ethan G.</first>
+        <last>Wilcox</last>
+      </author>
+      <author>
+        <first>Nafisa</first>
+        <last>Rashid</last>
+      </author>
+      <author>
+        <first>Leshem</first>
+        <last>Choshen</last>
+      </author>
+      <author>
+        <first>Roger</first>
+        <last>Levy</last>
+      </author>
+      <author>
+        <first>Evelina</first>
+        <last>Fedorenko</last>
+      </author>
+      <author>
+        <first>Joshua</first>
+        <last>Tenenbaum</last>
+      </author>
+      <author>
+        <first>Jacob</first>
+        <last>Andreas</last>
+      </author>
+      <doi>10.1162/tacl.a.38</doi>
+      <abstract>The ability to build and reason about models of the world is essential for situated language understanding. But evaluating world modeling capabilities in modern AI systems—especially those based on language models—has proven challenging, in large part because of the difficulty of disentangling conceptual knowledge about the world from knowledge of surface co-occurrence statistics. This paper presents Elements of World Knowledge (EWoK), a framework for evaluating language models’ understanding of the conceptual knowledge underlying world modeling. EWoK targets specific concepts from multiple knowledge domains known to be important for world modeling in humans, from social interactions (help, deceive) to spatial relations (left, right). Objects, agents, and locations in the items can be flexibly filled in, enabling easy generation of multiple controlled datasets. We then introduce EWoK-core-1.0, a dataset of 4,374 items covering 11 world knowledge domains. We evaluate 20 open-weights large language models (1.3B–70B parameters) and compare them with human performance. All tested models perform worse than humans, with results varying drastically across domains. Performance on social interactions and social properties was highest and performance on physical relations and spatial relations was lowest. Overall, this dataset highlights simple cases where even large models struggle and presents rich avenues for targeted research on LLM world modeling capabilities.</abstract>
+      <pages>1245–1270</pages>
+      <url>https://doi.org/10.1162/tacl.a.38</url>
+      <bibkey>ivanova-etal-2025-elements</bibkey>
+    </paper>
+    <paper id="58">
+      <title>End-to-End Long Document Summarization using Gradient Caching</title>
+      <author>
+        <first>Rohit</first>
+        <last>Saxena</last>
+      </author>
+      <author>
+        <first>Hao</first>
+        <last>Tang</last>
+      </author>
+      <author>
+        <first>Frank</first>
+        <last>Keller</last>
+      </author>
+      <doi>10.1162/tacl.a.40</doi>
+      <abstract>Training transformer-based encoder-decoder models for long document summarization poses a significant challenge due to the quadratic memory consumption during training. Several approaches have been proposed to extend the input length at test time, but training with these approaches is still difficult, requiring truncation of input documents and causing a mismatch between training and test conditions. In this work, we propose CachED (Gradient Caching for Encoder-Decoder models), an approach that enables end-to-end training of existing transformer-based encoder-decoder models, using the entire document without truncation. Specifically, we apply non-overlapping sliding windows to input documents, followed by fusion in decoder. During backpropagation, the gradients are cached at the decoder and are passed through the encoder in chunks by re-computing the hidden vectors, similar to gradient checkpointing. In the experiments on long document summarization, we extend BART to CachED BART, processing more than 500K tokens during training and achieving superior performance without using any additional parameters.</abstract>
+      <pages>1271–1297</pages>
+      <url>https://doi.org/10.1162/tacl.a.40</url>
+      <bibkey>saxena-etal-2025-end</bibkey>
+    </paper>
+    <paper id="59">
+      <title>TALE: Token-Adaptive Low-Rank KVCache Approximation with Reconstruction Elimination</title>
+      <author>
+        <first>Jaeseong</first>
+        <last>Lee</last>
+      </author>
+      <author>
+        <first>Seung-won</first>
+        <last>Hwang</last>
+      </author>
+      <author>
+        <first>Aurick</first>
+        <last>Qiao</last>
+      </author>
+      <author>
+        <first>Daniel</first>
+        <last>Campos</last>
+      </author>
+      <author>
+        <first>Zhewei</first>
+        <last>Yao</last>
+      </author>
+      <author>
+        <first>Yuxiong</first>
+        <last>He</last>
+      </author>
+      <doi>10.1162/tacl.a.39</doi>
+      <abstract>KVCache, by storing key-value pairs for reuse, has been crucial for enhancing inference efficiency for large language models (LLMs). However, the increasing memory demands of KVCache, especially with recent trends of longer input sequences, present a major challenge. In this work, we propose an innovative token-adaptive low-rank approximation strategy for KVCache compression. By applying varying ranks based on token significance, our method compresses KVCache efficiently while retaining critical information. Moreover, we introduce a lazy approximation technique, which approximates lazily only when needed, alongside a reconstruction-free design to bypass costly recalculations. Combined with multi-level quantization, this method reduces KVCache size by 9.1× on the Llama-3.1-8B model, with minimal performance degradation on complex tasks such as GSM8K. Moreover, our custom attention implementation shows up to 2× latency reduction compared to the conventional method in long context scenarios. The code is publicly available.</abstract>
+      <pages>1298–1318</pages>
+      <url>https://doi.org/10.1162/tacl.a.39</url>
+      <bibkey>lee-etal-2025-tale</bibkey>
+    </paper>
+    <paper id="60">
+      <title>Adding Chocolate to Mint : Mitigating Metric Interference in Machine Translation</title>
+      <author>
+        <first>José</first>
+        <last>Pombal</last>
+      </author>
+      <author>
+        <first>Nuno M.</first>
+        <last>Guerreiro</last>
+      </author>
+      <author>
+        <first>Ricardo</first>
+        <last>Rei</last>
+      </author>
+      <author>
+        <first>André F. T.</first>
+        <last>Martins</last>
+      </author>
+      <doi>10.1162/tacl.a.37</doi>
+      <abstract>As automatic metrics become increasingly stronger and widely adopted, the risk of unintentionally “gaming the metric” during model development rises. This issue is caused by metric interference (Mint), i.e., the use of the same or related metrics for both model tuning and evaluation. Mint can misguide practitioners into being overoptimistic about the performance of their systems: As system outputs become a function of the interfering metric, their estimated quality loses correlation with human judgments. In this work, we analyze two common cases of Mint in machine translation-related tasks: Filtering of training data, and decoding with quality signals. Importantly, we find that Mint strongly distorts instance-level metric scores, even when metrics are not directly optimized for—questioning the common strategy of leveraging a different, yet related metric for evaluation that is not used for tuning. To address this problem, we propose MintAdjust, a method for more reliable evaluation under Mint. On the WMT24 MT shared task test set, MintAdjust ranks translations and systems more accurately than state-of-the-art-metrics across a majority of language pairs, especially for high-quality systems. Furthermore, MintAdjust outperforms AutoRank, the ensembling method used by the organizers.1 We will release a codebase for replicating the results in this work upon publication.</abstract>
+      <pages>1319–1339</pages>
+      <url>https://doi.org/10.1162/tacl.a.37</url>
+      <bibkey>pombal-etal-2025-adding</bibkey>
+    </paper>
+    <paper id="61">
+      <title>FoVer: First-Order Logic Verification for Natural Language Reasoning</title>
+      <author>
+        <first>Yu</first>
+        <last>Pei</last>
+      </author>
+      <author>
+        <first>Yongping</first>
+        <last>Du</last>
+      </author>
+      <author>
+        <first>Xingnan</first>
+        <last>Jin</last>
+      </author>
+      <doi>10.1162/tacl.a.41</doi>
+      <abstract>Large Language Models (LLMs) have shown remarkable capabilities in various tasks, including logical reasoning. However, their propensity for generating incorrect or inconsistent responses remains a significant concern. To address this issue, we propose FoVer (First-order logic Verification), an automated pipeline that verifies the logical correctness of reasoning texts using first-order logic. The pipeline operates in two main steps: (1) LLM-driven translation of natural language into executable logical expressions, and (2) automated logical verification using the Z3 theorem prover. We evaluate FoVer on specialized logical datasets (ProofWriter and FOLIO) and real-world LLM outputs (REVEAL). The results demonstrate that FoVer outperforms existing methods in logical verification significantly, showing notable improvements in accuracy across both ideal and practical scenarios. The pipeline also demonstrates its potential in identifying annotation errors in existing datasets, and it could be utilized for constructing new logical reasoning datasets. This work presents a significant step forward in enhancing the trustworthiness of LLM outputs, particularly in tasks requiring logical integrity.1</abstract>
+      <pages>1340–1359</pages>
+      <url>https://doi.org/10.1162/tacl.a.41</url>
+      <bibkey>pei-etal-2025-fover</bibkey>
+    </paper>
+    <paper id="62">
+      <title>On the Effect of Instruction Tuning Loss on Generalization</title>
+      <author>
+        <first>Anwoy</first>
+        <last>Chatterjee</last>
+      </author>
+      <author>
+        <first>H. S. V. N. S.</first>
+        <last>Kowndinya Renduchintala</last>
+      </author>
+      <author>
+        <first>Sumit</first>
+        <last>Bhatia</last>
+      </author>
+      <author>
+        <first>Tanmoy</first>
+        <last>Chakraborty</last>
+      </author>
+      <doi>10.1162/tacl.a.42</doi>
+      <abstract>Instruction tuning has emerged as a pivotal post-training paradigm that enables pre-trained language models to better follow user instructions. Despite its significance, little attention has been given to optimizing the loss function used. A fundamental, yet often overlooked, question is whether the conventional auto-regressive objective—where loss is computed only on response tokens, excluding prompt tokens—is truly optimal for instruction tuning. In this work, we systematically investigate the impact of differentially weighting prompt and response tokens in instruction tuning loss, and propose Weighted Instruction Tuning (WIT) as a better alternative to conventional instruction tuning. Through extensive experiments on five language models of different families and scale, three finetuning datasets of different sizes, and five diverse evaluation benchmarks, we show that the standard instruction tuning loss often yields suboptimal performance and limited robustness to input prompt variations. We find that a low-to-moderate weight for prompt tokens coupled with a moderate-to-high weight for response tokens yields the best-performing models across settings and also serves as a better starting point for the subsequent preference alignment training. These findings highlight the need to reconsider instruction-tuning loss and offer actionable insights for developing more robust and generalizable models. Our code is open-sourced here.</abstract>
+      <pages>1360–1380</pages>
+      <url>https://doi.org/10.1162/tacl.a.42</url>
+      <bibkey>chatterjee-etal-2025-effect</bibkey>
+    </paper>
+    <paper id="63">
+      <title>Adversarial Defense without Adversarial Defense : Enhancing Language Model Robustness via Instance-level Principal Component Removal</title>
+      <author>
+        <first>Yang</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Chenghao</first>
+        <last>Xiao</last>
+      </author>
+      <author>
+        <first>Yizhi</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Stuart E.</first>
+        <last>Middleton</last>
+      </author>
+      <author>
+        <first>Noura Al</first>
+        <last>Moubayed</last>
+      </author>
+      <author>
+        <first>Chenghua</first>
+        <last>Lin</last>
+      </author>
+      <doi>10.1162/tacl.a.43</doi>
+      <abstract>Pre-trained language models (PLMs) have driven substantial progress in natural language processing but remain vulnerable to adversarial attacks, raising concerns about their robustness in real-world applications. Previous studies have sought to mitigate the impact of adversarial attacks by introducing adversarial perturbations into the training process, either implicitly or explicitly. While both strategies enhance robustness, they often incur high computational costs. In this work, we propose a simple yet effective add-on module that enhances the adversarial robustness of PLMs by removing instance-level principal components, without relying on conventional adversarial defenses or perturbing the original training data. Our approach transforms the embedding space to approximate Gaussian properties, thereby reducing its susceptibility to adversarial perturbations while preserving semantic relationships. This transformation aligns embedding distributions in a way that minimizes the impact of adversarial noise on decision boundaries, enhancing robustness without requiring adversarial examples or costly training-time augmentation. Evaluations on eight benchmark datasets show that our approach improves adversarial robustness while maintaining comparable before-attack accuracy to baselines, achieving a balanced trade-off between robustness and generalization.</abstract>
+      <pages>1381–1409</pages>
+      <url>https://doi.org/10.1162/tacl.a.43</url>
+      <bibkey>wang-etal-2025-adversarial</bibkey>
+    </paper>
+    <paper id="64">
+      <title>QE4PE: Word-level Quality Estimation for Human Post-Editing</title>
+      <author>
+        <first>Gabriele</first>
+        <last>Sarti</last>
+      </author>
+      <author>
+        <first>Vilém</first>
+        <last>Zouhar</last>
+      </author>
+      <author>
+        <first>Grzegorz</first>
+        <last>Chrupała</last>
+      </author>
+      <author>
+        <first>Ana</first>
+        <last>Guerberof-Arenas</last>
+      </author>
+      <author>
+        <first>Malvina</first>
+        <last>Nissim</last>
+      </author>
+      <author>
+        <first>Arianna</first>
+        <last>Bisazza</last>
+      </author>
+      <doi>10.1162/tacl.a.46</doi>
+      <abstract>Word-level quality estimation (QE) methods aim to detect erroneous spans in machine translations, which can direct and facilitate human post-editing. While the accuracy of word-level QE systems has been assessed extensively, their usability and downstream influence on the speed, quality, and editing choices of human post-editing remain understudied. In this study, we investigate the impact of word-level QE on machine translation (MT) post-editing in a realistic setting involving 42 professional post-editors across two translation directions. We compare four error-span highlight modalities, including supervised and uncertainty-based word-level QE methods, for identifying potential errors in the outputs of a state-of-the-art neural MT model. Post-editing effort and productivity are estimated from behavioral logs, while quality improvements are assessed by word- and segment-level human annotation. We find that domain, language and editors’ speed are critical factors in determining highlights’ effectiveness, with modest differences between human-made and automated QE highlights underlining a gap between accuracy and usability in professional workflows.</abstract>
+      <pages>1410–1435</pages>
+      <url>https://doi.org/10.1162/tacl.a.46</url>
+      <bibkey>sarti-etal-2025-word</bibkey>
+    </paper>
+    <paper id="65">
+      <title>Frame Representation Hypothesis: Multi-Token LLM Interpretability and Concept-Guided Text Generation</title>
+      <author>
+        <first>Pedro H. V.</first>
+        <last>Valois</last>
+      </author>
+      <author>
+        <first>Lincon S.</first>
+        <last>Souza</last>
+      </author>
+      <author>
+        <first>Erica K.</first>
+        <last>Shimomoto</last>
+      </author>
+      <author>
+        <first>Kazuhiro</first>
+        <last>Fukui</last>
+      </author>
+      <doi>10.1162/tacl.a.48</doi>
+      <abstract>Interpretability is a key challenge in fostering trust for Large Language Models (LLMs), which stems from the complexity of extracting reasoning from a model’s parameters. We present the Frame Representation Hypothesis, a theoretically robust framework grounded in the Linear Representation Hypothesis (LRH) to interpret and control LLMs by modeling multi-token words. Prior research explored LRH to connect LLM representations with linguistic concepts, but was limited to single token analysis. As most words are composed of several tokens, we extend LRH to multi-token words, thereby enabling usage on any textual data with thousands of concepts. To this end, we propose that words can be interpreted as frames, ordered sequences of vectors that better capture token-word relationships. Then, concepts can be represented as the average of word frames sharing a common concept. We showcase these tools through Top-k Concept-Guided Decoding, which can intuitively steer text generation using concepts of choice. We verify said ideas on Llama 3, Gemma 2, Phi 3, and Qwen-2-VL families, demonstrating gender and language biases, exposing harmful content, but also potential to remediate them, leading to safer and more transparent LLMs. Code is available at this https url.</abstract>
+      <pages>1436–1458</pages>
+      <url>https://doi.org/10.1162/tacl.a.48</url>
+      <bibkey>valois-etal-2025-frame</bibkey>
+    </paper>
+    <paper id="66">
+      <title>Early Detection and Reduction of Memorization for Domain Adaptation and Instruction Tuning</title>
+      <author>
+        <first>Dean L.</first>
+        <last>Slack</last>
+      </author>
+      <author>
+        <first>Noura</first>
+        <last>Al Moubayed</last>
+      </author>
+      <doi>10.1162/tacl.a.49</doi>
+      <abstract>Although large language models excel across many tasks, they can memorize training data and thereby expose private or copyrighted text. Most defenses target the pre-training stage, leaving memorization during fine-tuning–especially for domain adaptation and instruction tuning–poorly understood. We fine-tune Pythia, Llama3, and Mistral models spanning 1.4B–70B parameters on common evaluation datasets and track verbatim memorization throughout training. We find that memorization increases dramatically in the first few epochs, often significantly before either validation perplexity or evaluation performance is optimized. We use a simple but effective n-gram memorization score which reliably precedes verbatim memorization; using it as an early-stopping criterion mitigates memorization with minimal performance loss. Further, we introduce an n-gram–aware loss regularizer and show that it reduces memorization across all model families tested by up to 40% while minimizing evaluation performance trade-offs when compared to an existing memorization mitigation strategy. These results yield practical, scalable insights into memorization dynamics during language model fine-tuning.</abstract>
+      <pages>1459–1473</pages>
+      <url>https://doi.org/10.1162/tacl.a.49</url>
+      <bibkey>slack-etal-2025-early</bibkey>
+    </paper>
+    <paper id="67">
+      <title>Safe Pruning LoRA: Robust Distance-Guided Pruning for Safety Alignment in Adaptation of LLMs</title>
+      <author>
+        <first>Shuang</first>
+        <last>Ao</last>
+      </author>
+      <author>
+        <first>Yi</first>
+        <last>Dong</last>
+      </author>
+      <author>
+        <first>Jinwei</first>
+        <last>Hu</last>
+      </author>
+      <author>
+        <first>Sarvapali D.</first>
+        <last>Ramchurn</last>
+      </author>
+      <doi>10.1162/tacl.a.44</doi>
+      <abstract>Fine-tuning Large Language Models (LLMs) with Low-Rank Adaptation (LoRA) enhances adaptability while reducing computational costs. However, fine-tuning can compromise safety alignment, even with benign data, increasing susceptibility to harmful outputs. Existing safety alignment methods struggle to capture complex parameter shifts, leading to suboptimal safety-utility trade-offs. To address this issue, we propose Safe Pruning LoRA (SPLoRA), a novel pruning-based approach that selectively removes LoRA layers that weaken safety alignment, improving safety while preserving performance. At its core, we introduce Empirical-DIEM (E-DIEM), a dimension-insensitive similarity metric that effectively detects safety misalignment in LoRA-adapted models. We conduct extensive experiments on LLMs fine-tuned with mixed of benign and malicious data, and purely benign datasets, evaluating SPLoRA across utility, safety, and reliability metrics. Results demonstrate that SPLoRA outperforms state-of-the-art safety alignment techniques, significantly reducing safety risks while maintaining or improving model performance and reliability. Additionally, SPLoRA reduces inference overhead, making it a scalable and efficient solution for deploying safer and more reliable LLMs. The code is available at https://github.com/AoShuang92/SPLoRA.</abstract>
+      <pages>1474–1487</pages>
+      <url>https://doi.org/10.1162/tacl.a.44</url>
+      <bibkey>ao-etal-2025-safe</bibkey>
+    </paper>
+    <paper id="68">
+      <title>CRVQ: Channel-Relaxed Vector Quantization for Extreme Compression of LLMs</title>
+      <author>
+        <first>Yuzhuang</first>
+        <last>Xu</last>
+      </author>
+      <author>
+        <first>Shiyu</first>
+        <last>Ji</last>
+      </author>
+      <author>
+        <first>Qingfu</first>
+        <last>Zhu</last>
+      </author>
+      <author>
+        <first>Wanxiang</first>
+        <last>Che</last>
+      </author>
+      <doi>10.1162/tacl.a.45</doi>
+      <abstract>Powerful large language models (LLMs) are increasingly expected to be deployed with lower computational costs, enabling their capabilities on resource-constrained devices. Post-training quantization (PTQ) has emerged as a star approach to achieve this ambition, with best methods compressing weights to less than 2 bit on average. In this paper, we propose Channel-Relaxed Vector Quantization (CRVQ), a novel technique that significantly improves the performance of PTQ baselines at the cost of only minimal additional bits. This state-of-the-art extreme compression method achieves its results through two key innovations: (1) carefully selecting and reordering a very small subset of critical weight channels, and (2) leveraging extended codebooks to relax the constraint of critical channels. With our method, we demonstrate a 38.9% improvement over the current strongest sub-2-bit PTQ baseline, enabling nearer lossless 1-bit compression. Furthermore, our approach offers flexible customization of quantization bit-width and performance, providing a wider range of deployment options for diverse hardware platforms. Code and checkpoints are available at https://github.com/xuyuzhuang11/CRVQ.</abstract>
+      <pages>1488–1506</pages>
+      <url>https://doi.org/10.1162/tacl.a.45</url>
+      <bibkey>xu-etal-2025-crvq</bibkey>
+    </paper>
+    <paper id="69">
+      <title>Benchmarking Linguistic Diversity of Large Language Models</title>
+      <author>
+        <first>Yanzhu</first>
+        <last>Guo</last>
+      </author>
+      <author>
+        <first>Guokan</first>
+        <last>Shang</last>
+      </author>
+      <author>
+        <first>Chloé</first>
+        <last>Clavel</last>
+      </author>
+      <doi>10.1162/tacl.a.47</doi>
+      <abstract>The development and evaluation of Large Language Models (LLMs) has primarily focused on their task-solving capabilities, with recent models even surpassing human performance in some areas. However, this focus often neglects whether machine-generated language matches the human level of diversity, in terms of vocabulary choice, syntactic construction, and expression of meaning, raising questions about whether the fundamentals of language generation have been fully addressed. This paper emphasizes the importance of examining the preservation of human linguistic richness by language models, given the concerning surge in online content produced or aided by LLMs. We adapt a comprehensive framework for evaluating LLMs from various linguistic diversity perspectives including lexical, syntactic, and semantic dimensions. Using this framework, we benchmark several state-of-the-art LLMs across all diversity dimensions, and conduct an in-depth analysis for syntactic diversity. Finally, we analyze how the design, development, and deployment choices of LLMs impact the linguistic diversity of their outputs, focusing on the creative task of story generation.</abstract>
+      <pages>1507–1526</pages>
+      <url>https://doi.org/10.1162/tacl.a.47</url>
+      <bibkey>guo-etal-2025-benchmarking</bibkey>
+    </paper>
+    <paper id="70">
+      <title>Objectifying the Subjective: Cognitive Biases in Topic Interpretations</title>
+      <author>
+        <first>Swapnil</first>
+        <last>Hingmire</last>
+      </author>
+      <author>
+        <first>Ze Shi</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Shiyu (Vivienne)</first>
+        <last>Zeng</last>
+      </author>
+      <author>
+        <first>Ahmed Musa</first>
+        <last>Awon</last>
+      </author>
+      <author>
+        <first>Luiz Franciscatto</first>
+        <last>Guerra</last>
+      </author>
+      <author>
+        <first>Neil</first>
+        <last>Ernst</last>
+      </author>
+      <doi>10.1162/tacl.a.50</doi>
+      <abstract>Interpretation of topics is crucial for their downstream applications. State-of-the-art evaluation measures of topic quality such as coherence and word intrusion do not measure how much a topic facilitates the exploration of a corpus. To design evaluation measures grounded on a task, and a population of users, we do user studies to understand how users interpret topics. We propose constructs of topic quality and ask users to assess them in the context of a topic and provide rationale behind evaluations. We use reflexive thematic analysis to identify themes of topic interpretations from rationales. Users interpret topics based on availability and representativeness heuristics rather than probability. We propose a theory of topic interpretation based on the anchoring-and-adjustment heuristic: users anchor on salient words and make semantic adjustments to arrive at an interpretation. Topic interpretation can be viewed as making a judgment under uncertainty by an ecologically rational user, and hence cognitive biases aware user models and evaluation frameworks are needed.</abstract>
+      <pages>1527–1559</pages>
+      <url>https://doi.org/10.1162/tacl.a.50</url>
+      <bibkey>hingmire-etal-2025-objectifying</bibkey>
+    </paper>
+    <paper id="71">
+      <title>Are Triggers Needed for Document-Level Event Extraction?</title>
+      <author>
+        <first>Shaden</first>
+        <last>Shaar</last>
+      </author>
+      <author>
+        <first>Wayne</first>
+        <last>Chen</last>
+      </author>
+      <author>
+        <first>Maitreyi</first>
+        <last>Chatterjee</last>
+      </author>
+      <author>
+        <first>Barry</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Wenting</first>
+        <last>Zhao</last>
+      </author>
+      <author>
+        <first>Claire</first>
+        <last>Cardie</last>
+      </author>
+      <doi>10.1162/tacl.a.51</doi>
+      <abstract>Most existing work on event extraction has focused on sentence-level texts and presumes the identification of a trigger-span—a word or phrase in the input that evokes the occurrence of an event of interest. Event arguments are then extracted with respect to the trigger. Indeed, triggers are treated as integral to, and trigger detection as an essential component of, event extraction. In this paper, we provide the first investigation of the role of triggers for the more difficult and much less studied task of document-level event extraction. We analyze their usefulness in multiple end-to-end and pipelined transformer-based event extraction models for three document-level event extraction datasets, measuring performance using triggers of varying quality (human-annotated, LLM-generated, keyword-based, and random). We find that whether or not systems benefit from explicitly extracting triggers depends both on dataset characteristics (i.e., the typical number of events per document) and task-specific information available during extraction (i.e., natural language event schemas). Perhaps surprisingly, we also observe that the mere existence of triggers in the input, even random ones, is important for prompt-based in-context learning approaches to the task.</abstract>
+      <pages>1560–1577</pages>
+      <url>https://doi.org/10.1162/tacl.a.51</url>
+      <bibkey>shaar-etal-2025-are</bibkey>
+    </paper>
+    <paper id="72">
+      <title>The Impact of Automatic Speech Transcription on Speaker Attribution</title>
+      <author>
+        <first>Cristina</first>
+        <last>Aggazzotti</last>
+      </author>
+      <author>
+        <first>Matthew</first>
+        <last>Wiesner</last>
+      </author>
+      <author>
+        <first>Elizabeth Allyn</first>
+        <last>Smith</last>
+      </author>
+      <author>
+        <first>Nicholas</first>
+        <last>Andrews</last>
+      </author>
+      <doi>10.1162/tacl.a.54</doi>
+      <abstract>Speaker attribution from speech transcripts is the task of identifying a speaker from the transcript of their speech based on patterns in their language use. This task is especially useful when the audio is unavailable (e.g., deleted) or unreliable (e.g., anonymized speech). Prior work in this area has primarily focused on the feasibility of attributing speakers using transcripts produced by human annotators. However, in real-world settings, one often only has more errorful transcripts produced by automatic speech recognition (ASR) systems. In this paper, we conduct what is, to our knowledge, the first comprehensive study of the impact of automatic transcription on speaker attribution performance. In particular, we study the extent to which speaker attribution performance degrades in the face of transcription errors, as well as how properties of the ASR system impact attribution. We find that attribution is surprisingly resilient to word-level transcription errors and that the objective of recovering the true transcript is minimally correlated with attribution performance. Overall, our findings suggest that speaker attribution on more errorful transcripts produced by ASR is as good, if not better, than attribution based on human-transcribed data, possibly because ASR transcription errors can capture speaker-specific features revealing of speaker identity.</abstract>
+      <pages>1578–1596</pages>
+      <url>https://doi.org/10.1162/tacl.a.54</url>
+      <bibkey>aggazzotti-etal-2025-impact</bibkey>
+    </paper>
+    <paper id="73">
+      <title>Surveying the Landscape of Image Captioning Evaluation: A Comprehensive Taxonomy, Trends, and Metrics Analysis</title>
+      <author>
+        <first>Uri</first>
+        <last>Berger</last>
+      </author>
+      <author>
+        <first>Gabriel</first>
+        <last>Stanovsky</last>
+      </author>
+      <author>
+        <first>Omri</first>
+        <last>Abend</last>
+      </author>
+      <author>
+        <first>Lea</first>
+        <last>Frermann</last>
+      </author>
+      <doi>10.1162/tacl.a.52</doi>
+      <abstract>The task of image captioning has recently been gaining popularity, and with it the complex task of evaluating the quality of image captioning models. In this work, we present the first survey and taxonomy of over 70 different image captioning metrics and their usage in hundreds of papers, specifically designed to help users select the most suitable metric for their needs. We find that despite the diversity of proposed metrics, the vast majority of studies rely on only five popular metrics, which we show to be weakly correlated with human ratings. We hypothesize that combining a diverse set of metrics can enhance correlation with human ratings. As an initial step, we demonstrate that a linear regression-based ensemble method, which we call EnsembEval, trained on one human ratings dataset, achieves improved correlation across five additional datasets, showing there is a lot of room for improvement by leveraging a diverse set of metrics.1</abstract>
+      <pages>1597–1644</pages>
+      <url>https://doi.org/10.1162/tacl.a.52</url>
+      <bibkey>berger-etal-2025-surveying</bibkey>
+    </paper>
+    <paper id="74">
+      <title>A Unifying Scheme for Extractive Content Selection Tasks</title>
+      <author>
+        <first>Shmuel</first>
+        <last>Amar</last>
+      </author>
+      <author>
+        <first>Ori</first>
+        <last>Shapira</last>
+      </author>
+      <author>
+        <first>Aviv</first>
+        <last>Slobodkin</last>
+      </author>
+      <author>
+        <first>Ido</first>
+        <last>Dagan</last>
+      </author>
+      <doi>10.1162/tacl.a.53</doi>
+      <abstract>A broad range of NLP tasks involve selecting relevant text spans from given source texts. Despite this shared objective, such content selection tasks have traditionally been studied in isolation, each with its own modeling approaches, datasets, and evaluation metrics. In this work, we propose instruction-guided content selection (IGCS) as a beneficial unified framework for such settings, where the task definition and any instance-specific request are encapsulated as instructions to a language model. To promote this framework, we introduce IGCS-Bench, the first unified benchmark covering diverse content selection tasks. Further, we create a large generic synthetic dataset that can be leveraged for diverse content selection tasks, and show that transfer learning with these datasets often boosts performance, whether dedicated training for the targeted task is available or not. Finally, we address generic inference time issues that arise in LLM-based modeling of content selection, assess a generic evaluation metric, and overall propose the utility of our resources and methods for future content selection models.1</abstract>
+      <pages>1645–1671</pages>
+      <url>https://doi.org/10.1162/tacl.a.53</url>
+      <bibkey>amar-etal-2025-unifying</bibkey>
+    </paper>
+    <paper id="75">
+      <title>BharatBBQ: A Multilingual Bias Benchmark for Question Answering in the Indian Context</title>
+      <author>
+        <first>Aditya</first>
+        <last>Tomar</last>
+      </author>
+      <author>
+        <first>Nihar Ranjan</first>
+        <last>Sahoo</last>
+      </author>
+      <author>
+        <first>Pushpak</first>
+        <last>Bhattacharyya</last>
+      </author>
+      <doi>10.1162/tacl.a.55</doi>
+      <abstract>Evaluating social biases in language models (LMs) is crucial for ensuring fairness and minimizing the reinforcement of harmful stereotypes in AI systems. Existing benchmarks, such as the Bias Benchmark for Question Answering (BBQ), primarily focus on Western contexts, limiting their applicability to the Indian context. To address this gap, we introduce BharatBBQ,1 a culturally adapted benchmark designed to assess biases in Hindi, English, Marathi, Bengali, Tamil, Telugu, Odia, and Assamese. BharatBBQ covers 13 social categories, including 3 intersectional groups, reflecting prevalent biases in the Indian sociocultural landscape. Our dataset contains 49,108 examples in one language that are expanded using translation and verification to 392,864 examples in eight different languages. We evaluate five multilingual LM families across zero- and few-shot settings, analyzing their bias and stereotypical bias scores. Our findings highlight persistent biases across languages and social categories and often amplified biases in Indian languages compared to English, demonstrating the necessity of linguistically and culturally grounded benchmarks for bias evaluation.</abstract>
+      <pages>1672–1692</pages>
+      <url>https://doi.org/10.1162/tacl.a.55</url>
+      <bibkey>tomar-etal-2025-bharatbbq</bibkey>
+    </paper>
+    <paper id="76">
+      <title>CRAFT Your Dataset: Task-Specific Synthetic Dataset Generation Through Corpus Retrieval and Augmentation</title>
+      <author>
+        <first>Ingo</first>
+        <last>Ziegler</last>
+      </author>
+      <author>
+        <first>Abdullatif</first>
+        <last>Köksal</last>
+      </author>
+      <author>
+        <first>Desmond</first>
+        <last>Elliott</last>
+      </author>
+      <author>
+        <first>Hinrich</first>
+        <last>Schütze</last>
+      </author>
+      <doi>10.1162/tacl.a.56</doi>
+      <abstract>Building high-quality datasets for specialized tasks is a time-consuming and resource-intensive process that often requires specialized domain knowledge. We propose Corpus Retrieval and Augmentation for Fine-Tuning (CRAFT), a method for generating synthetic datasets, given a small number of user-written few-shots that demonstrate the task to be performed. Given these examples, CRAFT uses large-scale public web-crawled corpora and similarity-based document retrieval to find other relevant human-written documents. Lastly, instruction-tuned large language models (LLMs) augment the retrieved documents into custom-formatted task samples, which then can be used for fine- tuning. We demonstrate that CRAFT can efficiently generate large-scale task-specific training datasets for four diverse tasks: biology, medicine, and commonsense question-answering (QA), as well as summarization. Our experiments show that CRAFT-based models outperform or match general LLMs on QA tasks, while exceeding models trained on human-curated summarization data by 46 preference points. CRAFT outperforms other synthetic dataset generation methods such as Self- and Evol-Instruct, and remains robust even when the quality of the initial few-shots varies.</abstract>
+      <pages>1693–1721</pages>
+      <url>https://doi.org/10.1162/tacl.a.56</url>
+      <bibkey>ziegler-etal-2025-craft</bibkey>
+    </paper>
+    <paper id="77">
+      <title>Persona-Aware Alignment Framework for Personalized Dialogue Generation</title>
+      <author>
+        <first>Guanrong</first>
+        <last>Li</last>
+      </author>
+      <author>
+        <first>Xinyu</first>
+        <last>Liu</last>
+      </author>
+      <author>
+        <first>Zhen</first>
+        <last>Wu</last>
+      </author>
+      <author>
+        <first>Xinyu</first>
+        <last>Dai</last>
+      </author>
+      <doi>10.1162/tacl.a.57</doi>
+      <abstract>Personalized dialogue generation aims to leverage persona profiles and dialogue history to generate persona-relevant and consistent responses. Mainstream models typically rely on token-level language model training with persona dialogue data, such as Next Token Prediction, to implicitly achieve personalization, meaning that these methods tend to neglect the given personas and generate generic responses. To address this issue, we propose a novel Persona-Aware Alignment Framework (PAL), which directly treats persona alignment as the training objective of dialogue generation. Specifically, PAL employs a two-stage training method including Persona-Aware Learning and Persona Alignment, equipped with an easy-to-use inference strategy Select then Generate, to improve persona sensitivity and generate more persona-relevant responses at the semantics level. Through extensive experiments, we demonstrate that our framework outperforms many state-of-the-art personalized dialogue methods and large language models.</abstract>
+      <pages>1722–1742</pages>
+      <url>https://doi.org/10.1162/tacl.a.57</url>
+      <bibkey>li-etal-2025-persona</bibkey>
+    </paper>
+    <paper id="78">
+      <title>Large Language Models Are Human-Like Internally</title>
+      <author>
+        <first>Tatsuki</first>
+        <last>Kuribayashi</last>
+      </author>
+      <author>
+        <first>Yohei</first>
+        <last>Oseki</last>
+      </author>
+      <author>
+        <first>Souhaib Ben</first>
+        <last>Taieb</last>
+      </author>
+      <author>
+        <first>Kentaro</first>
+        <last>Inui</last>
+      </author>
+      <author>
+        <first>Timothy</first>
+        <last>Baldwin</last>
+      </author>
+      <doi>10.1162/tacl.a.58</doi>
+      <abstract>Recent cognitive modeling studies have reported that larger language models (LMs) exhibit a poorer fit to human reading behavior (Oh and Schuler, 2023b; Shain et al., 2024; Kuribayashi et al., 2024), leading to claims of their cognitive implausibility. In this paper, we revisit this argument through the lens of mechanistic interpretability and argue that prior conclusions were skewed by an exclusive focus on the final layers of LMs. Our analysis reveals that next-word probabilities derived from internal layers of larger LMs align with human sentence processing data as well as, or better than, those from smaller LMs. This alignment holds consistently across behavioral (self-paced reading times, gaze durations, MAZE task processing times) and neurophysiological (N400 brain potentials) measures, challenging earlier mixed results and suggesting that the cognitive plausibility of larger LMs has been underestimated. Furthermore, we first identify an intriguing relationship between LM layers and human measures: Earlier layers correspond more closely with fast gaze durations, while later layers better align with relatively slower signals such as N400 potentials and MAZE processing times. Our work opens new avenues for interdisciplinary research at the intersection of mechanistic interpretability and cognitive modeling.1</abstract>
+      <pages>1743–1766</pages>
+      <url>https://doi.org/10.1162/tacl.a.58</url>
+      <bibkey>kuribayashi-etal-2025-large</bibkey>
+    </paper>
+    <paper id="79">
+      <title>Step-by-Step Unmasking for Parameter-Efficient Fine-Tuning of Large Language Models</title>
+      <author>
+        <first>Aradhye</first>
+        <last>Agarwal</last>
+      </author>
+      <author>
+        <first>Suhas Kamasetty</first>
+        <last>Ramesh</last>
+      </author>
+      <author>
+        <first>Ayan</first>
+        <last>Sengupta</last>
+      </author>
+      <author>
+        <first>Tanmoy</first>
+        <last>Chakraborty</last>
+      </author>
+      <doi>10.1162/tacl.a.59</doi>
+      <abstract>Fine-tuning large language models (LLMs) on downstream tasks requires substantial computational resources. Selective-PEFT, a class of parameter-efficient fine-tuning (PEFT) methodologies, aims to mitigate these computational challenges by selectively fine-tuning only a small fraction of the model parameters. Although parameter-efficient, these techniques often fail to match the performance of fully fine-tuned models, primarily due to inherent biases introduced during parameter selection. Traditional selective-PEFT techniques use a fixed set of parameters selected using different importance heuristics, failing to capture parameter importance dynamically and often leading to suboptimal performance. We introduce ID3, a novel selective-PEFT method that calculates parameter importance continually, and dynamically unmasks parameters by balancing exploration and exploitation in parameter selection. Our empirical study on 16 tasks spanning natural language understanding, mathematical reasoning, and summarization demonstrates the effectiveness of our method compared to fixed-masking selective-PEFT techniques. We analytically show that ID3 reduces the number of gradient updates by a factor of two, enhancing computational efficiency. Since ID3 is robust to random initialization of neurons and operates directly on the optimization process, it is highly flexible and can be integrated with existing additive and reparameterization-based PEFT techniques such as Adapters and LoRA, respectively.1</abstract>
+      <pages>1767–1788</pages>
+      <url>https://doi.org/10.1162/tacl.a.59</url>
+      <bibkey>agarwal-etal-2025-step</bibkey>
+    </paper>
+    <paper id="80">
+      <title>How to Select Datapoints for Efficient Human Evaluation of NLG Models?</title>
+      <author>
+        <first>Vilém</first>
+        <last>Zouhar</last>
+      </author>
+      <author>
+        <first>Peng</first>
+        <last>Cui</last>
+      </author>
+      <author>
+        <first>Mrinmaya</first>
+        <last>Sachan</last>
+      </author>
+      <doi>10.1162/tacl.a.60</doi>
+      <abstract>Human evaluation is the gold standard for evaluating text generation models. However, it is expensive. In order to fit budgetary constraints, a random subset of the test data is often chosen in practice for human evaluation. However, randomly selected data may not accurately represent test performance, making this approach economically inefficient for model comparison. Thus, in this work, we develop and analyze a suite of selectors to get the most informative datapoints for human evaluation, taking the evaluation costs into account. We show that selectors based on variance in automated metric scores, diversity in model outputs, or Item Response Theory outperform random selection. We further develop an approach to distill these selectors to the scenario where the model outputs are not yet available. In particular, we introduce source-based estimators, which predict item usefulness for human evaluation just based on the source texts. We demonstrate the efficacy of our selectors in two common NLG tasks, machine translation and summarization, and show that only ∼70% of the test data is needed to produce the same evaluation result as the entire data.</abstract>
+      <pages>1789–1811</pages>
+      <url>https://doi.org/10.1162/tacl.a.60</url>
+      <bibkey>zouhar-etal-2025-select</bibkey>
+    </paper>
+    <paper id="81">
+      <title>RepreGuard: Detecting LLM-Generated Text by Revealing Hidden Representation Patterns</title>
+      <author>
+        <first>Xin</first>
+        <last>Chen</last>
+      </author>
+      <author>
+        <first>Junchao</first>
+        <last>Wu</last>
+      </author>
+      <author>
+        <first>Shu</first>
+        <last>Yang</last>
+      </author>
+      <author>
+        <first>Runzhe</first>
+        <last>Zhan</last>
+      </author>
+      <author>
+        <first>Zeyu</first>
+        <last>Wu</last>
+      </author>
+      <author>
+        <first>Ziyang</first>
+        <last>Luo</last>
+      </author>
+      <author>
+        <first>Di</first>
+        <last>Wang</last>
+      </author>
+      <author>
+        <first>Min</first>
+        <last>Yang</last>
+      </author>
+      <author>
+        <first>Lidia S.</first>
+        <last>Chao</last>
+      </author>
+      <author>
+        <first>Derek F.</first>
+        <last>Wong</last>
+      </author>
+      <doi>10.1162/tacl.a.61</doi>
+      <abstract>Detecting content generated by large language models (LLMs) is crucial for preventing misuse and building trustworthy AI systems. Although existing detection methods perform well, their robustness in out-of-distribution (OOD) scenarios is still lacking. In this paper, we hypothesize that, compared to features used by existing detection methods, the internal representations of LLMs contain more comprehensive and raw features that can more effectively capture and distinguish the statistical pattern differences between LLM-generated texts (LGT) and human-written texts (HWT). We validated this hypothesis across different LLMs and observed significant differences in neural activation patterns when processing these two types of texts. Based on this, we propose RepreGuard, an efficient statistics-based detection method. Specifically, we first employ a surrogate model to collect representation of LGT and HWT, and extract the distinct activation feature that can better identify LGT. We can classify the text by calculating the projection score of the text representations along this feature direction and comparing with a precomputed threshold. Experimental results show that RepreGuard outperforms all baselines with average 94.92% AUROC on both in-distribution and OOD scenarios, while also demonstrating robust resilience to various text sizes and mainstream attacks.1</abstract>
+      <pages>1812–1831</pages>
+      <url>https://doi.org/10.1162/tacl.a.61</url>
+      <bibkey>chen-etal-2025-repreguard</bibkey>
+    </paper>
+    <paper id="82">
+      <title>Towards More Realistic Extraction Attacks: An Adversarial Perspective</title>
+      <author>
+        <first>Yash</first>
+        <last>More</last>
+      </author>
+      <author>
+        <first>Prakhar</first>
+        <last>Ganesh</last>
+      </author>
+      <author>
+        <first>Golnoosh</first>
+        <last>Farnadi</last>
+      </author>
+      <doi>10.1162/tacl.a.62</doi>
+      <abstract>Language models are prone to memorizing their training data, making them vulnerable to extraction attacks. While existing research often examines isolated setups, such as a single model or a fixed prompt, real-world adversaries have a considerably larger attack surface due to access to models across various sizes and checkpoints, and repeated prompting. In this paper, we revisit extraction attacks from an adversarial perspective—with multi-faceted access to the underlying data. We find significant churn in extraction trends, i.e., even unintuitive changes to the prompt, or targeting smaller models and earlier checkpoints, can extract distinct information. By combining multiple attacks, our adversary doubles (2 ×) the extraction risks, persisting even under mitigation strategies like data deduplication. We conclude with four case studies, including detecting pre-training data, copyright violations, extracting personally identifiable information, and attacking closed-source models, showing how our more realistic adversary can outperform existing adversaries in the literature.</abstract>
+      <pages>1832–1849</pages>
+      <url>https://doi.org/10.1162/tacl.a.62</url>
+      <bibkey>more-etal-2025-towards</bibkey>
     </paper>
   </volume>
 </collection>


### PR DESCRIPTION
## Summary
- Add **49 new papers** from TACL Volume 13 (pages 744-1849)
- Total papers in `2025.tacl.xml`: **82**

## Details
Papers were ingested using metadata from the CrossRef API. Two papers not yet indexed by CrossRef were added manually from the MIT Press website:
- MAKE: Memory-Associated Knowledge Editing (pages 938-952)
- Investigating Adversarial Trigger Transfer in Large Language Models (pages 953-979)

## URLs
New papers use DOI URLs (`https://doi.org/10.1162/...`) that redirect to MIT Press, since PDF files are not yet available for anthology hosting. When PDFs become available, maintainers can update the URLs to the standard anthology format with hashes.

## Checklist
- [x] XML validates correctly  
- [x] All 49 new papers added with metadata from CrossRef
- [x] Papers sorted by page number
- [x] URLs point to valid DOI links (MIT Press)

Resolves #6796

🤖 Generated with [Claude Code](https://claude.ai/code)

1. [ ] In the Github sidebar, add the PR to the current milestone
1. [ ] In the Github sidebar, add the PR to the "Anthology Work Items" project
1. [ ] In the Github sidebar, under "Development", link to the corresponding ingestion issue (if applicable)
1. [ ] Make sure the branch is merged with the latest `master` branch
1. [ ] Ensure that there are editors listed in the `<meta>` block
1. [ ] For workshops, add a `<venue>ws</venue>` tag to its meta block
1. [ ] For workshops, add a backlink from the main event's `<event>` block
1. [ ] Add events to their relevant SIGs
1. [ ] Look at the venue listing for prior years, and ensure that the new volume titles are consistent. You can do this by clicking on the venue name from a paper page, which will take you to the vendor listing.
1. [ ] Navigate to the event page preview (e.g., https://preview.aclanthology.org/icnlsp-ingestion/events/icnlsp-2021/), and page through, to see if there are any glaring mistakes
1. [ ] Skim through the complete listing, looking for mis-parsed author names.
1. [ ] Download the frontmatter and verify that the table of contents matches at least three randomly-selected papers
1. [ ] Download 3–5 PDFs (including the first and last one) and make sure they are correct (title, authors, page numbers).

After the PR is closed, for all events:
- [ ] Archive the ingestion materials in format `YYYY-MM-DD-{event}`

After the PR is closed, for ACL events:
- [ ] Generate the DOIs for all volumes (`generate_crossref_doi_metadata.py`)
- [ ] Upload to [Crossref](https://doi.crossref.org/servlet/home)
- [ ] Add the DOIs to the XML in a separate PR (`add_dois.py`)
