### PR TITLE
sitemap: undo fallback <lastmod> entries

### DIFF
--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -4,15 +4,7 @@
   {{ range .Data.Pages }}
   <url>
     <loc>{{ .Permalink }}</loc>
-    {{- $lastmod := .Lastmod -}}
-    {{- if .Lastmod.IsZero -}}
-      {{- if not .Date.IsZero -}}
-        {{- $lastmod = .Date -}} {{/* Fallback 1: Use Page creation date */}}
-      {{- else -}}
-        {{- $lastmod = now -}} {{/* Fallback 2: Use build execution time */}}
-      {{- end -}}
-    {{- end }}
-    <lastmod>{{ safeHTML ( $lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+    {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( $lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
     {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
   </url>

--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -4,7 +4,7 @@
   {{ range .Data.Pages }}
   <url>
     <loc>{{ .Permalink }}</loc>
-    {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( $lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
+    {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
     {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
   </url>


### PR DESCRIPTION
The attempt in #9182 caused problems with 0 dates showing up as 1900-01-01, which is invalid.

I think the problem is not missing `<lastmod>`s. So let's just generate them if we have real dates for them.