### PR TITLE
Update SIG URLs and add SIGs to SIGUL events

### DIFF
--- a/data/json/sigs.json
+++ b/data/json/sigs.json
@@ -41,12 +41,12 @@
   "sigbiomed": {
     "acronym": "SIGBIOMED",
     "name": "Special Interest Group on Biomedical Natural Language Processing",
-    "url": "http://www.sigbiomed.org/"
+    "url": "https://www.aclweb.org/aclwiki/SIGBIOMED"
   },
   "sigdat": {
     "acronym": "SIGDAT",
     "name": "Special Interest Group on Linguistic data and corpus-based approaches to NLP (SIGDAT)",
-    "url": "http://www.aclweb.org/sigdat",
+    "url": "https://sigdat.org/",
     "external_meetings": [
       {
         "year": "1994",
@@ -133,7 +133,7 @@
   "sigfsm": {
     "acronym": "SIGFSM",
     "name": "Special Interest Group on Finite-State Methods (SIGFSM)",
-    "url": "https://kitwiki.csc.fi/twiki/bin/view/KitWiki/SIGFSM"
+    "url": "https://www.aclweb.org/aclwiki/SIGFSM"
   },
   "siggen": {
     "acronym": "SIGGEN",
@@ -185,11 +185,12 @@
   "sighan": {
     "acronym": "SIGHAN",
     "name": "Special Interest Group on Chinese Language Processing (SIGHAN)",
-    "url": "http://www.sighan.org"
+    "url": " http://sighan.cs.uchicago.edu/"
   },
   "sighum": {
     "acronym": "SIGHUM",
     "name": "Special Interest Group on Language Technologies for the Socio-Economic Sciences and Humanities",
+    "url": "https://sighum.wordpress.com/"
     "external_meetings": [
       {
         "year": "2008",
@@ -465,7 +466,7 @@
   "sigslpat": {
     "acronym": "SIGSLPAT",
     "name": "Special Interest Group on Speech and Language Processing for Assistive Technologies",
-    "url": "http://www.slpat.org/"
+    "url": "https://www.isca-speech.org/Speech-and-Language-Processing-for-Assistive-Technologies-SLPAT "
   },
   "sigslt": {
     "acronym": "SIGSLT",
@@ -480,7 +481,7 @@
   "sigturk": {
     "acronym": "SIGTurk",
     "name": "Special Interest Group on Turkic Languages (SIGTURK)",
-    "url": "https://sigturk.org"
+    "url": "https://sigturk.github.io/"
   },
   "sigtyp": {
     "acronym": "SIGTYP",
@@ -489,7 +490,8 @@
   },
   "sigul": {
     "acronym": "SIGUL",
-    "name": "ELRA/ISCA Special Interest Group on Under-Resourced Languages"
+    "name": "ELRA/ISCA Special Interest Group on Under-Resourced Languages",
+    "url": "https://www.sigul.eu/"
   },
   "sigur": {
     "acronym": "SIGUR",

--- a/data/json/sigs.json
+++ b/data/json/sigs.json
@@ -190,8 +190,8 @@
   "sighum": {
     "acronym": "SIGHUM",
     "name": "Special Interest Group on Language Technologies for the Socio-Economic Sciences and Humanities",
-    "url": "https://sighum.wordpress.com/"
-    "external_meetings": [
+    "url": "https://sighum.wordpress.com/",
+		"external_meetings": [
       {
         "year": "2008",
         "name": "Workshop on Language Technology for Cultural Heritage, Social Sciences, and Humanities",
@@ -466,7 +466,7 @@
   "sigslpat": {
     "acronym": "SIGSLPAT",
     "name": "Special Interest Group on Speech and Language Processing for Assistive Technologies",
-    "url": "https://www.isca-speech.org/Speech-and-Language-Processing-for-Assistive-Technologies-SLPAT "
+    "url": "https://www.isca-speech.org/Speech-and-Language-Processing-for-Assistive-Technologies-SLPAT"
   },
   "sigslt": {
     "acronym": "SIGSLT",

--- a/data/json/sigs.json
+++ b/data/json/sigs.json
@@ -466,7 +466,7 @@
   "sigslpat": {
     "acronym": "SIGSLPAT",
     "name": "Special Interest Group on Speech and Language Processing for Assistive Technologies",
-    "url": "https://www.isca-speech.org/Speech-and-Language-Processing-for-Assistive-Technologies-SLPAT "
+    "url": "https://www.isca-speech.org/Speech-and-Language-Processing-for-Assistive-Technologies-SLPAT"
   },
   "sigslt": {
     "acronym": "SIGSLT",

--- a/data/json/sigs.json
+++ b/data/json/sigs.json
@@ -185,7 +185,7 @@
   "sighan": {
     "acronym": "SIGHAN",
     "name": "Special Interest Group on Chinese Language Processing (SIGHAN)",
-    "url": " http://sighan.cs.uchicago.edu/"
+    "url": "http://sighan.cs.uchicago.edu/"
   },
   "sighum": {
     "acronym": "SIGHUM",

--- a/data/json/sigs.json
+++ b/data/json/sigs.json
@@ -191,7 +191,7 @@
     "acronym": "SIGHUM",
     "name": "Special Interest Group on Language Technologies for the Socio-Economic Sciences and Humanities",
     "url": "https://sighum.wordpress.com/",
-		"external_meetings": [
+    "external_meetings": [
       {
         "year": "2008",
         "name": "Workshop on Language Technology for Cultural Heritage, Social Sciences, and Humanities",
@@ -466,7 +466,7 @@
   "sigslpat": {
     "acronym": "SIGSLPAT",
     "name": "Special Interest Group on Speech and Language Processing for Assistive Technologies",
-    "url": "https://www.isca-speech.org/Speech-and-Language-Processing-for-Assistive-Technologies-SLPAT"
+    "url": "https://www.isca-speech.org/Speech-and-Language-Processing-for-Assistive-Technologies-SLPAT "
   },
   "sigslt": {
     "acronym": "SIGSLT",

--- a/data/xml/2024.sigul.xml
+++ b/data/xml/2024.sigul.xml
@@ -11,6 +11,7 @@
       <month>May</month>
       <year>2024</year>
       <url hash="ec23435b">2024.sigul-1</url>
+      <sig>sigul</sig>
       <venue>sigul</venue>
       <venue>ws</venue>
     </meta>

--- a/data/xml/2026.sigul.xml
+++ b/data/xml/2026.sigul.xml
@@ -17,6 +17,7 @@
       <month>May</month>
       <year>2026</year>
       <url hash="d1a2217c">2026.sigul-1</url>
+      <sig>sigul</sig>
       <venue>sigul</venue>
       <venue>eurali</venue>
       <venue>dclrl</venue>


### PR DESCRIPTION
Closes #9644.

1. Updates websites for all SIGs that have outdated websites, with the exception of SIGMEDIA and SIGMT. For both of these SIGs, I could not find a good website. For SIGMT, maybe the Google group would work? https://groups.google.com/g/sigmt?pli=1 

2. Adds SIG tags to SIGUL 2024 and SIGUL 2026.