### PR TITLE
Fix bug to preserve Name.script attributes

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `PersonIndex.create` now deduplicates list of names (#7858)
 - `Event.colocated_ids` and `EventIndex.reverse` will now update dynamically when a Volume's `venue_ids` attribute is modified, or when a new Volume is created.
 - `Venue.item_ids` will now update dynamically when a Volume's `venue_ids` attribute is modified, or when a new Volume is created.
+- Fix a bug in `Name` where "script" attributes were not always preserved.
 
 ### Removed
 

--- a/python/acl_anthology/people/name.py
+++ b/python/acl_anthology/people/name.py
@@ -195,7 +195,7 @@ class Name:
     def from_dict(cls, name: dict[str, str]) -> Name:
         """
         Parameters:
-            name: A dictionary with "first" and "last" keys.
+            name: A dictionary with at least a "last" key, and optionally "first" and "script" keys.
 
         Returns:
             A corresponding Name object.
@@ -203,6 +203,7 @@ class Name:
         return cls(
             name.get("first"),
             name["last"],
+            script=name.get("script"),
         )
 
     @classmethod

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,7 +49,7 @@ packages = [{ include = "acl_anthology" }]
 repository = "https://github.com/acl-org/acl-anthology"
 
 [build-system]
-requires = ["uv_build>=0.9.17,<0.10.0"]
+requires = ["uv_build>=0.10.12,<0.11.0"]
 build-backend = "uv_build"
 
 [dependency-groups]

--- a/python/tests/data/anthology/yaml/people.yaml
+++ b/python/tests/data/anthology/yaml/people.yaml
@@ -54,6 +54,7 @@ yang-liu-icsi:
   comment: 刘扬; Ph.D Purdue; ICSI, Dallas, Facebook, Liulishuo, Amazon
   names:
   - {first: Yang, last: Liu}
+  - {first: 刘, last: 扬, script: hani}
 yang-liu-ict:
   comment: 刘洋; ICT, Tsinghua, Beijing Academy of Artificial Intelligence
   names:


### PR DESCRIPTION
This fix enables us to also use the "script" attribute for names in people.yaml, not just in the XML. I don’t really know why this wasn’t a thing already. Came up in #8156.