### PR TITLE
Add missing isbn and doi, update capitalization in UNLP proceedings

### DIFF
--- a/data/xml/2023.unlp.xml
+++ b/data/xml/2023.unlp.xml
@@ -10,13 +10,15 @@
       <year>2023</year>
       <url hash="4011460c">2023.unlp-1</url>
       <venue>unlp</venue>
+      <isbn>978-1-959429-52-4</isbn>
+      <doi>10.18653/v1/2023.unlp-1</doi>
     </meta>
     <frontmatter>
       <url hash="21cf972f">2023.unlp-1.0</url>
       <bibkey>unlp-2023-ukrainian</bibkey>
     </frontmatter>
     <paper id="1">
-      <title>Introducing <fixed-case>U</fixed-case>ber<fixed-case>T</fixed-case>ext 2.0: A Corpus of <fixed-case>M</fixed-case>odern <fixed-case>U</fixed-case>krainian at Scale</title>
+      <title>Introducing <fixed-case>U</fixed-case>ber<fixed-case>T</fixed-case>ext 2.0: A Corpus of Modern <fixed-case>U</fixed-case>krainian at Scale</title>
       <author><first>Dmytro</first><last>Chaplynskyi</last><affiliation>Lang-uk Initiative</affiliation></author>
       <pages>1-10</pages>
       <abstract>This paper addresses the need for massive corpora for a low-resource language and presents the publicly available UberText 2.0 corpus for the Ukrainian language and discusses the methodology of its construction. While the collection and maintenance of such a corpus is more of a data extraction and data engineering task, the corpus itself provides a solid foundation for natural language processing tasks. It can enable the creation of contemporary language models and word embeddings, resulting in a better performance of numerous downstream tasks for the Ukrainian language. In addition, the paper and software developed can be used as a guidance and model solution for other low-resource languages. The resulting corpus is available for download on the project page. It has 3.274 billion tokens, consists of 8.59 million texts and takes up 32 gigabytes of space.</abstract>
@@ -134,7 +136,7 @@
       <doi>10.18653/v1/2023.unlp-1.10</doi>
     </paper>
     <paper id="11">
-      <title>Creating a <fixed-case>POS</fixed-case> Gold Standard Corpus of <fixed-case>M</fixed-case>odern <fixed-case>U</fixed-case>krainian</title>
+      <title>Creating a <fixed-case>POS</fixed-case> Gold Standard Corpus of Modern <fixed-case>U</fixed-case>krainian</title>
       <author><first>Vasyl</first><last>Starko</last><affiliation>Ukrainian Catholic University</affiliation></author>
       <author><first>Andriy</first><last>Rysin</last><affiliation>Independent researcher</affiliation></author>
       <pages>91-95</pages>

--- a/data/xml/2024.unlp.xml
+++ b/data/xml/2024.unlp.xml
@@ -13,6 +13,8 @@
       <year>2024</year>
       <url hash="ec6afe3d">2024.unlp-1</url>
       <venue>unlp</venue>
+      <isbn>978-2-493814-43-2</isbn>
+      <doi>10.63317/5bwu58575ghh</doi>
     </meta>
     <frontmatter>
       <url hash="91949aa7">2024.unlp-1.0</url>
@@ -30,15 +32,17 @@
       <abstract>We present a corpus of contemporary Ukrainian news articles published between 2019 and 2022 on the news website of the national public broadcaster of Ukraine, commonly known as SUSPILNE. The current release comprises 87 210 364 words in 292 955 texts. Texts are annotated with titles and their time of publication. In addition, the corpus has been linguistically annotated at the token level with a dependency parser. To provide further aspects for investigation, a topic model was trained on the corpus. The corpus is hosted (Fischer et al., 2023) at the Saarbrücken CLARIN center under a CC BY-NC-ND 4.0 license and available in two tab-separated formats: CoNLL-U (de Marneffe et al., 2021) and vertical text format (VRT) as used by the IMS Open Corpus Workbench (CWB; Evert and Hardie, 2011) and CQPweb (Hardie, 2012). We show examples of using the CQPweb interface, which allows to extract the quantitative data necessary for distributional and collocation analyses of the CNC-UA. As the CNC-UA contains news texts documenting recent events, it is highly relevant not only for linguistic analyses of the modern Ukrainian language but also for socio-cultural and political studies.</abstract>
       <url hash="d6ecf284">2024.unlp-1.1</url>
       <bibkey>fischer-etal-2024-contemporary</bibkey>
+      <doi>10.63317/33t837pync7y</doi>
     </paper>
     <paper id="2">
-      <title>Introducing the Djinni Recruitment Dataset: A Corpus of Anonymized <fixed-case>CV</fixed-case>s and Job Postings</title>
+      <title>Introducing the <fixed-case>D</fixed-case>jinni Recruitment Dataset: A Corpus of Anonymized <fixed-case>CV</fixed-case>s and Job Postings</title>
       <author><first>Nazarii</first><last>Drushchak</last></author>
       <author><first>Mariana</first><last>Romanyshyn</last></author>
       <pages>8–13</pages>
       <abstract>This paper introduces the Djinni Recruitment Dataset, a large-scale open-source corpus of candidate profiles and job descriptions. With over 150,000 jobs and 230,000 candidates, the dataset includes samples in English and Ukrainian, thereby facilitating advancements in the recruitment domain of natural language processing (NLP) for both languages. It is one of the first open-source corpora in the recruitment domain, opening up new opportunities for AI-driven recruitment technologies and related fields. Notably, the dataset is accessible under the MIT license, encouraging widespread adoption for both scientific research and commercial projects.</abstract>
       <url hash="2967cd2a">2024.unlp-1.2</url>
       <bibkey>drushchak-romanyshyn-2024-introducing</bibkey>
+      <doi>10.63317/2dcvy45ws6yb</doi>
     </paper>
     <paper id="3">
       <title>Creating Parallel Corpora for <fixed-case>U</fixed-case>krainian: A <fixed-case>G</fixed-case>erman-<fixed-case>U</fixed-case>krainian Parallel Corpus (<fixed-case>P</fixed-case>ara<fixed-case>R</fixed-case>ook||<fixed-case>DE</fixed-case>-<fixed-case>UK</fixed-case>)</title>
@@ -48,6 +52,7 @@
       <abstract>Parallel corpora are currently a popular and vibrantly developing category of linguistic resources, used both in literature and translation studies, as well as in the field of NLP. For Ukrainian, though, there are still not enough significant parallel corpora compiled within a single roof project and made available to the research community. In this paper we present a newly developed resource, the German-Ukrainian Parallel Corpus — ParaRook||DE-UK, searchable online. We describe various issues related to its compilation, text selection, and annotation. The paper also features several examples of how the corpus can be used in linguistic research and translation studies. Using the experience of the German-Ukrainian parallel corpus, parallel corpora for other languages with Ukrainian can be developed.</abstract>
       <url hash="566c894e">2024.unlp-1.3</url>
       <bibkey>shvedova-lukashevskyi-2024-creating</bibkey>
+      <doi>10.63317/4rnmjmmsncum</doi>
     </paper>
     <paper id="4">
       <title>Introducing <fixed-case>NER</fixed-case>-<fixed-case>UK</fixed-case> 2.0: A Rich Corpus of Named Entities for <fixed-case>U</fixed-case>krainian</title>
@@ -57,6 +62,7 @@
       <abstract>This paper presents NER-UK 2.0, a corpus of texts in the Ukrainian language manually annotated for the named entity recognition task. The corpus contains 560 texts of multiple genres, boasting 21,993 entities in total. The annotation scheme covers 13 entity types, namely location, person name, organization, artifact, document, job title, date, time, period, money, percentage, quantity, and miscellaneous. Such a rich set of entities makes the corpus valuable for training named-entity recognition models in various domains, including news, social media posts, legal documents, and procurement contracts. The paper presents an updated baseline solution for named entity recognition in Ukrainian with 0.89 F1. The corpus is the largest of its kind for the Ukrainian language and is available for download.</abstract>
       <url hash="d44f70d8">2024.unlp-1.4</url>
       <bibkey>chaplynskyi-romanyshyn-2024-introducing</bibkey>
+      <doi>10.63317/5mqwb7ftiezv</doi>
     </paper>
     <paper id="5">
       <title>Instant Messaging Platforms News Multi-Task Classification for Stance, Sentiment, and Discrimination Detection</title>
@@ -66,6 +72,7 @@
       <abstract>In the digital age, geopolitical events frequently catalyze discussions among global web users. Platforms such as social networks and messaging applications serve as vital means for information spreading and acquisition. The Russian aggression against Ukraine has notably intensified online discourse on the matter, drawing a significant audience eager for real-time updates. This surge in online activity inevitably results in the proliferation of content, some of which may be unreliable or manipulative. Given this context, the identification of such content with information distortion is imperative to mitigate bias and promote fairness. However, this task presents considerable challenges, primarily due to the lack of sophisticated language models capable of understanding the nuances and context of texts in low-resource languages, and the scarcity of well-annotated datasets for training such models. To address these gaps, we introduce the TRWU dataset - a meticulously annotated collection of Telegram news about the Russian war in Ukraine gathered starting from January 1, 2022. This paper outlines our methodology for semantic analysis and classification of these messages, aiming to ascertain their bias. Such an approach enhances our ability to detect manipulative and destructive content. Through descriptive statistical analysis, we explore deviations in message sentiment, stance, and metadata across different types of channels and levels of content creation activity. Our findings indicate a predominance of negative sentiment within the dataset. Additionally, our research elucidates distinct differences in the linguistic choices and phraseology among channels, based on their stance towards the war. This study contributes to the broader effort of understanding the spread and mitigating the impact of biased and manipulative content in digital communications.</abstract>
       <url hash="3c3a4960">2024.unlp-1.5</url>
       <bibkey>ustyianovych-barbosa-2024-instant</bibkey>
+      <doi>10.63317/4uv55pnermm6</doi>
     </paper>
     <paper id="6">
       <title>Setting up the Data Printer with Improved <fixed-case>E</fixed-case>nglish to <fixed-case>U</fixed-case>krainian Machine Translation</title>
@@ -77,6 +84,7 @@
       <abstract>To build large language models for Ukrainian we need to expand our corpora with large amounts of new algorithmic tasks expressed in natural language. Examples of task performance expressed in English are abundant, so with a high-quality translation system our community will be enabled to curate datasets faster. To aid this goal, we introduce a recipe to build a translation system using supervised finetuning of a large pretrained language model with a noisy parallel dataset of 3M pairs of Ukrainian and English sentences followed by a second phase of training using 17K examples selected by k-fold perplexity filtering on another dataset of higher quality. Our decoder-only model named Dragoman beats performance of previous state of the art encoder-decoder models on the FLORES devtest set.</abstract>
       <url hash="de56ad9f">2024.unlp-1.6</url>
       <bibkey>paniv-etal-2024-setting</bibkey>
+      <doi>10.63317/36tfnj3sqbe9</doi>
     </paper>
     <paper id="7">
       <title>Automated Extraction of Hypo-Hypernym Relations for the <fixed-case>U</fixed-case>krainian <fixed-case>W</fixed-case>ord<fixed-case>N</fixed-case>et</title>
@@ -87,6 +95,7 @@
       <abstract>WordNet is a crucial resource in linguistics and natural language processing, providing a detailed and expansive set of lexico-semantic relationships among words in a language. The trend toward automated construction and expansion of WordNets has become increasingly popular due to the high costs of manual development. This study aims to automate the development of the Ukrainian WordNet, explicitly concentrating on hypo-hypernym relations that are crucial building blocks of the hierarchical structure of WordNet. Utilizing the linking between Princeton WordNet, Wikidata, and multilingual resources from Wikipedia, the proposed approach successfully mapped 17% of Princeton WordNet (PWN) content to Ukrainian Wikipedia. Furthermore, the study introduces three innovative strategies for generating new entries to fill in the gaps of the Ukrainian WordNet: machine translation, the Hypernym Discovery model, and the Hypernym Instruction-Following LLaMA model. The latter model shows a high level of effectiveness, evidenced by a 41.61% performance on the Mean Overlap Coefficient (MOC) metric. With the proposed approach that combines automated techniques with expert human input, we provide a reliable basis for creating the Ukrainian WordNet.</abstract>
       <url hash="edaeeda9">2024.unlp-1.7</url>
       <bibkey>romanyshyn-etal-2024-automated</bibkey>
+      <doi>10.63317/4ekekaazwpeq</doi>
     </paper>
     <paper id="8">
       <title><fixed-case>U</fixed-case>krainian Visual Word Sense Disambiguation Benchmark</title>
@@ -101,6 +110,7 @@
       <abstract>This study presents a benchmark for evaluating the Visual Word Sense Disambiguation (Visual-WSD) task in Ukrainian. The main goal of the Visual-WSD task is to identify, with minimal contextual information, the most appropriate representation of a given ambiguous word from a set of ten images. To construct this benchmark, we followed a methodology similar to that proposed by (CITATION), who previously introduced benchmarks for the Visual-WSD task in English, Italian, and Farsi. This approach allows us to incorporate the Ukrainian benchmark into a broader framework for cross-language model performance comparisons. We collected the benchmark data semi-automatically and refined it with input from domain experts. We then assessed eight multilingual and multimodal large language models using this benchmark. All tested models performed worse than the zero-shot CLIP-based baseline model (CITATION) used by (CITATION) for the English Visual-WSD task. Our analysis revealed a significant performance gap in the Visual-WSD task between Ukrainian and English.</abstract>
       <url hash="fa727494">2024.unlp-1.8</url>
       <bibkey>laba-etal-2024-ukrainian</bibkey>
+      <doi>10.63317/3pn6eqt8c2n9</doi>
     </paper>
     <paper id="9">
       <title>The <fixed-case>UNLP</fixed-case> 2024 Shared Task on Fine-Tuning Large Language Models for <fixed-case>U</fixed-case>krainian</title>
@@ -111,6 +121,7 @@
       <abstract>This paper presents the results of the UNLP 2024 shared task, the first Shared Task on Fine-Tuning Large Language Models for the Ukrainian language. The goal of the task was to facilitate the creation of models that have knowledge of the Ukrainian language, history, and culture, as well as common knowledge, and are capable of generating fluent and accurate responses in Ukrainian. The participants were required to use models with open weights and reasonable size to ensure the reproducibility of the solutions. The participating systems were evaluated using multiple-choice exam questions and manually crafted open questions. Three teams submitted their solutions before the deadline, and two teams submitted papers that were accepted to appear in the UNLP workshop proceedings and are referred to in this report. The Codabench leaderboard is left open for further submissions.</abstract>
       <url hash="9aa5f906">2024.unlp-1.9</url>
       <bibkey>romanyshyn-etal-2024-unlp</bibkey>
+      <doi>10.63317/57pbivswb65o</doi>
     </paper>
     <paper id="10">
       <title>Fine-Tuning and Retrieval Augmented Generation for Question Answering Using Affordable Large Language Models</title>
@@ -122,9 +133,10 @@
       <abstract>We present our proposed system named Sherlock to UNLP 2024 Shared Task on Question Answering winning first place. We employ a mix of methods, from using automatically translated datasets to perform supervised fine-tuning and direct preference optimization on instruction-tuned models, to model weight merging and retrieval augmented generation. We present and motivate our chosen sequence of steps, as well as an ablation study to understand the effect of each additional step. The resulting model and code are made publicly available (download links provided in the paper).</abstract>
       <url hash="b393400e">2024.unlp-1.10</url>
       <bibkey>boros-etal-2024-fine</bibkey>
+      <doi>10.63317/4c7u52x7u2tx</doi>
     </paper>
     <paper id="11">
-      <title>From Bytes to Borsch: Fine-Tuning Gemma and Mistral for the <fixed-case>U</fixed-case>krainian Language Representation</title>
+      <title>From Bytes to Borsch: Fine-Tuning <fixed-case>G</fixed-case>emma and <fixed-case>M</fixed-case>istral for the <fixed-case>U</fixed-case>krainian Language Representation</title>
       <author><first>Artur</first><last>Kiulian</last></author>
       <author><first>Anton</first><last>Polishko</last></author>
       <author><first>Mykola</first><last>Khandoga</last></author>
@@ -136,6 +148,7 @@
       <abstract>In the rapidly advancing field of AI and NLP, generative large language models (LLMs) stand at the forefront of innovation, showcasing unparalleled abilities in text understanding and generation. However, the limited representation of low-resource languages like Ukrainian poses a notable challenge, restricting the reach and relevance of this technology. Our paper addresses this by fine-tuning the open-source Gemma and Mistral LLMs with Ukrainian datasets, aiming to improve their linguistic proficiency and benchmarking them against other existing models capable of processing Ukrainian language. This endeavor not only aims to mitigate language bias in technology but also promotes inclusivity in the digital realm. Our transparent and reproducible approach encourages further NLP research and development. Additionally, we present the Ukrainian Knowledge and Instruction Dataset (UKID) to aid future efforts in language model fine-tuning. Our research not only advances the field of NLP but also highlights the importance of linguistic diversity in AI, which is crucial for cultural preservation, education, and expanding AI’s global utility. Ultimately, we advocate for a future where technology is inclusive, enabling AI to communicate effectively across all languages, especially those currently underrepresented.</abstract>
       <url hash="4119aac5">2024.unlp-1.11</url>
       <bibkey>kiulian-etal-2024-bytes</bibkey>
+      <doi>10.63317/5dowr7hgrb4v</doi>
     </paper>
     <paper id="12">
       <title>Spivavtor: An Instruction Tuned <fixed-case>U</fixed-case>krainian Text Editing Model</title>
@@ -147,6 +160,7 @@
       <abstract>We introduce Spivavtor, a dataset, and instruction-tuned models for text editing focused on the Ukrainian language. Spivavtor is the Ukrainian-focused adaptation of the English-only CoEdIT (Raheja et al., 2023) model. Similar to CoEdIT, Spivavtor performs text editing tasks by following instructions in Ukrainian like “Виправте граматику в цьому реченнi” and “Спростiть це речення” which translate to “Correct the grammar in this sentence” and “Simplify this sentence” in English, respectively. This paper describes the details of the Spivavtor-Instruct dataset and Spivavtor models. We evaluate Spivavtor on a variety of text editing tasks in Ukrainian, such as Grammatical Error Correction (GEC), Text Simplification, Coherence, and Paraphrasing, and demonstrate its superior performance on all of them. We publicly release our best performing models and data as resources to the community to advance further research in this space.</abstract>
       <url hash="ff2172a0">2024.unlp-1.12</url>
       <bibkey>saini-etal-2024-spivavtor</bibkey>
+      <doi>10.63317/59qw7bvuvej8</doi>
     </paper>
     <paper id="13">
       <title>Eval-<fixed-case>UA</fixed-case>-tion 1.0: Benchmark for Evaluating <fixed-case>U</fixed-case>krainian (Large) Language Models</title>
@@ -157,6 +171,7 @@
       <abstract>In this paper, we introduce Eval-UA-tion, a set of novel Ukrainian-language datasets aimed at evaluating the performance of language models on the Ukrainian language. The tasks include UA-CBT (inspired by the Children’s Book Test, a fill-in-the-gaps type task aimed at gauging the extent to which a story narrative is understood), UP-Titles (where the online newspaper <i>Ukrainska Pravda</i>‘s articles have to be matched to the correct title among 10 similar ones), and LMentry-static-UA/LMES (inspired by the LMentry benchmark, a set of tasks simple to solve for humans but hard for LMs, such as ‘which of these words is longer’ and ‘what is the fifth word of this sentence’). With the exception of UP-Titles, the tasks are built in a way to minimize contamination and use material unlikely to be present in the training sets of language models, and include a split for few-shot model prompting use that minimizes contamination. For each task human and random baselines are provided.</abstract>
       <url hash="a3ebe10b">2024.unlp-1.13</url>
       <bibkey>hamotskyi-etal-2024-eval</bibkey>
+      <doi>10.63317/5m5wwkb5zzks</doi>
     </paper>
     <paper id="14">
       <title><fixed-case>L</fixed-case>i<fixed-case>BERT</fixed-case>a: Advancing <fixed-case>U</fixed-case>krainian Language Modeling through Pre-training from Scratch</title>
@@ -174,6 +189,7 @@
       <abstract>The present work focuses on the entity embellishments when named entities are accompanied by additional information that is not supported by the context or the source material. Our paper contributes into mitigating this problem in large language model’s generated texts, summaries in particular, by proposing the approach with synthetic noise injection in the generated samples that are further used for alignment of finetuned LLM. We also challenge the issue of solutions scarcity for low-resourced languages and test our approach with corpora in Ukrainian.</abstract>
       <url hash="5fda4d1f">2024.unlp-1.15</url>
       <bibkey>galeshchuk-2024-entity</bibkey>
+      <doi>10.63317/4sm99nhtbh45</doi>
     </paper>
     <paper id="16">
       <title>Language-Specific Pruning for Efficient Reduction of Large Language Models</title>
@@ -182,6 +198,7 @@
       <abstract>Delving into pruning techniques is essential to boost the efficiency of Large Language Models (LLMs) by reducing their size and computational demands, resulting in faster and more cost-effective inference. In this work, our key contribution lies in recognizing that LLMs trained on diverse languages manifest distinct language-specific weight distributions. Exploiting this insight, we illustrate that pruning LLMs using language-specific data results in a more potent model compression. Empirical evidence underscores the critical nature of pruning on language-specific data, highlighting a noteworthy impact on the perplexity of Ukrainian texts compared to pruning on English data. The proposed methodology significantly reduces the size of LLaMA, LLaMA 2 and Mistral models while preserving competitive performance. This research underscores the significance of linguistic considerations in LLM pruning and advocates for language-specific optimization, establishing a framework for more efficient and tailored language models across diverse linguistic contexts. Additionally, all experiments were conducted using a single consumer-grade NVIDIA RTX 3090 GPU, and the code is available at https://github.com/mshamrai/language-specific-pruning.</abstract>
       <url hash="b1a51aaa">2024.unlp-1.16</url>
       <bibkey>shamrai-2024-language</bibkey>
+      <doi>10.63317/55g6qr4jy7ip</doi>
     </paper>
   </volume>
 </collection>

--- a/data/xml/2025.unlp.xml
+++ b/data/xml/2025.unlp.xml
@@ -77,7 +77,7 @@
       <doi>10.18653/v1/2025.unlp-1.4</doi>
     </paper>
     <paper id="5">
-      <title>Comparing Methods for Multi-Label Classification of Manipulation Techniques in <fixed-case>U</fixed-case>krainian Telegram Content</title>
+      <title>Comparing Methods for Multi-Label Classification of Manipulation Techniques in <fixed-case>U</fixed-case>krainian <fixed-case>T</fixed-case>elegram Content</title>
       <author><first>Oleh</first><last>Melnychuk</last><affiliation>Kyiv Aviation Institute</affiliation></author>
       <pages>45-48</pages>
       <abstract>Detecting manipulation techniques in online text is vital for combating misinformation, a task complicated by generative AI. This paper compares machine learning approaches for multi-label classification of 10 techniques in Ukrainian Telegram content (UNLP 2025 Shared Task 1). Our evaluation included TF-IDF, fine-tuned XLM-RoBERTa-Large, PEFT-LLM (Gemma, Mistral) and a RAG approach (E5 + Mistral Nemo). The fine-tuned XLM-RoBERTa-Large model, which incorporates weighted loss to address class imbalance, yielded the highest Macro F1 score (0.4346). This result surpassed the performance of TF-IDF (Macro F1 0.32-0.36), the PEFT-LLM (0.28-0.33) and RAG (0.309). Synthetic data slightly helped TF-IDF but reduced transformer model performance. The results demonstrate the strong performance of standard transformers like XLM-R when appropriately configured for this classification task.</abstract>
@@ -86,7 +86,7 @@
       <doi>10.18653/v1/2025.unlp-1.5</doi>
     </paper>
     <paper id="6">
-      <title>Framing the Language: Fine-Tuning Gemma 3 for Manipulation Detection</title>
+      <title>Framing the Language: Fine-Tuning <fixed-case>G</fixed-case>emma 3 for Manipulation Detection</title>
       <author><first>Mykola</first><last>Khandoga</last><affiliation>OpenBabylon</affiliation></author>
       <author><first>Yevhen</first><last>Kostiuk</last><affiliation>University of Dundee</affiliation></author>
       <author><first>Anton</first><last>Polishko</last><affiliation>OpenBabylon</affiliation></author>
@@ -133,7 +133,7 @@
       <doi>10.18653/v1/2025.unlp-1.9</doi>
     </paper>
     <paper id="10">
-      <title>Vuyko Mistral: Adapting <fixed-case>LLM</fixed-case>s for Low-Resource Dialectal Translation</title>
+      <title>Vuyko <fixed-case>M</fixed-case>istral: Adapting <fixed-case>LLM</fixed-case>s for Low-Resource Dialectal Translation</title>
       <author><first>Roman</first><last>Kyslyi</last><affiliation>National Technical University of Ukraine “Igor Sikorsky Kyiv Polytechnic Institute”</affiliation></author>
       <author><first>Yuliia</first><last>Maksymiuk</last><affiliation>Ukrainian Catholic University</affiliation></author>
       <author><first>Ihor</first><last>Pysmennyi</last><affiliation>National Technical University of Ukraine “Igor Sikorsky Kyiv Polytechnic Institute”</affiliation></author>
@@ -167,7 +167,7 @@
       <doi>10.18653/v1/2025.unlp-1.12</doi>
     </paper>
     <paper id="13">
-      <title>Transforming Causal <fixed-case>LLM</fixed-case> into <fixed-case>MLM</fixed-case> Encoder for Detecting Social Media Manipulation in Telegram</title>
+      <title>Transforming Causal <fixed-case>LLM</fixed-case> into <fixed-case>MLM</fixed-case> Encoder for Detecting Social Media Manipulation in <fixed-case>T</fixed-case>elegram</title>
       <author><first>Anton</first><last>Bazdyrev</last><affiliation>Dun &amp; Bradstreet, NTUU “Igor Sikorsky Kyiv Polytechnic Institute”</affiliation></author>
       <author><first>Ivan</first><last>Bashtovyi</last><affiliation>National Technical University of Ukraine “Igor Sikorsky Kyiv Polytechnic Institute”</affiliation></author>
       <author><first>Ivan</first><last>Havlytskyi</last><affiliation>National Technical University of Ukraine “Igor Sikorsky Kyiv Polytechnic Institute”</affiliation></author>
@@ -243,7 +243,7 @@
       <doi>10.18653/v1/2025.unlp-1.19</doi>
     </paper>
     <paper id="20">
-      <title>Detecting Manipulation in <fixed-case>U</fixed-case>krainian Telegram: A Transformer-Based Approach to Technique Classification and Span Identification</title>
+      <title>Detecting Manipulation in <fixed-case>U</fixed-case>krainian <fixed-case>T</fixed-case>elegram: A Transformer-Based Approach to Technique Classification and Span Identification</title>
       <author><first>Md. Abdur</first><last>Rahman</last><affiliation>Southeast University</affiliation></author>
       <author><first>Md Ashiqur</first><last>Rahman</last><affiliation>Southeast University</affiliation></author>
       <pages>203-213</pages>


### PR DESCRIPTION
UNLP 2024, co-located with LREC-Coling 2024, finally received DOIs: https://lrec.elra.info/conference/2024/workshop/unlp.

I added them to the corresponding XML, along with the ISBN. I also fixed minor capitalization issues along the way.

@mjpost, please have a look when you have a chance 🙏 