### PR TITLE
Sort more values in build pipeline to ensure deterministic data

### DIFF
--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -363,6 +363,9 @@ def export_people(anthology, builddir, dryrun):
                     key=lambda item: (
                         -item[1],
                         anthology.people[item[0]].canonical_name.last,
+                        # Some people lack a first name
+                        anthology.people[item[0]].canonical_name.first or "",
+                        anthology.people[item[0]].id,
                     ),
                 ),
                 "venues": sorted(

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -452,16 +452,22 @@ def export_venues(anthology, builddir, dryrun):
         if venue.type is not None:
             data["type"] = venue.type
         data["volumes_by_year"] = {}
-        for volume in venue.volumes():
+        sorted_volumes = sorted(
+            venue.volumes(),
+            key=lambda volume: (
+                volume.year,
+                volume.parent.id,
+                # Follow order of volumes within a collection
+                list(volume.parent.keys()).index(volume.id),
+            ),
+        )
+        for volume in sorted_volumes:
             year, volume_id = volume.year, volume.full_id
             try:
                 data["volumes_by_year"][year].append(volume_id)
             except KeyError:
                 data["volumes_by_year"][year] = [volume_id]
-        data["volumes_by_year"] = {
-            k: sorted(v) for k, v in sorted(data["volumes_by_year"].items())
-        }
-        data["years"] = sorted(list(data["volumes_by_year"].keys()))
+        data["years"] = list(data["volumes_by_year"].keys())
         all_venues[venue_id] = data
 
     if not dryrun:

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -253,7 +253,7 @@ def volume_to_dict(volume):
     if volume.editors:
         data["editor"] = [person_to_dict(ns.resolve().id, ns) for ns in volume.editors]
     if volume.type != VolumeType.JOURNAL and (events := volume.get_events()):
-        data["events"] = [event.id for event in events]
+        data["events"] = sorted(event.id for event in events)
     if sigs := volume.get_sigs():
         data["sigs"] = [sig.acronym for sig in sigs]
     if volume.type == VolumeType.JOURNAL:

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -292,9 +292,9 @@ def export_papers_and_volumes(anthology, builddir, dryrun):
                         volume_data[key] = value
                 if events := volume.get_events():
                     # TODO: This information is currently not used on paper templates
-                    volume_data["events"] = [
+                    volume_data["events"] = sorted(
                         event.id for event in events if event.is_explicit
-                    ]
+                    )
 
                 # Now build the data for every paper
                 for paper in volume.papers():

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -459,6 +459,9 @@ def export_venues(anthology, builddir, dryrun):
                 data["volumes_by_year"][year].append(volume_id)
             except KeyError:
                 data["volumes_by_year"][year] = [volume_id]
+        data["volumes_by_year"] = {
+            k: sorted(v) for k, v in sorted(data["volumes_by_year"].items())
+        }
         data["years"] = sorted(list(data["volumes_by_year"].keys()))
         all_venues[venue_id] = data
 

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -346,7 +346,8 @@ def export_people(anthology, builddir, dryrun):
             cname = person.canonical_name
             papers = sorted(
                 person.papers(),
-                key=lambda paper: paper.year,
+                # TODO: Sort by month as well? Converting from string first?
+                key=lambda paper: (paper.year, paper.full_id),
                 reverse=True,
             )
             data = {

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -410,7 +410,10 @@ def export_people(anthology, builddir, dryrun):
             if len(ids) > 1:
                 target_id = sorted(
                     ids,
-                    key=lambda pid: len(list(anthology.people[pid].anthology_items())),
+                    key=lambda pid: (
+                        len(list(anthology.people[pid].anthology_items())),
+                        pid,
+                    ),
                 )[-1]
             else:
                 target_id = list(ids)[0]

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -421,6 +421,9 @@ def export_people(anthology, builddir, dryrun):
                 people[target_id]["aliases"].append(slug)
             else:
                 people[target_id]["aliases"] = [slug]
+        for person in people.values():
+            if "aliases" in person:
+                person["aliases"].sort()
 
         if not dryrun:
             with open(f"{builddir}/data/people.json", "wb") as f:

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -255,7 +255,7 @@ def volume_to_dict(volume):
     if volume.type != VolumeType.JOURNAL and (events := volume.get_events()):
         data["events"] = sorted(event.id for event in events)
     if sigs := volume.get_sigs():
-        data["sigs"] = [sig.acronym for sig in sigs]
+        data["sigs"] = sorted(sig.acronym for sig in sigs)
     if volume.type == VolumeType.JOURNAL:
         data["meta_journal_title"] = volume.journal_title
         data["meta_issue"] = volume.journal_issue

--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -363,8 +363,7 @@ def export_people(anthology, builddir, dryrun):
                     key=lambda item: (
                         -item[1],
                         anthology.people[item[0]].canonical_name.last,
-                        # Some people lack a first name
-                        anthology.people[item[0]].canonical_name.first or "",
+                        anthology.people[item[0]].canonical_name.as_last_first(),
                         anthology.people[item[0]].id,
                     ),
                 ),


### PR DESCRIPTION
I noticed a problem in abstract output, but before I create an issue proposing fixes, I want to look through the data and make sure the fixes actually work as expected. Unfortunately, the output of `create_hugo_data.py` was non-deterministic, which means I would have had very noisy diffs.

These changes make the first step of the build process (`make hugo_data`) output the same exact files across runs. Some previously unsorted fields are now sorted, and some previously sorted fields are now sorted more consistently by defining better sort keys.

I have not tried making the entire site generation process deterministic, and I don't plan to. This PR is just to make it significantly easier to test changes to `create_hugo_data.py`.