### PR TITLE
Fix author typo "Chistopher Thomas" → "Christopher Thomas" and attribute to chris-thomas (W14-4423)

### DIFF
--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -3326,7 +3326,7 @@
     <meta>
       <booktitle>Proceedings of the First Workshop on Argumentation Mining</booktitle>
       <url hash="989571f4">W14-21</url>
-      <editor id="nancy-green"><first>Nancy</first><last>Green</last></editor>
+      <editor id="nancy-green"><first>Nancy L.</first><last>Green</last></editor>
       <editor id="kevin-d-ashley"><first>Kevin</first><last>Ashley</last></editor>
       <editor id="diane-litman"><first>Diane</first><last>Litman</last></editor>
       <editor id="chris-reed"><first>Chris</first><last>Reed</last></editor>

--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -8154,7 +8154,7 @@
       <title><fixed-case>TBI</fixed-case>-Doc: Generating Patient &amp; Clinician Reports from Brain Imaging Data</title>
       <author id="pamela-jordan"><first>Pamela</first><last>Jordan</last></author>
       <author id="nancy-green"><first>Nancy</first><last>Green</last></author>
-      <author><first>Chistopher</first><last>Thomas</last></author>
+      <author id="chris-thomas" orcid="0000-0002-3226-396X"><first>Christopher</first><last>Thomas</last></author>
       <author><first>Susan</first><last>Holm</last></author>
       <pages>143–146</pages>
       <url hash="376726b7">W14-4423</url>

--- a/data/xml/W14.xml
+++ b/data/xml/W14.xml
@@ -3326,7 +3326,7 @@
     <meta>
       <booktitle>Proceedings of the First Workshop on Argumentation Mining</booktitle>
       <url hash="989571f4">W14-21</url>
-      <editor id="nancy-green"><first>Nancy L.</first><last>Green</last></editor>
+      <editor id="nancy-green"><first>Nancy</first><last>Green</last></editor>
       <editor id="kevin-d-ashley"><first>Kevin</first><last>Ashley</last></editor>
       <editor id="diane-litman"><first>Diane</first><last>Litman</last></editor>
       <editor id="chris-reed"><first>Chris</first><last>Reed</last></editor>


### PR DESCRIPTION
## What
This corrects the third author of **W14-4423** — *TBI-Doc: Generating Patient & Clinician Reports from Brain Imaging Data* (INLG 2014):

- Fixes the name typo **"Chistopher Thomas" → "Christopher Thomas"** (the paper PDF spells my name correctly; the typo is only in the metadata).
- Adds `id="chris-thomas"` (with my ORCID `0000-0002-3226-396X`) so the paper attaches to my existing author page (https://aclanthology.org/people/chris-thomas/), whose `people.yaml` entry has `disable_name_matching: true` and therefore requires an explicit id.

## Why
I'm the author. Because of the typo, this paper currently sits on an auto-generated page (https://aclanthology.org/people/chistopher-thomas/) instead of my real author page. I co-authored it as a student at the University of Pittsburgh, and I'm now an Assistant Professor at Virginia Tech (ORCID 0000-0002-3226-396X). The PDF lists me correctly as "Christopher Thomas" (Department of Computer Science, University of Pittsburgh; clt29@pitt.edu).

## Change
Single-line edit in `data/xml/W14.xml` (paper id 23):

```
-      <author><first>Chistopher</first><last>Thomas</last></author>
+      <author id="chris-thomas" orcid="0000-0002-3226-396X"><first>Christopher</first><last>Thomas</last></author>
```
