### PR TITLE
Python performance optimizations: Markup copying & LaTeX-encoding

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Sped up `MarkupText` by avoiding unnecessary deep copies of XML elements.
+- Sped up BibTeX generation significantly by speeding up Unicode-to-LaTeX encoding.
+
 ## [1.3.1] — 2026-08-09
 
 ## Changed

--- a/python/acl_anthology/text/markuptext.py
+++ b/python/acl_anthology/text/markuptext.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from attrs import define, field, validators as v
 from collections import defaultdict
-from copy import deepcopy
+from copy import copy
 from functools import total_ordering
 from lxml import etree
 from typing import Optional, SupportsIndex, TYPE_CHECKING
@@ -120,13 +120,33 @@ class MarkupText:
         These operate on the [stringified XML representation][acl_anthology.text.markuptext.MarkupText.as_xml] of the class.
     """
 
-    # IMPLEMENTATION NOTE: Deepcopy-ing (or newly instantiating) etree._Element
-    # is very expensive, as shown by profiling. Therefore, markup elements
-    # which don't actually contain any markup are simply stored as
-    # strings. This makes the implementation slightly more verbose (we need to
-    # check everywhere whether we're dealing with etree._Element or str), but
-    # much faster. ---For further optimization, we could explore if there's an
-    # alternative that doesn't require deepcopy-ing XML elements at all.
+    # IMPLEMENTATION NOTE: Copying (or newly instantiating) etree._Element is
+    # very expensive, as shown by profiling. Therefore, markup elements which
+    # don't actually contain any markup are simply stored as strings. This
+    # makes the implementation slightly more verbose (we need to check
+    # everywhere whether we're dealing with etree._Element or str), but much
+    # faster.
+    #
+    # Whenever we do need an independent copy of an etree._Element (either to
+    # detach it from a much bigger source document that may be discarded
+    # right after -- see e.g. `Collection.load()` -- or to get a working copy
+    # we can mutate without touching `_content` itself), we call
+    # `copy.copy(element)` instead of `copy.deepcopy(element)`. lxml's
+    # `_Element.__copy__` already performs a full, independent recursive copy
+    # of the element (there is no cheaper "shallow" copy for a tree of
+    # libxml2-owned nodes), so this produces the exact same result while
+    # skipping some of the generic `copy` module's deepcopy-specific
+    # bookkeeping (memo dict, id()-based cycle tracking), which is measurably
+    # faster at the volume we call this. This relies on an lxml
+    # implementation detail rather than a documented guarantee, so its
+    # behaviour is pinned by
+    # `test_markup_from_xml_copies_element_independently_of_source` and
+    # `test_markup_rendering_does_not_mutate_stored_content` in
+    # `markuptext_test.py` -- if a future lxml release ever changes what
+    # `__copy__` does, those tests should catch it.
+    #
+    # For further optimization, we could explore an alternative that doesn't
+    # require etree._Element at all for storing markup.
     _content: etree._Element | str = field(validator=v.instance_of((etree._Element, str)))
 
     # For caching
@@ -182,7 +202,7 @@ class MarkupText:
             return remove_extra_whitespace(self._content)
         if self._text is not None:
             return self._text
-        element = deepcopy(self._content)
+        element = copy(self._content)
         for sub in element.iterfind(".//tex-math"):
             sub.text = TexMath.to_unicode(sub)
         has_par = protect_par(element)
@@ -204,7 +224,7 @@ class MarkupText:
             return xml_escape(remove_extra_whitespace(self._content))
         if self._html is not None:
             return self._html
-        element = deepcopy(self._content)
+        element = copy(self._content)
         for sub in element.iter():
             if sub.tag == "url":
                 if allow_url:
@@ -327,7 +347,7 @@ class MarkupText:
             Instantiated MarkupText object corresponding to the element.
         """
         if len(element):
-            return cls(deepcopy(element))
+            return cls(copy(element))
         return cls(str(element.text) if element.text is not None else "")
 
     @classmethod
@@ -366,7 +386,7 @@ class MarkupText:
             if self._content:
                 element.text = self._content
         else:
-            element = deepcopy(self._content)
+            element = copy(self._content)
             element.tag = tag
         return element
 

--- a/python/acl_anthology/text/markuptext.py
+++ b/python/acl_anthology/text/markuptext.py
@@ -120,37 +120,24 @@ class MarkupText:
         These operate on the [stringified XML representation][acl_anthology.text.markuptext.MarkupText.as_xml] of the class.
     """
 
-    # IMPLEMENTATION NOTE: Copying (or newly instantiating) etree._Element is
-    # very expensive, as shown by profiling. Therefore, markup elements which
-    # don't actually contain any markup are simply stored as strings. This
-    # makes the implementation slightly more verbose (we need to check
-    # everywhere whether we're dealing with etree._Element or str), but much
-    # faster.
+    # IMPLEMENTATION NOTE:
+    # --------------------
+    # Copying (or newly instantiating) `etree._Element` is very expensive,
+    # as shown by profiling. Therefore, markup elements which don't actually
+    # contain any markup are simply stored as strings. This makes the
+    # implementation slightly more verbose (we need to check everywhere
+    # whether we're dealing with `etree._Element` or `str`), but much faster.
     #
-    # Whenever we do need an independent copy of an etree._Element (either to
-    # detach it from a much bigger source document that may be discarded
-    # right after -- see e.g. `Collection.load()` -- or to get a working copy
-    # we can mutate without touching `_content` itself), we call
-    # `copy.copy(element)` instead of `copy.deepcopy(element)`. lxml's
-    # `_Element.__copy__` already performs a full, independent recursive copy
-    # of the element (there is no cheaper "shallow" copy for a tree of
-    # libxml2-owned nodes), so this produces the exact same result while
-    # skipping some of the generic `copy` module's deepcopy-specific
-    # bookkeeping (memo dict, id()-based cycle tracking), which is measurably
-    # faster at the volume we call this. This relies on an lxml
-    # implementation detail rather than a documented guarantee, so its
-    # behaviour is pinned by
-    # `test_markup_from_xml_copies_element_independently_of_source` and
-    # `test_markup_rendering_does_not_mutate_stored_content` in
-    # `markuptext_test.py` -- if a future lxml release ever changes what
-    # `__copy__` does, those tests should catch it.
+    # We use `copy()` as it is slightly faster than `deepcopy()`, and lxml's
+    # `_Element.__copy__` already performs a full, independent recursive
+    # copy of the element (there is no cheaper "shallow" copy for a tree of
+    # libxml2-owned nodes), so this produces the exact same result. This
+    # relies on an lxml implementation detail, so it is pinned by tests in
+    # `markuptext_test.py` in case a future lxml release ever changes this.
     #
-    # We considered dropping etree._Element for markup storage entirely (a
-    # custom node type) to avoid copying it, but this isn't worth pursuing:
-    # profiling `Anthology.load_all()` shows the copy.copy() call above is
-    # already <1% of its runtime, and the remaining construction/rendering
-    # work would still be needed with any representation -- likely faster
-    # via lxml's C-level tree operations than an equivalent pure-Python walk.
+    # Dropping `etree._Element` for markup storage entirely doesn't seem
+    # worth pursuing: profiling `Anthology.load_all()` shows the `copy()`
+    # call is already <1% of its total runtime.
     _content: etree._Element | str = field(validator=v.instance_of((etree._Element, str)))
 
     # For caching

--- a/python/acl_anthology/text/markuptext.py
+++ b/python/acl_anthology/text/markuptext.py
@@ -145,8 +145,12 @@ class MarkupText:
     # `markuptext_test.py` -- if a future lxml release ever changes what
     # `__copy__` does, those tests should catch it.
     #
-    # For further optimization, we could explore an alternative that doesn't
-    # require etree._Element at all for storing markup.
+    # We considered dropping etree._Element for markup storage entirely (a
+    # custom node type) to avoid copying it, but this isn't worth pursuing:
+    # profiling `Anthology.load_all()` shows the copy.copy() call above is
+    # already <1% of its runtime, and the remaining construction/rendering
+    # work would still be needed with any representation -- likely faster
+    # via lxml's C-level tree operations than an equivalent pure-Python walk.
     _content: etree._Element | str = field(validator=v.instance_of((etree._Element, str)))
 
     # For caching

--- a/python/acl_anthology/utils/latex.py
+++ b/python/acl_anthology/utils/latex.py
@@ -17,9 +17,10 @@
 from __future__ import annotations
 
 import re
-from functools import lru_cache
+import unicodedata
+from functools import cache
 from lxml import etree
-from typing import cast, Iterable, Optional, TypeAlias, TYPE_CHECKING
+from typing import Iterable, Optional, TypeAlias, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..people.name import NameSpecification
@@ -37,6 +38,7 @@ from pylatexenc.latexencode import (
     UnicodeToLatexEncoder,
     UnicodeToLatexConversionRule,
     RULE_DICT,
+    get_builtin_uni2latex_dict,
 )
 from pylatexenc.latexwalker import (
     LatexWalker,
@@ -62,30 +64,56 @@ log = get_logger()
 ### UNICODE TO LATEX (BIBTEX)
 ################################################################################
 
+LATEX_CUSTOM_OVERRIDES = {
+    ord("‘"): "`",  # defaults to \textquoteleft
+    ord("’"): "'",  # defaults to \textquoteright
+    ord("“"): "``",  # defaults to \textquotedblleft
+    ord("”"): "''",  # defaults to \textquotedblright
+    ord("–"): "--",  # defaults to \textendash
+    ord("—"): "---",  # defaults to \textemdash
+    ord("í"): "\\'i",  # defaults to using dotless \i
+    ord("ì"): "\\`i",
+    ord("î"): "\\^i",
+    ord("ï"): '\\"i',
+}
+"""Unicode-to-LaTeX overrides for `LATEXENC`, taking priority over its defaults."""
+
 LATEXENC = UnicodeToLatexEncoder(
     conversion_rules=[
-        UnicodeToLatexConversionRule(
-            RULE_DICT,
-            {
-                ord("‘"): "`",  # defaults to \textquoteleft
-                ord("’"): "'",  # defaults to \textquoteright
-                ord("“"): "``",  # defaults to \textquotedblleft
-                ord("”"): "''",  # defaults to \textquotedblright
-                ord("–"): "--",  # defaults to \textendash
-                ord("—"): "---",  # defaults to \textemdash
-                ord("í"): "\\'i",  # defaults to using dotless \i
-                ord("ì"): "\\`i",
-                ord("î"): "\\^i",
-                ord("ï"): '\\"i',
-            },
-        ),
+        UnicodeToLatexConversionRule(RULE_DICT, LATEX_CUSTOM_OVERRIDES),
         "defaults",
     ],
     replacement_latex_protection="braces-all",
     unknown_char_policy="keep",
     unknown_char_warning=False,
 )
-"""A UnicodeToLatexEncoder instance intended for BibTeX generation."""
+"""A UnicodeToLatexEncoder instance intended for BibTeX generation.
+
+Note:
+    `latex_encode()` below does not actually call this encoder. Its
+    conversion rules are dict-only (no regexes), with
+    `unknown_char_policy="keep"` and `replacement_latex_protection="braces-all"`;
+    given that, its output for *any* string is fully determined by a single
+    codepoint->replacement mapping (unmapped characters pass through
+    unchanged). `_build_fast_latex_table()` derives that mapping so
+    `latex_encode()` can apply it via `str.translate()` -- a single C-level
+    pass -- instead of pylatexenc's per-character, per-rule dispatch loop,
+    which profiling showed to dominate BibTeX generation time. If `LATEXENC`'s
+    configuration above ever changes, update `_build_fast_latex_table()`
+    accordingly; `tests/utils/latex_test.py` cross-checks the two against
+    every string in `data/xml/*.xml` and will fail if they diverge.
+"""
+
+
+def _build_fast_latex_table() -> dict[int, str]:
+    """Builds the `str.translate()` table `latex_encode()` uses; see the note on `LATEXENC` above."""
+    table = {cp: "{" + repl + "}" for cp, repl in get_builtin_uni2latex_dict().items()}
+    table.update({cp: "{" + repl + "}" for cp, repl in LATEX_CUSTOM_OVERRIDES.items()})
+    return table
+
+
+FAST_LATEX_TABLE = _build_fast_latex_table()
+"""`str.translate()` table equivalent to `LATEXENC.unicode_to_latex()`; see the note on `LATEXENC` above."""
 
 BIBTEX_FIELD_NEEDS_ENCODING = {"journal", "address", "publisher", "note"}
 """Any BibTeX field whose value should be LaTeX-encoded first."""
@@ -178,7 +206,7 @@ def has_unbalanced_braces(string: str) -> bool:
     return c != 0
 
 
-@lru_cache
+@cache
 def latex_encode(text: Optional[str]) -> str:
     """
     Arguments:
@@ -189,8 +217,7 @@ def latex_encode(text: Optional[str]) -> str:
     """
     if text is None:
         return ""
-    text = cast(str, LATEXENC.unicode_to_latex(text))
-    return text
+    return unicodedata.normalize("NFC", text).translate(FAST_LATEX_TABLE)
 
 
 def latex_convert_quotes(text: str) -> str:

--- a/python/tests/text/markuptext_test.py
+++ b/python/tests/text/markuptext_test.py
@@ -309,6 +309,49 @@ def test_markup_from_xml(inp, out):
     assert markup.contains_markup == ("<" in out["html"])
 
 
+def test_markup_from_xml_copies_element_independently_of_source():
+    """`MarkupText.from_xml()` must return an independent copy of the given
+    element, not a view into it.
+
+    This matters because `Collection.load()` parses XML with
+    `etree.iterparse()`, which is only memory-efficient because the *source*
+    document is discarded shortly after each `<paper>` is turned into Python
+    objects. If `MarkupText` held a live reference into that source document
+    instead of a detached copy, every title/abstract would keep the whole
+    (potentially large) source document reachable -- and thus resident in
+    memory -- for as long as the `MarkupText` object lives.
+
+    `from_xml()` currently satisfies this by calling `element.__copy__()`
+    (see the implementation note on `MarkupText._content`), which happens to
+    be faster than `copy.deepcopy()` for lxml elements but is not guaranteed
+    to remain so by lxml's public API -- it is an implementation detail we
+    are relying on. This test pins the *behaviour* we actually need
+    (independence), so a future lxml release that changes what `__copy__`
+    does would be caught here regardless of how `from_xml()` is implemented.
+    """
+    xml = "A <fixed-case>GPT</fixed-case>-based model"
+    # Embed the element in a larger tree, mimicking a real <paper> element
+    # with siblings, rather than a standalone root element.
+    parent = etree.fromstring(
+        f"<paper><title>{xml}</title><abstract>x</abstract></paper>"
+    )
+    element = parent.find("title")
+
+    markup = MarkupText.from_xml(element)
+
+    # The stored content must not be the same object as the source element.
+    assert markup._content is not element
+
+    # Mutating the source element after the fact must not affect the
+    # already-constructed MarkupText.
+    element.text = "MUTATED "
+    element.append(etree.fromstring("<b>extra</b>"))
+    parent.remove(element)  # also detach it from its former parent
+
+    assert markup.as_xml() == xml
+    assert markup.as_text() == "A GPT-based model"
+
+
 test_cases_markup_no_url = (
     (  # <url> is rendered as a plain <span>, not a hyperlink
         "The source code will be available at <url>https://github.com/zhang-yu-wei/MTP-CLNN</url>.",
@@ -328,6 +371,31 @@ def test_markup_as_html_without_url(inp, html):
     assert markup.as_html(allow_url=False) == html
     # The XML representation should be unaffected by the rendering option
     assert markup.as_xml() == inp
+
+
+def test_markup_rendering_does_not_mutate_stored_content():
+    """`as_text()`, `as_html()`, and `to_xml()` each work on their own copy
+    of the stored content (currently via `element.__copy__()`, for the same
+    reasons as `from_xml()` -- see
+    `test_markup_from_xml_copies_element_independently_of_source`). Calling
+    any of them mutates tags/text on their local copy (e.g. `as_html()`
+    renames `<url>` to `<a>`); none of that must ever leak back into
+    `self._content`, or leak between calls.
+    """
+    xml = "See <url>https://example.com</url> for details"
+    markup = MarkupText.from_xml(etree.fromstring(f"<title>{xml}</title>"))
+
+    # Exercise every renderer, in a deliberately mutation-provoking order.
+    markup.as_html(allow_url=False)
+    markup.as_html(allow_url=True)
+    markup.as_text()
+    etree.tostring(markup.to_xml("title"))
+
+    # The canonical XML representation must still be pristine...
+    assert markup.as_xml() == xml
+    # ...and calling the same renderer twice must be idempotent.
+    assert markup.as_html() == markup.as_html()
+    assert markup.as_text() == markup.as_text()
 
 
 def test_markup_from_simple_string():

--- a/python/tests/utils/latex_test.py
+++ b/python/tests/utils/latex_test.py
@@ -12,10 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unicodedata
 import pytest
 from acl_anthology.people.name import Name, NameSpecification
 from acl_anthology.text import MarkupText
 from acl_anthology.utils import latex
+
+
+def test_latexenc_configuration_assumptions():
+    """`latex_encode()` replaces calling `LATEXENC.unicode_to_latex()` with a
+    single `str.translate()` pass, which is only equivalent because
+    `LATEXENC` uses dict-only conversion rules together with the specific
+    settings checked here (see the note on `LATEXENC` in `utils/latex.py`).
+    If this test fails, `_build_fast_latex_table()`/`latex_encode()` need to
+    be revisited -- they may silently produce incorrect BibTeX otherwise.
+    """
+    assert latex.LATEXENC.non_ascii_only is False
+    assert latex.LATEXENC.unknown_char_policy == "keep"
+    assert latex.LATEXENC.replacement_latex_protection == "braces-all"
+    assert latex.LATEXENC.latex_string_class is str
+
+
+def test_latex_encode_matches_reference_for_every_mapped_codepoint():
+    """Exhaustively checks latex_encode()'s fast path against the reference
+    `LATEXENC.unicode_to_latex()` for every codepoint it claims to handle."""
+    for codepoint in latex.FAST_LATEX_TABLE:
+        char = chr(codepoint)
+        assert latex.latex_encode(char) == latex.LATEXENC.unicode_to_latex(char)
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        "",
+        "Plain ASCII text, with punctuation: (a, b) & c! 100%.",
+        "Mixed café naïve façade 中文 русский",  # mapped + unmapped non-ASCII
+        "\N{GRINNING FACE}",  # unmapped and outside the BMP-adjacent ranges
+        "\t\n\r control whitespace",
+        "e\N{COMBINING ACUTE ACCENT}",  # decomposed; NFC-normalizes to "é"
+    ),
+)
+def test_latex_encode_matches_reference_for_arbitrary_text(text):
+    assert latex.latex_encode(text) == latex.LATEXENC.unicode_to_latex(text)
+
+
+def test_latex_encode_none_and_empty():
+    assert latex.latex_encode(None) == ""
+    assert latex.latex_encode("") == ""
+
+
+def test_latex_encode_normalizes_nfc():
+    decomposed = "e\N{COMBINING ACUTE ACCENT}"
+    assert unicodedata.normalize("NFC", decomposed) != decomposed  # sanity check
+    assert latex.latex_encode(decomposed) == latex.latex_encode("é")
+
 
 # Tests helper function used during conversion of our XML markup to LaTeX.
 # Straight quotation marks (") will have been converted to double apostrophes,
@@ -102,3 +152,43 @@ def test_make_bibtex_entry_malformed():
         latex.make_bibtex_entry("", "", [("author", [Name("John", "Doé")])])
     with pytest.raises(ValueError):
         latex.make_bibtex_entry("", "", [("title", "}{")])
+
+
+@pytest.mark.integration
+def test_latex_encode_matches_reference_on_full_corpus():
+    """Cross-checks latex_encode()'s fast path against the reference
+    `LATEXENC.unicode_to_latex()` for every string in data/xml/*.xml, not
+    just the hand-picked cases above."""
+    import os
+    from lxml import etree
+    from pathlib import Path
+
+    datadir = (
+        Path(os.path.dirname(os.path.realpath(__file__))) / ".." / ".." / ".." / "data"
+    )
+    texts = set()
+    for xmlpath in sorted(datadir.glob("xml/*.xml")):
+        tree = etree.parse(xmlpath)
+        for element in tree.iter(
+            "title",
+            "abstract",
+            "first",
+            "last",
+            "booktitle",
+            "publisher",
+            "address",
+            "note",
+        ):
+            text = "".join(element.itertext())
+            if text:
+                texts.add(text)
+
+    assert texts, "expected to find at least some text in data/xml/*.xml"
+    mismatches = [
+        text
+        for text in texts
+        if latex.latex_encode(text) != latex.LATEXENC.unicode_to_latex(text)
+    ]
+    assert not mismatches, (
+        f"{len(mismatches)} strings mismatched, e.g. {mismatches[:3]!r}"
+    )


### PR DESCRIPTION
## Summary

Two targeted performance optimizations to the `acl_anthology` Python library, found via profiling (`memray` for memory, `pyinstrument` for CPU time) of `Anthology.load_all()` (the path every library user exercises) and `bin/create_hugo_data.py` (this repo's website-build pipeline).

1. **`MarkupText` element copying** (`deepcopy` → `copy.copy`): lxml's `_Element.__copy__` already performs the same full recursive copy `__deepcopy__` does, so `copy.copy()` produces byte-identical, fully independent copies while skipping deepcopy-specific bookkeeping this call site never needs — ~31% faster per call, verified against 1,970+ real markup-bearing elements.
2. **BibTeX LaTeX-encoding** (`pylatexenc` per-character dispatch loop → `str.translate()`): our `LATEXENC` instance only uses dict-based conversion rules, so its output for any string reduces to a single codepoint→replacement mapping — exactly what `str.translate()` does in one C-level pass. ~38x faster per call, verified byte-identical against the reference encoder for all 491,202 distinct strings in `data/xml/*.xml`.

Net effect on `bin/create_hugo_data.py` wall-clock (same machine, same data): **~108s → ~66s**.

Both changes rely on library internals/implementation details rather than documented guarantees (lxml's `__copy__` semantics; `pylatexenc`'s rule-dispatch behavior under our specific config), so each is paired with tests that pin the relied-upon behavior and would catch a future upstream change:
- `test_markup_from_xml_copies_element_independently_of_source`, `test_markup_rendering_does_not_mutate_stored_content`
- `test_latexenc_configuration_assumptions`, `test_latex_encode_matches_reference_for_every_mapped_codepoint`, `test_latex_encode_matches_reference_on_full_corpus` (integration test over the whole corpus)

All confirmed to actually fail when the relevant behavior is broken (verified via temporary sabotage during development), and pass with it restored.

## Verification

- Full unit + integration test suites pass; `mypy` and `pre-commit` clean.
- End-to-end check: ran `bin/create_hugo_data.py` before/after on identical data — generated output is byte-identical (one pre-existing, unrelated `sigs.json` key-ordering non-determinism that reproduces on unmodified code alone, ignored).

## Commits

- Speed up MarkupText element copying (deepcopy -> copy.copy)
- Resolve TODO about avoiding etree._Element for markup storage
- Speed up BibTeX LaTeX-encoding ~38x via str.translate()
- Add changelog entry for performance optimizations

🤖 Generated with [Claude Code](https://claude.com/claude-code)