### PR TITLE
author page template: in page meta, set URL without "unverified" as canonical

### DIFF
--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -1,6 +1,6 @@
 {{ define "meta" }}
 {{ $person := index hugo.Data.people .Params.name }}
-  <link rel="canonical" href="/people/{{ $person.slug | strings.TrimSuffix "/unverified" }}" />
+  <link rel="canonical" href="/people/{{ $person.slug | strings.TrimSuffix "/unverified" }}/" />
 {{ end }}
 
 {{ define "main" }}

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -1,6 +1,6 @@
 {{ define "meta" }}
 {{ $person := index hugo.Data.people .Params.name }}
-  <link rel="canonical" href="/people/{{ $person.slug | strings.TrimSuffix "/unverified" }}/" />
+  <link rel="canonical" href="{{ (printf "/people/%s/" ($person.slug | strings.TrimSuffix "/unverified")) | absURL }}" />
 {{ end }}
 
 {{ define "main" }}

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -1,6 +1,6 @@
 {{ define "meta" }}
 {{ $person := index hugo.Data.people .Params.name }}
-  <link rel="canonical" href="{{ (printf "/people/%s/" ($person.slug | strings.TrimSuffix "/unverified")) | absURL }}" />
+  <link rel="canonical" href="{{ (printf "people/%s/" ($person.slug | strings.TrimSuffix "/unverified")) | absURL }}" />
 {{ end }}
 
 {{ define "main" }}

--- a/hugo/layouts/people/single.html
+++ b/hugo/layouts/people/single.html
@@ -1,3 +1,8 @@
+{{ define "meta" }}
+{{ $person := index hugo.Data.people .Params.name }}
+  <link rel="canonical" href="/people/{{ $person.slug | strings.TrimSuffix "/unverified" }}" />
+{{ end }}
+
 {{ define "main" }}
 {{ $person := index hugo.Data.people .Params.name }}
 {{ $is_verified := not (hasSuffix $person.slug "/unverified") }}


### PR DESCRIPTION
So search engines won't serve results with the /unverified URL, which may disappear when an author becomes verified. See #9273