### PR TITLE
Enable SIG YAML saving in save_all

### DIFF
--- a/python/acl_anthology/anthology.py
+++ b/python/acl_anthology/anthology.py
@@ -232,11 +232,8 @@ class Anthology:
             self.people.save()
         if self.venues.is_data_loaded:
             self.venues.save()
-        warnings.warn(
-            UserWarning(
-                "SIG metadata is not yet automatically saved.  Call `.sigs.save()` manually if you need this."
-            )
-        )
+        if self.sigs.is_data_loaded:
+            self.sigs.save()
         return self
 
     def reset_indices(self) -> Self:

--- a/python/docs/guide/modifying-data.md
+++ b/python/docs/guide/modifying-data.md
@@ -20,10 +20,7 @@ are some rules of thumb when making modifications to the data:
     - It also includes persons where `Person.is_explicit == True`, as those have
       an explicit representation in `people.yaml`.
 3. **Saving data is always non-destructive**.  In XML files, it will also avoid
-   introducing unnecessary changes (e.g. no needless reordering of tags).  The
-   only exception to this is saving SIG YAML files, as they currently frequently
-   contain comments, which will be lost when saving these files through the
-   library.
+   introducing unnecessary changes (e.g. no needless reordering of tags).
 4. If you need to refer to indices such as
    [PersonIndex][acl_anthology.people.index.PersonIndex],
    [EventIndex][acl_anthology.collections.eventindex.EventIndex], or
@@ -373,8 +370,3 @@ caveats:
 - **YAML files will always be written**.  Serializing all YAML files is much
   faster than serializing all XML files, so they are written unconditionally,
   without tracking changes.
-
-- **SIG YAML files are currently not written automatically**.  This is because
-  the current format of the SIG YAML files is a bit arcane, and existing files
-  use a lot of comments, which would be deleted upon writing these files.
-  {==This may change in the future.==}

--- a/python/tests/anthology_integration_test.py
+++ b/python/tests/anthology_integration_test.py
@@ -60,7 +60,6 @@ def full_anthology():
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::acl_anthology.exceptions.SchemaMismatchWarning")
-@pytest.mark.filterwarnings("ignore:SIG metadata:UserWarning")
 def test_anthology_from_repo(tmp_path):
     # Test that we can instantiate from the GitHub repo
     anthology = Anthology.from_repo(path=tmp_path, verbose=True)

--- a/python/tests/anthology_test.py
+++ b/python/tests/anthology_test.py
@@ -20,6 +20,7 @@ from acl_anthology import Anthology
 from acl_anthology.collections import Collection
 from acl_anthology.people import PersonIndex, Name
 from acl_anthology.venues import VenueIndex
+from acl_anthology.sigs import SIGIndex
 
 
 def test_instantiate(shared_datadir):
@@ -198,7 +199,7 @@ def test_save_all(anthology):
         patch.object(Collection, "save", autospec=True) as mock,
         patch.object(PersonIndex, "save") as people_mock,
         patch.object(VenueIndex, "save") as venue_mock,
-        pytest.warns(UserWarning),
+        patch.object(SIGIndex, "save") as sig_mock,
     ):
         anthology.save_all()
 
@@ -211,3 +212,4 @@ def test_save_all(anthology):
         # Check the others
         people_mock.assert_called_once()
         venue_mock.assert_called_once()
+        sig_mock.assert_called_once()


### PR DESCRIPTION
Since a recent ingestion overwrote all SIG YAML files with their canonical versions anyway, there’s no reason not to save them anymore as part of `save_all()`.