### PR TITLE
bulk_process_metadata.py: switch to non-deprecated resolve()

### DIFF
--- a/bin/correct/bulk_process_metadata.py
+++ b/bin/correct/bulk_process_metadata.py
@@ -357,7 +357,7 @@ class AnthologyMetadataUpdater:
         # they do not have hidden attributes like affiliations attached
         current_author_namespecs_by_id = {}
         for current_author in paper.authors or paper.parent.editors:
-            person = self.anthology.resolve(current_author)
+            person = current_author.resolve()
             if person.id in current_author_namespecs_by_id:
                 # duplicate. check that namespecs are identical
                 assert current_author == (
@@ -368,7 +368,7 @@ class AnthologyMetadataUpdater:
 
         # edit current namespecs for non-added authors. this retains any existing hidden attributes like orcid
         for current_author in paper.authors or paper.parent.editors:
-            person = self.anthology.resolve(current_author)
+            person = current_author.resolve()
             if person.id in retained_author_json_by_id:
                 retained_author_json_by_id[person.id]["namespec"] = current_author
                 # update namespec based on JSON


### PR DESCRIPTION
Update for the Python library release 1.1.0 (#7688)