### PR TITLE
Fix paper metadata dialog: make author addition/deletion explicit in JSON

### DIFF
--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -123,7 +123,7 @@
   };
 
   const deleted_authors = [];
-  
+
   // Initial authors data
   function showMetadataDialog() {
     // Populate the modal with current values


### PR DESCRIPTION
This will add a `deleted_authors` list and explicitly say "##ADDED##" for the ID of added authors to support the new bulk metadata processing script (#7274), which requires explicit matching of author IDs between the old and new lists.