### PR TITLE
Add visualization for external links

### DIFF
--- a/bin/create_hugo_data.py
+++ b/bin/create_hugo_data.py
@@ -195,8 +195,11 @@ def paper_to_dict(paper):
         else:
             data["pages"] = page_first
     if paper.pdf is not None:
-        data["pdf"] = paper.pdf.url
-        data["thumbnail"] = paper.thumbnail.url
+        if paper.pdf.is_local:
+            data["pdf"] = paper.pdf.url
+            data["thumbnail"] = paper.thumbnail.url
+        else:
+            data["external"] = paper.pdf.url
     if paper.errata:
         data["erratum"] = [
             {
@@ -261,7 +264,10 @@ def volume_to_dict(volume):
         data["meta_issue"] = volume.journal_issue
         data["meta_volume"] = volume.journal_volume
     if volume.pdf is not None:
-        data["pdf"] = volume.pdf.url
+        if volume.pdf.is_local:
+            data["pdf"] = volume.pdf.url
+        else:
+            data["external"] = volume.pdf.url
     return data
 
 

--- a/hugo/layouts/events/single.html
+++ b/hugo/layouts/events/single.html
@@ -87,6 +87,10 @@
       <a class="badge text-bg-primary align-middle me-1" href="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Open full proceedings volume as PDF">pdf&nbsp;(full)</a>
       <br class="d-none d-sm-inline-block" />
       {{- end -}}
+      {{- with $volume.external -}}
+      <a class="badge text-bg-primary align-middle me-1" href="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Open external proceedings" aria-label="Open external proceedings"><i class="fas fa-external-link-alt" aria-hidden="true"></i></a>
+      <br class="d-none d-sm-inline-block" />
+      {{- end -}}
       {{- $bibfile := printf "volumes/%s.bib" . -}}
       {{- if (fileExists (printf "/data-export/%s" $bibfile)) -}}
       <a class="badge text-bg-secondary align-middle me-1" href="{{ relURL $bibfile }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Export to BibTeX">bib&nbsp;(full)</a>

--- a/hugo/layouts/papers/list-entry-author.html
+++ b/hugo/layouts/papers/list-entry-author.html
@@ -8,6 +8,11 @@
         pdf
       </a>
       {{- end -}}
+      {{- with $paper.external -}}
+      <a class="badge text-bg-primary align-middle me-1" href="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Open external publication" aria-label="Open external publication">
+        <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+      </a>
+      {{- end -}}
       {{- if (fileExists (printf "/data-export/volumes/%s.bib" $paper.parent_volume_id)) -}}
       <a class="badge text-bg-secondary align-middle me-1" href="{{ (printf "%s.bib" .Params.anthology_id) | relURL }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Export to BibTeX" aria-label="Export to BibTeX">
         bib

--- a/hugo/layouts/papers/list-entry.html
+++ b/hugo/layouts/papers/list-entry.html
@@ -9,6 +9,11 @@
         pdf
       </a>
       {{- end -}}
+      {{- with $paper.external -}}
+      <a class="badge text-bg-primary align-middle me-1" href="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Open external publication" aria-label="Open external publication">
+        <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+      </a>
+      {{- end -}}
       {{- if and (not $paper.retracted) (fileExists (printf "/data-export/volumes/%s.bib" $paper.parent_volume_id)) -}}
       <a class="badge text-bg-secondary align-middle me-1" href="{{ (printf "%s.bib" .Params.anthology_id) | relURL }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Export to BibTeX" aria-label="Export to BibTeX">
         bib

--- a/hugo/layouts/papers/single.html
+++ b/hugo/layouts/papers/single.html
@@ -130,7 +130,7 @@
     document.getElementById("paperIdSpan").textContent = paper_params.anthology_id;
     document.getElementById("paperTitle").value = paper_params.title;
     document.getElementById("paperAbstract").value = paper_params.abstract;
-    document.getElementById("paperPDF").href = "{{ $paper.pdf }}";
+    document.getElementById("paperPDF").href = "{{ or $paper.pdf $paper.external }}";
     document.getElementById("paperSnapshot").href = "https://aclanthology.org/thumb/" + paper_params.anthology_id + "-trimmed.jpg";
     document.getElementById("paperSnapshotImg").src = "https://aclanthology.org/thumb/" + paper_params.anthology_id + "-trimmed.jpg";
 
@@ -394,7 +394,11 @@
       {{ with $paper.pdf }}
       <a href="{{ . }}">{{ $paper.title_html | safeHTML }}</a>
       {{ else }}
+      {{ with $paper.external }}
+      <a href="{{ . }}">{{ $paper.title_html | safeHTML }} <i class="fas fa-external-link-alt fa-xs" aria-hidden="true"></i></a>
+      {{ else }}
       {{ $paper.title_html | safeHTML }}
+      {{ end }}
       {{ end }}
     </h2>
     {{ with $paper.author }}
@@ -449,7 +453,7 @@
             <div class="mb-3">
               <label class="form-label d-block">Verification against PDF</label>
               <small class="form-text text-muted d-block mb-2">Ensure that the new title/authors match the snapshot below. (If there
-                is no snapshot or it is too small, consult <a href="#" id="paperPDF">the PDF</a>.)</small>
+                is no snapshot or it is too small, consult <a href="#" id="paperPDF">{{ if $paper.external }}the external publication <i class="fas fa-external-link-alt fa-xs" aria-hidden="true"></i>{{ else }}the PDF{{ end }}</a>.)</small>
               <div style="max-height:150px;" class="overflow-hidden w-100" style="text-align: center;">
                 <a id="paperSnapshot" href="#"><img id="paperSnapshotImg" src=""
                     style="min-width: 80%; max-width: 100%"></a>
@@ -573,8 +577,8 @@
         <dd>{{ with $paper.pages }}{{ . }}{{ end }}</dd>
         <dt>Language:</dt>
         <dd>{{ with $paper.language }}{{ . }}{{ end }}</dd>
-        <dt>URL:</dt>
-        <dd><a href="{{ $paper.url }}">{{ $paper.url }}</a></dd>
+        <dt>{{ if $paper.external }}External URL:{{ else }}URL:{{ end }}</dt>
+        <dd><a href="{{ $paper.url }}">{{ $paper.url }}{{ if $paper.external }} <i class="fas fa-external-link-alt fa-xs" aria-hidden="true"></i>{{ end }}</a></dd>
         <dt>DOI:</dt>
         <dd>{{ with $paper.doi }}<a href="https://doi.org/{{ . }}" title="To the current version of the paper by DOI">{{
             . }}</a>{{ end }}</dd>
@@ -664,6 +668,11 @@
         <i class="far fa-file-pdf"></i><span class="ps-2">PDF</span>
       </a>
       {{ end }}
+      {{ end }}
+      {{ with $paper.external }}
+      <a class="btn btn-primary" href="{{ . }}" title="Open external publication for '{{ $paper.title | htmlEscape }}'">
+        <i class="fas fa-external-link-alt"></i><span class="ps-2">External</span>
+      </a>
       {{ end }}
       {{ if and (not $paper.retracted) (not $paper.removed) ($paper.bibtex) }}
       <a class="btn btn-secondary" title="Open dialog for exporting citations" data-bs-toggle="modal"

--- a/hugo/layouts/volumes/single.html
+++ b/hugo/layouts/volumes/single.html
@@ -10,7 +10,11 @@
     {{ with $paper.pdf }}
       <a href="{{ . }}">{{ $paper.title_html | safeHTML }}</a>
     {{ else }}
-      {{ $paper.title_html | safeHTML }}
+      {{ with $paper.external }}
+        <a href="{{ . }}">{{ $paper.title_html | safeHTML }} <i class="fas fa-external-link-alt fa-xs" aria-hidden="true"></i></a>
+      {{ else }}
+        {{ $paper.title_html | safeHTML }}
+      {{ end }}
     {{ end }}
   </h2>
   {{ with $paper.editor }}
@@ -79,8 +83,8 @@
 
       <dt>Publisher:</dt>
       <dd>{{ with $paper.publisher }}{{ . }}{{ end }}</dd>
-      <dt>URL:</dt>
-      <dd><a href="{{ $paper.url }}">{{ $paper.url }}</a></dd>
+      <dt>{{ if $paper.external }}External URL:{{ else }}URL:{{ end }}</dt>
+      <dd><a href="{{ $paper.url }}">{{ $paper.url }}{{ if $paper.external }} <i class="fas fa-external-link-alt fa-xs" aria-hidden="true"></i>{{ end }}</a></dd>
       <dt>DOI:</dt>
       <dd>{{ with $paper.doi }}<a href="https://doi.org/{{ . }}" title="To the current version of the paper by DOI">{{ . }}</a>{{ end }}</dd>
       {{ with $paper.isbn }}
@@ -119,6 +123,11 @@
       {{ with $paper.pdf }}
       <a class="btn btn-primary" href="{{ . }}" title="Open PDF of '{{ $paper.title | htmlEscape }}'">
         <i class="far fa-file-pdf"></i><span class="ps-2">PDF&nbsp;<small>(full)</small></span>
+      </a>
+      {{ end }}
+      {{ with $paper.external }}
+      <a class="btn btn-primary" href="{{ . }}" title="Open external publication for '{{ $paper.title | htmlEscape }}'">
+        <i class="fas fa-external-link-alt"></i><span class="ps-2">External</span>
       </a>
       {{ end }}
       {{ $bibfile := printf "/volumes/%s.bib" $anthology_id }}

--- a/tests/test_create_hugo_data.py
+++ b/tests/test_create_hugo_data.py
@@ -1,0 +1,35 @@
+"""Tests for bin/create_hugo_data.py."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from bin.create_hugo_data import paper_to_dict
+
+from acl_anthology import Anthology
+
+
+@pytest.fixture(scope="module")
+def anthology():
+    return Anthology.from_within_repo()
+
+
+def test_external_paper_url_is_not_exported_as_pdf(anthology):
+    data = paper_to_dict(anthology.get_paper("1998.amta-papers.1"))
+
+    assert data["external"] == (
+        "https://link.springer.com/chapter/10.1007/3-540-49478-2_1"
+    )
+    assert "pdf" not in data
+    assert "thumbnail" not in data
+
+
+def test_local_paper_url_is_exported_as_pdf(anthology):
+    data = paper_to_dict(anthology.get_paper("2025.acl-long.1"))
+
+    assert data["pdf"] == "https://aclanthology.org/2025.acl-long.1.pdf"
+    assert data["thumbnail"] == ("https://aclanthology.org/thumb/2025.acl-long.1.jpg")
+    assert "external" not in data

--- a/tests/test_create_hugo_data.py
+++ b/tests/test_create_hugo_data.py
@@ -9,7 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from bin.create_hugo_data import paper_to_dict
 
-from acl_anthology import Anthology
+from acl_anthology import Anthology, config
 
 
 @pytest.fixture(scope="module")
@@ -30,6 +30,6 @@ def test_external_paper_url_is_not_exported_as_pdf(anthology):
 def test_local_paper_url_is_exported_as_pdf(anthology):
     data = paper_to_dict(anthology.get_paper("2025.acl-long.1"))
 
-    assert data["pdf"] == "https://aclanthology.org/2025.acl-long.1.pdf"
-    assert data["thumbnail"] == ("https://aclanthology.org/thumb/2025.acl-long.1.jpg")
+    assert data["pdf"] == f"{config.url_prefix}/2025.acl-long.1.pdf"
+    assert data["thumbnail"] == f"{config.url_prefix}/thumb/2025.acl-long.1.jpg"
     assert "external" not in data


### PR DESCRIPTION
## Preview examples

- [External paper page](https://preview.aclanthology.org/external-links/1998.amta-papers.1/)
- [Volume listing with external-link badges](https://preview.aclanthology.org/external-links/volumes/1998.amta-papers/)
- [Local PDF control (unchanged)](https://preview.aclanthology.org/external-links/2025.acl-long.1/)