### PR TITLE
Python library release 1.2.0

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.2.0] — 2026-05-21
 
 This release refactors internals of the library to improve modification tracking and dynamic updating of relevant attributes when data is modified.  The breaking changes here are mostly relevant if you are modifying data.
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## [Unreleased]
 
+This release refactors internals of the library to improve modification tracking and dynamic updating of relevant attributes when data is modified.  The breaking changes here are mostly relevant if you are modifying data.
+
 ### Added
 
 - Added `PersonIndex.remove_person()` to properly remove a Person from the index, and make `Person.merge_into()` call this. (fixes #8068)
+- `<paper>` elements can now have `<month>` and `<year>` tags.
 
 ### Changed
 

--- a/python/justfile
+++ b/python/justfile
@@ -110,7 +110,7 @@ prepare-new-release VERSION: no-uncommitted-changes check test-all test-integrat
   # Build package
   uv build
   # Commit changes
-  git add CHANGELOG.md pyproject.toml uv.lock
+  git add CHANGELOG.md pyproject.toml uv.lock ../uv.lock
   git commit -m "Bump to version v$VERSION"
   # Done!
   set +x

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "acl-anthology"
-version = "1.1.0"
+version = "1.2.0"
 description = "A library for accessing the ACL Anthology"
 authors = [{ name = "Marcel Bollmann", email = "marcel@bollmann.me" }]
 requires-python = ">3.11, <3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ members = [
 
 [[package]]
 name = "acl-anthology"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "python" }
 dependencies = [
     { name = "app-paths" },


### PR DESCRIPTION
I planned to make a release after #8022 and other major upcoming changes, but prioritized this now since #8294 highlighted that the current release is incompatible with our data.