### PR TITLE
Fix Hugo version sed regex in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 
 # hugo version check
 HUGO_VERSION_MIN=154
-HUGO_VERSION=$(shell hugo version | sed 's/^.* v0\.\(.*\)\..*/\1/')
+HUGO_VERSION=$(shell hugo version | sed 's/^.* v0\.\([0-9]*\)\..*/\1/')
 HUGO_VERSION_TOO_LOW:=$(shell [[ $(HUGO_VERSION_MIN) -gt $(HUGO_VERSION) ]] && echo true)
 ifeq ($(HUGO_VERSION_TOO_LOW),true)
   $(error "incorrect hugo version installed! Need hugo 0.$(HUGO_VERSION_MIN), but only found hugo 0.$(HUGO_VERSION)!")


### PR DESCRIPTION
The regex assumed that the version string has exactly 2 periods. However, this is not true for the version of Hugo packaged by Fedora:

```console
$ hugo version
hugo v0.152.2+extended linux/amd64 BuildDate=2025-12-14T00:00:00+00:00 VendorInfo=Fedora:0.152.2-1.fc43
```

From what I can tell, the improved regex is still compliant for POSIX-2024 sed:
https://pubs.opengroup.org/onlinepubs/9799919799/utilities/sed.html