### PR TITLE
Fixed-case placenames and script names supporting Rongorongo script.

### DIFF
--- a/bin/fixedcase/truelist
+++ b/bin/fixedcase/truelist
@@ -3022,6 +3022,7 @@ Děčín
 Ealing
 Earley
 Early Tripuri
+Easter Island
 Ebira
 Eblan
 Ebonyi
@@ -4534,6 +4535,7 @@ Isingiro
 Isirawa
 Isistanitos
 Isla
+Isla de Pascua
 Isla de la Juventud
 Islamabad
 Islamic Republic of Afghanistan
@@ -5515,6 +5517,7 @@ Kofei
 Kofyar
 Kogi
 Koguryo
+Kohau
 Kohgīlūyeh va Būyer Ahmad
 Kohin
 Kohistani Shina
@@ -9106,10 +9109,12 @@ Polish Sign Language
 Poljčane
 Polonombauk
 Poltavs'ka Oblast'
-Põlvamaa
-Pólya
+Polynesia
+Polynesian
 Polynésie française
 Polzela
+Pólya
+Põlvamaa
 Pomo
 Pomoravski okrug
 Pomorskie
@@ -9447,6 +9452,7 @@ Rankovce
 Ranong
 Rao
 Rapa
+Rapa Nui
 Rapanui
 Raplamaa
 Rapoisi
@@ -9672,6 +9678,7 @@ Ronga
 Rongelap
 Rongga
 Rongmei Naga
+Rongorongo
 Rongpo
 Ronji
 Roon


### PR DESCRIPTION
Adding the context surrounding the Easter Island (potential) writing system - Rongorongo.