### PR TITLE
author page permalinks (without /unverified)

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -6,6 +6,7 @@ rssLimit = 1000
 
 [permalinks]
   papers = "/:slug/"
+  people = "/people/:permapath/"
 
 [markup]
 

--- a/hugo/content/people/_content.gotmpl
+++ b/hugo/content/people/_content.gotmpl
@@ -2,6 +2,7 @@
    {{ $page := dict
       "kind" "page"
       "path" $person_id
+      "permapath" (strings.TrimSuffix "/unverified" $person_id)
       "slug" (index (split $person_id "/") -1)
       "aliases" $person.aliases
       "params" (dict "name" $person_id "lastname" $person.last)


### PR DESCRIPTION
Attempting to customize the permalinks for author page so they match canonical URLs (#9720) and will be listed correctly in the sitemap. Addresses part of #9273.