### PR TITLE
Hardened deployment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Deployment trust boundaries require review from Anthology maintainers.
+/.github/actions/setup-site-build/ @acl-org/anthology
+/.github/dependabot.yml @acl-org/anthology
+/.github/workflows/deploy-preview.yml @acl-org/anthology
+/.github/workflows/preview.yml @acl-org/anthology
+/.github/workflows/publish.yml @acl-org/anthology
+/bin/aclanthology.org/README @acl-org/anthology
+/bin/aclanthology.org/deploy.toml.example @acl-org/anthology
+/bin/aclanthology.org/deploy_site_archive.py @acl-org/anthology
+/bin/aclanthology.org/validate_site_archive.py @acl-org/anthology
+/tests/test_deploy_site_archive.py @acl-org/anthology
+/tests/test_validate_site_archive.py @acl-org/anthology

--- a/.github/actions/setup-site-build/action.yml
+++ b/.github/actions/setup-site-build/action.yml
@@ -1,0 +1,62 @@
+name: Set up ACL Anthology site build
+
+description: Install the pinned, checksum-verified site build toolchain.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Hugo
+      shell: bash
+      env:
+        HUGO_SHA256: f84c6b2aacc3b0ab633a826dd5e6f08e054a59ead33f4f150567cadfea226c46
+        HUGO_VERSION: 0.160.0
+      run: |
+        set -euo pipefail
+        package="hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+        curl \
+          --fail \
+          --location \
+          --output "${package}" \
+          --show-error \
+          --silent \
+          "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${package}"
+        printf '%s  %s\n' "${HUGO_SHA256}" "${package}" | sha256sum --check --strict -
+        sudo dpkg -i "${package}"
+        rm "${package}"
+
+    - name: Install Dart Sass
+      shell: bash
+      env:
+        DART_SASS_SHA256: 08867d2f63f458bc07985d0fd96bfef42ed759a4dd9b3d5e1a87b85b52b76112
+        DART_SASS_VERSION: 1.97.1
+      run: |
+        set -euo pipefail
+        archive="dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
+        curl \
+          --fail \
+          --location \
+          --output "${archive}" \
+          --show-error \
+          --silent \
+          "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/${archive}"
+        printf '%s  %s\n' "${DART_SASS_SHA256}" "${archive}" | sha256sum --check --strict -
+        mkdir -p "${HOME}/.local"
+        tar -C "${HOME}/.local" -xf "${archive}"
+        rm "${archive}"
+        echo "${HOME}/.local/dart-sass" >> "${GITHUB_PATH}"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+      with:
+        version: latest-known
+
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        sudo apt-get install -y bibutils jing libpython3-dev libyaml-dev
+
+    - name: Download NLTK data
+      shell: bash
+      run: uv run python -c "import nltk; nltk.download('punkt_tab')"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Etc/UTC
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -14,26 +14,12 @@ jobs:
   check-build:
     runs-on:
       labels: ubuntu-latest-m
-    env:
-      HUGO_VERSION: 0.160.0
-      DART_SASS_VERSION: 1.97.1
     steps:
-    - name: Install Hugo
-      run: wget "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" && sudo dpkg -i "hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-    - name: Install Dart Sass
-      run: |
-        mkdir -p "${HOME}/.local"
-        curl -sLJO "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        tar -C "${HOME}/.local" -xf "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        rm "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        echo "${HOME}/.local/dart-sass" >> "${GITHUB_PATH}"
-    - name: Install uv
-      uses: astral-sh/setup-uv@v9.0.0
-    - name: Install other dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y jing bibutils openssh-client rsync libyaml-dev libpython3-dev
-    - uses: actions/checkout@v7
+    - name: Check out proposed changes
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Set up site build
+      uses: ./.github/actions/setup-site-build
 
     - name: Run Python library integration tests
       run: uv run --locked pytest -m "integration"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,431 @@
+# This workflow is loaded from master. It treats the triggering branch workflow
+# and its artifact as untrusted until authorization and archive validation pass.
+
+name: Deploy maintainer branch preview
+
+on:
+  workflow_run:
+    workflows:
+      - Build maintainer branch preview
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: preview-deploy-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    if: >-
+      github.repository == 'acl-org/acl-anthology' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.authorize.outputs.allowed }}
+      artifact_id: ${{ steps.authorize.outputs.artifact_id }}
+      actor: ${{ steps.authorize.outputs.actor }}
+      branch: ${{ steps.authorize.outputs.branch }}
+      head_sha: ${{ steps.authorize.outputs.head_sha }}
+      slug: ${{ steps.authorize.outputs.slug }}
+      triggering_actor: ${{ steps.authorize.outputs.triggering_actor }}
+    steps:
+      - name: Reauthorize triggering run
+        id: authorize
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const crypto = require('crypto');
+            const run = context.payload.workflow_run;
+            const expectedRepository = `${context.repo.owner}/${context.repo.repo}`;
+            core.setOutput('allowed', 'false');
+
+            if (run.repository?.full_name !== expectedRepository ||
+                run.head_repository?.full_name !== expectedRepository) {
+              core.notice('Skipping preview from a different repository.');
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/.test(run.head_sha || '')) {
+              core.notice('Skipping preview with an invalid head SHA.');
+              return;
+            }
+
+            const branch = run.head_branch || '';
+            if (!branch || branch.length > 255 || /[\x00-\x1f\x7f]/.test(branch) ||
+                branch === 'master' || branch.startsWith('python-')) {
+              core.notice(`Skipping unexpected preview branch: ${JSON.stringify(branch)}`);
+              return;
+            }
+
+            const actor = run.actor?.login || '';
+            const triggeringActor = run.triggering_actor?.login || actor;
+            const actors = [...new Set([actor, triggeringActor].filter(Boolean))];
+            if (actors.length === 0 || actors.some(
+              username => !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/.test(username),
+            )) {
+              core.notice('Skipping preview without a triggering actor.');
+              return;
+            }
+            for (const username of actors) {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username,
+              });
+              if (data.user.permissions?.maintain !== true) {
+                core.notice(
+                  `Skipping preview for ${username}: ${data.role_name} role`,
+                );
+                return;
+              }
+            }
+
+            let branchRef;
+            try {
+              ({ data: branchRef } = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              }));
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice(`Skipping deleted branch: ${branch}`);
+                return;
+              }
+              throw error;
+            }
+            if (branchRef.object.sha !== run.head_sha) {
+              core.notice(
+                `Skipping stale preview ${run.head_sha}; branch is now ${branchRef.object.sha}.`,
+              );
+              return;
+            }
+
+            const allArtifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              },
+            );
+            const artifacts = allArtifacts.filter(
+              artifact => artifact.name === 'preview-site.tar.gz' && !artifact.expired,
+            );
+            if (artifacts.length !== 1) {
+              core.notice(
+                `Expected one preview artifact, found ${artifacts.length}.`,
+              );
+              return;
+            }
+            const artifact = artifacts[0];
+            if (artifact.size_in_bytes <= 0 || artifact.size_in_bytes > 4294967296) {
+              core.notice(`Preview artifact has invalid size: ${artifact.size_in_bytes}.`);
+              return;
+            }
+
+            const readable = branch
+              .replace(/[^A-Za-z0-9._-]+/g, '-')
+              .replace(/^[-._]+|[-._]+$/g, '')
+              .slice(0, 60) || 'branch';
+            const digest = crypto.createHash('sha256').update(branch).digest('hex');
+            const slug = `${readable}-${digest.slice(0, 12)}`;
+
+            core.setOutput('allowed', 'true');
+            core.setOutput('artifact_id', artifact.id.toString());
+            core.setOutput('actor', actor);
+            core.setOutput('branch', branch);
+            core.setOutput('head_sha', run.head_sha);
+            core.setOutput('slug', slug);
+            core.setOutput('triggering_actor', triggeringActor);
+
+  validate:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
+    runs-on:
+      labels: ubuntu-latest-m
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check out trusted validator
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download triggering run artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.authorize.outputs.artifact_id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/preview-artifact
+          skip-decompress: true
+
+      - name: Validate and sanitize preview site
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/preview-artifact"
+          archive="${artifact_dir}/preview-site.tar.gz"
+          [[ -f "${archive}" && ! -L "${archive}" ]]
+          [[ $(find "${artifact_dir}" -mindepth 1 -type f | wc -l) -eq 1 ]]
+          [[ -z $(find "${artifact_dir}" -mindepth 1 ! -type f -print -quit) ]]
+          python bin/aclanthology.org/validate_site_archive.py \
+            "${archive}" \
+            validated-site \
+            --max-archive-bytes 4294967296 \
+            --max-expanded-bytes 17179869184 \
+            --max-file-bytes 1073741824 \
+            --max-entries 750000
+          tar --hard-dereference -C validated-site -czf validated-preview-site.tar.gz .
+
+      - name: Upload validated preview site
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: validated-preview-site.tar.gz
+          archive: false
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    needs:
+      - authorize
+      - validate
+    if: needs.authorize.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: preview
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download validated preview site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: validated-preview-site.tar.gz
+          path: ${{ runner.temp }}/validated-preview
+          skip-decompress: true
+
+      - name: Recheck branch and actor authorization
+        env:
+          ACTOR: ${{ needs.authorize.outputs.actor }}
+          BRANCH_NAME: ${{ needs.authorize.outputs.branch }}
+          EXPECTED_SHA: ${{ needs.authorize.outputs.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          TRIGGERING_ACTOR: ${{ needs.authorize.outputs.triggering_actor }}
+        run: |
+          set -euo pipefail
+          current_sha=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}" \
+            --jq .object.sha)
+          if [[ "${current_sha}" != "${EXPECTED_SHA}" ]]; then
+            echo "Branch moved from ${EXPECTED_SHA} to ${current_sha}; refusing stale deploy." >&2
+            exit 1
+          fi
+
+          for username in "${ACTOR}" "${TRIGGERING_ACTOR}"; do
+            [[ "${username}" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,38})$ ]]
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/collaborators/${username}/permission" \
+              --jq '.user.permissions.maintain == true' | grep -Fx true >/dev/null
+          done
+
+      - name: Deploy preview site
+        env:
+          DEPLOY_HOST: ${{ vars.ANTHOLOGY_DEPLOY_HOST }}
+          DEPLOY_KEY: ${{ secrets.PREVIEW_DEPLOY_SSH_KEY }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          PREVIEW_SLUG: ${{ needs.authorize.outputs.slug }}
+          SSH_KNOWN_HOSTS: ${{ vars.ANTHOLOGY_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          [[ -n "${DEPLOY_HOST}" && -n "${DEPLOY_KEY}" && -n "${SSH_KNOWN_HOSTS}" ]]
+          [[ "${PREVIEW_SLUG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$ ]]
+          [[ "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
+
+          archive="${RUNNER_TEMP}/validated-preview/validated-preview-site.tar.gz"
+          [[ -f "${archive}" && ! -L "${archive}" ]]
+          [[ $(find "${RUNNER_TEMP}/validated-preview" -mindepth 1 -type f | wc -l) -eq 1 ]]
+          [[ -z $(find "${RUNNER_TEMP}/validated-preview" -mindepth 1 ! -type f -print -quit) ]]
+          archive_size=$(stat -c '%s' "${archive}")
+          archive_digest=$(sha256sum "${archive}" | cut -d' ' -f1)
+          if (( archive_size == 0 || archive_size > 4294967296 )); then
+            echo "Preview archive has unexpected size: ${archive_size} bytes" >&2
+            exit 1
+          fi
+
+          umask 077
+          install -d -m 700 "${HOME}/.ssh"
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" > "${HOME}/.ssh/known_hosts"
+          printf '%s\n' "${DEPLOY_KEY}" > "${HOME}/.ssh/preview_deploy"
+          unset DEPLOY_KEY SSH_KNOWN_HOSTS
+          trap 'rm -f "${HOME}/.ssh/preview_deploy"' EXIT
+
+          ssh-keygen -F "${DEPLOY_HOST}" -f "${HOME}/.ssh/known_hosts" >/dev/null
+          ssh \
+            -i "${HOME}/.ssh/preview_deploy" \
+            -o BatchMode=yes \
+            -o ClearAllForwardings=yes \
+            -o ConnectTimeout=30 \
+            -o IdentitiesOnly=yes \
+            -o RequestTTY=no \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="${HOME}/.ssh/known_hosts" \
+            "anthology-preview-deploy@${DEPLOY_HOST}" \
+            "deploy ${PREVIEW_SLUG} ${HEAD_SHA} ${archive_digest} ${archive_size}" < "${archive}"
+
+  notify:
+    needs:
+      - authorize
+      - deploy
+    if: needs.authorize.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Announce preview
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BRANCH_NAME: ${{ needs.authorize.outputs.branch }}
+          PREVIEW_SLUG: ${{ needs.authorize.outputs.slug }}
+        with:
+          script: |
+            const branch = process.env.BRANCH_NAME;
+            const previewUrl = `https://preview.aclanthology.org/${process.env.PREVIEW_SLUG}`;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open',
+            });
+            if (prs.length === 0) return;
+
+            const pr = prs[0];
+            const marker = '<!-- add-pr-comment:preview -->';
+            const previewComment = [
+              marker,
+              '',
+              'Build successful. Some useful links:',
+              `* Complete site preview: ${previewUrl}`,
+              '',
+              'This preview will be removed after it expires.',
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              comment => (comment.body || '').includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: previewComment,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: previewComment,
+              });
+            }
+
+            if (!/^ingest\b/i.test(pr.title)) return;
+            const body = pr.body || '';
+            const previewHeading =
+              'Navigate to the preview site and check the following:';
+            const linkedPreviewHeading =
+              `Navigate to [the preview](${previewUrl}) site and check the following:`;
+            const updated = body.replace(previewHeading, linkedPreviewHeading);
+            if (updated !== body) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                body: updated,
+              });
+            }
+
+            const lines = updated.split(/\r?\n/);
+            const blockStart = lines.findIndex(
+              line => line.trim() === linkedPreviewHeading,
+            );
+            if (blockStart === -1) return;
+            let blockEnd = blockStart + 1;
+            while (blockEnd < lines.length && lines[blockEnd].trim() !== '') {
+              blockEnd += 1;
+            }
+            const previewBlock = lines.slice(blockStart, blockEnd).join('\n');
+
+            const result = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 20) {
+                      nodes {
+                        number
+                        repository {
+                          name
+                          owner { login }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: pr.number,
+              },
+            );
+
+            const issueMarker = `<!-- ingestion-preview-pr-${pr.number} -->`;
+            const issueComment = [
+              'A preview has been generated that requires your attention.',
+              '',
+              previewBlock,
+              '',
+              'The preview will be merged once you have completed the checklist.',
+              '',
+              issueMarker,
+            ].join('\n');
+            for (const issue of
+              result.repository.pullRequest.closingIssuesReferences.nodes) {
+              const issueOwner = issue.repository.owner.login;
+              const issueRepo = issue.repository.name;
+              const issueComments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: issueOwner,
+                  repo: issueRepo,
+                  issue_number: issue.number,
+                  per_page: 100,
+                },
+              );
+              if (issueComments.some(
+                comment => (comment.body || '').includes(issueMarker),
+              )) {
+                continue;
+              }
+              await github.rest.issues.createComment({
+                owner: issueOwner,
+                repo: issueRepo,
+                issue_number: issue.number,
+                body: issueComment,
+              });
+            }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,211 +1,127 @@
-# Builds a preview of all non-master branches and publishes them
-# to https://aclanthology.org/previews/BRANCHNAME
+# Branch code is built without secrets or a write-scoped token. A separate
+# workflow_run workflow, loaded from master, authorizes and deploys the artifact.
 
-name: Create website preview
+name: Build maintainer branch preview
 
 on:
   push:
     branches:
-    - '**'
-    - '!master'
-    - '!python-*'
-
-# only run one at a time per branch
-concurrency:
-  group: preview-${{ github.ref }}
-  cancel-in-progress: true
+      - '**'
+      - '!master'
+      - '!python-*'
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  pull-requests: read
+
+concurrency:
+  group: preview-build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  preview:
+  authorize:
     if: github.repository == 'acl-org/acl-anthology'
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.permission.outputs.allowed }}
+    steps:
+      - name: Require maintainer permission
+        id: permission
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = data.user.permissions?.maintain === true;
+            core.setOutput('allowed', allowed.toString());
+            if (!allowed) {
+              core.notice(
+                `Skipping preview for ${context.actor}: ${data.role_name} role`,
+              );
+            }
+
+  build:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
     runs-on:
       labels: ubuntu-latest-m
-    env:
-      HUGO_VERSION: 0.160.0
-      DART_SASS_VERSION: 1.97.1
+    timeout-minutes: 90
     steps:
-    - name: install hugo
-      run: wget "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" && sudo dpkg -i "hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-    - name: Install Dart Sass
-      run: |
-        mkdir -p "${HOME}/.local"
-        curl -sLJO "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        tar -C "${HOME}/.local" -xf "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        rm "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        echo "${HOME}/.local/dart-sass" >> "${GITHUB_PATH}"
-    - name: install uv
-      uses: astral-sh/setup-uv@v9.0.0
-    - name: update
-      run: sudo apt-get update
-    - name: install other deps
-      run: sudo apt-get install -y jing bibutils openssh-client rsync libyaml-dev libpython3-dev
-    - name: dump secret key
-      env:
-        SSH_KEY: ${{ secrets.PUBLISH_SSH_KEY }}
-      run: |
-        mkdir -p $HOME/.ssh/
-        echo "$SSH_KEY" > $HOME/.ssh/id_rsa
-        chmod 600 $HOME/.ssh/id_rsa
-    - uses: actions/checkout@v7
-    - name: fetch master branch
-      run: |
-        git fetch origin master
-    - name: install pip dependencies
-      run: |
-        python -m pip install -U pip
-        python -m pip install lxml
-    - name: extract branch name
-      shell: bash
-      run: |
-        raw_branch="${GITHUB_REF#refs/heads/}"
-        branch="${raw_branch//\//___}"
-        echo "branch=$(echo ${branch})" >> $GITHUB_OUTPUT
-      id: extract_branch
-    - name: list changes
-      shell: bash
-      run: echo "changes=$(git diff --name-only $GITHUB_REF origin/master | python ./bin/get_changes_from_git_diff.py https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }})" >> $GITHUB_OUTPUT
-      id: list_changes
-#    - name: list volumes debug
-#      shell: bash
-#      run: |
-#        git diff --name-only $GITHUB_REF origin/master
-#        git diff --name-only $GITHUB_REF origin/master | python ./bin/volumes_from_diff.py https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}
-    - name: Download NLTK data
-      # Needed by bin/fixedcase (imported via bin/ingest.py) during `make check`.
-      run: uv run python -c "import nltk; nltk.download('punkt_tab')"
-    - name: find pull request
-      id: pull_request
-      uses: actions/github-script@v6
-      with:
-        result-encoding: string
-        script: |
-          const branch = context.ref.replace('refs/heads/', '');
-          const { data: pullRequests } = await github.rest.pulls.list({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            head: `${context.repo.owner}:${branch}`,
-            state: 'open',
-          });
-          return pullRequests[0]?.html_url || '';
-    - name: preview
-      shell: bash
-      env:
-        ANTHOLOGY_PREFIX: https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}
-        HUGO_PARAMS_PREVIEWPRURL: ${{ steps.pull_request.outputs.result }}
-      run: |
-        make NOBIB=true ANTHOLOGY_PREFIX=${ANTHOLOGY_PREFIX} check site preview
-    - uses: mshick/add-pr-comment@v2
-      with:
-        # this causes pushes to update the old message, instead of generating a new one
-        message-id: preview
-        message: |
-          Build successful. Some useful links:
-          * Complete site preview: https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}
-          * Potential changes of interest: ${{ steps.list_changes.outputs.changes }}
+      - name: Check out branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-          This preview will be removed when the branch is merged.
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        allow-repeats: false
-    - name: Notify ingestion reviewers of preview
-      uses: actions/github-script@v8
-      with:
-        script: |
-          const branch = context.ref.replace('refs/heads/', '');
-          const { data: prs } = await github.rest.pulls.list({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            head: `${context.repo.owner}:${branch}`,
-            state: 'open',
-          });
-          if (prs.length === 0) return;
-          const pr = prs[0];
-          if (!/^ingest\b/i.test(pr.title)) return;
+      - name: Derive safe preview name
+        id: preview
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import os
+          import re
 
-          const body = pr.body || '';
-          const previewUrl = 'https://preview.aclanthology.org/${{ steps.extract_branch.outputs.branch }}';
-          const previewHeading = 'Navigate to the preview site and check the following:';
-          const linkedPreviewHeading = `Navigate to [the preview](${previewUrl}) site and check the following:`;
-          const updated = body.replace(
-            previewHeading,
-            linkedPreviewHeading
-          );
-          if (updated !== body) {
-            await github.rest.pulls.update({
+          branch = os.environ['BRANCH_NAME']
+          readable = re.sub(r'[^A-Za-z0-9._-]+', '-', branch).strip('-._')[:60]
+          digest = hashlib.sha256(branch.encode()).hexdigest()[:12]
+          slug = f'{readable or "branch"}-{digest}'
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              print(f'slug={slug}', file=output)
+          PY
+
+      - name: Find pull request
+        id: pull_request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          result-encoding: string
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pr.number,
-              body: updated,
+              head: `${context.repo.owner}:${context.ref.replace('refs/heads/', '')}`,
+              state: 'open',
             });
-          }
+            return pullRequests[0]?.html_url || '';
 
-          const lines = updated.split(/\r?\n/);
-          const blockStart = lines.findIndex(line => line.trim() === linkedPreviewHeading);
-          if (blockStart === -1) return;
+      - name: Set up site build
+        uses: ./.github/actions/setup-site-build
 
-          let blockEnd = blockStart + 1;
-          while (blockEnd < lines.length && lines[blockEnd].trim() !== '') {
-            blockEnd += 1;
-          }
-          const previewBlock = lines.slice(blockStart, blockEnd).join('\n');
+      - name: Build and check preview
+        env:
+          ANTHOLOGY_PREFIX: https://preview.aclanthology.org/${{ steps.preview.outputs.slug }}
+          HUGO_PARAMS_PREVIEWPRURL: ${{ steps.pull_request.outputs.result }}
+        run: make NOBIB=true ANTHOLOGY_PREFIX="${ANTHOLOGY_PREFIX}" check site
 
-          const result = await github.graphql(
-            `query($owner: String!, $repo: String!, $number: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $number) {
-                  closingIssuesReferences(first: 20) {
-                    nodes {
-                      number
-                      repository {
-                        name
-                        owner {
-                          login
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }`,
-            {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              number: pr.number,
-            }
-          );
+      - name: Package preview site
+        env:
+          PREVIEW_SLUG: ${{ steps.preview.outputs.slug }}
+        run: |
+          set -euo pipefail
+          site_dir="build/website/${PREVIEW_SLUG}"
 
-          const marker = `<!-- ingestion-preview-pr-${pr.number} -->`;
-          const commentBody = [
-            'A preview has been generated that requires your attention.',
-            '',
-            previewBlock,
-            '',
-            'The preview will be merged once you have completed the checklist.',
-            '',
-            marker,
-          ].join('\n');
+          # The server creates this one known symlink after safe extraction.
+          if [[ -L "${site_dir}/anthology-files" ]]; then
+            rm "${site_dir}/anthology-files"
+          fi
+          unexpected_symlink=$(find "${site_dir}" -type l -print -quit)
+          if [[ -n "${unexpected_symlink}" ]]; then
+            echo "Unexpected symlink in generated preview: ${unexpected_symlink}" >&2
+            exit 1
+          fi
 
-          for (const issue of result.repository.pullRequest.closingIssuesReferences.nodes) {
-            const issueOwner = issue.repository.owner.login;
-            const issueRepo = issue.repository.name;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: issueOwner,
-              repo: issueRepo,
-              issue_number: issue.number,
-              per_page: 100,
-            });
-            if (comments.some(comment => (comment.body || '').includes(marker))) {
-              continue;
-            }
+          tar --hard-dereference -C "${site_dir}" -czf preview-site.tar.gz .
+          archive_size=$(stat -c '%s' preview-site.tar.gz)
+          if (( archive_size == 0 || archive_size > 4294967296 )); then
+            echo "Preview archive has unexpected size: ${archive_size} bytes" >&2
+            exit 1
+          fi
 
-            await github.rest.issues.createComment({
-              owner: issueOwner,
-              repo: issueRepo,
-              issue_number: issue.number,
-              body: commentBody,
-            });
-          }
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: preview-site.tar.gz
+          archive: false
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,55 +1,185 @@
-# Publishes the build to our current mirror, aclanthology.org
+# Builds master without credentials, then deploys the resulting archive from a
+# separate job using a production-only, server-restricted SSH key.
 
-name: publish-aclanthology
+name: Publish ACL Anthology
 
 on:
   push:
     branches:
       - master
 
-# only run one at a time
-concurrency: publish
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
 
 jobs:
-  publish-aclanthology:
+  build:
     if: github.repository == 'acl-org/acl-anthology'
     runs-on:
       labels: ubuntu-latest-m
-    env:
-      HUGO_VERSION: 0.160.0
-      DART_SASS_VERSION: 1.97.1
+    timeout-minutes: 90
     steps:
-    - name: install hugo
-      run: wget "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" && sudo dpkg -i "hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-    - name: Install Dart Sass
-      run: |
-        mkdir -p "${HOME}/.local"
-        curl -sLJO "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        tar -C "${HOME}/.local" -xf "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        rm "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-        echo "${HOME}/.local/dart-sass" >> "${GITHUB_PATH}"
-    - name: install uv
-      uses: astral-sh/setup-uv@v9.0.0
-    - name: update
-      run: sudo apt-get update
-    - name: install other deps
-      run: sudo apt-get install -y jing bibutils openssh-client rsync libyaml-dev libpython3-dev
-    - name: dump secret key
-      env:
-        SSH_KEY: ${{ secrets.PUBLISH_SSH_KEY }}
-      run: |
-        mkdir -p $HOME/.ssh/
-        echo "$SSH_KEY" > $HOME/.ssh/id_rsa
-        chmod 600 $HOME/.ssh/id_rsa
-    - uses: actions/checkout@v7
-    - name: Download NLTK data
-      # Needed by bin/fixedcase (imported via bin/ingest.py) during `make check`.
-      run: uv run python -c "import nltk; nltk.download('punkt_tab')"
-    - name: build
-      env:
-        ANTHOLOGY_PREFIX: https://aclanthology.org
-      run: |
-        make ANTHOLOGY_PREFIX=${ANTHOLOGY_PREFIX} check site
-    - name: publish
-      run: |
-        make ANTHOLOGY_PREFIX=${ANTHOLOGY_PREFIX} upload
+      - name: Check out master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up site build
+        uses: ./.github/actions/setup-site-build
+
+      - name: Build and check the production site
+        env:
+          ANTHOLOGY_PREFIX: https://aclanthology.org
+        run: make ANTHOLOGY_PREFIX="${ANTHOLOGY_PREFIX}" check site
+
+      - name: Package the production site
+        run: |
+          set -euo pipefail
+          site_dir='build/website'
+
+          # The server creates this one known symlink after safe extraction.
+          if [[ -L "${site_dir}/anthology-files" ]]; then
+            rm "${site_dir}/anthology-files"
+          fi
+          unexpected_symlink=$(find "${site_dir}" -type l -print -quit)
+          if [[ -n "${unexpected_symlink}" ]]; then
+            echo "Unexpected symlink in generated site: ${unexpected_symlink}" >&2
+            exit 1
+          fi
+
+          tar --hard-dereference -C "${site_dir}" -czf anthology-site.tar.gz .
+          archive_size=$(stat -c '%s' anthology-site.tar.gz)
+          if (( archive_size == 0 || archive_size > 8589934592 )); then
+            echo "Production archive has unexpected size: ${archive_size} bytes" >&2
+            exit 1
+          fi
+
+      - name: Upload production site artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: anthology-site.tar.gz
+          archive: false
+          if-no-files-found: error
+          retention-days: 1
+
+  validate:
+    needs: build
+    if: github.repository == 'acl-org/acl-anthology'
+    runs-on:
+      labels: ubuntu-latest-m
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check out trusted validator
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download production site artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: anthology-site.tar.gz
+          path: ${{ runner.temp }}/production-artifact
+          skip-decompress: true
+
+      - name: Validate and sanitize production site
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/production-artifact"
+          archive="${artifact_dir}/anthology-site.tar.gz"
+          [[ -f "${archive}" && ! -L "${archive}" ]]
+          [[ $(find "${artifact_dir}" -mindepth 1 -type f | wc -l) -eq 1 ]]
+          [[ -z $(find "${artifact_dir}" -mindepth 1 ! -type f -print -quit) ]]
+          python bin/aclanthology.org/validate_site_archive.py \
+            "${archive}" \
+            validated-site \
+            --max-archive-bytes 8589934592 \
+            --max-expanded-bytes 34359738368 \
+            --max-file-bytes 2147483648 \
+            --max-entries 1000000
+          tar --hard-dereference -C validated-site -czf validated-anthology-site.tar.gz .
+
+      - name: Upload validated production site
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: validated-anthology-site.tar.gz
+          archive: false
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    needs: validate
+    if: github.repository == 'acl-org/acl-anthology'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: production
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download production site artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: validated-anthology-site.tar.gz
+          path: ${{ runner.temp }}/validated-production
+          skip-decompress: true
+
+      - name: Refuse stale production deployment
+        id: freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_sha=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/master" \
+            --jq .object.sha)
+          if [[ "${current_sha}" == "${GITHUB_SHA}" ]]; then
+            echo 'deploy=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo "Master moved from ${GITHUB_SHA} to ${current_sha}; skipping stale deploy."
+            echo 'deploy=false' >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Deploy production site
+        if: steps.freshness.outputs.deploy == 'true'
+        env:
+          DEPLOY_HOST: ${{ vars.ANTHOLOGY_DEPLOY_HOST }}
+          DEPLOY_KEY: ${{ secrets.PRODUCTION_DEPLOY_SSH_KEY }}
+          SSH_KNOWN_HOSTS: ${{ vars.ANTHOLOGY_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          [[ -n "${DEPLOY_HOST}" && -n "${DEPLOY_KEY}" && -n "${SSH_KNOWN_HOSTS}" ]]
+
+          archive="${RUNNER_TEMP}/validated-production/validated-anthology-site.tar.gz"
+          [[ -f "${archive}" && ! -L "${archive}" ]]
+          [[ $(find "${RUNNER_TEMP}/validated-production" -mindepth 1 -type f | wc -l) -eq 1 ]]
+          [[ -z $(find "${RUNNER_TEMP}/validated-production" -mindepth 1 ! -type f -print -quit) ]]
+          archive_size=$(stat -c '%s' "${archive}")
+          archive_digest=$(sha256sum "${archive}" | cut -d' ' -f1)
+          if (( archive_size == 0 || archive_size > 8589934592 )); then
+            echo "Production archive has unexpected size: ${archive_size} bytes" >&2
+            exit 1
+          fi
+
+          umask 077
+          install -d -m 700 "${HOME}/.ssh"
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" > "${HOME}/.ssh/known_hosts"
+          printf '%s\n' "${DEPLOY_KEY}" > "${HOME}/.ssh/production_deploy"
+          unset DEPLOY_KEY SSH_KNOWN_HOSTS
+          trap 'rm -f "${HOME}/.ssh/production_deploy"' EXIT
+
+          ssh-keygen -F "${DEPLOY_HOST}" -f "${HOME}/.ssh/known_hosts" >/dev/null
+          ssh \
+            -i "${HOME}/.ssh/production_deploy" \
+            -o BatchMode=yes \
+            -o ClearAllForwardings=yes \
+            -o ConnectTimeout=30 \
+            -o IdentitiesOnly=yes \
+            -o RequestTTY=no \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="${HOME}/.ssh/known_hosts" \
+            "anthology-production-deploy@${DEPLOY_HOST}" \
+            "deploy ${GITHUB_SHA} ${archive_digest} ${archive_size}" < "${archive}"

--- a/README.md
+++ b/README.md
@@ -38,13 +38,12 @@ To build the Anthology website, you will need:
 
 ### Building and deployment with GitHub
 
-There is a GitHub actions action performing deployment directly from GitHub.  To use this, you need to
-define this variable in your repository settings (web interface: settings -> secrets):
-
-+ `PUBLISH_SSH_KEY`: the secret key in standard pem format for authentication (without a passphrase)
-
-GitHub will then automatically build and deploy the current master whenever the master branch changes.
-This is done via the `upload` target in the Makefile.
+GitHub Actions builds and validates the production site and maintainer branch
+previews, then streams sanitized archives through separate, restricted SSH
+deployment accounts. The deployment keys cannot open a shell or choose a server
+destination. See [`bin/aclanthology.org/README`](bin/aclanthology.org/README) for
+the required GitHub environments, secrets, server accounts, quotas, and rollout
+instructions.
 
 ### Cloning
 

--- a/bin/aclanthology.org/README
+++ b/bin/aclanthology.org/README
@@ -1,1 +1,298 @@
 Scripts used on the server.
+
+# Hardened GitHub deployment
+
+The production and preview workflows build in GitHub Actions without SSH
+credentials. A separate validation job rejects unsafe archive entries and
+repackages regular files. A final job, which never checks out repository code,
+streams the sanitized archive to a server account with a forced SSH command.
+
+Production and preview deployment use different SSH keys and Unix accounts.
+Neither account has a general-purpose SSH shell, SFTP, forwarding, or permission
+to modify the other deployment tree.
+
+## Important rollout order
+
+The first merge containing `.github/workflows/publish.yml` immediately starts a
+production deployment. Complete the server and GitHub configuration below before
+merging it. Keep the current web roots in place until the first new deployment
+has created the `current` and preview symlinks, then switch the web server roots.
+
+## 1. Create dedicated SSH keys
+
+Generate these on an administrator machine, not on the web server:
+
+```sh
+ssh-keygen -t ed25519 -f anthology-production-deploy -C acl-anthology-production
+ssh-keygen -t ed25519 -f anthology-preview-deploy -C acl-anthology-preview
+```
+
+The private keys become GitHub environment secrets. The public keys are installed
+on the server below. Do not reuse `PUBLISH_SSH_KEY`.
+
+## 2. Install the server programs
+
+Run as root on the server from a trusted checkout of this branch:
+
+```sh
+useradd --system --create-home \
+	--home-dir /var/lib/anthology-production-deploy \
+	--shell /bin/bash anthology-production-deploy
+useradd --system --create-home \
+	--home-dir /var/lib/anthology-preview-deploy \
+	--shell /bin/bash anthology-preview-deploy
+
+install -d -o root -g root -m 0755 /usr/local/libexec/acl-anthology
+install -o root -g root -m 0755 \
+	bin/aclanthology.org/deploy_site_archive.py \
+	bin/aclanthology.org/validate_site_archive.py \
+	/usr/local/libexec/acl-anthology/
+
+install -d -o root -g root -m 0755 /etc/acl-anthology
+install -o root -g root -m 0644 \
+	bin/aclanthology.org/deploy.toml.example \
+	/etc/acl-anthology/deploy.toml
+
+install -d -o root -g root -m 0755 /srv/acl-anthology
+install -d -o anthology-production-deploy -g www-data -m 0755 \
+	/srv/acl-anthology/production \
+	/srv/acl-anthology/production/releases
+install -d -o anthology-preview-deploy -g www-data -m 0755 \
+	/srv/acl-anthology/previews \
+	/srv/acl-anthology/previews/releases \
+	/srv/acl-anthology/previews/public
+```
+
+Review `/etc/acl-anthology/deploy.toml`. In particular, verify the
+`anthology_files` target and storage limits. The configuration and installed
+programs must remain root-owned and not writable by either deployment account.
+
+The default limits are:
+
+- Production: 8 GiB compressed, 32 GiB expanded, one million entries, three
+	retained releases.
+- Previews: 4 GiB compressed, 16 GiB expanded per deployment, 50 GiB total,
+	30-day expiration.
+
+The script limits are defense in depth. Also give the preview account a hard
+filesystem or project quota slightly above `max_total_bytes` (for example,
+60 GiB) and an inode quota. Exact quota commands depend on whether the server
+uses ext4, XFS, ZFS, or another filesystem.
+
+## 3. Install public keys and force commands
+
+Make both deployment home directories and their SSH authorization files
+root-owned, so a compromised deployment process cannot authorize another key:
+
+```sh
+chown root:root \
+	/var/lib/anthology-production-deploy \
+	/var/lib/anthology-preview-deploy
+chmod 0755 \
+	/var/lib/anthology-production-deploy \
+	/var/lib/anthology-preview-deploy
+install -d -o root -g root -m 0755 \
+	/var/lib/anthology-production-deploy/.ssh \
+	/var/lib/anthology-preview-deploy/.ssh
+```
+
+Create an `authorized_keys` file for each account, owned by root with mode 0644.
+Each file should contain only its corresponding public key, prefixed with
+`restrict`:
+
+```text
+restrict ssh-ed25519 AAAA... acl-anthology-production
+```
+
+```text
+restrict ssh-ed25519 AAAA... acl-anthology-preview
+```
+
+Set ownership and permissions:
+
+```sh
+chown root:root /var/lib/anthology-*-deploy/.ssh/authorized_keys
+chmod 0644 /var/lib/anthology-*-deploy/.ssh/authorized_keys
+```
+
+Add `/etc/ssh/sshd_config.d/acl-anthology-deploy.conf`:
+
+```text
+Match User anthology-production-deploy
+		AuthenticationMethods publickey
+		PasswordAuthentication no
+		KbdInteractiveAuthentication no
+		PermitTTY no
+		PermitTunnel no
+		AllowAgentForwarding no
+		AllowTcpForwarding no
+		X11Forwarding no
+		PermitUserEnvironment no
+		PermitUserRC no
+		ForceCommand /usr/bin/timeout --signal=KILL 3600 /usr/bin/prlimit --as=8589934592 --cpu=3300 --fsize=8589934592 --nofile=1024 -- /usr/bin/python3 /usr/local/libexec/acl-anthology/deploy_site_archive.py --config /etc/acl-anthology/deploy.toml production
+
+Match User anthology-preview-deploy
+		AuthenticationMethods publickey
+		PasswordAuthentication no
+		KbdInteractiveAuthentication no
+		PermitTTY no
+		PermitTunnel no
+		AllowAgentForwarding no
+		AllowTcpForwarding no
+		X11Forwarding no
+		PermitUserEnvironment no
+		PermitUserRC no
+		ForceCommand /usr/bin/timeout --signal=KILL 2700 /usr/bin/prlimit --as=4294967296 --cpu=2400 --fsize=4294967296 --nofile=1024 -- /usr/bin/python3 /usr/local/libexec/acl-anthology/deploy_site_archive.py --config /etc/acl-anthology/deploy.toml preview
+
+Match all
+```
+
+Validate and reload SSH before closing the administrator session:
+
+```sh
+sshd -t
+systemctl reload ssh
+```
+
+The forced command parses only these request forms from `SSH_ORIGINAL_COMMAND`:
+
+```text
+deploy COMMIT_SHA ARCHIVE_SHA256 ARCHIVE_SIZE
+deploy PREVIEW_SLUG COMMIT_SHA ARCHIVE_SHA256 ARCHIVE_SIZE
+```
+
+Archive bytes arrive only on standard input. No argument is used as a filesystem
+path.
+
+## 4. Configure static web roots
+
+After one successful deployment, configure the production virtual host to serve:
+
+```text
+/srv/acl-anthology/production/current
+```
+
+Configure the preview virtual host to serve:
+
+```text
+/srv/acl-anthology/previews/public
+```
+
+Both roots contain symlinks managed by the forced command, so the web server must
+follow those specific symlinks. The production release contains one server-made
+`anthology-files` symlink to the configured object-file tree.
+
+The preview virtual host must be static-only, with directory listings and script
+execution disabled. For Apache, use `AllowOverride None`; do not let uploaded
+`.htaccess` files change server behavior. Add at least these response headers:
+
+```text
+X-Content-Type-Options: nosniff
+X-Robots-Tag: noindex, noarchive
+```
+
+Add a Content Security Policy only after testing it against the site's required
+asset origins; an overly narrow generic policy will break previews.
+
+Keep a `robots.txt` with `Disallow: /` in the preview public root.
+
+## 5. Expire previews independently of deployments
+
+Install a systemd service and timer so expiration still runs when no new preview
+is deployed:
+
+```ini
+# /etc/systemd/system/acl-anthology-preview-cleanup.service
+[Unit]
+Description=Expire ACL Anthology branch previews
+
+[Service]
+Type=oneshot
+User=anthology-preview-deploy
+Group=anthology-preview-deploy
+ExecStart=/usr/bin/python3 /usr/local/libexec/acl-anthology/deploy_site_archive.py --config /etc/acl-anthology/deploy.toml cleanup-previews
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/srv/acl-anthology/previews
+RestrictAddressFamilies=AF_UNIX
+```
+
+```ini
+# /etc/systemd/system/acl-anthology-preview-cleanup.timer
+[Unit]
+Description=Run ACL Anthology preview cleanup daily
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=30m
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable it with:
+
+```sh
+systemctl daemon-reload
+systemctl enable --now acl-anthology-preview-cleanup.timer
+```
+
+The old `remove-previews.sh` job is unnecessary after this timer is active.
+
+## 6. Configure GitHub
+
+Create two GitHub environments:
+
+- `production`: allow deployments only from `master`; add secret
+	`PRODUCTION_DEPLOY_SSH_KEY` containing the complete production private key.
+- `preview`: allow deployments only from `master`; add secret
+	`PREVIEW_DEPLOY_SSH_KEY` containing the complete preview private key. The
+	trusted `workflow_run` workflow itself runs from `master` even though its
+	artifact came from a maintainer branch.
+
+Create these repository variables:
+
+- `ANTHOLOGY_DEPLOY_HOST`: the SSH hostname, normally `aclanthology.org`.
+- `ANTHOLOGY_SSH_KNOWN_HOSTS`: an OpenSSH `known_hosts` line for that hostname.
+
+Obtain the host key from the server console and verify its fingerprint there.
+Do not trust an unverified `ssh-keyscan` result. The workflows require strict host
+key checking and never use `accept-new`.
+
+Set the repository's default `GITHUB_TOKEN` permission to read-only. The
+workflows explicitly request only the additional API permissions needed for
+preview comments.
+
+Protect `master` with a ruleset that:
+
+- Requires pull requests and at least one approval.
+- Requires review from Code Owners. `.github/CODEOWNERS` assigns deployment
+	boundaries to `@acl-org/anthology`.
+- Dismisses stale approvals when deployment files change.
+- Restricts direct and force pushes and branch deletion.
+- Requires the website build check before merge.
+
+In Actions settings, require approval for first-time outside contributors, keep
+`GITHUB_TOKEN` read-only by default, and disable GitHub Actions creating or
+approving pull requests unless another workflow explicitly needs it.
+
+After both new deployment paths work:
+
+1. Remove `PUBLISH_SSH_KEY` from GitHub.
+2. Remove its old public key from every server account.
+3. Rotate that old key if it was used anywhere else.
+
+## Trust boundaries
+
+- Branch and production builds receive no SSH secret.
+- A trusted workflow loaded from `master` rechecks preview actor permission,
+	repository identity, current branch SHA, artifact identity, and artifact size.
+- Archive validation rejects absolute paths, traversal, duplicate paths,
+	symlinks, hardlinks, devices, sockets, oversized files, excessive expansion,
+	and excessive entry counts.
+- Deploy jobs do not check out or execute repository code.
+- The server repeats byte-count, digest, archive, and resource validation before
+	creating one known symlink and atomically switching a fixed public link.

--- a/bin/aclanthology.org/deploy.toml.example
+++ b/bin/aclanthology.org/deploy.toml.example
@@ -1,0 +1,23 @@
+[common]
+anthology_files = "/var/www/anthology-files"
+
+[production]
+release_root = "/srv/acl-anthology/production/releases"
+current_link = "/srv/acl-anthology/production/current"
+lock_file = "/srv/acl-anthology/production/deploy.lock"
+keep_releases = 3
+max_archive_bytes = 8589934592
+max_expanded_bytes = 34359738368
+max_file_bytes = 2147483648
+max_entries = 1000000
+
+[preview]
+release_root = "/srv/acl-anthology/previews/releases"
+public_root = "/srv/acl-anthology/previews/public"
+lock_file = "/srv/acl-anthology/previews/deploy.lock"
+max_age_days = 30
+max_total_bytes = 53687091200
+max_archive_bytes = 4294967296
+max_expanded_bytes = 17179869184
+max_file_bytes = 1073741824
+max_entries = 750000

--- a/bin/aclanthology.org/deploy_site_archive.py
+++ b/bin/aclanthology.org/deploy_site_archive.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Receive and atomically activate a validated ACL Anthology site archive."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import fcntl
+import hashlib
+import os
+from pathlib import Path
+import re
+import shutil
+import sys
+import tempfile
+import time
+import tomllib
+from typing import BinaryIO, Any
+
+from validate_site_archive import ArchiveValidationError, validate_and_extract
+
+
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+PREVIEW_SLUG_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
+RELEASE_PATTERN = re.compile(r"^[0-9a-f]{40}-[0-9a-f]{16}$")
+
+
+class DeploymentError(RuntimeError):
+    """Raised when a deployment request is invalid or cannot be activated."""
+
+
+@dataclass(frozen=True)
+class Limits:
+    max_archive_bytes: int
+    max_expanded_bytes: int
+    max_file_bytes: int
+    max_entries: int
+
+
+@dataclass(frozen=True)
+class CommonConfig:
+    anthology_files: Path
+
+
+@dataclass(frozen=True)
+class ProductionConfig:
+    release_root: Path
+    current_link: Path
+    lock_file: Path
+    keep_releases: int
+    limits: Limits
+
+
+@dataclass(frozen=True)
+class PreviewConfig:
+    release_root: Path
+    public_root: Path
+    lock_file: Path
+    max_age_days: int
+    max_total_bytes: int
+    limits: Limits
+
+
+@dataclass(frozen=True)
+class DeploymentRequest:
+    commit: str
+    digest: str
+    size: int
+    slug: str | None = None
+
+
+def required_path(section: dict[str, Any], key: str) -> Path:
+    value = section.get(key)
+    if not isinstance(value, str) or not value.startswith("/"):
+        raise DeploymentError(f"configuration value {key!r} must be an absolute path")
+    return Path(value)
+
+
+def required_positive_int(section: dict[str, Any], key: str) -> int:
+    value = section.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise DeploymentError(f"configuration value {key!r} must be positive")
+    return value
+
+
+def load_limits(section: dict[str, Any]) -> Limits:
+    return Limits(
+        max_archive_bytes=required_positive_int(section, "max_archive_bytes"),
+        max_expanded_bytes=required_positive_int(section, "max_expanded_bytes"),
+        max_file_bytes=required_positive_int(section, "max_file_bytes"),
+        max_entries=required_positive_int(section, "max_entries"),
+    )
+
+
+def load_config(
+    config_path: Path,
+) -> tuple[CommonConfig, ProductionConfig, PreviewConfig]:
+    with config_path.open("rb") as config_file:
+        raw = tomllib.load(config_file)
+
+    common_section = raw.get("common", {})
+    production_section = raw.get("production", {})
+    preview_section = raw.get("preview", {})
+    if not all(
+        isinstance(section, dict)
+        for section in (common_section, production_section, preview_section)
+    ):
+        raise DeploymentError("deployment configuration sections must be tables")
+
+    common = CommonConfig(
+        anthology_files=required_path(common_section, "anthology_files")
+    )
+    production = ProductionConfig(
+        release_root=required_path(production_section, "release_root"),
+        current_link=required_path(production_section, "current_link"),
+        lock_file=required_path(production_section, "lock_file"),
+        keep_releases=required_positive_int(production_section, "keep_releases"),
+        limits=load_limits(production_section),
+    )
+    preview = PreviewConfig(
+        release_root=required_path(preview_section, "release_root"),
+        public_root=required_path(preview_section, "public_root"),
+        lock_file=required_path(preview_section, "lock_file"),
+        max_age_days=required_positive_int(preview_section, "max_age_days"),
+        max_total_bytes=required_positive_int(preview_section, "max_total_bytes"),
+        limits=load_limits(preview_section),
+    )
+    return common, production, preview
+
+
+def parse_request(mode: str, original_command: str) -> DeploymentRequest:
+    if not original_command or any(
+        ord(character) < 32 or ord(character) == 127 for character in original_command
+    ):
+        raise DeploymentError("invalid SSH deployment command")
+
+    fields = original_command.split(" ")
+    if any(not field for field in fields):
+        raise DeploymentError("invalid SSH deployment command spacing")
+    expected_fields = 4 if mode == "production" else 5
+    if len(fields) != expected_fields or fields[0] != "deploy":
+        raise DeploymentError(f"invalid {mode} deployment command")
+
+    if mode == "production":
+        _, commit, digest, size_text = fields
+        slug = None
+    else:
+        _, slug, commit, digest, size_text = fields
+        if not PREVIEW_SLUG_PATTERN.fullmatch(slug):
+            raise DeploymentError("invalid preview slug")
+
+    if not COMMIT_PATTERN.fullmatch(commit):
+        raise DeploymentError("invalid deployment commit")
+    if not DIGEST_PATTERN.fullmatch(digest):
+        raise DeploymentError("invalid deployment digest")
+    if not size_text.isascii() or not size_text.isdecimal():
+        raise DeploymentError("invalid deployment size")
+
+    return DeploymentRequest(
+        commit=commit,
+        digest=digest,
+        size=int(size_text),
+        slug=slug,
+    )
+
+
+def ensure_managed_directory(path: Path) -> None:
+    if not path.is_dir() or path.is_symlink():
+        raise DeploymentError(f"managed directory is missing or unsafe: {path}")
+
+
+def lexists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def receive_archive(
+    stream: BinaryIO,
+    destination_dir: Path,
+    request: DeploymentRequest,
+    max_archive_bytes: int,
+) -> Path:
+    if request.size <= 0 or request.size > max_archive_bytes:
+        raise DeploymentError(
+            f"archive size {request.size} is outside 1..{max_archive_bytes} bytes"
+        )
+
+    digest = hashlib.sha256()
+    archive_file = tempfile.NamedTemporaryFile(
+        dir=destination_dir,
+        prefix=".incoming-",
+        suffix=".tar.gz",
+        delete=False,
+    )
+    archive_path = Path(archive_file.name)
+    try:
+        remaining = request.size
+        with archive_file:
+            while remaining:
+                chunk = stream.read(min(1024 * 1024, remaining))
+                if not chunk:
+                    raise DeploymentError("deployment stream ended early")
+                archive_file.write(chunk)
+                digest.update(chunk)
+                remaining -= len(chunk)
+            if stream.read(1):
+                raise DeploymentError("deployment stream exceeds declared size")
+            archive_file.flush()
+            os.fsync(archive_file.fileno())
+
+        if digest.hexdigest() != request.digest:
+            raise DeploymentError("deployment digest does not match archive bytes")
+        return archive_path
+    except Exception:
+        archive_path.unlink(missing_ok=True)
+        raise
+
+
+def directory_size(path: Path) -> int:
+    total = 0
+    if not path.exists():
+        return total
+    for root, directories, files in os.walk(path, followlinks=False):
+        root_path = Path(root)
+        directories[:] = [
+            name for name in directories if not (root_path / name).is_symlink()
+        ]
+        for name in files:
+            file_path = root_path / name
+            if not file_path.is_symlink():
+                total += file_path.stat().st_size
+    return total
+
+
+def cleanup_staging(root: Path, now: float | None = None) -> None:
+    current_time = time.time() if now is None else now
+    cutoff = current_time - 24 * 60 * 60
+    for candidate in root.iterdir():
+        if not candidate.name.startswith((".incoming-", ".extract-")):
+            continue
+        if candidate.is_symlink() or candidate.lstat().st_mtime >= cutoff:
+            continue
+        if candidate.is_dir():
+            shutil.rmtree(candidate)
+        elif candidate.is_file():
+            candidate.unlink()
+
+
+def atomic_link(link: Path, target: Path) -> None:
+    ensure_managed_directory(link.parent)
+    if lexists(link) and not link.is_symlink():
+        raise DeploymentError(f"activation path is not a symlink: {link}")
+
+    temporary_link = link.parent / f".{link.name}.new-{os.getpid()}"
+    temporary_link.unlink(missing_ok=True)
+    try:
+        relative_target = os.path.relpath(target, link.parent)
+        temporary_link.symlink_to(relative_target, target_is_directory=True)
+        os.replace(temporary_link, link)
+    finally:
+        temporary_link.unlink(missing_ok=True)
+
+
+def prepare_release(
+    archive_path: Path,
+    release_path: Path,
+    staging_root: Path,
+    common: CommonConfig,
+    limits: Limits,
+) -> tuple[Path, int]:
+    if lexists(release_path):
+        if not release_path.is_dir() or release_path.is_symlink():
+            raise DeploymentError(f"existing release is unsafe: {release_path}")
+        return release_path, directory_size(release_path)
+
+    staging_dir = Path(tempfile.mkdtemp(dir=staging_root, prefix=".extract-"))
+    extracted_site = staging_dir / "site"
+    try:
+        _, expanded_bytes = validate_and_extract(
+            archive_path,
+            extracted_site,
+            max_archive_bytes=limits.max_archive_bytes,
+            max_expanded_bytes=limits.max_expanded_bytes,
+            max_file_bytes=limits.max_file_bytes,
+            max_entries=limits.max_entries,
+        )
+        index_file = extracted_site / "index.html"
+        if not index_file.is_file() or index_file.is_symlink():
+            raise DeploymentError("site archive does not contain a regular index.html")
+
+        anthology_files_link = extracted_site / "anthology-files"
+        if lexists(anthology_files_link):
+            raise DeploymentError("site archive contains a reserved anthology-files path")
+        anthology_files_link.symlink_to(common.anthology_files, target_is_directory=True)
+
+        release_path.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
+        try:
+            os.replace(extracted_site, release_path)
+        except OSError:
+            if not release_path.is_dir() or release_path.is_symlink():
+                raise
+        return release_path, expanded_bytes
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+def cleanup_production(config: ProductionConfig, active_release: Path) -> None:
+    releases = [
+        path
+        for path in config.release_root.iterdir()
+        if path.is_dir()
+        and not path.is_symlink()
+        and RELEASE_PATTERN.fullmatch(path.name)
+    ]
+    releases.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    inactive_releases = [release for release in releases if release != active_release]
+    keep = {
+        active_release,
+        *inactive_releases[: max(0, config.keep_releases - 1)],
+    }
+    for release in releases:
+        if release not in keep:
+            shutil.rmtree(release)
+
+
+def preview_deployments(config: PreviewConfig) -> list[tuple[float, str, Path]]:
+    deployments = []
+    for link in config.public_root.iterdir():
+        if not link.is_symlink() or not PREVIEW_SLUG_PATTERN.fullmatch(link.name):
+            continue
+        deployments.append((link.lstat().st_mtime, link.name, link))
+    return deployments
+
+
+def remove_preview(config: PreviewConfig, slug: str, link: Path) -> None:
+    link.unlink(missing_ok=True)
+    release_dir = config.release_root / slug
+    if release_dir.is_dir() and not release_dir.is_symlink():
+        shutil.rmtree(release_dir)
+
+
+def cleanup_previews(config: PreviewConfig, now: float | None = None) -> None:
+    ensure_managed_directory(config.release_root)
+    ensure_managed_directory(config.public_root)
+    current_time = time.time() if now is None else now
+    cutoff = current_time - config.max_age_days * 24 * 60 * 60
+    cleanup_staging(config.release_root, current_time)
+
+    for modified, slug, link in preview_deployments(config):
+        if modified < cutoff:
+            remove_preview(config, slug, link)
+
+    active_slugs = {slug for _, slug, _ in preview_deployments(config)}
+    for release_dir in config.release_root.iterdir():
+        if (
+            release_dir.is_dir()
+            and not release_dir.is_symlink()
+            and PREVIEW_SLUG_PATTERN.fullmatch(release_dir.name)
+            and release_dir.name not in active_slugs
+        ):
+            shutil.rmtree(release_dir)
+
+    deployments = sorted(preview_deployments(config))
+    total_bytes = directory_size(config.release_root)
+    for _, slug, link in deployments:
+        if total_bytes <= config.max_total_bytes:
+            break
+        remove_preview(config, slug, link)
+        total_bytes = directory_size(config.release_root)
+
+
+def deploy_production(
+    stream: BinaryIO,
+    request: DeploymentRequest,
+    common: CommonConfig,
+    config: ProductionConfig,
+) -> str:
+    ensure_managed_directory(config.release_root)
+    ensure_managed_directory(config.current_link.parent)
+    if not common.anthology_files.is_dir():
+        raise DeploymentError(
+            f"anthology-files directory is missing: {common.anthology_files}"
+        )
+    cleanup_staging(config.release_root)
+    release_name = f"{request.commit}-{request.digest[:16]}"
+    release_path = config.release_root / release_name
+
+    archive_path = receive_archive(
+        stream, config.release_root, request, config.limits.max_archive_bytes
+    )
+    try:
+        release_path, _ = prepare_release(
+            archive_path, release_path, config.release_root, common, config.limits
+        )
+        atomic_link(config.current_link, release_path)
+        cleanup_production(config, release_path)
+    finally:
+        archive_path.unlink(missing_ok=True)
+    return release_name
+
+
+def evict_previews_for_space(
+    config: PreviewConfig,
+    incoming_slug: str,
+    incoming_bytes: int,
+) -> None:
+    existing_slug_bytes = directory_size(config.release_root / incoming_slug)
+    projected_bytes = (
+        directory_size(config.release_root) - existing_slug_bytes + incoming_bytes
+    )
+    deployments = sorted(
+        deployment
+        for deployment in preview_deployments(config)
+        if deployment[1] != incoming_slug
+    )
+    for _, slug, link in deployments:
+        if projected_bytes <= config.max_total_bytes:
+            break
+        removed_bytes = directory_size(config.release_root / slug)
+        remove_preview(config, slug, link)
+        projected_bytes -= removed_bytes
+    if projected_bytes > config.max_total_bytes:
+        raise DeploymentError(
+            f"preview quota of {config.max_total_bytes} bytes would be exceeded"
+        )
+
+
+def deploy_preview(
+    stream: BinaryIO,
+    request: DeploymentRequest,
+    common: CommonConfig,
+    config: PreviewConfig,
+) -> str:
+    if request.slug is None:  # pragma: no cover - enforced by parse_request
+        raise DeploymentError("preview deployment is missing a slug")
+    ensure_managed_directory(config.release_root)
+    ensure_managed_directory(config.public_root)
+    if not common.anthology_files.is_dir():
+        raise DeploymentError(
+            f"anthology-files directory is missing: {common.anthology_files}"
+        )
+    cleanup_previews(config)
+
+    release_name = f"{request.commit}-{request.digest[:16]}"
+    slug_root = config.release_root / request.slug
+    release_path = slug_root / release_name
+    release_existed = lexists(release_path)
+    if lexists(slug_root) and (not slug_root.is_dir() or slug_root.is_symlink()):
+        raise DeploymentError(f"preview release root is unsafe: {slug_root}")
+    archive_path = receive_archive(
+        stream, config.release_root, request, config.limits.max_archive_bytes
+    )
+    try:
+        release_path, expanded_bytes = prepare_release(
+            archive_path, release_path, config.release_root, common, config.limits
+        )
+        archive_path.unlink(missing_ok=True)
+        evict_previews_for_space(config, request.slug, expanded_bytes)
+        public_link = config.public_root / request.slug
+        atomic_link(public_link, release_path)
+
+        for old_release in slug_root.iterdir():
+            if (
+                old_release != release_path
+                and old_release.is_dir()
+                and not old_release.is_symlink()
+            ):
+                shutil.rmtree(old_release)
+    except Exception:
+        if (
+            not release_existed
+            and release_path.is_dir()
+            and not release_path.is_symlink()
+        ):
+            shutil.rmtree(release_path)
+        if (
+            slug_root.is_dir()
+            and not slug_root.is_symlink()
+            and not any(slug_root.iterdir())
+        ):
+            slug_root.rmdir()
+        raise
+    finally:
+        archive_path.unlink(missing_ok=True)
+    return f"{request.slug}/{release_name}"
+
+
+def locked(lock_file: Path):
+    lock_file.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
+    lock = lock_file.open("a+")
+    fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+    return lock
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("/etc/acl-anthology/deploy.toml"),
+    )
+    parser.add_argument("mode", choices=("production", "preview", "cleanup-previews"))
+    args = parser.parse_args()
+
+    try:
+        common, production, preview = load_config(args.config)
+        if args.mode == "cleanup-previews":
+            with locked(preview.lock_file):
+                cleanup_previews(preview)
+            print("Preview cleanup complete.")
+            return
+
+        request = parse_request(args.mode, os.environ.get("SSH_ORIGINAL_COMMAND", ""))
+        if args.mode == "production":
+            with locked(production.lock_file):
+                release = deploy_production(sys.stdin.buffer, request, common, production)
+        else:
+            with locked(preview.lock_file):
+                release = deploy_preview(sys.stdin.buffer, request, common, preview)
+        print(f"Activated {args.mode} release {release}.")
+    except (ArchiveValidationError, DeploymentError, OSError) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/aclanthology.org/validate_site_archive.py
+++ b/bin/aclanthology.org/validate_site_archive.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Validate and safely extract a generated website tar archive."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import tarfile
+
+
+class ArchiveValidationError(ValueError):
+    """Raised when a site archive violates the deployment contract."""
+
+
+def canonical_member_path(member: tarfile.TarInfo) -> PurePosixPath | None:
+    """Return a safe relative path, or None for the archive's root directory."""
+    name = member.name
+    if "\x00" in name or "\\" in name:
+        raise ArchiveValidationError(f"unsafe archive path: {name!r}")
+    if any(ord(character) < 32 or ord(character) == 127 for character in name):
+        raise ArchiveValidationError(f"control character in archive path: {name!r}")
+
+    while name.startswith("./"):
+        name = name[2:]
+    if member.isdir():
+        name = name.rstrip("/")
+    if name in ("", "."):
+        if member.isdir():
+            return None
+        raise ArchiveValidationError("the archive root must be a directory")
+    if name.startswith("/"):
+        raise ArchiveValidationError(f"absolute archive path: {member.name!r}")
+
+    parts = name.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise ArchiveValidationError(f"unsafe archive path: {member.name!r}")
+    if len(name.encode("utf-8")) > 4096:
+        raise ArchiveValidationError(f"archive path is too long: {member.name!r}")
+    if any(len(part.encode("utf-8")) > 255 for part in parts):
+        raise ArchiveValidationError(
+            f"archive path component is too long: {member.name!r}"
+        )
+
+    return PurePosixPath(*parts)
+
+
+def validate_and_extract(
+    archive_path: Path,
+    output_dir: Path,
+    *,
+    max_archive_bytes: int,
+    max_expanded_bytes: int,
+    max_file_bytes: int,
+    max_entries: int,
+) -> tuple[int, int]:
+    """Validate archive_path and extract regular files into a new output_dir."""
+    archive_size = archive_path.stat().st_size
+    if archive_size == 0 or archive_size > max_archive_bytes:
+        raise ArchiveValidationError(
+            f"archive size {archive_size} is outside 1..{max_archive_bytes} bytes"
+        )
+    if output_dir.exists():
+        raise ArchiveValidationError(f"output path already exists: {output_dir}")
+
+    members: list[tuple[tarfile.TarInfo, PurePosixPath, bool]] = []
+    path_types: dict[PurePosixPath, bool] = {}
+    expanded_bytes = 0
+
+    try:
+        with tarfile.open(archive_path, mode="r:gz") as archive:
+            for entry_number, member in enumerate(archive, start=1):
+                if entry_number > max_entries:
+                    raise ArchiveValidationError(
+                        f"archive contains more than {max_entries} entries"
+                    )
+                if not (member.isdir() or member.isfile()):
+                    raise ArchiveValidationError(
+                        f"unsupported archive entry type for {member.name!r}"
+                    )
+
+                member_path = canonical_member_path(member)
+                if member_path is None:
+                    continue
+                if member_path in path_types:
+                    raise ArchiveValidationError(
+                        f"duplicate archive path: {member_path.as_posix()!r}"
+                    )
+
+                is_directory = member.isdir()
+                path_types[member_path] = is_directory
+                if is_directory:
+                    if member.size != 0:
+                        raise ArchiveValidationError(
+                            f"directory has nonzero size: {member_path.as_posix()!r}"
+                        )
+                else:
+                    if member.size < 0 or member.size > max_file_bytes:
+                        raise ArchiveValidationError(
+                            f"file {member_path.as_posix()!r} exceeds the "
+                            f"{max_file_bytes}-byte limit"
+                        )
+                    expanded_bytes += member.size
+                    if expanded_bytes > max_expanded_bytes:
+                        raise ArchiveValidationError(
+                            f"expanded archive exceeds {max_expanded_bytes} bytes"
+                        )
+                members.append((member, member_path, is_directory))
+
+            for member_path in path_types:
+                for parent in member_path.parents:
+                    if parent == PurePosixPath("."):
+                        break
+                    if parent in path_types and not path_types[parent]:
+                        raise ArchiveValidationError(
+                            f"file is used as a parent directory: {parent.as_posix()!r}"
+                        )
+
+            output_dir.mkdir(parents=True, mode=0o755)
+            os.chmod(output_dir, 0o755)
+            for _, member_path, is_directory in sorted(
+                members, key=lambda item: (not item[2], len(item[1].parts))
+            ):
+                if is_directory:
+                    destination = output_dir.joinpath(*member_path.parts)
+                    destination.mkdir(parents=True, exist_ok=True, mode=0o755)
+                    os.chmod(destination, 0o755)
+
+            file_count = 0
+            for member, member_path, is_directory in members:
+                if is_directory:
+                    continue
+                destination = output_dir.joinpath(*member_path.parts)
+                destination.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
+                source = archive.extractfile(member)
+                if source is None:
+                    raise ArchiveValidationError(
+                        f"could not read archive file: {member_path.as_posix()!r}"
+                    )
+
+                remaining = member.size
+                with source, destination.open("xb") as target:
+                    while remaining:
+                        chunk = source.read(min(1024 * 1024, remaining))
+                        if not chunk:
+                            raise ArchiveValidationError(
+                                f"truncated archive file: {member_path.as_posix()!r}"
+                            )
+                        target.write(chunk)
+                        remaining -= len(chunk)
+                    if source.read(1):
+                        raise ArchiveValidationError(
+                            f"archive file exceeds declared size: {member_path.as_posix()!r}"
+                        )
+                os.chmod(destination, 0o644)
+                file_count += 1
+    except (ArchiveValidationError, OSError, tarfile.TarError):
+        shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+
+    return file_count, expanded_bytes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--max-archive-bytes", type=int, required=True)
+    parser.add_argument("--max-expanded-bytes", type=int, required=True)
+    parser.add_argument("--max-file-bytes", type=int, required=True)
+    parser.add_argument("--max-entries", type=int, required=True)
+    args = parser.parse_args()
+
+    try:
+        file_count, expanded_bytes = validate_and_extract(
+            args.archive,
+            args.output,
+            max_archive_bytes=args.max_archive_bytes,
+            max_expanded_bytes=args.max_expanded_bytes,
+            max_file_bytes=args.max_file_bytes,
+            max_entries=args.max_entries,
+        )
+    except (ArchiveValidationError, OSError, tarfile.TarError) as error:
+        parser.error(str(error))
+
+    print(
+        f"Validated {file_count} files ({expanded_bytes} expanded bytes) "
+        f"from {args.archive}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deploy_site_archive.py
+++ b/tests/test_deploy_site_archive.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import time
+
+import pytest
+
+
+SCRIPT_DIR = Path(__file__).parents[1] / "bin" / "aclanthology.org"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location(
+    "validate_site_archive", SCRIPT_DIR / "validate_site_archive.py"
+)
+assert VALIDATOR_SPEC is not None and VALIDATOR_SPEC.loader is not None
+validator = importlib.util.module_from_spec(VALIDATOR_SPEC)
+sys.modules[VALIDATOR_SPEC.name] = validator
+VALIDATOR_SPEC.loader.exec_module(validator)
+
+DEPLOY_SPEC = importlib.util.spec_from_file_location(
+    "deploy_site_archive", SCRIPT_DIR / "deploy_site_archive.py"
+)
+assert DEPLOY_SPEC is not None and DEPLOY_SPEC.loader is not None
+deploy = importlib.util.module_from_spec(DEPLOY_SPEC)
+sys.modules[DEPLOY_SPEC.name] = deploy
+DEPLOY_SPEC.loader.exec_module(deploy)
+
+
+def make_archive(path: Path, files: dict[str, bytes]) -> bytes:
+    with tarfile.open(path, "w:gz") as archive:
+        for name, value in files.items():
+            member = tarfile.TarInfo(name)
+            member.size = len(value)
+            archive.addfile(member, io.BytesIO(value))
+    return path.read_bytes()
+
+
+def make_config(tmp_path: Path, *, preview_quota: int = 10_000) -> Path:
+    paths = {
+        "anthology_files": tmp_path / "anthology-files",
+        "production_root": tmp_path / "production",
+        "preview_root": tmp_path / "previews",
+    }
+    paths["anthology_files"].mkdir()
+    (paths["production_root"] / "releases").mkdir(parents=True)
+    (paths["preview_root"] / "releases").mkdir(parents=True)
+    (paths["preview_root"] / "public").mkdir(parents=True)
+
+    config = tmp_path / "deploy.toml"
+    config.write_text(
+        f"""
+[common]
+anthology_files = "{paths["anthology_files"]}"
+
+[production]
+release_root = "{paths["production_root"] / "releases"}"
+current_link = "{paths["production_root"] / "current"}"
+lock_file = "{paths["production_root"] / "deploy.lock"}"
+keep_releases = 2
+max_archive_bytes = 10000
+max_expanded_bytes = 10000
+max_file_bytes = 5000
+max_entries = 100
+
+[preview]
+release_root = "{paths["preview_root"] / "releases"}"
+public_root = "{paths["preview_root"] / "public"}"
+lock_file = "{paths["preview_root"] / "deploy.lock"}"
+max_age_days = 30
+max_total_bytes = {preview_quota}
+max_archive_bytes = 10000
+max_expanded_bytes = 10000
+max_file_bytes = 5000
+max_entries = 100
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return config
+
+
+def request(mode: str, archive: bytes, *, slug: str = "branch-123456789abc"):
+    commit = "a" * 40
+    digest = hashlib.sha256(archive).hexdigest()
+    if mode == "production":
+        command = f"deploy {commit} {digest} {len(archive)}"
+    else:
+        command = f"deploy {slug} {commit} {digest} {len(archive)}"
+    return deploy.parse_request(mode, command)
+
+
+def test_production_deploys_and_retains_previous_release(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path)
+    common, production, _ = deploy.load_config(config_path)
+
+    first_archive = make_archive(tmp_path / "first.tar.gz", {"index.html": b"first"})
+    first_release = deploy.deploy_production(
+        io.BytesIO(first_archive),
+        request("production", first_archive),
+        common,
+        production,
+    )
+    assert production.current_link.is_symlink()
+    assert (production.current_link / "index.html").read_bytes() == b"first"
+    assert (
+        production.current_link / "anthology-files"
+    ).resolve() == common.anthology_files
+
+    second_archive = make_archive(tmp_path / "second.tar.gz", {"index.html": b"second"})
+    second_request = request("production", second_archive)
+    second_request = deploy.DeploymentRequest(
+        commit="b" * 40,
+        digest=second_request.digest,
+        size=second_request.size,
+    )
+    second_release = deploy.deploy_production(
+        io.BytesIO(second_archive), second_request, common, production
+    )
+
+    assert first_release != second_release
+    assert (production.current_link / "index.html").read_bytes() == b"second"
+    assert len(list(production.release_root.iterdir())) == 2
+
+
+def test_preview_deploys_atomically_and_replaces_old_release(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path)
+    common, _, preview = deploy.load_config(config_path)
+    slug = "feature-123456789abc"
+
+    first_archive = make_archive(tmp_path / "first.tar.gz", {"index.html": b"first"})
+    deploy.deploy_preview(
+        io.BytesIO(first_archive),
+        request("preview", first_archive, slug=slug),
+        common,
+        preview,
+    )
+    public_link = preview.public_root / slug
+    assert public_link.is_symlink()
+    assert (public_link / "index.html").read_bytes() == b"first"
+
+    second_archive = make_archive(tmp_path / "second.tar.gz", {"index.html": b"second"})
+    second_request = request("preview", second_archive, slug=slug)
+    second_request = deploy.DeploymentRequest(
+        commit="b" * 40,
+        digest=second_request.digest,
+        size=second_request.size,
+        slug=slug,
+    )
+    deploy.deploy_preview(io.BytesIO(second_archive), second_request, common, preview)
+
+    assert (public_link / "index.html").read_bytes() == b"second"
+    assert len(list((preview.release_root / slug).iterdir())) == 1
+
+
+def test_rejects_wrong_digest_and_cleans_incoming_file(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path)
+    common, production, _ = deploy.load_config(config_path)
+    archive = make_archive(tmp_path / "site.tar.gz", {"index.html": b"site"})
+    invalid_request = deploy.DeploymentRequest(
+        commit="a" * 40,
+        digest="0" * 64,
+        size=len(archive),
+    )
+
+    with pytest.raises(deploy.DeploymentError, match="digest"):
+        deploy.deploy_production(io.BytesIO(archive), invalid_request, common, production)
+    assert not list(production.release_root.glob(".incoming-*"))
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "",
+        "deploy bad-sha " + "0" * 64 + " 1",
+        "deploy  " + "a" * 40 + " " + "0" * 64 + " 1",
+        "deploy ../escape " + "a" * 40 + " " + "0" * 64 + " 1",
+    ],
+)
+def test_rejects_invalid_commands(command: str) -> None:
+    mode = "preview" if "../escape" in command else "production"
+    with pytest.raises(deploy.DeploymentError):
+        deploy.parse_request(mode, command)
+
+
+def test_cleanup_removes_expired_preview(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path)
+    common, _, preview = deploy.load_config(config_path)
+    slug = "expired-123456789abc"
+    archive = make_archive(tmp_path / "site.tar.gz", {"index.html": b"site"})
+    deploy.deploy_preview(
+        io.BytesIO(archive),
+        request("preview", archive, slug=slug),
+        common,
+        preview,
+    )
+    link = preview.public_root / slug
+    expired_time = time.time() - 31 * 24 * 60 * 60
+    os.utime(link, (expired_time, expired_time), follow_symlinks=False)
+
+    deploy.cleanup_previews(preview)
+
+    assert not os.path.lexists(link)
+    assert not (preview.release_root / slug).exists()
+
+
+def test_preview_quota_evicts_oldest_other_preview(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path, preview_quota=16)
+    common, _, preview = deploy.load_config(config_path)
+    first_slug = "first-123456789abc"
+    second_slug = "second-123456789abc"
+    first_archive = make_archive(tmp_path / "first.tar.gz", {"index.html": b"1234567890"})
+    deploy.deploy_preview(
+        io.BytesIO(first_archive),
+        request("preview", first_archive, slug=first_slug),
+        common,
+        preview,
+    )
+
+    second_archive = make_archive(
+        tmp_path / "second.tar.gz", {"index.html": b"abcdefghij"}
+    )
+    deploy.deploy_preview(
+        io.BytesIO(second_archive),
+        request("preview", second_archive, slug=second_slug),
+        common,
+        preview,
+    )
+
+    assert not os.path.lexists(preview.public_root / first_slug)
+    assert (preview.public_root / second_slug).is_symlink()
+
+
+def test_quota_failure_leaves_no_unactivated_release(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path, preview_quota=5)
+    common, _, preview = deploy.load_config(config_path)
+    slug = "too-large-123456789abc"
+    archive = make_archive(tmp_path / "site.tar.gz", {"index.html": b"123456"})
+
+    with pytest.raises(deploy.DeploymentError, match="quota"):
+        deploy.deploy_preview(
+            io.BytesIO(archive),
+            request("preview", archive, slug=slug),
+            common,
+            preview,
+        )
+
+    assert not os.path.lexists(preview.public_root / slug)
+    assert not (preview.release_root / slug).exists()
+
+
+def test_cleanup_removes_orphans_and_stale_staging(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path)
+    _, _, preview = deploy.load_config(config_path)
+    orphan = preview.release_root / "orphan-123456789abc"
+    orphan.mkdir()
+    (orphan / "file").write_text("orphan", encoding="utf-8")
+    incoming = preview.release_root / ".incoming-old.tar.gz"
+    incoming.write_bytes(b"old")
+    extraction = preview.release_root / ".extract-old"
+    extraction.mkdir()
+    (extraction / "file").write_text("old", encoding="utf-8")
+    old_time = time.time() - 2 * 24 * 60 * 60
+    os.utime(incoming, (old_time, old_time))
+    os.utime(extraction, (old_time, old_time))
+
+    deploy.cleanup_previews(preview)
+
+    assert not orphan.exists()
+    assert not incoming.exists()
+    assert not extraction.exists()
+
+
+def test_forced_command_cli_activates_production(tmp_path: Path) -> None:
+    config_path = make_config(tmp_path)
+    _, production, _ = deploy.load_config(config_path)
+    archive = make_archive(tmp_path / "site.tar.gz", {"index.html": b"cli"})
+    deployment_request = request("production", archive)
+    command = (
+        f"deploy {deployment_request.commit} {deployment_request.digest} "
+        f"{deployment_request.size}"
+    )
+    environment = os.environ.copy()
+    environment["SSH_ORIGINAL_COMMAND"] = command
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT_DIR / "deploy_site_archive.py",
+            "--config",
+            config_path,
+            "production",
+        ],
+        input=archive,
+        capture_output=True,
+        check=False,
+        env=environment,
+    )
+
+    assert result.returncode == 0, result.stderr.decode()
+    assert b"Activated production release" in result.stdout
+    assert (production.current_link / "index.html").read_bytes() == b"cli"

--- a/tests/test_validate_site_archive.py
+++ b/tests/test_validate_site_archive.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+from pathlib import Path
+import tarfile
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).parents[1] / "bin" / "aclanthology.org" / "validate_site_archive.py"
+)
+SPEC = importlib.util.spec_from_file_location("validate_site_archive", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+validate_site_archive = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_site_archive)
+
+ArchiveValidationError = validate_site_archive.ArchiveValidationError
+validate_and_extract = validate_site_archive.validate_and_extract
+
+
+def make_archive(path: Path, entries: list[tuple[str, str, bytes | str]]) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        for entry_type, name, value in entries:
+            member = tarfile.TarInfo(name)
+            if entry_type == "file":
+                assert isinstance(value, bytes)
+                member.size = len(value)
+                archive.addfile(member, io.BytesIO(value))
+            elif entry_type == "directory":
+                member.type = tarfile.DIRTYPE
+                archive.addfile(member)
+            elif entry_type == "symlink":
+                member.type = tarfile.SYMTYPE
+                member.linkname = str(value)
+                archive.addfile(member)
+            elif entry_type == "hardlink":
+                member.type = tarfile.LNKTYPE
+                member.linkname = str(value)
+                archive.addfile(member)
+            else:  # pragma: no cover
+                raise AssertionError(f"unknown test entry type: {entry_type}")
+
+
+def extract(archive: Path, output: Path, **overrides: int) -> tuple[int, int]:
+    limits = {
+        "max_archive_bytes": 1024 * 1024,
+        "max_expanded_bytes": 1024 * 1024,
+        "max_file_bytes": 1024 * 1024,
+        "max_entries": 100,
+    }
+    limits.update(overrides)
+    return validate_and_extract(archive, output, **limits)
+
+
+def test_extracts_only_regular_files_and_directories(tmp_path: Path) -> None:
+    archive = tmp_path / "site.tar.gz"
+    output = tmp_path / "output"
+    make_archive(
+        archive,
+        [
+            ("directory", ".", ""),
+            ("directory", "./assets/", ""),
+            ("file", "./index.html", b"<h1>ACL</h1>"),
+            ("file", "./assets/site.css", b"body {}"),
+        ],
+    )
+
+    assert extract(archive, output) == (2, 19)
+    assert (output / "index.html").read_bytes() == b"<h1>ACL</h1>"
+    assert (output / "assets" / "site.css").read_bytes() == b"body {}"
+    assert (output / "index.html").stat().st_mode & 0o777 == 0o644
+    assert (output / "assets").stat().st_mode & 0o777 == 0o755
+
+
+@pytest.mark.parametrize(
+    ("entry_type", "name", "value"),
+    [
+        ("file", "../escape", b"bad"),
+        ("file", "/absolute", b"bad"),
+        ("file", "dir\\windows", b"bad"),
+        ("symlink", "link", "target"),
+        ("hardlink", "link", "target"),
+    ],
+)
+def test_rejects_unsafe_entries(
+    tmp_path: Path, entry_type: str, name: str, value: bytes | str
+) -> None:
+    archive = tmp_path / "site.tar.gz"
+    output = tmp_path / "output"
+    make_archive(archive, [(entry_type, name, value)])
+
+    with pytest.raises(ArchiveValidationError):
+        extract(archive, output)
+    assert not output.exists()
+
+
+def test_rejects_duplicate_paths(tmp_path: Path) -> None:
+    archive = tmp_path / "site.tar.gz"
+    output = tmp_path / "output"
+    make_archive(
+        archive,
+        [("file", "index.html", b"first"), ("file", "./index.html", b"second")],
+    )
+
+    with pytest.raises(ArchiveValidationError, match="duplicate"):
+        extract(archive, output)
+
+
+def test_rejects_file_used_as_parent(tmp_path: Path) -> None:
+    archive = tmp_path / "site.tar.gz"
+    output = tmp_path / "output"
+    make_archive(
+        archive,
+        [("file", "assets", b"file"), ("file", "assets/site.css", b"child")],
+    )
+
+    with pytest.raises(ArchiveValidationError, match="parent directory"):
+        extract(archive, output)
+
+
+@pytest.mark.parametrize(
+    ("override", "value", "match"),
+    [
+        ("max_file_bytes", 3, "file.*exceeds"),
+        ("max_expanded_bytes", 3, "expanded archive exceeds"),
+        ("max_entries", 1, "more than 1 entries"),
+    ],
+)
+def test_enforces_resource_limits(
+    tmp_path: Path, override: str, value: int, match: str
+) -> None:
+    archive = tmp_path / "site.tar.gz"
+    output = tmp_path / "output"
+    make_archive(
+        archive,
+        [("file", "one", b"1234"), ("file", "two", b"5678")],
+    )
+
+    with pytest.raises(ArchiveValidationError, match=match):
+        extract(archive, output, **{override: value})


### PR DESCRIPTION
The discussion in #9698 triggered the idea that we should harden our current server-based deployments. This PR is a draft based on suggestions from ChatGPT-5.6-Sol.

## Summary

The current production and preview workflows expose the same unrestricted SSH key to jobs that also execute repository code. This draft separates building, validation, and deployment into distinct trust boundaries and replaces the shared key with two narrowly scoped deployment credentials.

### Production deployment

- Merges to `master` build and test the complete Anthology in GitHub Actions without deployment credentials.
- A separate job validates and sanitizes the generated archive.
- A fresh deployment job, which does not check out or execute repository code, sends the sanitized archive through a production-only SSH account.
- The server verifies the archive again and atomically activates it, retaining previous releases for rollback.

### Branch previews

- Preview builds run only for branches pushed by users with `maintain` or `admin` permission.
- Branch-controlled jobs are read-only and receive no SSH credentials.
- A trusted `workflow_run` loaded from `master` independently verifies the repository, triggering actors, current branch SHA, artifact identity, and artifact size.
- The preview archive is sanitized before a separate credential-bearing job uploads it.
- The server enforces preview storage limits, removes expired previews, and atomically updates preview links.

### Server hardening

This adds server-side tools that:

- Reject path traversal, absolute paths, duplicate entries, links, devices, sockets, and archive bombs.
- Verify the declared byte count and SHA-256 digest.
- Enforce compressed size, expanded size, file size, and entry-count limits.
- Accept only fixed deployment command formats.
- Maintain separate production and preview roots.
- Apply preview TTL and total-storage quotas.
- Clean up interrupted uploads, stale extraction directories, and orphan releases.

The proposed setup uses separate `anthology-production-deploy` and `anthology-preview-deploy` Unix accounts. Both are restricted with SSH forced commands and have no shell, TTY, forwarding, SFTP, or arbitrary destination access.

### Build reproducibility

PR checks, previews, and production now use the same local composite action for their build toolchain. Hugo and Dart Sass downloads are pinned and checksum-verified, third-party Actions are pinned to immutable commit SHAs, and Dependabot is configured to submit grouped weekly GitHub Actions updates.

Deployment-sensitive files are assigned to `@acl-org/anthology` through `CODEOWNERS`.

## Required rollout

The server and GitHub configuration must be completed before merging because the merge itself triggers production deployment. The full procedure is documented in `bin/aclanthology.org/README`.

GitHub requires:

- A `production` environment with `PRODUCTION_DEPLOY_SSH_KEY`
- A `preview` environment with `PREVIEW_DEPLOY_SSH_KEY`
- `ANTHOLOGY_DEPLOY_HOST`
- `ANTHOLOGY_SSH_KNOWN_HOSTS`

After both deployment paths are verified, the existing `PUBLISH_SSH_KEY` should be removed from GitHub and its public key removed from the server.

## Validation

- 70 root tests pass.
- 23 focused archive and deployment security tests pass.
- Ruff formatting and linting pass.
- `actionlint` passes all changed workflows.
- Embedded GitHub Script code parses successfully.
- Pinned Action SHAs were verified against their upstream release tags.
- Structural checks confirm that SSH secrets are available only to jobs that execute no repository code or local actions.