### PR TITLE
strip "/unverified/" from sitemap URLs

### DIFF
--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages -}}{{/* PART 1: All HTML pages */}}
-  {{- $nameSlug := .Path | strings.TrimPrefix "people/" | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
+  {{- $nameSlug := .Path | strings.TrimPrefix "/people/" | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
   {{- if not (and (strings.HasSuffix .Path "/unverified") (index site.Data.people $nameSlug))}}{{/* Don't duplicate an existing verified person URL */}}
   <url>
     <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" | strings.TrimSuffix "/" }}/</loc>

--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -2,10 +2,10 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages -}}{{/* PART 1: All HTML pages */}}
-  {{- $barePersonID := .Path | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
+  {{- $barePersonID := .Path | strings.TrimPrefix "people/" | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
   {{- if not (index site.Data.people $barePersonID) }}{{/* Don't duplicate an existing verified person URL */}}
   <url>
-    <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" }}</loc>
+    <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" | strings.TrimSuffix "/" }}/</loc>
     {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
     {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}

--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -1,22 +1,25 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range .Data.Pages -}}{{/* PART 1: All HTML pages */}}
+  {{- $barePersonID := .path | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
+  {{- if not (index site.Data.people $barePersonID) }}{{/* Don't duplicate an existing verified person URL */}}
   <url>
-    <loc>{{ .Permalink }}</loc>
+    <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" }}</loc>
     {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}
     {{ if ge .Sitemap.Priority 0.0 }}<priority>{{ .Sitemap.Priority }}</priority>{{ end }}
   </url>
+  {{- end -}}
   {{ end }}
-  {{ range hugo.Data.volumes }}
+  {{ range hugo.Data.volumes }}{{/* PART 2: Volume PDFs */}}
     {{ with .pdf }}
       {{ if (hasPrefix . "https://aclanthology.org") }}
   <url><loc>{{ . }}</loc></url>
       {{ end }}
     {{ end }}
   {{ end }}
-  {{ range hugo.Data.papers }}
+  {{ range hugo.Data.papers }}{{/* PART 3: Paper PDFs */}}
     {{ range . }}
       {{ $volume := index hugo.Data.volumes .parent_volume_id }}
       {{ with .pdf }}

--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -2,9 +2,9 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages -}}{{/* PART 1: All HTML pages */}}
-  {{- $barePersonID := .Path | strings.TrimPrefix "people/" | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
-  {{- if not (index site.Data.people $barePersonID) }}{{/* Don't duplicate an existing verified person URL */}}
-  <url>
+  {{- $nameSlug := .Path | strings.TrimPrefix "people/" | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
+  {{- if not (index site.Data.people $nameSlug) }}{{/* Don't duplicate an existing verified person URL */}}
+  <url><!-- {{ $nameSlug }} -->
     <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" | strings.TrimSuffix "/" }}/</loc>
     {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}

--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages -}}{{/* PART 1: All HTML pages */}}
-  {{- $barePersonID := .path | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
+  {{- $barePersonID := .Path | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
   {{- if not (index site.Data.people $barePersonID) }}{{/* Don't duplicate an existing verified person URL */}}
   <url>
     <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" }}</loc>

--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -3,8 +3,8 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages -}}{{/* PART 1: All HTML pages */}}
   {{- $nameSlug := .Path | strings.TrimPrefix "people/" | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
-  {{- if not (index site.Data.people $nameSlug) }}{{/* Don't duplicate an existing verified person URL */}}
-  <url><!-- {{ $nameSlug }} -->
+  {{- if not (and (strings.HasSuffix .Path "/unverified") (index site.Data.people $nameSlug))}}{{/* Don't duplicate an existing verified person URL */}}
+  <url>{{ printf "<!-- %s -->" $nameSlug | safeHTML }}
     <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" | strings.TrimSuffix "/" }}/</loc>
     {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}

--- a/hugo/layouts/sitemap.xml
+++ b/hugo/layouts/sitemap.xml
@@ -4,7 +4,7 @@
   {{ range .Data.Pages -}}{{/* PART 1: All HTML pages */}}
   {{- $nameSlug := .Path | strings.TrimPrefix "people/" | strings.TrimSuffix "/unverified" -}}{{/* Canonical URL omits /unverified */}}
   {{- if not (and (strings.HasSuffix .Path "/unverified") (index site.Data.people $nameSlug))}}{{/* Don't duplicate an existing verified person URL */}}
-  <url>{{ printf "<!-- %s -->" $nameSlug | safeHTML }}
+  <url>
     <loc>{{ .Permalink | strings.TrimSuffix "/unverified/" | strings.TrimSuffix "/" }}/</loc>
     {{ if not .Lastmod.IsZero }}<lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}
     {{ with .Sitemap.ChangeFreq }}<changefreq>{{ . }}</changefreq>{{ end }}


### PR DESCRIPTION
So they match canonical URLs per #9720. Addresses part of #9273.

(replaces #9724, which sought to modify page permalinks. see discussion there)