### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/bin/normalize_joint_yaml.py
+++ b/bin/normalize_joint_yaml.py
@@ -32,10 +32,10 @@ import yaml
 from anthology.utils import infer_year
 
 try:
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as Loader
     from yaml import CSafeDumper as Dumper
 except ImportError:
-    from yaml import Loader
+    from yaml import SafeLoader as Loader
     from yaml import SafeDumper as Dumper
 
 data = None

--- a/bin/split_venues.py
+++ b/bin/split_venues.py
@@ -23,10 +23,10 @@ Takes each venue and writes its data to a new file under venues/
 import yaml
 
 try:
-    from yaml import CLoader as Loader
+    from yaml import CSafeLoader as Loader
     from yaml import CSafeDumper as Dumper
 except ImportError:
-    from yaml import Loader
+    from yaml import SafeLoader as Loader
     from yaml import SafeDumper as Dumper
 
 with open("venues.yaml") as f:


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `bin/split_venues.py:L17`

The script uses `yaml.load(f, Loader=Loader)` where `Loader` is imported as `CLoader`. While `CLoader` is generally safer than the standard `Loader`, it is not a *Safe* Loader. Using `yaml.load` without explicitly specifying a Safe Loader can lead to arbitrary code execution if a malicious YAML file is processed. The code should use `yaml.safe_load()` or explicitly specify `CSafeLoader`.

## Solution

Replace `yaml.load(f, Loader=Loader)` with `yaml.safe_load(f)` or ensure `Loader` is `yaml.CSafeLoader`.

## Changes

- `bin/split_venues.py` (modified)
- `bin/normalize_joint_yaml.py` (modified)