### PR TITLE
Add PersonIndex.remove_person

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `PersonIndex.remove_person()` to properly remove a Person from the index, and make `Person.merge_into()` call this. (fixes #8068)
+
 ### Changed
 
 - **Breaking change:** Collection items now use tuples instead of list attributes, and many objects that can be child attributes on collections (e.g. PDFReference, PaperRevision, ...) have been made immutable.

--- a/python/acl_anthology/people/index.py
+++ b/python/acl_anthology/people/index.py
@@ -400,6 +400,33 @@ class PersonIndex(SlottedDict[Person]):
             self._similar.add(similar_id)  # might not have been added yet
             self._similar.merge(pid, similar_id)
 
+    def remove_person(self, person: Person) -> None:
+        """Remove a person from the index.
+
+        Warning:
+            The person object should not be used in any way after this operation.
+
+        Parameters:
+            person: The person to remove, which must be explicit.
+
+        Raises:
+            ValueError: If the person does not exist in in the index, is not explicit, or if there are still NameSpecifications associated with this person.
+        """
+        if (pid := person.id) not in self.data:
+            raise ValueError(f"A Person with ID '{pid}' does not exist in the index")
+        if not person.is_explicit:
+            raise ValueError(f"Cannot remove Person with ID '{pid}' that is not explicit")
+        if person.item_ids:
+            raise ValueError(
+                f"Cannot remove Person with ID '{pid}' that still has items associated with them"
+            )
+
+        person.orcid = None  # ensure ORCID gets removed from index
+        for name in person.names:
+            self._remove_name(pid, name)
+        person.is_explicit = False
+        del self.data[pid]
+
     def create(
         self,
         id: str,
@@ -485,7 +512,7 @@ class PersonIndex(SlottedDict[Person]):
         """
         if not self.is_data_loaded:
             return
-        if old is not None and old in self._by_orcid:
+        if old is not None and self._by_orcid.get(old) == pid:
             del self._by_orcid[old]
         if new is not None:
             self._by_orcid[new] = pid

--- a/python/acl_anthology/people/name.py
+++ b/python/acl_anthology/people/name.py
@@ -376,6 +376,12 @@ class NameSpecification:
             if person_before != person_after:
                 person_before.item_ids.discard(self.parent.full_id_tuple)
                 person_after.item_ids.add(self.parent.full_id_tuple)
+                if (
+                    hasattr(self.parent, "frontmatter")
+                    and (frontmatter := self.parent.frontmatter) is not None
+                ):
+                    person_before.item_ids.discard(frontmatter.full_id_tuple)
+                    person_after.item_ids.add(frontmatter.full_id_tuple)
         else:
             self._name = _Name_from(value)
 
@@ -398,6 +404,12 @@ class NameSpecification:
             if person_before != person_after:
                 person_before.item_ids.discard(self.parent.full_id_tuple)
                 person_after.item_ids.add(self.parent.full_id_tuple)
+                if (
+                    hasattr(self.parent, "frontmatter")
+                    and (frontmatter := self.parent.frontmatter) is not None
+                ):
+                    person_before.item_ids.discard(frontmatter.full_id_tuple)
+                    person_after.item_ids.add(frontmatter.full_id_tuple)
         else:
             self._id = value
 

--- a/python/acl_anthology/people/person.py
+++ b/python/acl_anthology/people/person.py
@@ -337,6 +337,8 @@ class Person:
 
         This will move all attributes, papers, and volumes currently associated with this person over to the `other` person.  The other person's ID will be explicitly set on all items currently associated with this person.  If an attribute (e.g. ORCID iD, comment) is already set on the other person, it will _not_ be changed.
 
+        This Person object should no longer be used after calling this function.
+
         Parameters:
             other: A person to merge this person into.  Must be explicit.
 
@@ -360,6 +362,10 @@ class Person:
             other.add_name(name, inferred=False)
         for namespec in namespecs:
             namespec.id = other.id
+
+        if self.is_explicit:
+            # This person should no longer exist
+            self.parent.remove_person(self)
 
     def set_id_on_items(
         self, exclude: Optional[list[AnthologyID | Paper | Volume]] = None

--- a/python/tests/data/anthology/yaml/people.yaml
+++ b/python/tests/data/anthology/yaml/people.yaml
@@ -1,3 +1,7 @@
+aline-villavicencio-test:
+  disable_name_matching: true
+  names:
+  - {first: Aline, last: Villavicencio}
 emily-prudhommeaux:
   names:
   - {first: Emily, last: Prud’hommeaux}

--- a/python/tests/people/person_test.py
+++ b/python/tests/people/person_test.py
@@ -352,17 +352,26 @@ def test_person_merge_into_verified_verified(anthology, pid1, pid2):
     person2 = anthology.get_person(pid2)
     expected_canonical_name = person2.canonical_name
 
-    # Test merging
     person1.merge_into(person2)
+
+    # Item assignment should have changed
     assert not person1.item_ids
     assert set(person2.item_ids) == {("2022.naloma", "1", "7"), ("2022.naloma", "1", "8")}
     namespec = anthology.get_paper(("2022.naloma", "1", "8")).authors[0]
     assert namespec.id == pid2
+
+    # New person should have the old person's attributes
     assert person2.has_name(Name("M.", "Bollmann"))
     assert person2.has_name(Name("Marcel", "Bollmann"))
     assert person2.canonical_name == expected_canonical_name
     assert person2.degree == "Ruhr-Universität Bochum"
     assert person2.orcid == "0000-0003-2598-8150"
+
+    # Old person should no longer exist in index
+    assert anthology.people.get_by_orcid("0000-0003-2598-8150") is person2
+    assert set(anthology.people.get_by_name(Name("Marcel", "Bollmann"))) == set([person2])
+    assert pid2 in anthology.people
+    assert pid1 not in anthology.people
 
     anthology.reset_indices()
 

--- a/python/tests/people/personindex_test.py
+++ b/python/tests/people/personindex_test.py
@@ -775,9 +775,33 @@ def test_namespec_change_name_affects_name_resolution(anthology):
     namespec.name = Name("Nathan Middlename", "Noiry")
     person2 = namespec.resolve()
     assert person2 is not person1
+    assert person2.id == UNVERIFIED_PID_FORMAT.format(pid="nathan-middlename-noiry")
     assert item_id not in person1.item_ids
     assert item_id in person2.item_ids
-    assert person2.id == UNVERIFIED_PID_FORMAT.format(pid="nathan-middlename-noiry")
+
+
+def test_namespec_change_name_affects_volume_and_frontmatter(anthology):
+    index = anthology.people
+    # Precondition: Find a volume that resolves to a given (unverified) person
+    item_id = ("2022.acl", "long", None)
+    frontmatter_id = ("2022.acl", "long", "0")
+    namespec = anthology.get_volume(item_id).editors[-1]
+    person1 = index.get(UNVERIFIED_PID_FORMAT.format(pid="aline-villavicencio"))
+    assert namespec.resolve() is person1
+    assert item_id in person1.item_ids
+    assert frontmatter_id in person1.item_ids
+
+    # Changing the name should move the volume AND its frontmatter
+    namespec.name = Name("Aline Middlename", "Villavicencio")
+    person2 = namespec.resolve()
+    assert person2 is not person1
+    assert person2.id == UNVERIFIED_PID_FORMAT.format(
+        pid="aline-middlename-villavicencio"
+    )
+    assert item_id not in person1.item_ids
+    assert frontmatter_id not in person1.item_ids
+    assert item_id in person2.item_ids
+    assert frontmatter_id in person2.item_ids
 
 
 def test_namespec_change_id_affects_name_resolution(anthology):
@@ -796,6 +820,28 @@ def test_namespec_change_id_affects_name_resolution(anthology):
     assert namespec.resolve() is person2
     assert item_id not in person1.item_ids
     assert item_id in person2.item_ids
+
+
+def test_namespec_change_id_affects_volume_and_frontmatter(anthology):
+    index = anthology.people
+    # Precondition: Find a volume that resolves to a given (unverified) person
+    item_id = ("2022.acl", "long", None)
+    frontmatter_id = ("2022.acl", "long", "0")
+    namespec = anthology.get_volume(item_id).editors[-1]
+    person1 = index.get(UNVERIFIED_PID_FORMAT.format(pid="aline-villavicencio"))
+    assert namespec.resolve() is person1
+    assert item_id in person1.item_ids
+    assert frontmatter_id in person1.item_ids
+
+    # Changing the name should move the volume AND its frontmatter
+    namespec.id = "aline-villavicencio-test"
+    person2 = namespec.resolve()
+    assert person2 is not person1
+    assert person2.id == "aline-villavicencio-test"
+    assert item_id not in person1.item_ids
+    assert frontmatter_id not in person1.item_ids
+    assert item_id in person2.item_ids
+    assert frontmatter_id in person2.item_ids
 
 
 def test_namespec_remove_id_affects_name_resolution(anthology):

--- a/python/tests/people/personindex_test.py
+++ b/python/tests/people/personindex_test.py
@@ -85,6 +85,44 @@ def test_add_person(index_stub):
         index.add_person(Person("yang-liu", index))
 
 
+def test_remove_person(index):
+    # Preconditions
+    pid = "xu-huang-nanjing"
+    name = Name("Xu", "Huang")
+    person = index[pid]
+    assert index._by_orcid.get("0009-0006-0385-4054") == pid
+    assert pid in index._by_name[name]
+    assert pid in index._slugs_to_verified_ids["xu-huang"]
+    assert len(person.item_ids) == 0
+
+    # Remove person
+    index.remove_person(person)
+
+    assert pid not in index
+    assert index._by_orcid.get("0009-0006-0385-4054") is None
+    assert pid not in index._by_name[name]
+    assert pid not in index._slugs_to_verified_ids["xu-huang"]
+
+    with pytest.raises(ValueError):
+        # Can't remove again...
+        index.remove_person(person)
+
+
+def test_remove_person_should_raise(index):
+    assert "yang-liu/unverified" in index
+    person1 = index["yang-liu/unverified"]
+    # Can't remove unverified
+    with pytest.raises(ValueError):
+        index.remove_person(person1)
+
+    assert "yang-liu-icsi" in index
+    person2 = index["yang-liu-icsi"]
+    assert len(person2.item_ids) > 0
+    # Can't remove if papers still attached to Person
+    with pytest.raises(ValueError):
+        index.remove_person(person2)
+
+
 def test_similar_names_defined_in_people_index(index_stub):
     index = index_stub
     index.reset()


### PR DESCRIPTION
Surprisingly, there was no clean way to remove a person from the index yet. Closes #8068.