### PR TITLE
Mark more venues as workshops

### DIFF
--- a/data/json/venues.json
+++ b/data/json/venues.json
@@ -203,7 +203,8 @@
   },
   "beyondalignment": {
     "acronym": "BeyondAlignment",
-    "name": "Beyond Alignment: Transdisciplinary Conversations on Human-AI Futures"
+    "name": "Beyond Alignment: Transdisciplinary Conversations on Human-AI Futures",
+    "type": "workshop"
   },
   "bhasha": {
     "acronym": "BHASHA",
@@ -292,7 +293,8 @@
   },
   "cas": {
     "acronym": "CAS",
-    "name": "Computational Affective Science"
+    "name": "Computational Affective Science",
+    "type": "workshop"
   },
   "case": {
     "acronym": "CASE",
@@ -508,7 +510,8 @@
   },
   "comedi": {
     "acronym": "CoMeDi",
-    "name": "Context and Meaning: Navigating Disagreements in NLP Annotation"
+    "name": "Context and Meaning: Navigating Disagreements in NLP Annotation",
+    "type": "workshop"
   },
   "computel": {
     "acronym": "ComputEL",
@@ -615,7 +618,8 @@
   "cvir": {
     "acronym": "CVIR",
     "name": "Content Visualization and Intermedia Representations",
-    "is_acl": true
+    "is_acl": true,
+    "type": "workshop"
   },
   "cvsc": {
     "acronym": "CVSC",
@@ -736,7 +740,8 @@
   },
   "dstc": {
     "acronym": "DSTC",
-    "name": "The Eleventh Dialog System Technology Challenge"
+    "name": "The Eleventh Dialog System Technology Challenge",
+    "type": "workshop"
   },
   "dt4tp": {
     "acronym": "DT4TP",
@@ -745,7 +750,8 @@
   },
   "dtf": {
     "acronym": "DTF",
-    "name": "Leveraging Derived Text Formats to Unlock Copyrighted Collections for Open Science"
+    "name": "Leveraging Derived Text Formats to Unlock Copyrighted Collections for Open Science",
+    "type": "workshop"
   },
   "eacl": {
     "acronym": "EACL",
@@ -1028,7 +1034,8 @@
   },
   "hackashop": {
     "acronym": "Hackashop",
-    "name": "EACL Hackashop on News Media Content Analysis and Automated Report Generation"
+    "name": "EACL Hackashop on News Media Content Analysis and Automated Report Generation",
+    "type": "workshop"
   },
   "hcinlp": {
     "acronym": "HCINLP",
@@ -1273,7 +1280,8 @@
   },
   "lanlp": {
     "acronym": "LANLP",
-    "name": "Bridging Ibero and Latin American NLP Communities"
+    "name": "Bridging Ibero and Latin American NLP Communities",
+    "type": "workshop"
   },
   "lantern": {
     "acronym": "LANTERN",
@@ -1373,7 +1381,8 @@
   },
   "llms4ssh": {
     "acronym": "LLMs4SSH",
-    "name": "Shaping Multilingual, Multimodal AI for the Social Sciences and Humanities"
+    "name": "Shaping Multilingual, Multimodal AI for the Social Sciences and Humanities",
+    "type": "workshop"
   },
   "llmsec": {
     "acronym": "LLMSEC",
@@ -1891,7 +1900,8 @@
   },
   "nslp": {
     "acronym": "NSLP",
-    "name": "Natural Scientific Language Processing"
+    "name": "Natural Scientific Language Processing",
+    "type": "workshop"
   },
   "nsurl": {
     "acronym": "NSURL",
@@ -2243,7 +2253,8 @@
   },
   "seretod": {
     "acronym": "SereTOD",
-    "name": "Towards Semi-Supervised and Reinforced Task-Oriented Dialog Systems"
+    "name": "Towards Semi-Supervised and Reinforced Task-Oriented Dialog Systems",
+    "type": "workshop"
   },
   "sew": {
     "acronym": "SEW",
@@ -2354,7 +2365,8 @@
   },
   "speakable": {
     "acronym": "SPEAKABLE",
-    "name": "Speech Language Models in Low-Resource Settings: Performance, Evaluation, and Bias Analysis"
+    "name": "Speech Language Models in Low-Resource Settings: Performance, Evaluation, and Bias Analysis",
+    "type": "workshop"
   },
   "splu": {
     "acronym": "SpLU",
@@ -2594,7 +2606,8 @@
   },
   "udfestbr": {
     "acronym": "UDFestBR",
-    "name": "Universal Dependencies Brazilian Festival"
+    "name": "Universal Dependencies Brazilian Festival",
+    "type": "workshop"
   },
   "udw": {
     "acronym": "UDW",

--- a/data/json/venues.json
+++ b/data/json/venues.json
@@ -1896,7 +1896,8 @@
   },
   "nonliteral": {
     "acronym": "NonLiteral",
-    "name": "Learning Non-Literal Expressions with Small Data"
+    "name": "Learning Non-Literal Expressions with Small Data",
+    "type": "workshop"
   },
   "nslp": {
     "acronym": "NSLP",

--- a/data/json/venues.json
+++ b/data/json/venues.json
@@ -30,7 +30,8 @@
   "aespen": {
     "acronym": "AESPEN",
     "name": "Automated Extraction of Socio-political Events from News",
-    "url": "https://emw.ku.edu.tr"
+    "url": "https://emw.ku.edu.tr",
+    "type": "workshop"
   },
   "africanlp": {
     "acronym": "AfricaNLP",
@@ -181,7 +182,8 @@
   },
   "babylm": {
     "acronym": "BabyLM",
-    "name": "BabyLM Challenge"
+    "name": "BabyLM Challenge",
+    "type": "workshop"
   },
   "banglalp": {
     "acronym": "BanglaLP",
@@ -215,7 +217,8 @@
   },
   "bigscience": {
     "acronym": "BigScience",
-    "name": "Challenges & Perspectives in Creating Large Language Models"
+    "name": "Challenges & Perspectives in Creating Large Language Models",
+    "type": "workshop"
   },
   "bioasq": {
     "acronym": "BioASQ",
@@ -268,7 +271,8 @@
   },
   "c3nlp": {
     "acronym": "C3NLP",
-    "name": "Cross-Cultural Considerations in NLP"
+    "name": "Cross-Cultural Considerations in NLP",
+    "type": "workshop"
   },
   "cai": {
     "acronym": "CAI",
@@ -292,7 +296,8 @@
   },
   "case": {
     "acronym": "CASE",
-    "name": "Challenges and Applications of Automated Extraction of Socio-political Events from Text"
+    "name": "Challenges and Applications of Automated Extraction of Socio-political Events from Text",
+    "type": "workshop"
   },
   "catocl": {
     "acronym": "CAtoCL",
@@ -416,11 +421,13 @@
   },
   "cllrd": {
     "acronym": "CLLRD",
-    "name": "Citizen Linguistics in Language Resource Development"
+    "name": "Citizen Linguistics in Language Resource Development",
+    "type": "workshop"
   },
   "clp": {
     "acronym": "CLP",
-    "name": "Chinese Language Processing"
+    "name": "Chinese Language Processing",
+    "type": "workshop"
   },
   "clpsych": {
     "acronym": "CLPsych",
@@ -451,7 +458,8 @@
   },
   "cmlc": {
     "acronym": "CMLC",
-    "name": "Challenges in the Management of Large Corpora"
+    "name": "Challenges in the Management of Large Corpora",
+    "type": "workshop"
   },
   "cnl": {
     "acronym": "CNL",
@@ -632,7 +640,8 @@
   },
   "dclrl": {
     "acronym": "DCLRL",
-    "name": "Dataset Creation for Lower-Resourced Languages"
+    "name": "Dataset Creation for Lower-Resourced Languages",
+    "type": "workshop"
   },
   "deelio": {
     "acronym": "DeeLIO",
@@ -655,7 +664,8 @@
   },
   "determit": {
     "acronym": "DeTermIt",
-    "name": "DeTermIt! Evaluating Text Difficulty in a Multilingual Context"
+    "name": "DeTermIt! Evaluating Text Difficulty in a Multilingual Context",
+    "type": "workshop"
   },
   "dialdoc": {
     "acronym": "dialdoc",
@@ -669,7 +679,8 @@
   },
   "digitam": {
     "acronym": "DigitAm",
-    "name": "Processing Language Variation: Digital Armenian"
+    "name": "Processing Language Variation: Digital Armenian",
+    "type": "workshop"
   },
   "discann": {
     "acronym": "DiscAnn",
@@ -699,7 +710,8 @@
   },
   "dlnld": {
     "acronym": "DLnLD",
-    "name": "Deep Learning and Linked Data"
+    "name": "Deep Learning and Linked Data",
+    "type": "workshop"
   },
   "dmr": {
     "acronym": "DMR",
@@ -948,7 +960,8 @@
   "gems": {
     "acronym": "GEMS",
     "name": "GEometrical Models of Natural Language Semantics",
-    "is_acl": true
+    "is_acl": true,
+    "type": "workshop"
   },
   "genaidetect": {
     "acronym": "GenAIDetect",
@@ -995,7 +1008,8 @@
   },
   "globalnlp": {
     "acronym": "GlobalNLP",
-    "name": "Beyond English: Natural Language Processing for All Languages in an Era of Large Language Models"
+    "name": "Beyond English: Natural Language Processing for All Languages in an Era of Large Language Models",
+    "type": "workshop"
   },
   "gramlex": {
     "acronym": "GramLex",
@@ -1061,7 +1075,8 @@
   },
   "icard": {
     "acronym": "ICARD",
-    "name": "Connecting Multiple Disciplines to AI Techniques in Interaction-centric Autism Research and Diagnosis"
+    "name": "Connecting Multiple Disciplines to AI Techniques in Interaction-centric Autism Research and Diagnosis",
+    "type": "workshop"
   },
   "icnlsp": {
     "acronym": "ICNLSP",
@@ -1123,7 +1138,8 @@
   },
   "intellang": {
     "acronym": "IntelLanG",
-    "name": "Intelligent Information Processing and Natural Language Generation"
+    "name": "Intelligent Information Processing and Natural Language Generation",
+    "type": "workshop"
   },
   "internlp": {
     "acronym": "InterNLP",
@@ -1347,11 +1363,13 @@
   },
   "lincr": {
     "acronym": "LiNCr",
-    "name": "Linguistic and Neurocognitive Resources"
+    "name": "Linguistic and Neurocognitive Resources",
+    "type": "workshop"
   },
   "llm4medr": {
     "acronym": "LLM4MedR",
-    "name": "LLM Reasoning on Medicine: Challenges, Opportunities, and Future"
+    "name": "LLM Reasoning on Medicine: Challenges, Opportunities, and Future",
+    "type": "workshop"
   },
   "llms4ssh": {
     "acronym": "LLMs4SSH",
@@ -1407,7 +1425,8 @@
   "lr4sshoc": {
     "acronym": "LR4SSHOC",
     "name": "Language Resources in the SSH Cloud: Bringing Language Technologies for Social Sciences and Humanities (in)to the European Open Science Cloud",
-    "url": "https://www.sshopencloud.eu"
+    "url": "https://www.sshopencloud.eu",
+    "type": "workshop"
   },
   "lrec": {
     "acronym": "LREC",
@@ -1429,11 +1448,13 @@
   },
   "lt4gov": {
     "acronym": "LT4Gov",
-    "name": "Language Technologies for Government and Public Administration"
+    "name": "Language Technologies for Government and Public Administration",
+    "type": "workshop"
   },
   "lt4hala": {
     "acronym": "LT4HALA",
-    "name": "Language Technologies for Historical and Ancient Languages"
+    "name": "Language Technologies for Historical and Ancient Languages",
+    "type": "workshop"
   },
   "lt4var": {
     "acronym": "LT4VAR",
@@ -1448,7 +1469,8 @@
   },
   "luhme": {
     "acronym": "LUHME",
-    "name": "Language Understanding in the Human-Machine Era"
+    "name": "Language Understanding in the Human-Machine Era",
+    "type": "workshop"
   },
   "magmar": {
     "acronym": "MAGMaR",
@@ -1533,7 +1555,8 @@
   },
   "mmnlu": {
     "acronym": "MMNLU",
-    "name": "Massively Multilingual Natural Language Understanding"
+    "name": "Massively Multilingual Natural Language Understanding",
+    "type": "workshop"
   },
   "mmsr": {
     "acronym": "MMSR",
@@ -1609,7 +1632,8 @@
   },
   "multilingualbio": {
     "acronym": "MultilingualBIO",
-    "name": "Multilingual Biomedical Text Processing"
+    "name": "Multilingual Biomedical Text Processing",
+    "type": "workshop"
   },
   "mwe": {
     "acronym": "MWE",
@@ -1652,12 +1676,14 @@
   },
   "neollm": {
     "acronym": "NeoLLM",
-    "name": "Neology and Large Language Models"
+    "name": "Neology and Large Language Models",
+    "type": "workshop"
   },
   "nespnlp": {
     "acronym": "NeSp-NLP",
     "name": "Negation and Speculation in Natural Language Processing",
-    "is_acl": true
+    "is_acl": true,
+    "type": "workshop"
   },
   "neusymbridge": {
     "acronym": "NeusymBridge",
@@ -1688,7 +1714,8 @@
   },
   "nilli": {
     "acronym": "NILLI",
-    "name": "Novel Ideas in Learning-to-Learn through Interaction"
+    "name": "Novel Ideas in Learning-to-Learn through Interaction",
+    "type": "workshop"
   },
   "nl4xai": {
     "acronym": "NL4XAI",
@@ -1890,7 +1917,8 @@
   },
   "onion": {
     "acronym": "ONION",
-    "name": "People in Language, Vision and the Mind"
+    "name": "People in Language, Vision and the Mind",
+    "type": "workshop"
   },
   "ontolex": {
     "acronym": "ontolex",
@@ -1915,7 +1943,8 @@
   },
   "pals": {
     "acronym": "PALS",
-    "name": "Tailoring AI: Exploring Active and Passive LLM Personalization"
+    "name": "Tailoring AI: Exploring Active and Passive LLM Personalization",
+    "type": "workshop"
   },
   "pam": {
     "acronym": "PaM",
@@ -1924,7 +1953,8 @@
   },
   "pandl": {
     "acronym": "PANDL",
-    "name": "Pattern-based Approaches to NLP in the Age of Deep Learning"
+    "name": "Pattern-based Approaches to NLP in the Age of Deep Learning",
+    "type": "workshop"
   },
   "parlaclarin": {
     "acronym": "ParlaCLARIN",
@@ -1951,11 +1981,13 @@
   "poleval": {
     "acronym": "PolEval",
     "name": "PolEval: The Evaluation Campaign for Natural Language Processing Tools for Polish",
-    "url": "https://poleval.pl"
+    "url": "https://poleval.pl",
+    "type": "workshop"
   },
   "politicalnlp": {
     "acronym": "PoliticalNLP",
-    "name": "Natural Language Processing for Political Sciences"
+    "name": "Natural Language Processing for Political Sciences",
+    "type": "workshop"
   },
   "practicald2t": {
     "acronym": "PracticalD2T",
@@ -1970,7 +2002,8 @@
   },
   "pressmint": {
     "acronym": "PressMint",
-    "name": "Creating Interoperable Corpora of Historical Newspapers"
+    "name": "Creating Interoperable Corpora of Historical Newspapers",
+    "type": "workshop"
   },
   "privatenlp": {
     "acronym": "PrivateNLP",
@@ -2044,7 +2077,8 @@
   },
   "readi": {
     "acronym": "READI",
-    "name": "Tools and Resources to Empower People with REAding Difficulties"
+    "name": "Tools and Resources to Empower People with REAding Difficulties",
+    "type": "workshop"
   },
   "realm": {
     "acronym": "REALM",
@@ -2080,7 +2114,8 @@
   },
   "restup": {
     "acronym": "ResTUP",
-    "name": "Resources and Techniques for User and Author Profiling in Abusive Language"
+    "name": "Resources and Techniques for User and Author Profiling in Abusive Language",
+    "type": "workshop"
   },
   "retroeval": {
     "acronym": "RetroEval",
@@ -2116,7 +2151,8 @@
   },
   "safety4convai": {
     "acronym": "Safety4ConvAI",
-    "name": "Workhop on Safety for Conversational AI"
+    "name": "Workhop on Safety for Conversational AI",
+    "type": "workshop"
   },
   "salld": {
     "acronym": "SALLD",
@@ -2252,7 +2288,8 @@
     "acronym": "SIGTYP",
     "name": "Special Interest Group on Typology",
     "is_acl": true,
-    "url": "https://sigtyp.github.io"
+    "url": "https://sigtyp.github.io",
+    "type": "workshop"
   },
   "sigul": {
     "acronym": "SIGUL",
@@ -2266,7 +2303,8 @@
   },
   "slide": {
     "acronym": "SLiDE",
-    "name": "Structured Linguistic Data and Evaluation"
+    "name": "Structured Linguistic Data and Evaluation",
+    "type": "workshop"
   },
   "slpat": {
     "acronym": "SLPAT",
@@ -2374,7 +2412,8 @@
   },
   "stoc": {
     "acronym": "STOC",
-    "name": "Social Threats in Online Conversations"
+    "name": "Social Threats in Online Conversations",
+    "type": "workshop"
   },
   "storynlp": {
     "acronym": "Story-NLP",
@@ -2498,7 +2537,8 @@
   "tipster": {
     "acronym": "TIPSTER",
     "name": "NIST's TIPSTER Text Program",
-    "oldstyle_letter": "X"
+    "oldstyle_letter": "X",
+    "type": "workshop"
   },
   "tllm": {
     "acronym": "TLLM",
@@ -2563,7 +2603,8 @@
   },
   "umios": {
     "acronym": "UM-IoS",
-    "name": "Unimodal and Multimodal Induction of Linguistic Structures"
+    "name": "Unimodal and Multimodal Induction of Linguistic Structures",
+    "type": "workshop"
   },
   "umrpw": {
     "acronym": "UMRPW",
@@ -2723,7 +2764,8 @@
   },
   "wraicogs": {
     "acronym": "WRAICOGS",
-    "name": "Writing Aids at the Crossroads of AI, Cognitive Science and NLP"
+    "name": "Writing Aids at the Crossroads of AI, Cognitive Science and NLP",
+    "type": "workshop"
   },
   "ws": {
     "acronym": "WS",
@@ -2755,6 +2797,7 @@
   },
   "yrrsds": {
     "acronym": "YRRSDS",
-    "name": "The 19th Annual Meeting of the Young Researchers' Roundtable on Spoken Dialogue Systems"
+    "name": "The 19th Annual Meeting of the Young Researchers' Roundtable on Spoken Dialogue Systems",
+    "type": "workshop"
   }
 }

--- a/data/xml/2023.stil.xml
+++ b/data/xml/2023.stil.xml
@@ -487,4 +487,9 @@
       <bibkey>santos-etal-2023-explorando</bibkey>
     </paper>
   </volume>
+  <event id="stil-2023">
+    <colocated>
+      <volume-id>2023.udfestbr-1</volume-id>
+    </colocated>
+  </event>
 </collection>


### PR DESCRIPTION
Apply venue type = "workshop":

- If the latest volume title designates it as a workshop, or
- by manual review of venues not obviously designated as workshop, journal, or "conference" in the venue info or volume title.

Notes:

- [LANLP](https://aclanthology.org/venues/lanlp/) bills itself as a "networking symposium" colocated with LREC. I will treat that as a workshop.
- Treating shared task venues like GermEval as workshops.
- Treating ["hackashops"](https://aclanthology.org/volumes/2021.hackashop-1/) as workshops.

Also, UDFestBR 2023 was colocated with STIL 2023.

Observation: at LREC 2026, workshop proceedings titles were inconsistent. Most but not all ended in "@ LREC 2026". Many had "The Nth Workshop" or "Proceedings of the Nth Workshop". Others omitted the word "workshop", e.g. [Proceedings of Natural Scientific Language Processing (NSLP) @ LREC 2026](https://aclanthology.org/2026.nslp-1.pdf) (though the title page says "workshop proceedings"). Several new workshop venues were thus ingested without the word "workshop". We may want to advise future pub chairs to enforce some consistency of workshop proceedings titles.