### PR TITLE
ingest.py hotfix: deleting line breaks causes sentences to run together

### DIFF
--- a/bin/ingest.py
+++ b/bin/ingest.py
@@ -236,26 +236,11 @@ def latex_to_text(text: Optional[str]) -> Optional[str]:
 #   "$1") gets double-escaped to ``\\$``, which LaTeX reads as a line break
 #   (``\\``) followed by a math-mode toggle (``$``). The stray toggle then
 #   desynchronizes every following ``$...$`` span. Collapse it back to ``\$``.
-#
-# - double_newlines_to_par_break: \n\n is assumed to signal a paragraph break.
-#
-# - clean_whitespace: whitespace sequences (including single newlines) are
-#   converted to a single space.
 LATEX_REPAIRS: List[Tuple[str, "re.Pattern[str]", str]] = [
     (
         "over_escaped_dollar",
         re.compile(r"\\\\\$"),
         r"\\$",
-    ),
-    (
-        "double_newlines_to_par_break",
-        re.compile("\n\n"),
-        "<par/>",
-    ),
-    (
-        "clean_whitespace",
-        re.compile(r"\s+"),
-        " ",
     ),
 ]
 

--- a/bin/ingest.py
+++ b/bin/ingest.py
@@ -237,15 +237,10 @@ def latex_to_text(text: Optional[str]) -> Optional[str]:
 #   (``\\``) followed by a math-mode toggle (``$``). The stray toggle then
 #   desynchronizes every following ``$...$`` span. Collapse it back to ``\$``.
 #
-# - texttt_unwrap: ``MarkupText.from_latex_maybe()`` silently DROPS the content
-#   of ``\texttt{...}`` (monospace has no Anthology markup equivalent), which
-#   empties acronyms such as ``\textbf{\texttt{RBED}}`` -> ``<b></b>``. Since we
-#   cannot represent monospace anyway, unwrap ``\texttt{X}`` to its literal
-#   content ``X`` so the text survives. (Non-nested braces only.)
+# - double_newlines_to_par_break: \n\n is assumed to signal a paragraph break.
 #
-# - strip_newlines: Source text (especially YAML-wrapped abstracts) often
-#   contains hard line breaks that are not meaningful LaTeX; drop them so the
-#   text is flattened to a single line before parsing.
+# - clean_whitespace: whitespace sequences (including single newlines) are
+#   converted to a single space.
 LATEX_REPAIRS: List[Tuple[str, "re.Pattern[str]", str]] = [
     (
         "over_escaped_dollar",
@@ -253,14 +248,14 @@ LATEX_REPAIRS: List[Tuple[str, "re.Pattern[str]", str]] = [
         r"\\$",
     ),
     (
-        "texttt_unwrap",
-        re.compile(r"\\texttt\s*\{([^{}]*)\}"),
-        r"\1",
+        "double_newlines_to_par_break",
+        re.compile("\n\n"),
+        "<par/>",
     ),
     (
-        "strip_newlines",
-        re.compile(r"\n"),
-        "",
+        "clean_whitespace",
+        re.compile(r"\s+"),
+        " ",
     ),
 ]
 


### PR DESCRIPTION
A frequent error noticed in abstracts is that sentences are missing a space between them. I think this is in large part due to newlines being deleted at ingestion time; they should at least be replaced with a space. Here is a proposed fix.

Also, the handling of `\texttt` predated the introduction of `<tt>` elements into the schema. I don't think it is necessary now.