### PR TITLE
Add functions for adding/removing SIG/venue associations

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,7 @@
 - XML serialization now adds comments with the full web URL of each Anthology item, where applicable.
 - Added `Event.web_url` in analogy to the same property on other objects.
 - LaTeX line breaks are now normalized as whitespace, while blank lines are converted to `<par/>` paragraph breaks.
+- Added `Volume.add_sig`, `Volume.remove_sig`, `Volume.add_venue`, `Volume.remove_venue`.
 
 ### Changed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,7 +7,7 @@
 - XML serialization now adds comments with the full web URL of each Anthology item, where applicable.
 - Added `Event.web_url` in analogy to the same property on other objects.
 - LaTeX line breaks are now normalized as whitespace, while blank lines are converted to `<par/>` paragraph breaks.
-- Added `Volume.add_sig`, `Volume.remove_sig`, `Volume.add_venue`, `Volume.remove_venue`.
+- Added `Volume.add_sig()`, `Volume.remove_sig()`, `Volume.add_venue()`, `Volume.remove_venue()`.
 
 ### Changed
 

--- a/python/acl_anthology/collections/volume.py
+++ b/python/acl_anthology/collections/volume.py
@@ -171,7 +171,8 @@ class Volume(SlottedDict[Paper]):
 
     Attributes: Tuple Attributes:
         editors: Names of editors associated with this volume.
-        venue_ids: List of venue IDs associated with this volume. See also [venues][acl_anthology.collections.volume.Volume.venues].
+        sig_ids: List of SIG IDs associated with this volume. See also [sigs][acl_anthology.collections.volume.Volume.sigs]/[add_sig][acl_anthology.collections.volume.Volume.add_sig]/[remove_sig][acl_anthology.collections.volume.Volume.remove_sig].
+        venue_ids: List of venue IDs associated with this volume. See also [venues][acl_anthology.collections.volume.Volume.venues]/[add_venue][acl_anthology.collections.volume.Volume.add_venue]/[remove_venue][acl_anthology.collections.volume.Volume.remove_venue].
 
     Attributes: Optional Attributes:
         address: The publisher's address for this volume.
@@ -394,6 +395,39 @@ class Volume(SlottedDict[Paper]):
         """An iterator over all Paper objects in this volume."""
         yield from self.data.values()
 
+    def add_sig(self, sig: str | SIG) -> None:
+        """Associate a SIG with this volume.
+
+        If the SIG is already associated with this volume, this will do nothing.
+
+        Arguments:
+            sig: A SIG object, or a string representing a SIG ID.
+
+        Raises:
+            ValueError: If a string was given, but the SIG does not exist.
+        """
+        if isinstance(sig, str):
+            sig_id = sig
+            if sig_id not in self.root.sigs:
+                raise ValueError(f"SIG doesn't exist: '{sig_id}'")
+        else:
+            sig_id = sig.id
+        if sig_id in self.sig_ids:
+            return
+        self.sig_ids += (sig_id,)
+
+    def remove_sig(self, sig: str | SIG) -> None:
+        """Remove a SIG association from this volume.
+
+        If the SIG is not associated with this volume, this will do nothing.
+
+        Arguments:
+            sig: A SIG object, or a string representing a SIG ID.
+        """
+        sig_id = sig if isinstance(sig, str) else sig.id
+        if sig_id in self.sig_ids:
+            self.sig_ids = tuple(x for x in self.sig_ids if x != sig_id)
+
     def sigs(self) -> list[SIG]:
         """
         Returns:
@@ -406,6 +440,39 @@ class Volume(SlottedDict[Paper]):
                 f"Most likely, SIG ID '{exc.args[0]}' is not defined in sigs.json"
             )
             raise exc
+
+    def add_venue(self, venue: str | Venue) -> None:
+        """Associate a venue with this volume.
+
+        If the venue is already associated with this volume, this will do nothing.
+
+        Arguments:
+            venue: A Venue object, or a string representing a venue ID.
+
+        Raises:
+            ValueError: If a string was given, but the venue does not exist.
+        """
+        if isinstance(venue, str):
+            venue_id = venue
+            if venue_id not in self.root.venues:
+                raise ValueError(f"Venue doesn't exist: '{venue_id}'")
+        else:
+            venue_id = venue.id
+        if venue_id in self.venue_ids:
+            return
+        self.venue_ids += (venue_id,)
+
+    def remove_venue(self, venue: str | Venue) -> None:
+        """Remove a venue association from this volume.
+
+        If the venue is not associated with this volume, this will do nothing.
+
+        Arguments:
+            venue: A Venue object, or a string representing a venue ID.
+        """
+        venue_id = venue.id if isinstance(venue, Venue) else venue
+        if venue_id in self.venue_ids:
+            self.venue_ids = tuple(x for x in self.venue_ids if x != venue_id)
 
     def venues(self) -> list[Venue]:
         """A list of venues associated with this volume."""

--- a/python/tests/collections/volume_test.py
+++ b/python/tests/collections/volume_test.py
@@ -393,6 +393,77 @@ def test_volume_add_sig_raises(anthology):
         volume.sig_ids += ("doesntexist",)
 
 
+def test_volume_add_sig_by_id(anthology):
+    volume = anthology.get_volume("2022.acl-long")
+    sigdat = anthology.sigs["sigdat"]
+    assert "sigdat" not in volume.sig_ids
+    assert volume.full_id_tuple not in sigdat.item_ids
+
+    volume.add_sig("sigdat")
+
+    assert volume.sig_ids == ("sigdat",)
+    assert volume.full_id_tuple in sigdat.item_ids
+
+
+def test_volume_add_sig_by_object(anthology):
+    volume = anthology.get_volume("2022.acl-long")
+    sigdat = anthology.sigs["sigdat"]
+    assert "sigdat" not in volume.sig_ids
+
+    volume.add_sig(sigdat)
+
+    assert volume.sig_ids == ("sigdat",)
+    assert volume.full_id_tuple in sigdat.item_ids
+
+
+def test_volume_add_sig_already_present_is_noop(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    assert "sigdat" in volume.sig_ids
+
+    volume.add_sig("sigdat")
+
+    assert volume.sig_ids.count("sigdat") == 1
+
+
+def test_volume_add_sig_nonexistent_raises(anthology):
+    volume = anthology.get_volume("2022.acl-long")
+    anthology.sigs.load()
+    with pytest.raises(ValueError):
+        volume.add_sig("doesntexist")
+
+
+def test_volume_remove_sig_by_id(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    sigdat = anthology.sigs["sigdat"]
+    assert "sigdat" in volume.sig_ids
+    assert volume.full_id_tuple in sigdat.item_ids
+
+    volume.remove_sig("sigdat")
+
+    assert "sigdat" not in volume.sig_ids
+    assert volume.full_id_tuple not in sigdat.item_ids
+
+
+def test_volume_remove_sig_by_object(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    sigsem = anthology.sigs["sigsem"]
+    assert "sigsem" in volume.sig_ids
+
+    volume.remove_sig(sigsem)
+
+    assert "sigsem" not in volume.sig_ids
+    assert volume.full_id_tuple not in sigsem.item_ids
+
+
+def test_volume_remove_sig_not_present_is_noop(anthology):
+    volume = anthology.get_volume("2022.acl-long")
+    assert volume.sig_ids == ()
+
+    volume.remove_sig("sigdat")
+
+    assert volume.sig_ids == ()
+
+
 def test_volume_add_venue_updates_venue(anthology):
     volume = anthology.get_volume("2022.naloma-1")
     nlma = anthology.venues["nlma"]
@@ -457,6 +528,77 @@ def test_volume_remove_venue_updates_event(anthology):
     # Events should be updated
     events = anthology.events.by_volume(volume)
     assert set(ev.id for ev in events) == {"acl-2022", "ws-2022"}
+
+
+def test_volume_add_venue_by_id(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    humeval = anthology.venues["humeval"]
+    assert "humeval" not in volume.venue_ids
+    assert volume.full_id_tuple not in humeval.item_ids
+
+    volume.add_venue("humeval")
+
+    assert "humeval" in volume.venue_ids
+    assert volume.full_id_tuple in humeval.item_ids
+
+
+def test_volume_add_venue_by_object(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    humeval = anthology.venues["humeval"]
+    assert "humeval" not in volume.venue_ids
+
+    volume.add_venue(humeval)
+
+    assert "humeval" in volume.venue_ids
+    assert volume.full_id_tuple in humeval.item_ids
+
+
+def test_volume_add_venue_already_present_is_noop(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    assert "nlma" in volume.venue_ids
+
+    volume.add_venue("nlma")
+
+    assert volume.venue_ids.count("nlma") == 1
+
+
+def test_volume_add_venue_nonexistent_raises(anthology):
+    volume = anthology.get_volume("2022.acl-long")
+    anthology.venues.load()
+    with pytest.raises(ValueError):
+        volume.add_venue("doesntexist")
+
+
+def test_volume_remove_venue_by_id(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    nlma = anthology.venues["nlma"]
+    assert "nlma" in volume.venue_ids
+    assert volume.full_id_tuple in nlma.item_ids
+
+    volume.remove_venue("nlma")
+
+    assert "nlma" not in volume.venue_ids
+    assert volume.full_id_tuple not in nlma.item_ids
+
+
+def test_volume_remove_venue_by_object(anthology):
+    volume = anthology.get_volume("2022.naloma-1")
+    ws = anthology.venues["ws"]
+    assert "ws" in volume.venue_ids
+
+    volume.remove_venue(ws)
+
+    assert "ws" not in volume.venue_ids
+    assert volume.full_id_tuple not in ws.item_ids
+
+
+def test_volume_remove_venue_not_present_is_noop(anthology):
+    volume = anthology.get_volume("2022.acl-long")
+    assert volume.venue_ids == ("acl",)
+
+    volume.remove_venue("humeval")
+
+    assert volume.venue_ids == ("acl",)
 
 
 @pytest.mark.parametrize("xml", test_cases_volume_xml)


### PR DESCRIPTION
> While I'm complaining about corners of the library :), it would be nice if volumes had `add_venue()` and `remove_venue()` methods. 

 _Originally posted by @nschneid in [#9815](https://github.com/acl-org/acl-anthology/issues/9815#issuecomment-5419063215)_

That was trivial enough to do. ;)

(Implementation by me, tests by Claude Code.)