### PR TITLE
Add the last missing DOI; add ws tag to UNLP 2023 and 2024

### DIFF
--- a/data/xml/2023.unlp.xml
+++ b/data/xml/2023.unlp.xml
@@ -10,6 +10,7 @@
       <year>2023</year>
       <url hash="4011460c">2023.unlp-1</url>
       <venue>unlp</venue>
+      <venue>ws</venue>
       <isbn>978-1-959429-52-4</isbn>
       <doi>10.18653/v1/2023.unlp-1</doi>
     </meta>

--- a/data/xml/2024.unlp.xml
+++ b/data/xml/2024.unlp.xml
@@ -13,6 +13,7 @@
       <year>2024</year>
       <url hash="ec6afe3d">2024.unlp-1</url>
       <venue>unlp</venue>
+      <venue>ws</venue>
       <isbn>978-2-493814-43-2</isbn>
       <doi>10.63317/5bwu58575ghh</doi>
     </meta>
@@ -181,6 +182,7 @@
       <abstract>Recent advancements in Natural Language Processing (NLP) have spurred remarkable progress in language modeling, predominantly benefiting English. While Ukrainian NLP has long grappled with significant challenges due to limited data and computational resources, recent years have seen a shift with the emergence of new corpora, marking a pivotal moment in addressing these obstacles. This paper introduces LiBERTa Large, the inaugural BERT Large model pre-trained entirely from scratch only on Ukrainian texts. Leveraging extensive multilingual text corpora, including a substantial Ukrainian subset, LiBERTa Large establishes a foundational resource for Ukrainian NLU tasks. Our model outperforms existing multilingual and monolingual models pre-trained from scratch for Ukrainian, demonstrating competitive performance against those relying on cross-lingual transfer from English. This achievement underscores our ability to achieve superior performance through pre-training from scratch with additional enhancements, obviating the need to rely on decisions made for English models to efficiently transfer weights. We establish LiBERTa Large as a robust baseline, paving the way for future advancements in Ukrainian language modeling.</abstract>
       <url hash="2124bf19">2024.unlp-1.14</url>
       <bibkey>haltiuk-smywinski-pohl-2024-liberta</bibkey>
+      <doi>10.63317/38s36d2i3zdo</doi>
     </paper>
     <paper id="15">
       <title>Entity Embellishment Mitigation in <fixed-case>LLM</fixed-case>s Output with Noisy Synthetic Dataset for Alignment</title>

--- a/data/xml/2026.unlp.xml
+++ b/data/xml/2026.unlp.xml
@@ -95,7 +95,7 @@
       <bibkey>chaplynskyi-etal-2026-semantic</bibkey>
     </paper>
     <paper id="9">
-      <title>Graph-Based Detection of Disinformation Narrative Diffusion between <fixed-case>R</fixed-case>ussian and <fixed-case>U</fixed-case>krainian Telegram Channels</title>
+      <title>Graph-Based Detection of Disinformation Narrative Diffusion between <fixed-case>R</fixed-case>ussian and <fixed-case>U</fixed-case>krainian <fixed-case>T</fixed-case>elegram Channels</title>
       <author><first>Yuliia</first><last>Vistak</last><affiliation>Ukrainian Catholic University</affiliation></author>
       <author><first>Viktoriia</first><last>Makovska</last><affiliation>Ukrainian Catholic University</affiliation></author>
       <author><first>Vera</first><last>Schmitt</last><affiliation>Technische Universität Berlin, German Research Center for Artificial Intelligence</affiliation></author>
@@ -182,7 +182,7 @@
       <bibkey>syvokon-2026-dictionary</bibkey>
     </paper>
     <paper id="16">
-      <title>Scaling <fixed-case>ASR</fixed-case> for Hutsul Dialect: Multi-Speaker Data Collection, Enhanced Transcription and Cross-Speaker Evaluation</title>
+      <title>Scaling <fixed-case>ASR</fixed-case> for <fixed-case>H</fixed-case>utsul Dialect: Multi-Speaker Data Collection, Enhanced Transcription and Cross-Speaker Evaluation</title>
       <author><first>Artem</first><last>Orlovskyi</last><affiliation>Kyiv School of Economics</affiliation></author>
       <author><first>Zakhar</first><last>Guzii</last><affiliation>Kyiv School of Economics</affiliation></author>
       <author><first>Bohdan</first><last>Onyshchenko</last><affiliation>Kyiv School of Economics</affiliation></author>


### PR DESCRIPTION
@mjpost, apologies, I missed one DOI 🙈  Also added `ws` to UNLP 2023 and 2024 when it was still a workshop.

All previous changes work as expected, except for one tiny thing: the ISBN is not visible at https://aclanthology.org/volumes/2024.unlp-1 although it is present in the bib files. Do you happen to know why?