### PR TITLE
Fix IndexError in clean_unicode when string ends with dotless ı

### DIFF
--- a/python/acl_anthology/utils/text.py
+++ b/python/acl_anthology/utils/text.py
@@ -59,7 +59,7 @@ def clean_unicode(s: str) -> str:
     start = 0
     while (idx := s.find("ı", start)) > -1:
         # bug: we should only be looking for accents above, not below
-        if unicodedata.category(s[idx + 1]) == "Mn":
+        if idx + 1 < len(s) and unicodedata.category(s[idx + 1]) == "Mn":
             s = f"{s[:idx]}i{s[idx + 1 :]}"
         start = idx + 1
 

--- a/python/tests/utils/text_test.py
+++ b/python/tests/utils/text_test.py
@@ -36,6 +36,7 @@ test_cases_clean_unicode = (
     ("break\u00adable", "breakable"),  # soft hyphen
     ("break‐able", "break-able"),  # dash
     ("bı́r", "bír"),  # combining diacritic on ı vs. composed character í
+    ("Aslı", "Aslı"),  # dotless ı as final character
     ("afﬁrm", "affirm"),  # ligature
     ("see： here", "see: here"),  # wide colon
     ("fn²", "fn²"),  # unchanged


### PR DESCRIPTION
`clean_unicode()` raises `IndexError` for any input whose final character is a dotless ı, because the normalization loop reads `s[idx + 1]` without a bounds check (`python/acl_anthology/utils/text.py`, line 62 at 8c20b473):

```
$ uv run python -c "from acl_anthology.utils.text import clean_unicode; clean_unicode('Çağrı')"
  File ".../acl_anthology/utils/text.py", line 62, in clean_unicode
    if unicodedata.category(s[idx + 1]) == "Mn":
                            ~^^^^^^^^^
IndexError: string index out of range
```

This is reachable through the default path of the public API: `MarkupText.from_string()`, `from_latex()`, and `from_latex_maybe()` apply `clean_unicode` when `clean=True` (the default), so `MarkupText.from_string("Aslı")` raises the same error. Given names ending in dotless ı occur throughout the Anthology's own data — `data/xml` currently has 55 papers with `<first>Çağrı</first>`, 9 with `<first>Aslı</first>`, plus `Yankı` and `Ali Hakkı` — so creating or ingesting a paper by such an author through the library crashes.

The docstring states the function takes "Any text string" and returns "The cleaned up string", and credits the original implementation in `bin/normalize_anth.py`. The original handles this case correctly: its loop runs `for i in range(len(s) - 1):` (`bin/normalize_anth.py`, line 114) and never examines the final character. The bounds check was lost when the logic was ported to the library as a `str.find` loop.

Changes:

- guard the lookahead with `idx + 1 < len(s)` in `clean_unicode` (1 line);
- add a regression case `("Aslı", "Aslı")` to `test_cases_clean_unicode`; it fails with the `IndexError` above before the fix and passes after.

Checks run locally on the branch: `pytest -m "not integration"` → 894 passed, 1 xfailed; `mypy acl_anthology` → no issues; `pre-commit run` on the changed files → all hooks pass.

Disclosure: this bug was found and the patch prepared with AI assistance (Claude Code); the reproduction and test results above are from actual runs against 8c20b473.
