### PR TITLE
disable name matching for verified author hung-le

### DIFF
--- a/data/yaml/people.yaml
+++ b/data/yaml/people.yaml
@@ -21794,10 +21794,10 @@ hujun-yin:
   orcid: 0000-0002-9198-5401
 hung-le:
   comment: Deakin University
+  degree: Deakin University
   disable_name_matching: true
   names:
   - {first: Hung, last: Le}
-  - {first: Le Minh, last: Hung}
   orcid: 0000-0002-3126-184X
 hung-ting-hsieh:
   names:


### PR DESCRIPTION
As described in #5159, https://aclanthology.org/people/hung-le/ has a mix of authors.