### PR TITLE
New utility script: fetch_orcid_from_openreview.py

### DIFF
--- a/bin/correct/fetch_orcid_from_openreview.py
+++ b/bin/correct/fetch_orcid_from_openreview.py
@@ -29,10 +29,15 @@ Usage:
 
 # Drafted with Gemini
 
+from docopt import docopt
 import openreview
 import openreview.api
 import logging as log
+import os
+import re
+import urllib.parse
 from acl_anthology.utils.logging import setup_rich_logging
+from github import Github
 
 
 def get_user_orcid(email_or_id, version=2, username=None, password=None):
@@ -53,7 +58,7 @@ def get_user_orcid(email_or_id, version=2, username=None, password=None):
         "https://api2.openreview.net" if version == 2 else "https://api.openreview.net"
     )
 
-    log.info(f"Connecting to OpenReview API v{version}...")
+    # log.info(f"Connecting to OpenReview API v{version}...")
 
     try:
         # Initialize the client. Public data can generally be read using Guest access (no credentials).
@@ -70,27 +75,29 @@ def get_user_orcid(email_or_id, version=2, username=None, password=None):
         log.exception(e)
         return None
 
-    log.info(
-        f"Retrieving profile for: {email_or_id} / https://openreview.net/profile?id={email_or_id}"
-    )
+    # log.info(
+    #     f"Retrieving profile for: {email_or_id} / https://openreview.net/profile?id={email_or_id}"
+    # )
 
     # Safely look up the profile via openreview.tools (returns None instead of throwing an error if missing)
     profile = openreview.tools.get_profile(client, email_or_id)
 
     if not profile:
-        log.error(f"Profile matching '{email_or_id}' could not be found.")
+        log.error(
+            f"Profile matching '{email_or_id}' could not be found. It may exist but be unavailable to guest API users. Try checking manually: https://openreview.net/profile?id={email_or_id}"
+        )
         return None
 
     # OpenReview profile metadata is stored under the 'content' dictionary
     content = profile.content
     if not content:
-        log.error("No profile content")
+        # log.error("No profile content")
         return None
 
     orcid_data = content.get("orcid")
 
     if not orcid_data:
-        log.error(f"No ORCID entry found associated with the profile: {email_or_id}")
+        # log.error(f"No ORCID entry found associated with the profile: {email_or_id}")
         return None
 
     # Handle API response formatting variants
@@ -103,16 +110,91 @@ def get_user_orcid(email_or_id, version=2, username=None, password=None):
     return orcid_link
 
 
+def parse_issue_body(issue_body: str) -> dict[str, str] | None:
+    issue_body = issue_body.replace("\r\n", "\n").replace("\r", "\n")
+    m = re.search(
+        # r"### Author ORCID\n\n(https://orcid.org/[0-9X-]{19})\n.*### OpenReview profile page URL\n\n([^\n]+)(\n|$)",
+        r"### Author ORCID\n\n(https://orcid.org/[0-9X-]{19})\n",
+        issue_body,
+        re.MULTILINE,
+    )
+    if m is None:
+        return None
+    orcid = m.group(1)
+    m = re.search(
+        r"### OpenReview profile page URL\n\n([^\n]+)",
+        issue_body,
+        re.MULTILINE,
+    )
+    if m is None:
+        return None
+    return {"orcid": orcid, "orurl": m.group(1)}
+
+
+def check_issues(issues: list[str], github_token: str):
+    """
+    For each Anthology GitHub issue, check whether the listed ORCID link
+    is also present at the provided OpenReview URL.
+    """
+    aclrepo = Github(github_token).get_repo("acl-org/acl-anthology")
+    candidate_issues = aclrepo.get_issues(state="open")
+    issues_by_num = {iss.number: iss for iss in candidate_issues}
+    log.info(f"Found {len(issues_by_num)} open issues in repo")
+    for issnum in issues:
+        # Load info from issue
+        issue = issues_by_num.get(int(issnum))
+        if issue is None:
+            log.error(f"Cannot find open issue {issnum}")
+            continue
+        fields = parse_issue_body(issue.body)
+        if fields is None:
+            log.error(f"Cannot parse ORCID and OpenReview fields from issue {issnum}")
+            log.debug(issue.body)
+            continue
+
+        # Extract OR user ID from profile URL
+        orurl = fields["orurl"]
+        if "http" not in orurl:
+            log.warning(f"Skipping issue {issnum} due to empty OpenReview URL? {orurl}")
+            continue
+        oridM = re.search(r"/profile\?id=(\S+)", orurl)
+        assert oridM is not None, orurl
+        orid = urllib.parse.unquote(oridM.group(1))
+
+        # Extract issue's ORCID
+        issorcid = fields["orcid"]
+        assert issorcid is not None
+
+        # Query OpenReview
+        orcid_url = get_user_orcid(orid, version=2)
+
+        # Compare the two ORCIDs
+        if orcid_url is None:
+            log.warning(f"No ORCID at {orurl} from issue {issnum}")
+        elif issorcid != orcid_url:
+            log.warning(
+                f"ORCIDs do not match: {issorcid} in issue {issnum} vs. {orcid_url} at {orurl}"
+            )
+        else:
+            log.debug(f"Issue {issnum} ORCIDs match")
+
+
 if __name__ == "__main__":
+    args = docopt(__doc__)
+
     tracker = setup_rich_logging(level=log.DEBUG)
+    log.getLogger("urllib3.connectionpool").setLevel(log.WARNING)
 
-    # Substitute with the tilde ID or email you want to test
-    # target_user = "~Michael_Spector1"  # no ORCID
-    target_user = "~Hao_Chen1"
-
-    orcid_url = get_user_orcid(target_user, version=2)
-
-    if orcid_url:
-        log.info(f"Success! ORCID found: {orcid_url}")
+    if args["ISSUE"]:
+        github_token = os.getenv("GITHUB_TOKEN")
+        assert github_token is not None, "Set env variable GITHUB_TOKEN to access GitHub"
+        check_issues(args["ISSUE"], github_token)
     else:
-        log.error("Could not resolve an ORCID link for this user.")
+        for user in args[
+            "ORID"
+        ]:  # e.g. "~Hao_Chen1" (has ORCID), "~Michael_Spector1" (no ORCID)
+            orcid_url = get_user_orcid(user, version=2)
+            if orcid_url:
+                log.info(f"{user}: {orcid_url}")
+            else:
+                log.error(f"{user}: no ORCID link in OpenReview")

--- a/bin/correct/fetch_orcid_from_openreview.py
+++ b/bin/correct/fetch_orcid_from_openreview.py
@@ -15,6 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Queries the OpenReview API by one or more OpenReview user IDs
+and retrieves the ORCID link from the profile, if present.
+With -i, looks up the specified author page issue(s) in the Anthology issue tracker
+and checks the ORCID field in the issue against the OpenReview profile.
+Should be called on a small number of users to avoid hitting API limits.
+
+Usage:
+  fetch_orcid_from_openreview.py ORID ...
+  fetch_orcid_from_openreview.py -i ISSUE ...
+"""
+
 # Drafted with Gemini
 
 import openreview

--- a/bin/correct/fetch_orcid_from_openreview.py
+++ b/bin/correct/fetch_orcid_from_openreview.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Nathan Schneider (@nschneid)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Drafted with Gemini
+
+import openreview
+import openreview.api
+import logging as log
+from acl_anthology.utils.logging import setup_rich_logging
+
+
+def get_user_orcid(email_or_id, version=2, username=None, password=None):
+    """
+    Queries the OpenReview API for a user profile and returns their ORCID link.
+
+    Parameters:
+        email_or_id (str): The user's registered email or OpenReview ID (e.g., '~Michael_Spector1').
+        version (int): API version to use (1 for legacy, 2 for modern v2). Default is 2.
+        username (str, optional): Your OpenReview login email/username if authentication is needed.
+        password (str, optional): Your OpenReview login password.
+
+    Returns:
+        str: The ORCID URL or ID if found, otherwise None.
+    """
+    # Establish the appropriate base URL
+    baseurl = (
+        "https://api2.openreview.net" if version == 2 else "https://api.openreview.net"
+    )
+
+    log.info(f"Connecting to OpenReview API v{version}...")
+
+    try:
+        # Initialize the client. Public data can generally be read using Guest access (no credentials).
+        if version == 2:
+            client = openreview.api.OpenReviewClient(
+                baseurl=baseurl, username=username, password=password
+            )
+        else:
+            client = openreview.Client(
+                baseurl=baseurl, username=username, password=password
+            )
+    except Exception as e:
+        log.error("Initialization Error:")
+        log.exception(e)
+        return None
+
+    log.info(
+        f"Retrieving profile for: {email_or_id} / https://openreview.net/profile?id={email_or_id}"
+    )
+
+    # Safely look up the profile via openreview.tools (returns None instead of throwing an error if missing)
+    profile = openreview.tools.get_profile(client, email_or_id)
+
+    if not profile:
+        log.error(f"Profile matching '{email_or_id}' could not be found.")
+        return None
+
+    # OpenReview profile metadata is stored under the 'content' dictionary
+    content = profile.content
+    if not content:
+        log.error("No profile content")
+        return None
+
+    orcid_data = content.get("orcid")
+
+    if not orcid_data:
+        log.error(f"No ORCID entry found associated with the profile: {email_or_id}")
+        return None
+
+    # Handle API response formatting variants
+    # (API v2 wrapper schemas often enclose custom metadata targets inside a {'value': ...} wrapper)
+    if isinstance(orcid_data, dict):
+        orcid_link = orcid_data.get("value")
+    else:
+        orcid_link = orcid_data
+
+    return orcid_link
+
+
+if __name__ == "__main__":
+    tracker = setup_rich_logging(level=log.DEBUG)
+
+    # Substitute with the tilde ID or email you want to test
+    # target_user = "~Michael_Spector1"  # no ORCID
+    target_user = "~Hao_Chen1"
+
+    orcid_url = get_user_orcid(target_user, version=2)
+
+    if orcid_url:
+        log.info(f"Success! ORCID found: {orcid_url}")
+    else:
+        log.error("Could not resolve an ORCID link for this user.")

--- a/bin/correct/refresh_or_orcids.py
+++ b/bin/correct/refresh_or_orcids.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2026 Nathan Schneider (@nschneid)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+For NameSpecs that list an OpenReview ID but not an ORCID iD,
+query OpenReview to see if that profile now has an ORCID iD.
+If so, add it to the database, verifying the author if not already verified.
+
+See also fetch_orcid_from_openreview.py, which applies to a single user.
+"""
+
+from collections import defaultdict
+import openreview
+from openreview import Profile
+import openreview.api
+import logging as log
+import os
+import warnings
+from acl_anthology import Anthology
+from acl_anthology.collections import Paper
+from acl_anthology.exceptions import NameSpecResolutionWarning
+from acl_anthology.utils.logging import setup_rich_logging
+
+EARLIEST_YEAR_WITH_OR_IDS = 2026
+
+def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[str,str]:
+    """
+    Queries the OpenReview API for a user profile and returns their ORCID link.
+
+    Parameters:
+        email_or_id (str): The user's registered email or OpenReview ID (e.g., '~Michael_Spector1').
+        version (int): API version to use (1 for legacy, 2 for modern v2). Default is 2.
+        username (str, optional): Your OpenReview login email/username if authentication is needed.
+        password (str, optional): Your OpenReview login password.
+
+    Returns:
+        str: The ORCID URL or ID if found, otherwise None.
+    """
+    # Establish the appropriate base URL
+    baseurl = (
+        "https://api2.openreview.net" if version == 2 else "https://api.openreview.net"
+    )
+
+    log.info(f"Connecting to OpenReview API v{version}...")
+
+    try:
+        # Initialize the client. Public data can generally be read using Guest access (no credentials).
+        assert version==2
+        client = openreview.api.OpenReviewClient(
+            baseurl=baseurl, username=username, password=password
+        )
+    except Exception as e:
+        log.error("Initialization Error:")
+        log.exception(e)
+        return {}
+
+    log.info(
+        f"Retrieving profile for: {len(ids)} users: first 10 are {ids[:10]}"
+    )
+
+    # Safely look up the profile via openreview.tools (returns None instead of throwing an error if missing)
+    profiles = openreview.tools.get_profiles(client, ids)
+
+    if not profiles:
+        log.error(f"No profiles returned.")
+        return {}
+
+    orid2orcid = {}
+    for profile in profiles:
+        assert isinstance(profile, Profile)
+
+        # OpenReview profile metadata is stored under the 'content' dictionary
+        content = profile.content
+        if not content:
+            log.error("No profile content")
+            return {}
+
+        orcid_data = content.get("orcid")
+
+        if orcid_data:
+            # Handle API response formatting variants
+            # (API v2 wrapper schemas often enclose custom metadata targets inside a {'value': ...} wrapper)
+            if isinstance(orcid_data, dict):
+                orcid_link = orcid_data.get("value")
+            else:
+                orcid_link = orcid_data
+
+            orid2orcid[profile.id] = orcid_link
+            # TODO: what about aliases? look at profile.referent?
+
+    return orid2orcid
+
+TEST_CASES = [('2025.emnlp-main.8', 'Jandaghi', '~Pegah_Jandaghi1'),
+              ('2025.acl-demo.60', 'Zhuocheng', '~Zhang_Zhuocheng1'),
+              ('2023.findings-emnlp.773', 'Zhuocheng', '~Zhang_Zhuocheng1'),
+              ('2025.findings-emnlp.679', 'Rezaei', '~Mohammad_Reza_Rezaei1')]
+# TODO: test a legacy-verified author
+
+def refresh_or_orcids(username=None, password=None):
+    anthology = Anthology.from_within_repo()
+
+    user2nses = defaultdict(list)
+    if TEST_CASES:  # TODO: temporary
+        for itemid, lastname, user in TEST_CASES:
+            paper = anthology.get(itemid)
+            assert isinstance(paper, Paper)
+            for ns in paper.namespecs:
+                if ns.last == lastname:
+                    user2nses[user].append(ns)
+    else:
+        for vol in anthology.volumes():
+            if int(vol.year) >= EARLIEST_YEAR_WITH_OR_IDS:
+                for ns in vol.namespecs:
+                    if ns.orcid is None and ns.openreviewid is not None:
+                        user2nses[ns.openreviewid].append(ns)
+    
+    orid2orcid = get_user_orcids(list(user2nses), username=username, password=password)
+    if not orid2orcid:
+        log.info("No new ORCIDs found.")
+    else:
+        log.info(f"{len(orid2orcid)} new ORCIDs found.")
+        numUpdatedNSes = 0
+        for user,orcid in orid2orcid.items():
+            log.debug(f"{user}: {orcid}")
+            person = anthology.people.get_by_orcid(orcid)
+            # check if any namespecs have an explicit ID (could be a legacy-verified person)
+            explicit_ids = set(ns.id for ns in user2nses[user])
+            assert len(explicit_ids) < 2,f"OR ID is associated with multiple explicit Anthology people: {explicit_ids}"
+            if explicit_ids:
+                explicit_id, = explicit_ids
+                person = anthology.get_person(explicit_id)
+
+            if person is None:
+                log.debug("Will create a new verified person")
+            else:
+                log.debug(f"Found: {person.id}, current ORCID: {person.orcid}")
+                if person.orcid is None:
+                    person.orcid = orcid
+
+            for ns in user2nses[user]:
+                numUpdatedNSes += 1
+                if person is None:
+                    # log.debug("Creating a new verified person")
+                    new_aid = anthology.people.generate_person_id(ns.name, orcid=orcid)
+                    person = anthology.people.create(
+                        new_aid,
+                        [ns.name] + list(ns.variants),
+                    )
+                assert ns.id is None or ns.id == person.id,ns.id
+                ns.id = person.id
+                ns.orcid = orcid
+        log.info(f"{numUpdatedNSes} NameSpecs updated with ORCID.")
+        anthology.save_all()
+
+
+if __name__ == "__main__":
+    tracker = setup_rich_logging(level=log.DEBUG)
+
+    log.getLogger("acl-anthology").setLevel(log.WARNING)
+    log.getLogger("git.cmd").setLevel(log.WARNING)
+    log.getLogger("urllib3.connectionpool").setLevel(log.WARNING)
+
+    with warnings.catch_warnings(action="ignore", category=NameSpecResolutionWarning):
+        username = os.getenv("OR1")
+        password = os.getenv("OR2")
+        refresh_or_orcids(username=username, password=password)

--- a/bin/correct/refresh_or_orcids.py
+++ b/bin/correct/refresh_or_orcids.py
@@ -31,7 +31,6 @@ import logging as log
 import os
 import warnings
 from acl_anthology import Anthology
-from acl_anthology.collections import Paper
 from acl_anthology.exceptions import NameSpecResolutionWarning
 from acl_anthology.utils.logging import setup_rich_logging
 
@@ -86,7 +85,7 @@ def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[
         content = profile.content
         if not content:
             log.error("No profile content")
-            return {}
+            continue
 
         orcid_data = content.get("orcid")
 
@@ -98,18 +97,28 @@ def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[
             else:
                 orcid_link = orcid_data
 
-            orid2orcid[profile.id] = orcid_link
-            # TODO: what about aliases? look at profile.referent?
+            names = profile.content[
+                "names"
+            ]  # all the user's names including each username
+            # one of these usernames will be the queried ID (profile.id is the canonical one,
+            # which may be different from the preferred name)
+            for name in names:
+                if (u := name["username"]) in ids:
+                    # index the ORCID under the queried username
+                    orid2orcid[u] = orcid_link
+                    break
+            else:
+                assert False, names
 
     return orid2orcid
 
 
-TEST_CASES = [
-    ("2025.emnlp-main.8", "Jandaghi", "~Pegah_Jandaghi1"),
-    ("2025.acl-demo.60", "Zhuocheng", "~Zhang_Zhuocheng1"),
-    ("2023.findings-emnlp.773", "Zhuocheng", "~Zhang_Zhuocheng1"),
-    ("2025.findings-emnlp.679", "Rezaei", "~Mohammad_Reza_Rezaei1"),
-]
+# TEST_CASES = [
+#     ("2025.emnlp-main.8", "Jandaghi", "~Pegah_Jandaghi1"),
+#     ("2025.acl-demo.60", "Zhuocheng", "~Zhang_Zhuocheng1"),
+#     ("2023.findings-emnlp.773", "Zhuocheng", "~Zhang_Zhuocheng1"),
+#     ("2025.findings-emnlp.679", "Rezaei", "~Mohammad_Reza_Rezaei1"),
+# ]
 # TODO: test a legacy-verified author
 
 
@@ -117,19 +126,25 @@ def refresh_or_orcids(username=None, password=None):
     anthology = Anthology.from_within_repo()
 
     user2nses = defaultdict(list)
-    if TEST_CASES:  # TODO: temporary
-        for itemid, lastname, user in TEST_CASES:
-            paper = anthology.get(itemid)
-            assert isinstance(paper, Paper)
-            for ns in paper.namespecs:
-                if ns.last == lastname:
-                    user2nses[user].append(ns)
-    else:
-        for vol in anthology.volumes():
-            if int(vol.year) >= EARLIEST_YEAR_WITH_OR_IDS:
-                for ns in vol.namespecs:
-                    if ns.orcid is None and ns.openreviewid is not None:
-                        user2nses[ns.openreviewid].append(ns)
+    nORCIDOnly, nOROnly, nBoth, nNeither = 0, 0, 0, 0
+    nVols = 0
+    for vol in anthology.volumes():
+        if int(vol.year) >= EARLIEST_YEAR_WITH_OR_IDS:
+            nVols += 1
+            for paper in vol.papers():
+                for ns in paper.namespecs:
+                    if ns.orcid is None and ns.openreview is not None:
+                        user2nses[ns.openreview].append(ns)
+                        nOROnly += 1
+                    elif ns.orcid is None:
+                        nNeither += 1
+                    elif ns.openreview is not None:
+                        nBoth += 1
+                    else:
+                        nORCIDOnly += 1
+    log.info(
+        f"In {nVols} target volumes, {nOROnly} namespecs with openreview but not orcid, {nORCIDOnly} with orcid but not openreview, {nBoth} with both, {nNeither} with neither"
+    )
 
     orid2orcid = get_user_orcids(list(user2nses), username=username, password=password)
     if not orid2orcid:
@@ -137,11 +152,15 @@ def refresh_or_orcids(username=None, password=None):
     else:
         log.info(f"{len(orid2orcid)} new ORCIDs found.")
         numUpdatedNSes = 0
+        numNSErrors = 0
+        numNewPerson = 0
         for user, orcid in orid2orcid.items():
             log.debug(f"{user}: {orcid}")
-            person = anthology.people.get_by_orcid(orcid)
+            bare_orcid = orcid.split("/")[-1]
+            person = anthology.people.get_by_orcid(bare_orcid)
+            # assert user!="~Yuxi_Sun7",(orcid,bare_orcid,person is None)
             # check if any namespecs have an explicit ID (could be a legacy-verified person)
-            explicit_ids = set(ns.id for ns in user2nses[user])
+            explicit_ids = set(ns.id for ns in user2nses[user] if ns.id is not None)
             assert len(explicit_ids) < 2, (
                 f"OR ID is associated with multiple explicit Anthology people: {explicit_ids}"
             )
@@ -150,14 +169,13 @@ def refresh_or_orcids(username=None, password=None):
                 person = anthology.get_person(explicit_id)
 
             if person is None:
-                log.debug("Will create a new verified person")
+                log.debug("...will create a new verified person")
             else:
-                log.debug(f"Found: {person.id}, current ORCID: {person.orcid}")
+                log.debug(f"...found: {person.id}, current ORCID: {person.orcid}")
                 if person.orcid is None:
                     person.orcid = orcid
 
             for ns in user2nses[user]:
-                numUpdatedNSes += 1
                 if person is None:
                     # log.debug("Creating a new verified person")
                     new_aid = anthology.people.generate_person_id(ns.name, orcid=orcid)
@@ -165,10 +183,20 @@ def refresh_or_orcids(username=None, password=None):
                         new_aid,
                         [ns.name] + list(ns.variants),
                     )
+                    numNewPerson += 1
                 assert ns.id is None or ns.id == person.id, ns.id
+                person.add_name(ns.name)
                 ns.id = person.id
-                ns.orcid = orcid
+                try:
+                    ns.orcid = orcid
+                    person.orcid = orcid
+                    numUpdatedNSes += 1
+                except ValueError:
+                    log.error(f"ORCID is invalid: {orcid} for {user}")
+                    numNSErrors += 1
+        log.info(f"{numNewPerson} new Persons created.")
         log.info(f"{numUpdatedNSes} NameSpecs updated with ORCID.")
+        log.info(f"{numNSErrors} NameSpecs could not be updated due to an error.")
         anthology.save_all()
 
 

--- a/bin/correct/refresh_or_orcids.py
+++ b/bin/correct/refresh_or_orcids.py
@@ -37,7 +37,8 @@ from acl_anthology.utils.logging import setup_rich_logging
 
 EARLIEST_YEAR_WITH_OR_IDS = 2026
 
-def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[str,str]:
+
+def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[str, str]:
     """
     Queries the OpenReview API for a user profile and returns their ORCID link.
 
@@ -59,7 +60,7 @@ def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[
 
     try:
         # Initialize the client. Public data can generally be read using Guest access (no credentials).
-        assert version==2
+        assert version == 2
         client = openreview.api.OpenReviewClient(
             baseurl=baseurl, username=username, password=password
         )
@@ -68,15 +69,13 @@ def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[
         log.exception(e)
         return {}
 
-    log.info(
-        f"Retrieving profile for: {len(ids)} users: first 10 are {ids[:10]}"
-    )
+    log.info(f"Retrieving profile for: {len(ids)} users: first 10 are {ids[:10]}")
 
     # Safely look up the profile via openreview.tools (returns None instead of throwing an error if missing)
     profiles = openreview.tools.get_profiles(client, ids)
 
     if not profiles:
-        log.error(f"No profiles returned.")
+        log.error("No profiles returned.")
         return {}
 
     orid2orcid = {}
@@ -104,11 +103,15 @@ def get_user_orcids(ids: list, version=2, username=None, password=None) -> dict[
 
     return orid2orcid
 
-TEST_CASES = [('2025.emnlp-main.8', 'Jandaghi', '~Pegah_Jandaghi1'),
-              ('2025.acl-demo.60', 'Zhuocheng', '~Zhang_Zhuocheng1'),
-              ('2023.findings-emnlp.773', 'Zhuocheng', '~Zhang_Zhuocheng1'),
-              ('2025.findings-emnlp.679', 'Rezaei', '~Mohammad_Reza_Rezaei1')]
+
+TEST_CASES = [
+    ("2025.emnlp-main.8", "Jandaghi", "~Pegah_Jandaghi1"),
+    ("2025.acl-demo.60", "Zhuocheng", "~Zhang_Zhuocheng1"),
+    ("2023.findings-emnlp.773", "Zhuocheng", "~Zhang_Zhuocheng1"),
+    ("2025.findings-emnlp.679", "Rezaei", "~Mohammad_Reza_Rezaei1"),
+]
 # TODO: test a legacy-verified author
+
 
 def refresh_or_orcids(username=None, password=None):
     anthology = Anthology.from_within_repo()
@@ -127,21 +130,23 @@ def refresh_or_orcids(username=None, password=None):
                 for ns in vol.namespecs:
                     if ns.orcid is None and ns.openreviewid is not None:
                         user2nses[ns.openreviewid].append(ns)
-    
+
     orid2orcid = get_user_orcids(list(user2nses), username=username, password=password)
     if not orid2orcid:
         log.info("No new ORCIDs found.")
     else:
         log.info(f"{len(orid2orcid)} new ORCIDs found.")
         numUpdatedNSes = 0
-        for user,orcid in orid2orcid.items():
+        for user, orcid in orid2orcid.items():
             log.debug(f"{user}: {orcid}")
             person = anthology.people.get_by_orcid(orcid)
             # check if any namespecs have an explicit ID (could be a legacy-verified person)
             explicit_ids = set(ns.id for ns in user2nses[user])
-            assert len(explicit_ids) < 2,f"OR ID is associated with multiple explicit Anthology people: {explicit_ids}"
+            assert len(explicit_ids) < 2, (
+                f"OR ID is associated with multiple explicit Anthology people: {explicit_ids}"
+            )
             if explicit_ids:
-                explicit_id, = explicit_ids
+                (explicit_id,) = explicit_ids
                 person = anthology.get_person(explicit_id)
 
             if person is None:
@@ -160,7 +165,7 @@ def refresh_or_orcids(username=None, password=None):
                         new_aid,
                         [ns.name] + list(ns.variants),
                     )
-                assert ns.id is None or ns.id == person.id,ns.id
+                assert ns.id is None or ns.id == person.id, ns.id
                 ns.id = person.id
                 ns.orcid = orcid
         log.info(f"{numUpdatedNSes} NameSpecs updated with ORCID.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "lxml>=6.1.0",
     "msgspec>=0.20.0",
     "nltk>=3.9.2",
+    "openreview-py>=2.2.3",
     "pre-commit>=4.5.1",
     "pybtex>=0.26.1",
     "pygithub>=2.8.1",

--- a/uv.lock
+++ b/uv.lock
@@ -122,6 +122,7 @@ dependencies = [
     { name = "lxml" },
     { name = "msgspec" },
     { name = "nltk" },
+    { name = "openreview-py" },
     { name = "pre-commit" },
     { name = "pybtex" },
     { name = "pygithub" },
@@ -142,6 +143,7 @@ requires-dist = [
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "msgspec", specifier = ">=0.20.0" },
     { name = "nltk", specifier = ">=3.9.2" },
+    { name = "openreview-py", specifier = ">=2.2.3" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pybtex", specifier = ">=0.26.1" },
     { name = "pygithub", specifier = ">=2.8.1" },
@@ -715,6 +717,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +742,36 @@ name = "docopt"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
+
+[[package]]
+name = "editdistance"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/18/9f4f975ca87a390832b1c22478f3702fcdf739f83211e24d054b7551270d/editdistance-0.8.1.tar.gz", hash = "sha256:d1cdf80a5d5014b0c9126a69a42ce55a457b457f6986ff69ca98e4fe4d2d8fed", size = 50006, upload-time = "2024-02-10T07:44:53.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/dc/d0c29fd52d8f9e795653ed2b838a2a48c739cdfff04ac5b79c6c0ecbdf79/editdistance-0.8.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:486105603a273d73d12a54f347dffa70ab281749d7c3879658b377bc49e4b98c", size = 106079, upload-time = "2024-02-10T07:43:34.34Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c6/75fa45d7b78fbea6fd894f4e48895a75bd3c83d4a9a6b57673881d74d3e0/editdistance-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fad081f5f86a175c1a09a4e9e45b95c9349e454c21e181e842e01c85f1f536fc", size = 80580, upload-time = "2024-02-10T07:43:35.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a3/058d823b6285c3511dc94ed80620c3fb0c18b4aaa708f70ba71f3af28436/editdistance-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8cb78e125f6759398885a775f5eed07c2bb72b2f86da43e674c6b6a3335b273b", size = 79087, upload-time = "2024-02-10T07:43:36.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3a/0b13c7864c93b1e9b9952bd2a33c5ef3c4fd1bf70a5fad6924789e70e5eb/editdistance-0.8.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3778ca60aa89def9144b70e330bcec5330c7da1d69cb28c612e90b84510a1d3d", size = 409296, upload-time = "2024-02-10T07:43:38.52Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8a/db0fd79e8ddb9b5f86f274107c5d0a27ec4f2af88877df1f26c2c6d150cc/editdistance-0.8.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fba945eaa0436cf40bc53d7e299dc537c7c71353379a095b7459ff4af910da33", size = 412913, upload-time = "2024-02-10T07:43:39.852Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d2/98be7112750ff17b436dd76f988f1e38570dcec0df8578ee19ef046f22fe/editdistance-0.8.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:877f2a0d801f32bc1a1878901ffb947b974361e849c66e314a7f1d786a446b58", size = 407430, upload-time = "2024-02-10T07:43:41.048Z" },
+    { url = "https://files.pythonhosted.org/packages/03/62/1815e3bf164910c47ba1948c8b5e937a40c7f9763b64e98fb6666b01dd06/editdistance-0.8.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e79d351ca40a6ead5f3763253fd7521572ee0d3e5d42538630e56d10f48db481", size = 909217, upload-time = "2024-02-10T07:43:42.916Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d3/a832cea7b507a9be54e4ac3d1340fb66dca5f9c16c70bf38d5039e8fdede/editdistance-0.8.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:70ed382b3052a51161bad0149d4665003bf3b949fce0b01bf1253a4cc1a88239", size = 969407, upload-time = "2024-02-10T07:43:44.912Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b4/db291d2a3845cbf8047b4b5aad3b3e038a8a2994d87027b40e1a1b0f4b74/editdistance-0.8.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a529bfb384c4000775d76739c4e64f73337f0f5a3784933b1321b577a62bed4e", size = 922112, upload-time = "2024-02-10T07:43:47.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/7ddeacada4982d0b892a28897e21871d0f25bca165e3663e37c3a272808a/editdistance-0.8.1-cp311-cp311-win32.whl", hash = "sha256:b082232429e731f181af7f7d2bcf79da6ca8fadd04e9086c11e2973f7d330c81", size = 80799, upload-time = "2024-02-10T07:43:48.231Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a1/778af8590b8b12f03f62eacc3c8744407ade9e3d69be6dabe38d0afbf2dd/editdistance-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:cef1a4359252a49f2c4718e64e9d40027d9d951b289d045bdb278656e59f6af8", size = 79698, upload-time = "2024-02-10T07:43:49.234Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4c/7f195588949b4e72436dc7fc902632381f96e586af829685b56daebb38b8/editdistance-0.8.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b04af61b3fcdd287a07c15b6ae3b02af01c5e3e9c3aca76b8c1d13bd266b6f57", size = 106723, upload-time = "2024-02-10T07:43:50.268Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/82/31dc1640d830cd7d36865098329f34e4dad3b77f31cfb9404b347e700196/editdistance-0.8.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:18fc8b6eaae01bfd9cf999af726c1e8dcf667d120e81aa7dbd515bea7427f62f", size = 80998, upload-time = "2024-02-10T07:43:51.259Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2a/6b823e71cef694d6f070a1d82be2842706fa193541aab8856a8f42044cd0/editdistance-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6a87839450a5987028738d061ffa5ef6a68bac2ddc68c9147a8aae9806629c7f", size = 79248, upload-time = "2024-02-10T07:43:52.873Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/31/bfb8e590f922089dc3471ed7828a6da2fc9453eba38c332efa9ee8749fd7/editdistance-0.8.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24b5f9c9673c823d91b5973d0af8b39f883f414a55ade2b9d097138acd10f31e", size = 415262, upload-time = "2024-02-10T07:43:54.498Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/57423942b2f847cdbbb46494568d00cd8a45500904ea026f0aad6ca01bc7/editdistance-0.8.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c59248eabfad603f0fba47b0c263d5dc728fb01c2b6b50fb6ca187cec547fdb3", size = 418905, upload-time = "2024-02-10T07:43:55.779Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/05/dfa4cdcce063596cbf0d7a32c46cd0f4fa70980311b7da64d35f33ad02a0/editdistance-0.8.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e239d88ff52821cf64023fabd06a1d9a07654f364b64bf1284577fd3a79d0e", size = 412511, upload-time = "2024-02-10T07:43:57.567Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/14/39608ff724a9523f187c4e28926d78bc68f2798f74777ac6757981108345/editdistance-0.8.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2f7f71698f83e8c83839ac0d876a0f4ef996c86c5460aebd26d85568d4afd0db", size = 917293, upload-time = "2024-02-10T07:43:59.559Z" },
+    { url = "https://files.pythonhosted.org/packages/df/92/4a1c61d72da40dedfd0ff950fdc71ae83f478330c58a8bccfd776518bd67/editdistance-0.8.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:04e229d6f4ce0c12abc9f4cd4023a5b5fa9620226e0207b119c3c2778b036250", size = 975580, upload-time = "2024-02-10T07:44:01.328Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3d/9877566e724c8a37f2228a84ec5cbf66dbfd0673515baf68a0fe07caff40/editdistance-0.8.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e16721636da6d6b68a2c09eaced35a94f4a4a704ec09f45756d4fd5e128ed18d", size = 929121, upload-time = "2024-02-10T07:44:02.764Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/8c50757d198b8ca30ddb91e8b8f0247a8dca04ff2ec30755245f0ab1ff0c/editdistance-0.8.1-cp312-cp312-win32.whl", hash = "sha256:87533cf2ebc3777088d991947274cd7e1014b9c861a8aa65257bcdc0ee492526", size = 81039, upload-time = "2024-02-10T07:44:04.134Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f0/65101e51dc7c850e7b7581a5d8fa8721a1d7479a0dca6c08386328e19882/editdistance-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:09f01ed51746d90178af7dd7ea4ebb41497ef19f53c7f327e864421743dffb0a", size = 79853, upload-time = "2024-02-10T07:44:05.687Z" },
+]
 
 [[package]]
 name = "filelock"
@@ -745,6 +789,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "future"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
 ]
 
 [[package]]
@@ -1668,6 +1721,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openreview-py"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "editdistance" },
+    { name = "future" },
+    { name = "pycryptodome" },
+    { name = "pyjwt" },
+    { name = "pylatexenc" },
+    { name = "requests" },
+    { name = "tld" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/46/24e460af888fbe1b7819d1510e0fbc17831ccc4c3c1510454fb79341a114/openreview_py-2.2.3-py3-none-any.whl", hash = "sha256:86a6816af11f16cd9aaa5b6c84f4bf93497fde2f041297aa127413958d36db51", size = 702289, upload-time = "2026-06-11T15:01:16.113Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1748,6 +1820,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]
@@ -2536,6 +2638,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2698,4 +2809,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]


### PR DESCRIPTION
Could be used in a GitHub action (#8651) or in a periodic maintenance script that backfills ORCIDs (related: #8733).

Currently just logs the output; I haven't decided on a proper CLI.