### PR TITLE
Restore preview generation for branches with /

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -56,7 +56,8 @@ jobs:
       shell: bash
       run: |
         raw_branch="${GITHUB_REF#refs/heads/}"
-        server_branch="${raw_branch//\//_}"
+        branch="${raw_branch//\//_}"
+        echo "branch=$(echo ${branch})" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: list changes
       shell: bash

--- a/bin/get_changes_from_git_diff.py
+++ b/bin/get_changes_from_git_diff.py
@@ -24,6 +24,7 @@ Example usage:
 
     git diff --name-only master | ./bin/get_changes_from_git_diff.py https://preview.aclanthology.org/BRANCH
 
+The argument to the script is the URL root for the preview.
 
 """
 


### PR DESCRIPTION
Workflow target `*` doesn't match `/`. Also updated the server directory so it will remove the nesting. This creates a potential conflict if we have two branches, `fix/issue` and `fix_issue`, so let's not do that.