### PR TITLE
paper page: allow overlong attachment type label to wrap

### DIFF
--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -632,7 +632,7 @@
 
         {{ range $paper.attachment }}
         <dt class="acl-button-row">{{ humanize .type }}:</dt>
-        <dd class="acl-button-row"><a href="{{ .url }}" class="btn btn-attachment btn-sm">{{ partial
+        <dd class="acl-button-row"><a href="{{ .url }}" class="btn btn-attachment btn-sm text-wrap">{{ partial
             "attachment_repr.html" . }}&nbsp;{{ .filename }}</a></dd>
         {{ end }}
 
@@ -676,7 +676,7 @@
         <i class="ai ai-semantic-scholar"></i><span class="ps-sm-2 d-none d-sm-inline">Search</span>
       </a>
       {{ range $paper.attachment }}
-      <a class="btn btn-attachment d-flex flex-wrap justify-content-center" href="{{ .url }}"
+      <a class="btn btn-attachment d-flex flex-wrap justify-content-center text-wrap" href="{{ .url }}"
         title="Open {{ .type | humanize | lower }} for '{{ $paper.title | htmlEscape }}'">
         <span class="align-self-center px-1">{{ partial "attachment_repr.html" . -}}</span>
         <span class="px-1">{{ humanize .type }}</span>

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -631,8 +631,8 @@
         {{ end }}
 
         {{ range $paper.attachment }}
-        <dt class="acl-button-row">{{ humanize .type }}:</dt>
-        <dd class="acl-button-row"><a href="{{ .url }}" class="btn btn-attachment btn-sm text-wrap">{{ partial
+        <dt class="acl-button-row text-break" style="white-space: normal">{{ humanize .type }}:</dt>
+        <dd class="acl-button-row"><a href="{{ .url }}" class="btn btn-attachment btn-sm">{{ partial
             "attachment_repr.html" . }}&nbsp;{{ .filename }}</a></dd>
         {{ end }}
 
@@ -676,7 +676,7 @@
         <i class="ai ai-semantic-scholar"></i><span class="ps-sm-2 d-none d-sm-inline">Search</span>
       </a>
       {{ range $paper.attachment }}
-      <a class="btn btn-attachment d-flex flex-wrap justify-content-center text-wrap" href="{{ .url }}"
+      <a class="btn btn-attachment d-flex flex-wrap justify-content-center text-break" href="{{ .url }}"
         title="Open {{ .type | humanize | lower }} for '{{ $paper.title | htmlEscape }}'">
         <span class="align-self-center px-1">{{ partial "attachment_repr.html" . -}}</span>
         <span class="px-1">{{ humanize .type }}</span>


### PR DESCRIPTION
A surgical solution to close #7595 (deferring changes to the label itself to another day).