### PR TITLE
for unverified URLs, HTTP header indicating canonical URL

### DIFF
--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -103,6 +103,7 @@ RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 # Unverified URLs: extract and provide canonical URL in header
 # Extract the path before "unverified/" into a variable
 RewriteCond %{REQUEST_URI} ^(.*/people/[^/]+/)unverified/?$ [NC]
+RewriteCond %{REQUEST_FILENAME}/../index.html -f
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -103,7 +103,8 @@ RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 # Unverified URLs: extract and provide canonical URL in header
 # Extract the path before "unverified/" into a variable
 RewriteCond %{REQUEST_URI} ^(.*/people/[^/]+/)unverified/?$ [NC]
-RewriteCond %{REQUEST_FILENAME}/../index.html -f
+# Ensure /people/name/ is not a 404
+RewriteCond /%1 -U
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -100,6 +100,15 @@ RewriteCond %{REQUEST_FILENAME}/index.html !-f
 RewriteCond %{REQUEST_FILENAME}/unverified -d
 RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 
+# Unverified URLs: extract and provide canonical URL in header
+# Extract the path before "unverified/" into a variable
+RewriteCond %{REQUEST_URI} ^/(.*)unverified/?$ [NC]
+RewriteRule ^ - [E=CANONICAL_PATH:%1]
+# Inject the rel="canonical" Link header using the captured path
+<IfModule mod_headers.c>
+    Header set Link "<https://aclanthology.org/%{CANONICAL_PATH}e>; rel=\"canonical\"" env=CANONICAL_PATH
+</IfModule>
+
 # Videos
 ## match old-style URLs, e.g., /N13-1001.mp4 -> anthology-files/videos/N/N13-1001.mp4
 ## also supports videos split into pieces, e.g., /N13-4001.1.mp4

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -102,11 +102,11 @@ RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 
 # Unverified URLs: extract and provide canonical URL in header
 # Extract the path before "unverified/" into a variable
-RewriteCond %{REQUEST_URI} ^/(people/[^/]+/)unverified/?$ [NC]
+RewriteCond %{REQUEST_URI} ^(.*/people/[^/]+/)unverified/?$ [NC]
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>
-    Header set Link "<https://aclanthology.org/%{CANONICAL_PATH}e>; rel=\"canonical\"" env=CANONICAL_PATH
+    Header set Link "<https://aclanthology.org%{CANONICAL_PATH}e>; rel=\"canonical\"" env=CANONICAL_PATH
 </IfModule>
 
 # Videos

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -103,8 +103,10 @@ RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 # Unverified URLs: extract and provide canonical URL in header
 # Extract the path before "unverified/" into a variable
 RewriteCond %{REQUEST_URI} ^(.*/people/[^/]+/)unverified/?$ [NC]
-# Ensure /people/name/index.html actually exists on disk
-RewriteCond %{DOCUMENT_ROOT}%1index.html -f
+# Send the header if either the verified or the unverified page exists on disk;
+# only withhold it if neither exists (a genuine 404 with nothing to point to)
+RewriteCond %{DOCUMENT_ROOT}%1index.html -f [OR]
+RewriteCond %{DOCUMENT_ROOT}%1unverified/index.html -f
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -102,7 +102,7 @@ RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 
 # Unverified URLs: extract and provide canonical URL in header
 # Extract the path before "unverified/" into a variable
-RewriteCond %{REQUEST_URI} ^/(.*)unverified/?$ [NC]
+RewriteCond %{REQUEST_URI} ^(people/[^/]+/)unverified/?$ [NC]
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -103,8 +103,8 @@ RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 # Unverified URLs: extract and provide canonical URL in header
 # Extract the path before "unverified/" into a variable
 RewriteCond %{REQUEST_URI} ^(.*/people/[^/]+/)unverified/?$ [NC]
-# Ensure /people/name/ is not a 404
-RewriteCond /%1 -U
+# Ensure /people/name/index.html actually exists on disk
+RewriteCond %{DOCUMENT_ROOT}%1index.html -f
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -112,7 +112,6 @@ RewriteRule ^ - [E=CANONICAL_PATH:%1]
     # Handles Apache internal ErrorDocument subrequests (where CANONICAL_PATH becomes REDIRECT_CANONICAL_PATH)
     Header always set Link "<https://aclanthology.org%{REDIRECT_CANONICAL_PATH}e>; rel=\"canonical\"" env=REDIRECT_CANONICAL_PATH
 </IfModule>
-</IfModule>
 
 # Videos
 ## match old-style URLs, e.g., /N13-1001.mp4 -> anthology-files/videos/N/N13-1001.mp4

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -102,7 +102,7 @@ RewriteRule ^people/([^/]+)/?$ people/$1/unverified [L,R=307]
 
 # Unverified URLs: extract and provide canonical URL in header
 # Extract the path before "unverified/" into a variable
-RewriteCond %{REQUEST_URI} ^(people/[^/]+/)unverified/?$ [NC]
+RewriteCond %{REQUEST_URI} ^/(people/[^/]+/)unverified/?$ [NC]
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>

--- a/hugo/static/.htaccess
+++ b/hugo/static/.htaccess
@@ -106,7 +106,12 @@ RewriteCond %{REQUEST_URI} ^(.*/people/[^/]+/)unverified/?$ [NC]
 RewriteRule ^ - [E=CANONICAL_PATH:%1]
 # Inject the rel="canonical" Link header using the captured path
 <IfModule mod_headers.c>
-    Header set Link "<https://aclanthology.org%{CANONICAL_PATH}e>; rel=\"canonical\"" env=CANONICAL_PATH
+    # "always" forces the header onto 404 and other non-200 responses
+    Header always set Link "<https://aclanthology.org%{CANONICAL_PATH}e>; rel=\"canonical\"" env=CANONICAL_PATH
+
+    # Handles Apache internal ErrorDocument subrequests (where CANONICAL_PATH becomes REDIRECT_CANONICAL_PATH)
+    Header always set Link "<https://aclanthology.org%{REDIRECT_CANONICAL_PATH}e>; rel=\"canonical\"" env=REDIRECT_CANONICAL_PATH
+</IfModule>
 </IfModule>
 
 # Videos


### PR DESCRIPTION
Google Search Console is indicating that some canonical people URLs are not being indexed because they used to redirect to another page (the unverified page). That page is now a 404. Because we are serving a 404 we do not have a pointer to the canonical URL in a `<link>` meta tag.

This update (assisted by Gemini) should signal the canonical URL in an HTTP response header for any unverified URL. Docs: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-header-method

related: #9273