### PR TITLE
Add page numbers and volume metadata for W97-07

### DIFF
--- a/data/xml/W97.xml
+++ b/data/xml/W97.xml
@@ -892,6 +892,11 @@
   <volume id="7" type="proceedings">
     <meta>
       <booktitle>Intelligent Scalable Text Summarization</booktitle>
+      <editor><first>Inderjeet</first><last>Mani</last></editor>
+      <editor id="mark-t-maybury"><first>Mark</first><last>Maybury</last></editor>
+      <publisher>Association for Computational Linguistics</publisher>
+      <address>Madrid, Spain</address>
+      <month>July</month>
       <venue>ws</venue>
       <year>1997</year>
     </meta>
@@ -904,6 +909,7 @@
       <author id="karen-sparck-jones"><first>Karen</first><last>Sparck Jones</last></author>
       <url hash="9db8301b">W97-0701</url>
       <bibkey>sparck-jones-1997-summarising</bibkey>
+      <pages>1-1</pages>
     </paper>
     <paper id="2">
       <title>Salience-based Content Characterisation of Text Documents</title>
@@ -911,6 +917,7 @@
       <author><first>Christopher</first><last>Kennedy</last></author>
       <url hash="95da8b11">W97-0702</url>
       <bibkey>boguraev-kennedy-1997-salience</bibkey>
+      <pages>2-9</pages>
     </paper>
     <paper id="3">
       <title>Using Lexical Chains for Text Summarization</title>
@@ -918,6 +925,7 @@
       <author><first>Michael</first><last>Elhadad</last></author>
       <url hash="25011187">W97-0703</url>
       <bibkey>barzilay-elhadad-1997-using</bibkey>
+      <pages>10-17</pages>
     </paper>
     <paper id="4">
       <title>Automated Text Summarization in <fixed-case>SUMMARIST</fixed-case></title>
@@ -925,6 +933,7 @@
       <author id="chin-yew-lin"><first>ChinYew</first><last>Lin</last></author>
       <url hash="9ea476c4">W97-0704</url>
       <bibkey>hovy-lin-1997-automated</bibkey>
+      <pages>18-24</pages>
     </paper>
     <paper id="5">
       <title>How to Appreciate the Quality of Automatic Text Summarization? Examples of <fixed-case>FAN</fixed-case> and <fixed-case>MLUCE</fixed-case> Protocols and their Results on <fixed-case>SERAPHIN</fixed-case></title>
@@ -933,12 +942,14 @@
       <author><first>Gerald</first><last>Piat</last></author>
       <url hash="36080ae3">W97-0705</url>
       <bibkey>minel-etal-1997-appreciate</bibkey>
+      <pages>25-30</pages>
     </paper>
     <paper id="6">
       <title>A Proposal for Task-based Evaluation of Text Summarization Systems</title>
       <author id="therese-firmin"><first>Therese Firmin</first><last>Hand</last></author>
       <url hash="bdcc85a5">W97-0706</url>
       <bibkey>hand-1997-proposal</bibkey>
+      <pages>31-38</pages>
     </paper>
     <paper id="7">
       <title>Automatic Text Summarization by Paragraph Extraction</title>
@@ -947,6 +958,7 @@
       <author id="chris-buckley"><first>Chris</first><last>Buckley</last></author>
       <url hash="90a398e2">W97-0707</url>
       <bibkey>mitra-etal-1997-automatic</bibkey>
+      <pages>39-46</pages>
     </paper>
     <paper id="8">
       <title>Goal-Directed Approach for Text Summarization</title>
@@ -955,6 +967,7 @@
       <author><first>Fumihito</first><last>Nishino</last></author>
       <url hash="20756887">W97-0708</url>
       <bibkey>ochitani-etal-1997-goal</bibkey>
+      <pages>47-50</pages>
     </paper>
     <paper id="9">
       <title>Statistical methods for retrieving most significant paragraphs in newspaper articles</title>
@@ -962,12 +975,14 @@
       <author id="gabriel-lopes"><first>Gabriel Pereira</first><last>Lopes</last></author>
       <url hash="356e474a">W97-0709</url>
       <bibkey>abracos-lopes-1997-statistical</bibkey>
+      <pages>51-57</pages>
     </paper>
     <paper id="10">
       <title>Sentence extraction as a classification task</title>
       <author><first>Simone</first><last>Teufel</last></author>
       <url hash="eff9658d">W97-0710</url>
       <bibkey>teufel-1997-sentence</bibkey>
+      <pages>58-65</pages>
     </paper>
     <paper id="11">
       <title>A Scalable Summarization System Using Robust <fixed-case>NLP</fixed-case></title>
@@ -977,24 +992,28 @@
       <author><first>Bjornar</first><last>Larsen</last></author>
       <url hash="f3687da3">W97-0711</url>
       <bibkey>aone-etal-1997-scalable</bibkey>
+      <pages>66-73</pages>
     </paper>
     <paper id="12">
       <title><fixed-case>COSY</fixed-case>-<fixed-case>MATS</fixed-case>: An Intelligent and Scalable Summarisation Shell</title>
       <author><first>Maria</first><last>Aretoulaki</last></author>
       <url hash="80986a78">W97-0712</url>
       <bibkey>aretoulaki-1997-cosy</bibkey>
+      <pages>74-81</pages>
     </paper>
     <paper id="13">
       <title>From discourse structures to text summaries</title>
       <author><first>Daniel</first><last>Marcu</last></author>
       <url hash="fbfde1c6">W97-0713</url>
       <bibkey>marcu-1997-discourse</bibkey>
+      <pages>82-88</pages>
     </paper>
     <paper id="14">
       <title><fixed-case>S</fixed-case>im<fixed-case>S</fixed-case>um: Simulation of summarizing</title>
       <author><first>Brigitte</first><last>Endres-Niggemeyer</last></author>
       <url hash="049405e6">W97-0714</url>
       <bibkey>endres-niggemeyer-1997-simsum</bibkey>
+      <pages>89-96</pages>
     </paper>
     <paper id="15">
       <title>A Formal Model of Text Summarization Based on Condensation Operators of a Terminological Logic</title>
@@ -1002,6 +1021,7 @@
       <author><first>Udo</first><last>Hahn</last></author>
       <url hash="72c87a4a">W97-0715</url>
       <bibkey>reimer-hahn-1997-formal</bibkey>
+      <pages>97-104</pages>
     </paper>
   </volume>
   <volume id="8" type="proceedings">


### PR DESCRIPTION
Adds the missing page numbers and volume-level metadata for **W97-07**
  (*Intelligent Scalable Text Summarization*, 1997):

  - `<pages>` for all 15 papers, computed from the per-paper PDFs and
    verified against the proceedings table of contents (W97-0700).
  - Volume `<meta>`: editors (Inderjeet Mani, Mark Maybury), publisher,
    address (Madrid, Spain) and month (July) — from the frontmatter.

  This covers one volume of the broader cleanup tracked in #7955 (old venues
  missing page numbers and most volume metadata); the same approach applies
  to the other 1997 workshops. Related: #7954.