### PR TITLE
Correct editor order for CHum 2026

### DIFF
--- a/data/xml/2026.chum.xml
+++ b/data/xml/2026.chum.xml
@@ -3,11 +3,11 @@
   <volume id="1" type="proceedings" ingest-date="2026-06-28">
     <meta>
       <booktitle>Proceedings of the 2nd Workshop on Computational Humor (<fixed-case>CH</fixed-case>um 2026)</booktitle>
+      <editor><first>Tristan</first><last>Miller</last></editor>
       <editor><first>Ori</first><last>Amir</last></editor>
-      <editor><first>Christian F.</first><last>Hempelmann</last></editor>
       <editor><first>Julia</first><last>Rayz</last></editor>
       <editor><first>Tiansi</first><last>Dong</last></editor>
-      <editor><first>Tristan</first><last>Miller</last></editor>
+      <editor><first>Christian F.</first><last>Hempelmann</last></editor>
       <publisher>Association for Computational Linguistics</publisher>
       <address>Online</address>
       <isbn>979-8-89176-431-6</isbn>


### PR DESCRIPTION
This metadata edit changes the order of the editors of the CHum 2026 proceedings to match what appears in [the preface of the proceedings itself](https://aclanthology.org/2026.chum-1.0.pdf).  (The incorrect editor order in the metadata submitted to the ACL 2026 Publications Chairs was an oversight and [has since been fixed](https://github.com/aclpub2026/ws_chum/commit/10c16d8b483a7d481cd82b71a19914328c262dcd).)