### PR TITLE
Move name normalization to ingestion

### DIFF
--- a/bin/ingest.py
+++ b/bin/ingest.py
@@ -34,6 +34,7 @@ import re
 import shutil
 import sys
 import PyPDF2
+import unicodedata
 
 from collections import defaultdict
 from datetime import datetime
@@ -56,6 +57,95 @@ from acl_anthology.utils import setup_rich_logging
 from fixedcase.protect import protect as protect_fixedcase
 
 ARCHIVAL_DEFAULT = True
+
+LAST_NAME_LOWERCASE_PREFIXES = {
+    "al",
+    "bin",
+    "bint",
+    "da",
+    "de",
+    "del",
+    "de la",
+    "dela",
+    "della",
+    "di",
+    "dos",
+    "du",
+    "el",
+    "la",
+    "le",
+    "van",
+    "van den",
+    "van der",
+    "von",
+    "von der",
+}
+_LAST_NAME_LOWERCASE_REGEX = re.compile(
+    f"^({'|'.join(sorted(LAST_NAME_LOWERCASE_PREFIXES, key=lambda value: -len(value)))}) ",
+    flags=re.IGNORECASE,
+)
+_LAST_NAME_CAPITALIZATION_RULES = (
+    (r"^Mc([a-z])", lambda match: "Mc" + match.group(1).upper()),
+)
+_DOTTED_INITIAL_COMPONENT_REGEX = re.compile(r"(?<=\.)[a-z](?=\.|$)")
+_INITIAL_LED_DOTTED_TOKEN_REGEX = re.compile(
+    r"(?<!\S)[A-Za-z](?:\.[A-Za-z]+)+\.?(?=\s|$)"
+)
+_VALID_NAME_PART_REGEX = re.compile(
+    r"[^ '\",.:;!@#$%^&*()=+/?<>\[\]`\\–-](\S*( \S+)* ?[^ ,-])?"
+)
+_UNDERCAPITALIZED_INITIAL_REGEX = re.compile(r"\.[a-z]|\. [a-z]\b|\b[a-uw-z]\.")
+_VALID_NAME_PUNCTUATION = "'’.,‘\"“”„-–—&/()"
+
+
+def normalize_name_part(value: str) -> str:
+    """Repair dotted initials in a first- or last-name component."""
+    value = _DOTTED_INITIAL_COMPONENT_REGEX.sub(
+        lambda match: match.group().upper(), value
+    )
+    return _INITIAL_LED_DOTTED_TOKEN_REGEX.sub(lambda match: match.group().title(), value)
+
+
+def validate_name_part(value: str, part: str) -> None:
+    """Reject malformed first- or last-name input before it enters the Anthology."""
+    if not value or value.isalpha():
+        return
+    if not _VALID_NAME_PART_REGEX.fullmatch(value):
+        raise ValueError(f"Invalid {part} name: {value}")
+    if _UNDERCAPITALIZED_INITIAL_REGEX.search(value):
+        raise ValueError(f"Invalid {part} name (initial should be capitalized): {value}")
+    for character in set(value) - {" "}:
+        is_bad_punctuation = (
+            character not in _VALID_NAME_PUNCTUATION
+            and unicodedata.category(character).startswith(("P", "S"))
+        )
+        if character.isdigit() or is_bad_punctuation:
+            if character.isdigit() and " 3rd" in value and part == "last":
+                continue
+            raise ValueError(
+                f"Invalid {part} name (bad character): {value!r} "
+                f"({character}, \\u{hex(ord(character))})"
+            )
+
+
+def normalize_name(first: Optional[str], last: str) -> Tuple[Optional[str], str]:
+    """Normalize and validate name parts supplied by an ingestion source."""
+    first = normalize_name_part(first) if first is not None else None
+    last = normalize_name_part(last)
+    full_name = f"{first} {last}" if first else last
+
+    if full_name.islower() or full_name.isupper():
+        first = first.title() if first is not None else None
+        last = last.title()
+        if match := _LAST_NAME_LOWERCASE_REGEX.match(last):
+            last = match.group(0).lower() + last[match.end() :]
+        for pattern, substitute in _LAST_NAME_CAPITALIZATION_RULES:
+            last = re.sub(pattern, substitute, last)
+
+    if first is not None:
+        validate_name_part(first, "first")
+    validate_name_part(last, "last")
+    return first, last
 
 
 def read_meta(path: str) -> Dict[str, Any]:
@@ -376,6 +466,7 @@ def namespec_from(
     first = latex_to_text(first.strip()) if first else None
     last = latex_to_text(last.strip()) if last else ""
     try:
+        first, last = normalize_name(first, last)
         name = Name(first or None, last)
     except ValueError as e:
         log.error(

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,7 +7,14 @@
 - Added support for recording OpenReview IDs for authors.
 - Added support for (redundant) math-mode delimiters within `<tex-math>` tags.
 - Added support for more text markup in XML: `<a href=...>`, `<sc>` `<tt>`, `<u>`, `<par/>`.
-- Validate author names on instantiation of `Name`.
+
+### Changed
+
+- Name casing normalization and validation now happen in `bin/ingest.py`; the library preserves supplied name data unchanged.
+
+### Removed
+
+- Removed `Name.case_normalize()` and `NameSpecification.case_normalize()`.
 
 ## [1.2.0] — 2026-05-21
 

--- a/python/acl_anthology/collections/collection.py
+++ b/python/acl_anthology/collections/collection.py
@@ -196,7 +196,6 @@ class Collection(SlottedDict[Volume]):
         # If editors were given, we fill in their ID & add them to the index
         if volume.editors:
             for namespec in volume.editors:
-                namespec._name = namespec.name.case_normalize()
                 self.root.people.ingest_namespec(namespec)
             self.root.people._add_to_index(volume.editors, volume.full_id_tuple)
         # Register this volume with the EventIndex

--- a/python/acl_anthology/collections/volume.py
+++ b/python/acl_anthology/collections/volume.py
@@ -436,12 +436,10 @@ class Volume(SlottedDict[Paper]):
         # If authors/editors were given, we fill in their ID & add them to the index
         if paper.authors:
             for namespec in paper.authors:
-                namespec._name = namespec.name.case_normalize()
                 self.root.people.ingest_namespec(namespec)
             self.root.people._add_to_index(paper.authors, paper.full_id_tuple)
         if paper.editors:
             for namespec in paper.editors:
-                namespec._name = namespec.name.case_normalize()
                 self.root.people.ingest_namespec(namespec)
             self.root.people._add_to_index(paper.editors, paper.full_id_tuple)
 

--- a/python/acl_anthology/people/name.py
+++ b/python/acl_anthology/people/name.py
@@ -14,14 +14,13 @@
 
 from __future__ import annotations
 
-from attrs import Attribute, define, field, setters, validators as v
+from attrs import define, field, setters, validators as v
 from functools import cache, cached_property
 from lxml import etree
 from lxml.builder import E
 import re
-import unicodedata
 from slugify import slugify
-from typing import Any, Iterable, Optional, cast, Self, TypeAlias, TYPE_CHECKING
+from typing import Any, Iterable, Optional, cast, TypeAlias, TYPE_CHECKING
 import yaml
 
 try:
@@ -53,102 +52,6 @@ SLUGIFY_REPLACEMENTS = (
 """Custom replacement rules for name slugs."""
 
 
-LAST_NAME_LOWERCASE_PREFIXES = {
-    "al",
-    "bin",
-    "bint",
-    "da",
-    "de",
-    "del",
-    "de la",
-    "dela",
-    "della",
-    "di",
-    "dos",
-    "du",
-    "el",
-    "la",
-    "le",
-    "van",
-    "van den",
-    "van der",
-    "von",
-    "von der",
-}
-"""Strings that tend to be lowercased when prefixing a last name; used for [`NameSpecification.case_normalize()`][acl_anthology.people.name.NameSpecification.case_normalize]."""
-
-# Automatically compile LAST_NAME_LOWERCASE_PREFIXES into a regex; the prefixes
-# are reverse-sorted by length so that it is always the longest string that
-# matches (e.g. so that "von der Weide" matches "von der", not just "von").
-_LAST_NAME_LOWERCASE_REGEX = re.compile(
-    f"^({'|'.join(sorted(LAST_NAME_LOWERCASE_PREFIXES, key=lambda s: -len(s)))}) ",
-    flags=re.IGNORECASE,
-)
-
-LAST_NAME_CAPITALIZATION_RULES = ((r"^Mc([a-z])", lambda p: "Mc" + p.group(1).upper()),)
-"""Regex rules for heuristically normalizing last names; used for [acl_anthology.people.name.Name.case_normalize][]."""
-
-
-RE_NAME_VALID = re.compile(r"[^ \'\",.:;!@#$%^&*()=+/?<>\[\]`\\–-](\S*( \S+)* ?[^ ,-])?")
-r"""Regex that partially checks validity of first and last names.
-
-First and last names should not start with punctuation, should not end with a comma or hyphen, and should not contain whitespace unless it is a space surrounded on both sides by non-whitespace. (It would be better to use the ``regex`` module with ``\p{P}`` for all Unicode punctuation, but that would add an extra dependency.)
-
-Used by [`is_valid_name_part()`][acl_anthology.people.name.is_valid_name_part].
-"""
-
-RE_NAME_UNDERCAPITALIZED = re.compile(r"\.[a-z]|\. [a-z]\b|\b[a-uw-z]\.")
-"""Regex that checks for spurious lowercase characters in a name.
-
-First and last names should not contain a lowercase initial after/before a dot, or any lowercase character immediately following a dot. (Exception: "v."--"v. Hahn" short for "von Hahn" is attested.)
-"""
-
-EN_DASH = "\u2013"
-EM_DASH = "\u2014"
-
-VALID_NAME_PUNCT = "'’.,‘\"“”„-" + EN_DASH + EM_DASH + "&/()"
-"""Punctuation characters allowed in names."""
-
-
-def _is_bad_punct(c: str) -> bool:
-    """Check for invalid punctuation/symbol characters in a first or last name.
-
-    [`VALID_NAME_PUNCT`][acl_anthology.people.name.VALID_NAME_PUNCT] is the whitelist of valid punctuation characters.
-    """
-    if c in VALID_NAME_PUNCT:
-        return False
-    elif unicodedata.category(c).startswith(("P", "S")):
-        return True
-    return False
-
-
-def is_valid_name_part(instance: Name, attribute: Attribute[Any], value: str) -> bool:
-    """Check if attribute is a valid first or last name.  Intended to be used as an attrs validator.
-
-    Returns:
-        True _iff_ the name matches [`RE_NAME_VALID`][acl_anthology.people.name.RE_NAME_VALID], does not contain punctuation/symbols apart from the ones in [`VALID_NAME_PUNCT`][acl_anthology.people.name.VALID_NAME_PUNCT], does not contain digits (except '3rd' in a last name), and does not contain a lowercase initial with a dot or a lowercase character immediately after a dot (exception: 'v.' which can be short for 'von').
-    """
-    if not value or value.isalpha():
-        # If all characters are alphabetic, it is guaranteed to be valid.
-        # Empirically this applies to 80% of names. This test short-circuits the slower checks.
-        return True
-    elif not RE_NAME_VALID.fullmatch(value):
-        raise ValueError(f"Invalid {attribute.name} name: {value}")
-    elif RE_NAME_UNDERCAPITALIZED.search(value):
-        raise ValueError(
-            f"Invalid {attribute.name} name (initial should be capitalized): {value}"
-        )
-    else:
-        for c in set(value) - {" "}:
-            if c.isdigit() or _is_bad_punct(c):
-                if c.isdigit() and " 3rd" in value and attribute.name == "last":
-                    continue
-                raise ValueError(
-                    f"Invalid {attribute.name} name (bad character): {value!r} ({c}, \\u{hex(ord(c))})"
-                )
-    return True
-
-
 @define(frozen=True)
 class Name:
     """A person's name.
@@ -161,8 +64,6 @@ class Name:
         last: Last name part.
         script: The script in which the name is written; only used for non-Latin script name variants.
 
-    First and last names are validated by [`is_valid_name_part()`][acl_anthology.people.name.is_valid_name_part]. Impermissible punctuation or digits, excessive whitespace, or lowercase characters in a few contexts will trigger a `ValueError` on instantiation.
-
     Examples:
         >>> Name("Yang", "Liu")
         Name('Yang', 'Liu')
@@ -174,9 +75,9 @@ class Name:
 
     first: Optional[str] = field(
         eq=lambda x: x if x else None,
-        validator=(v.optional(v.instance_of(str)), v.optional(is_valid_name_part)),
+        validator=v.optional(v.instance_of(str)),
     )
-    last: str = field(validator=(v.instance_of(str), v.min_len(1), is_valid_name_part))
+    last: str = field(validator=(v.instance_of(str), v.min_len(1)))
     script: Optional[str] = field(
         default=None, eq=False, validator=v.optional(v.instance_of(str))
     )
@@ -253,52 +154,6 @@ class Name:
         if self.first and len(self.first) > len(self.last):
             score += 0.5
         return score
-
-    def case_normalize(self, force: bool = False) -> Name:
-        """Try to heuristically normalize the casing of the name.
-
-        By default, this changes the name only if it is currently all-lowercased
-        or all-uppercased.
-
-        Examples:
-            Normalize a name that is entirely uppercase:
-
-            >>> Name("MARCEL", "BOLLMANN").case_normalize()
-            Name('Marcel', 'Bollmann')
-
-        Arguments:
-            force: Apply title-casing even when the full name is mixed-case.
-
-        Returns:
-            The original object when no changes are needed; otherwise, a new
-            instance of the same concrete class with normalized name parts.
-
-        Note:
-            Names with a `script` attribute are returned unchanged.
-        """
-        if self.script is not None:
-            # Non-Latin script variants are left unchanged;
-            # should never trigger, but just in case...
-            return self  # pragma: no cover
-
-        first, last = self.first, self.last
-        firstlast = self.as_first_last()
-
-        if not (force or firstlast.islower() or firstlast.isupper()):
-            return self
-
-        if first is not None:
-            first = first.title()
-        last = last.title()
-        # Prefixes
-        if (m := _LAST_NAME_LOWERCASE_REGEX.match(last)) is not None:
-            print(m)
-            last = m.group(0).lower() + last[m.end() :]
-        # Other normalization rules
-        for pattern, substitute in LAST_NAME_CAPITALIZATION_RULES:
-            last = re.sub(pattern, substitute, last)
-
-        return self.__class__(first, last)
 
     @cache
     def slugify(self) -> str:
@@ -562,14 +417,6 @@ class NameSpecification:
         if not self.name.first:
             return {"family": self.name.last}
         return {"family": self.name.last, "given": self.name.first}
-
-    def case_normalize(self, force: bool = False) -> Self:
-        """Try to heuristically normalize the casing of the name.
-
-        See [acl_anthology.people.name.Name.case_normalize][].
-        """
-        self.name = self.name.case_normalize(force=force)
-        return self
 
     def resolve(self) -> Person:
         """Resolve this name specification to a natural person.

--- a/python/tests/collections/volume_test.py
+++ b/python/tests/collections/volume_test.py
@@ -559,9 +559,7 @@ def test_volume_create_paper_with_new_explicit_author(name, anthology):
         authors=authors,
     )
     assert (person := anthology.people.get_by_orcid("0000-0002-9659-1532")) is not None
-    assert person.canonical_name == Name.from_(
-        "Tånnander, Christina"
-    )  # always the case-normalized version
+    assert person.canonical_name == Name.from_(name)
     assert paper.authors[0].id == "christina-tannander"
     assert paper.authors[0].resolve() is person
     assert person.item_ids == set([paper.full_id_tuple])

--- a/python/tests/people/name_test.py
+++ b/python/tests/people/name_test.py
@@ -331,75 +331,9 @@ def test_name_from_any():
         Name.from_(["Jane", "Doe"])  # ... but could be allowed maybe?
 
 
-test_cases_valid_names = [
-    ("Hal", "Daumé III"),
-    ("Hal", "Daumé 3rd"),
-    ("Jan", "Hajic jr."),
-    ("Jan", "Hajic, jr."),
-    ("B.L. B. LT", "B.L"),
-]
-
-
-@pytest.mark.parametrize("first, last", test_cases_valid_names)
-def test_name_valid(first, last):
-    Name(first, last)
-
-
-test_cases_invalid_names = [
-    ("Hal", "Daum?"),
-    ("C`ecile", "Fabre"),
-    ("Mausam", "."),
-    ("Mausam", "-"),
-    ("Mausam", "_"),
-    ("Noor-e-", "Hira"),
-    ("Sir", "C3PO"),
-    ("Bonnie", "Lynn_Webber"),
-    ("b.", "Webber"),
-    ("Jonathan q.", "Arbuckle"),
-    ("B.l.", "Webber"),
-    ("B. l.", "Webber"),
-    ("B.     ", "Webber"),
-    ("Bonnie.lynn", "Webber"),
-    ("Bonnie", "Webber,"),
-    ("Bonnie", ".Webber"),
-    ("Bonnie", "Webber1"),
-    ("Bonnie", "Webber*"),
-]
-
-
-@pytest.mark.parametrize("first, last", test_cases_invalid_names)
-def test_name_invalid(first, last):
-    with pytest.raises(ValueError):
-        Name(first, last)
-
-
 def test_name_as_bibtex():
     n1 = Name.from_string("André Rieu")
     assert n1.as_bibtex() == "Rieu, Andr{\\'e}"
-
-
-test_cases_name_case_normalize = (
-    (("marcel", "bollmann"), ("Marcel", "Bollmann")),
-    (("MARCEL", "BOLLMANN"), ("Marcel", "Bollmann")),
-    (
-        ("MIRYAM", "DE LHONEUX"),
-        ("Miryam", "de Lhoneux"),
-    ),  # heuristic for last name particle
-    (
-        ("simon", "von der weide"),
-        ("Simon", "von der Weide"),
-    ),  # heuristic for multi-part last name particle
-    (("marc-andre", "hackforth-jones"), ("Marc-Andre", "Hackforth-Jones")),
-    (("james", "o'neill"), ("James", "O'Neill")),
-    (("JAMES", "O’NEILL"), ("James", "O’Neill")),
-    (("ken", "mcguire"), ("Ken", "McGuire")),
-)
-
-
-@pytest.mark.parametrize("before, after", test_cases_name_case_normalize)
-def test_name_case_normalize(before, after):
-    name = Name(*before)
-    assert name.case_normalize() == Name(*after)
 
 
 def test_namespec_root_is_anthology(parent):

--- a/python/tests/people/personindex_test.py
+++ b/python/tests/people/personindex_test.py
@@ -880,24 +880,6 @@ def test_namespec_add_id_affects_name_resolution(anthology):
     assert item_id in person2.item_ids
 
 
-def test_namespec_case_normalize_affects_person_names_unverified(anthology):
-    index = anthology.people
-    # Precondition: Find a paper that resolves to a person with all-lowercase name
-    item_id = ("2022.naloma", "1", "4")
-    namespec = anthology.get_paper(item_id).authors[-1]
-    person = index.get(UNVERIFIED_PID_FORMAT.format(pid="mihalis-yannakakis"))
-    assert namespec.resolve() is person
-    assert namespec.name == Name("mihalis", "yannakakis")
-    assert person.names == [Name("mihalis", "yannakakis")]
-
-    # Case-normalizing should update the person's name
-    namespec.case_normalize()
-    assert namespec.name == Name("Mihalis", "Yannakakis")
-    assert (
-        Name("Mihalis", "Yannakakis") in person.names
-    )  # for an unverified person, it's fine that the old name is still in here
-
-
 ##############################################################################
 ### Tests for ingestion logic
 ##############################################################################

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -8,7 +8,78 @@ from unittest.mock import MagicMock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "bin"))
 
-from bin.ingest import configure_event
+import pytest
+
+from acl_anthology.people import Name
+from bin.ingest import configure_event, namespec_from
+
+
+@pytest.mark.parametrize(
+    "before, after",
+    [
+        (("marcel", "bollmann"), ("Marcel", "Bollmann")),
+        (("MARCEL", "BOLLMANN"), ("Marcel", "Bollmann")),
+        (("MIRYAM", "DE LHONEUX"), ("Miryam", "de Lhoneux")),
+        (("simon", "von der weide"), ("Simon", "von der Weide")),
+        (("marc-andre", "hackforth-jones"), ("Marc-Andre", "Hackforth-Jones")),
+        (("james", "o'neill"), ("James", "O’Neill")),
+        (("JAMES", "O’NEILL"), ("James", "O’Neill")),
+        (("ken", "mcguire"), ("Ken", "McGuire")),
+        (("C`ecile", "Fabre"), ("C‘ecile", "Fabre")),
+        (("B.l.", "Webber"), ("B.L.", "Webber")),
+        (("B.     ", "Webber"), ("B.", "Webber")),
+        (("John C.s.", "Lui"), ("John C.S.", "Lui")),
+        (("Santosh", "T.y.s.s"), ("Santosh", "T.Y.S.S")),
+        ((None, "S.b.priya"), (None, "S.B.Priya")),
+        (("Shri", "Sashmitha.s"), ("Shri", "Sashmitha.S")),
+    ],
+)
+def test_namespec_from_normalizes_name(before, after):
+    assert namespec_from(*before).name == Name(*after)
+
+
+@pytest.mark.parametrize(
+    "first, last",
+    [
+        ("Hal", "Daumé III"),
+        ("Hal", "Daumé 3rd"),
+        ("Jan", "Hajic jr."),
+        ("Jan", "Hajic, jr."),
+        ("B.L. B. LT", "B.L"),
+    ],
+)
+def test_namespec_from_accepts_valid_name(first, last):
+    namespec_from(first, last)
+
+
+@pytest.mark.parametrize(
+    "first, last",
+    [
+        ("Hal", "Daum?"),
+        ("Mausam", "."),
+        ("Mausam", "-"),
+        ("Mausam", "_"),
+        ("Noor-e-", "Hira"),
+        ("Sir", "C3PO"),
+        ("Bonnie", "Lynn_Webber"),
+        ("b.", "Webber"),
+        ("Jonathan q.", "Arbuckle"),
+        ("B. l.", "Webber"),
+        ("Bonnie.lynn", "Webber"),
+        ("Bonnie", "Webber,"),
+        ("Bonnie", ".Webber"),
+        ("Bonnie", "Webber1"),
+        ("Bonnie", "Webber*"),
+    ],
+)
+def test_namespec_from_rejects_invalid_name(first, last):
+    with pytest.raises(ValueError):
+        namespec_from(first, last)
+
+
+def test_name_library_preserves_supplied_casing():
+    name = Name("John C.s.", "Lui")
+    assert (name.first, name.last) == ("John C.s.", "Lui")
 
 
 def event_args(tmp_path, **overrides):


### PR DESCRIPTION
This moves the name normalization routines to ingestion, based on the idea that the data in the Anthology itself should be correct already, so we shouldn't be applying these routines at load time.

The PR is against #9222  so we can examine it separately.