### PR TITLE
verify me

### DIFF
--- a/data/json/people.json
+++ b/data/json/people.json
@@ -10306,6 +10306,12 @@
       {"first": "Arne", "last": "Jonsson"}
     ]
   },
+  "arne-koehn": {
+    "names": [
+      {"first": "Arne", "last": "Köhn"}
+    ],
+    "orcid": "0000-0002-4880-2016"
+  },
   "arne-robben": {
     "names": [
       {"first": "Arne", "last": "Robben"}

--- a/data/xml/2020.coling.xml
+++ b/data/xml/2020.coling.xml
@@ -3323,7 +3323,7 @@
     <paper id="252">
       <!-- https://aclanthology.org/2020.coling-main.252/ -->
       <title>Generating Instructions at Different Levels of Abstraction</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Julia</first><last>Wichlacz</last></author>
       <author><first>Álvaro</first><last>Torralba</last></author>
       <author><first>Daniel</first><last>Höller</last></author>

--- a/data/xml/2020.sigdial.xml
+++ b/data/xml/2020.sigdial.xml
@@ -112,7 +112,7 @@
     <paper id="7">
       <!-- https://aclanthology.org/2020.sigdial-1.7/ -->
       <title><fixed-case>MC</fixed-case>-Saar-Instruct: a Platform for <fixed-case>M</fixed-case>inecraft Instruction Giving Agents</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Julia</first><last>Wichlacz</last></author>
       <author><first>Christine</first><last>Schäfer</last></author>
       <author><first>Álvaro</first><last>Torralba</last></author>

--- a/data/xml/2021.emnlp.xml
+++ b/data/xml/2021.emnlp.xml
@@ -8146,7 +8146,7 @@
       <author><first>Lucia</first><last>Donatelli</last></author>
       <author><first>Theresa</first><last>Schmidt</last></author>
       <author><first>Debanjali</first><last>Biswas</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Fangzhou</first><last>Zhai</last></author>
       <author><first>Alexander</first><last>Koller</last></author>
       <pages>6930–6942</pages>

--- a/data/xml/2023.nlposs.xml
+++ b/data/xml/2023.nlposs.xml
@@ -152,7 +152,7 @@
       <title>Two Decades of the <fixed-case>ACL</fixed-case> <fixed-case>A</fixed-case>nthology: Development, Impact, and Open Challenges</title>
       <author id="marcel-bollmann"><first>Marcel</first><last>Bollmann</last><affiliation>Linköping University</affiliation></author>
       <author><first>Nathan</first><last>Schneider</last><affiliation>Georgetown University</affiliation></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Matt</first><last>Post</last><affiliation>Microsoft and Johns Hopkins University</affiliation></author>
       <pages>83-94</pages>
       <abstract>The ACL Anthology is a prime resource for research papers within computational linguistics and natural language processing, while continuing to be an open-source and community-driven project. Since Gildea et al. (2018) reported on its state and planned directions, the Anthology has seen major technical changes. We discuss what led to these changes and how they impact long-term maintainability and community engagement, describe which open-source data and software tools the Anthology currently provides, and provide a survey of literature that has used the Anthology as a main data source.</abstract>

--- a/data/xml/C16.xml
+++ b/data/xml/C16.xml
@@ -308,7 +308,7 @@
     <paper id="26">
       <!-- https://aclanthology.org/C16-1026/ -->
       <title>Predictive Incremental Parsing Helps Language Modeling</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author id="timo-baumann"><first>Timo</first><last>Baumann</last></author>
       <pages>268–277</pages>
       <url hash="fd0afe22">C16-1026</url>

--- a/data/xml/C18.xml
+++ b/data/xml/C18.xml
@@ -2954,7 +2954,7 @@
     <paper id="253">
       <!-- https://aclanthology.org/C18-1253/ -->
       <title>Incremental Natural Language Processing: Challenges, Strategies, and Evaluation</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <pages>2990–3003</pages>
       <abstract>Incrementality is ubiquitous in human-human interaction and beneficial for human-computer interaction. It has been a topic of research in different parts of the NLP community, mostly with focus on the specific topic at hand even though incremental systems have to deal with similar challenges regardless of domain. In this survey, I consolidate and categorize the approaches, identifying similarities and differences in the computation and data, and show trade-offs that have to be considered. A focus lies on evaluating incremental systems because the standard metrics often fail to capture the incremental properties of a system and coming up with a suitable evaluation scheme is non-trivial.</abstract>
       <url hash="2fe570d1">C18-1253</url>

--- a/data/xml/D15.xml
+++ b/data/xml/D15.xml
@@ -2908,7 +2908,7 @@
     <paper id="246">
       <!-- https://aclanthology.org/D15-1246/ -->
       <title>What’s in an Embedding? Analyzing Word Embeddings through Multilingual Evaluation</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <pages>2067–2073</pages>
       <url hash="d0408499">D15-1246</url>
       <doi>10.18653/v1/D15-1246</doi>

--- a/data/xml/K18.xml
+++ b/data/xml/K18.xml
@@ -1194,7 +1194,7 @@
       <author><first>Fynn</first><last>Schröder</last></author>
       <author><first>Marcel</first><last>Kamlot</last></author>
       <author><first>Gregor</first><last>Billing</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <pages>76–85</pages>
       <url hash="bd7d4a33">K18-3009</url>
       <doi>10.18653/v1/K18-3009</doi>

--- a/data/xml/L14.xml
+++ b/data/xml/L14.xml
@@ -7792,7 +7792,7 @@
     <paper id="666">
       <!-- https://aclanthology.org/L14-1666/ -->
       <author id="kilian-a-foth"><first>Kilian A.</first><last>Foth</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Niels</first><last>Beuck</last></author>
       <author><first>Wolfgang</first><last>Menzel</last></author>
       <title>Because Size Does Matter: The <fixed-case>H</fixed-case>amburg Dependency Treebank</title>

--- a/data/xml/L16.xml
+++ b/data/xml/L16.xml
@@ -8562,7 +8562,7 @@
     <paper id="735">
       <!-- https://aclanthology.org/L16-1735/ -->
       <title>Mining the Spoken <fixed-case>W</fixed-case>ikipedia for Speech Data and Beyond</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Florian</first><last>Stegen</last></author>
       <author id="timo-baumann"><first>Timo</first><last>Baumann</last></author>
       <pages>4644–4647</pages>

--- a/data/xml/P14.xml
+++ b/data/xml/P14.xml
@@ -3471,7 +3471,7 @@
     <paper id="130">
       <!-- https://aclanthology.org/P14-2130/ -->
       <title>Incremental Predictive Parsing with <fixed-case>T</fixed-case>urbo<fixed-case>P</fixed-case>arser</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Wolfgang</first><last>Menzel</last></author>
       <pages>803–808</pages>
       <url hash="e5b4ef06">P14-2130</url>

--- a/data/xml/P19.xml
+++ b/data/xml/P19.xml
@@ -6539,7 +6539,7 @@
       <author><first>Rami</first><last>Aly</last></author>
       <author><first>Shantanu</first><last>Acharya</last></author>
       <author><first>Alexander</first><last>Ossa</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author id="chris-biemann"><first>Chris</first><last>Biemann</last></author>
       <author><first>Alexander</first><last>Panchenko</last></author>
       <pages>4811–4817</pages>
@@ -8030,7 +8030,7 @@
       <!-- https://aclanthology.org/P19-1584/ -->
       <title>Adversarial Learning of Privacy-Preserving Text Representations for De-Identification of Medical Records</title>
       <author><first>Max</first><last>Friedrich</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Gregor</first><last>Wiedemann</last></author>
       <author id="chris-biemann"><first>Chris</first><last>Biemann</last></author>
       <pages>5829–5839</pages>

--- a/data/xml/R13.xml
+++ b/data/xml/R13.xml
@@ -493,7 +493,7 @@
     <paper id="48">
       <!-- https://aclanthology.org/R13-1048/ -->
       <title>Incremental and Predictive Dependency Parsing under Real-Time Conditions</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Wolfgang</first><last>Menzel</last></author>
       <pages>373–381</pages>
       <url hash="7ff44fc8">R13-1048</url>

--- a/data/xml/W11.xml
+++ b/data/xml/W11.xml
@@ -9015,7 +9015,7 @@
       <!-- https://aclanthology.org/W11-4605/ -->
       <title>Decision Strategies for Incremental <fixed-case>POS</fixed-case> Tagging</title>
       <author><first>Niels</first><last>Beuck</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Wolfgang</first><last>Menzel</last></author>
       <pages>26–33</pages>
       <url hash="533191d4">W11-4605</url>

--- a/data/xml/W16.xml
+++ b/data/xml/W16.xml
@@ -5595,7 +5595,7 @@
     <paper id="12">
       <!-- https://aclanthology.org/W16-2512/ -->
       <title>Evaluating Embeddings using Syntax-based Classification Tasks as a Proxy for Parser Performance</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <pages>67–71</pages>
       <url hash="b4044d0d">W16-2512</url>
       <doi>10.18653/v1/W16-2512</doi>

--- a/data/xml/W17.xml
+++ b/data/xml/W17.xml
@@ -950,7 +950,7 @@
       <!-- https://aclanthology.org/W17-0407/ -->
       <title>Dependency Tree Transformation with Tree Transducers</title>
       <author><first>Felix</first><last>Hennig</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <pages>58–66</pages>
       <url hash="13041593">W17-0407</url>
       <bibkey>hennig-kohn-2017-dependency</bibkey>

--- a/data/xml/W18.xml
+++ b/data/xml/W18.xml
@@ -8691,7 +8691,7 @@
       <!-- https://aclanthology.org/W18-4914/ -->
       <title>An Annotated Corpus of Picture Stories Retold by Language Learners</title>
       <author><first>Christine</first><last>Köhn</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <pages>121–132</pages>
       <url hash="1b42499e">W18-4914</url>
       <abstract>Corpora with language learner writing usually consist of essays, which are difficult to annotate reliably and to process automatically due to the high degree of freedom and the nature of learner language. We develop a task which mildly constrains learner utterances to facilitate consistent annotation and reliable automatic processing but at the same time does not prime learners with textual information. In this task, learners retell a comic strip. We present the resulting task-based corpus of stories written by learners of German. We designed the corpus to be able to serve multiple purposes: The corpus was manually annotated, including target hypotheses and syntactic structures. We achieve a very high inter-annotator agreement: κ = 0.765 for the annotation of minimal target hypotheses and κ = 0.507 for the extended target hypotheses. We attribute this to the design of our task and the annotation guidelines, which are based on those for the Falko corpus (Reznicek et al., 2012).</abstract>

--- a/data/xml/W19.xml
+++ b/data/xml/W19.xml
@@ -18553,7 +18553,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
       <author><first>Emanuel</first><last>Borges Völker</last></author>
       <author><first>Maximilian</first><last>Wendt</last></author>
       <author><first>Felix</first><last>Hennig</last></author>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <pages>46–57</pages>
       <url hash="a8a2858d">W19-8006</url>
       <doi>10.18653/v1/W19-8006</doi>
@@ -19093,7 +19093,7 @@ One of the references was wrong therefore it is corrected to cite the appropriat
     <paper id="1">
       <!-- https://aclanthology.org/W19-8601/ -->
       <title>Talking about what is not there: Generating indefinite referring expressions in <fixed-case>M</fixed-case>inecraft</title>
-      <author><first>Arne</first><last>Köhn</last></author>
+      <author id="arne-koehn"><first>Arne</first><last>Köhn</last></author>
       <author><first>Alexander</first><last>Koller</last></author>
       <pages>1–10</pages>
       <abstract>When generating technical instructions, it is often necessary to describe an object that does not exist yet. For example, an NLG system which explains how to build a house needs to generate sentences like “build <i>a wall of height five to your left</i>” and “now build <i>a wall on the other side</i>.” Generating (indefinite) referring expressions to objects that do not exist yet is fundamentally different from generating the usual definite referring expressions, because the new object must be distinguished from an infinite set of possible alternatives. We formalize this problem and present an algorithm for generating such expressions, in the context of generating building instructions within the Minecraft video game.</abstract>


### PR DESCRIPTION
> associate 0000-0002-4880-2016 with the author Arne Köhn.

(agy computing, making use of the new agents.md)

> can you make the identifier arne-koehn instead of arne-kohn?

Looks like the AGENTS.md works, agy needed to search a bit through the files to find the correct approach though.