### PR TITLE
Update 02-name-correction.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-name-correction.yml
+++ b/.github/ISSUE_TEMPLATE/02-name-correction.yml
@@ -10,6 +10,13 @@ body:
       value: >
         This form will report issues with author pages, such as when a single individual's papers are split across multiple author pages
         and should be merged, or papers by multiple individuals with the same name appear on the same page.
+
+        > [!IMPORTANT]
+        > If you authored an **ACL 2026** publication submitted via OpenReview and wish to verify your author page with an ORCID iD,
+        > simply [add your ORCID link to your OpenReview profile](https://aclanthology.org/info/author-pages/#2-link-your-profiles-on-conference-management-systems-to-your-orcid-id)
+        > and it will appear on your Anthology page within a few weeks.
+        > To keep staff workloads manageable, please only submit an issue here if you need to change
+        > the papers listed on your author page.
   - type: checkboxes
     id: in_anth_check
     attributes:


### PR DESCRIPTION
To forestall a flood of simple verification requests when the ACL proceedings are published.